### PR TITLE
Add enums

### DIFF
--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -127,6 +123,56 @@ pub struct CertificateDetail {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CertificateStatus {
+    Expired,
+    Failed,
+    Inactive,
+    Issued,
+    PendingValidation,
+    Revoked,
+    ValidationTimedOut,
+}
+
+impl Into<String> for CertificateStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CertificateStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CertificateStatus::Expired => "EXPIRED",
+            CertificateStatus::Failed => "FAILED",
+            CertificateStatus::Inactive => "INACTIVE",
+            CertificateStatus::Issued => "ISSUED",
+            CertificateStatus::PendingValidation => "PENDING_VALIDATION",
+            CertificateStatus::Revoked => "REVOKED",
+            CertificateStatus::ValidationTimedOut => "VALIDATION_TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CertificateStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EXPIRED" => Ok(CertificateStatus::Expired),
+            "FAILED" => Ok(CertificateStatus::Failed),
+            "INACTIVE" => Ok(CertificateStatus::Inactive),
+            "ISSUED" => Ok(CertificateStatus::Issued),
+            "PENDING_VALIDATION" => Ok(CertificateStatus::PendingValidation),
+            "REVOKED" => Ok(CertificateStatus::Revoked),
+            "VALIDATION_TIMED_OUT" => Ok(CertificateStatus::ValidationTimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>This structure is returned in the response object of <a>ListCertificates</a> action.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CertificateSummary {
@@ -138,6 +184,41 @@ pub struct CertificateSummary {
     #[serde(rename="DomainName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub domain_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CertificateType {
+    AmazonIssued,
+    Imported,
+}
+
+impl Into<String> for CertificateType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CertificateType {
+    fn into(self) -> &'static str {
+        match self {
+            CertificateType::AmazonIssued => "AMAZON_ISSUED",
+            CertificateType::Imported => "IMPORTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CertificateType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AMAZON_ISSUED" => Ok(CertificateType::AmazonIssued),
+            "IMPORTED" => Ok(CertificateType::Imported),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -160,6 +241,44 @@ pub struct DescribeCertificateResponse {
     #[serde(rename="Certificate")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub certificate: Option<CertificateDetail>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DomainStatus {
+    Failed,
+    PendingValidation,
+    Success,
+}
+
+impl Into<String> for DomainStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DomainStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DomainStatus::Failed => "FAILED",
+            DomainStatus::PendingValidation => "PENDING_VALIDATION",
+            DomainStatus::Success => "SUCCESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DomainStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(DomainStatus::Failed),
+            "PENDING_VALIDATION" => Ok(DomainStatus::PendingValidation),
+            "SUCCESS" => Ok(DomainStatus::Success),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains information about the validation of each domain name in the certificate.</p>"]
@@ -191,6 +310,50 @@ pub struct DomainValidationOption {
     #[doc="<p>The domain name that you want ACM to use to send you validation emails. This domain name is the suffix of the email addresses that you want ACM to use. This must be the same as the <code>DomainName</code> value or a superdomain of the <code>DomainName</code> value. For example, if you request a certificate for <code>testing.example.com</code>, you can specify <code>example.com</code> for this value. In that case, ACM sends domain validation emails to the following five addresses:</p> <ul> <li> <p>admin@example.com</p> </li> <li> <p>administrator@example.com</p> </li> <li> <p>hostmaster@example.com</p> </li> <li> <p>postmaster@example.com</p> </li> <li> <p>webmaster@example.com</p> </li> </ul>"]
     #[serde(rename="ValidationDomain")]
     pub validation_domain: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FailureReason {
+    AdditionalVerificationRequired,
+    DomainNotAllowed,
+    InvalidPublicDomain,
+    NoAvailableContacts,
+    Other,
+}
+
+impl Into<String> for FailureReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FailureReason {
+    fn into(self) -> &'static str {
+        match self {
+            FailureReason::AdditionalVerificationRequired => "ADDITIONAL_VERIFICATION_REQUIRED",
+            FailureReason::DomainNotAllowed => "DOMAIN_NOT_ALLOWED",
+            FailureReason::InvalidPublicDomain => "INVALID_PUBLIC_DOMAIN",
+            FailureReason::NoAvailableContacts => "NO_AVAILABLE_CONTACTS",
+            FailureReason::Other => "OTHER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FailureReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADDITIONAL_VERIFICATION_REQUIRED" => Ok(FailureReason::AdditionalVerificationRequired),
+            "DOMAIN_NOT_ALLOWED" => Ok(FailureReason::DomainNotAllowed),
+            "INVALID_PUBLIC_DOMAIN" => Ok(FailureReason::InvalidPublicDomain),
+            "NO_AVAILABLE_CONTACTS" => Ok(FailureReason::NoAvailableContacts),
+            "OTHER" => Ok(FailureReason::Other),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -252,6 +415,44 @@ pub struct ImportCertificateResponse {
     pub certificate_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum KeyAlgorithm {
+    EcPrime256V1,
+    Rsa1024,
+    Rsa2048,
+}
+
+impl Into<String> for KeyAlgorithm {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for KeyAlgorithm {
+    fn into(self) -> &'static str {
+        match self {
+            KeyAlgorithm::EcPrime256V1 => "EC_prime256v1",
+            KeyAlgorithm::Rsa1024 => "RSA_1024",
+            KeyAlgorithm::Rsa2048 => "RSA_2048",
+        }
+    }
+}
+
+impl ::std::str::FromStr for KeyAlgorithm {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EC_prime256v1" => Ok(KeyAlgorithm::EcPrime256V1),
+            "RSA_1024" => Ok(KeyAlgorithm::Rsa1024),
+            "RSA_2048" => Ok(KeyAlgorithm::Rsa2048),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListCertificatesRequest {
     #[doc="<p>The status or statuses on which to filter the list of ACM Certificates.</p>"]
@@ -305,6 +506,47 @@ pub struct RemoveTagsFromCertificateRequest {
     pub tags: Vec<Tag>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RenewalStatus {
+    Failed,
+    PendingAutoRenewal,
+    PendingValidation,
+    Success,
+}
+
+impl Into<String> for RenewalStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RenewalStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RenewalStatus::Failed => "FAILED",
+            RenewalStatus::PendingAutoRenewal => "PENDING_AUTO_RENEWAL",
+            RenewalStatus::PendingValidation => "PENDING_VALIDATION",
+            RenewalStatus::Success => "SUCCESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RenewalStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(RenewalStatus::Failed),
+            "PENDING_AUTO_RENEWAL" => Ok(RenewalStatus::PendingAutoRenewal),
+            "PENDING_VALIDATION" => Ok(RenewalStatus::PendingValidation),
+            "SUCCESS" => Ok(RenewalStatus::Success),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about the status of ACM's <a href=\"http://docs.aws.amazon.com/acm/latest/userguide/acm-renewal.html\">managed renewal</a> for the certificate. This structure exists only when the certificate type is <code>AMAZON_ISSUED</code>.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RenewalSummary {
@@ -354,6 +596,65 @@ pub struct ResendValidationEmailRequest {
     #[doc="<p>The base validation domain that will act as the suffix of the email addresses that are used to send the emails. This must be the same as the <code>Domain</code> value or a superdomain of the <code>Domain</code> value. For example, if you requested a certificate for <code>site.subdomain.example.com</code> and specify a <b>ValidationDomain</b> of <code>subdomain.example.com</code>, ACM sends email to the domain registrant, technical contact, and administrative contact in WHOIS and the following five addresses:</p> <ul> <li> <p>admin@subdomain.example.com</p> </li> <li> <p>administrator@subdomain.example.com</p> </li> <li> <p>hostmaster@subdomain.example.com</p> </li> <li> <p>postmaster@subdomain.example.com</p> </li> <li> <p>webmaster@subdomain.example.com</p> </li> </ul>"]
     #[serde(rename="ValidationDomain")]
     pub validation_domain: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RevocationReason {
+    AffiliationChanged,
+    AACompromise,
+    CaCompromise,
+    CertificateHold,
+    CessationOfOperation,
+    KeyCompromise,
+    PrivilegeWithdrawn,
+    RemoveFromCrl,
+    Superceded,
+    Unspecified,
+}
+
+impl Into<String> for RevocationReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RevocationReason {
+    fn into(self) -> &'static str {
+        match self {
+            RevocationReason::AffiliationChanged => "AFFILIATION_CHANGED",
+            RevocationReason::AACompromise => "A_A_COMPROMISE",
+            RevocationReason::CaCompromise => "CA_COMPROMISE",
+            RevocationReason::CertificateHold => "CERTIFICATE_HOLD",
+            RevocationReason::CessationOfOperation => "CESSATION_OF_OPERATION",
+            RevocationReason::KeyCompromise => "KEY_COMPROMISE",
+            RevocationReason::PrivilegeWithdrawn => "PRIVILEGE_WITHDRAWN",
+            RevocationReason::RemoveFromCrl => "REMOVE_FROM_CRL",
+            RevocationReason::Superceded => "SUPERCEDED",
+            RevocationReason::Unspecified => "UNSPECIFIED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RevocationReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AFFILIATION_CHANGED" => Ok(RevocationReason::AffiliationChanged),
+            "A_A_COMPROMISE" => Ok(RevocationReason::AACompromise),
+            "CA_COMPROMISE" => Ok(RevocationReason::CaCompromise),
+            "CERTIFICATE_HOLD" => Ok(RevocationReason::CertificateHold),
+            "CESSATION_OF_OPERATION" => Ok(RevocationReason::CessationOfOperation),
+            "KEY_COMPROMISE" => Ok(RevocationReason::KeyCompromise),
+            "PRIVILEGE_WITHDRAWN" => Ok(RevocationReason::PrivilegeWithdrawn),
+            "REMOVE_FROM_CRL" => Ok(RevocationReason::RemoveFromCrl),
+            "SUPERCEDED" => Ok(RevocationReason::Superceded),
+            "UNSPECIFIED" => Ok(RevocationReason::Unspecified),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A key-value pair that identifies or specifies metadata about an ACM resource.</p>"]
@@ -1363,7 +1664,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1389,7 +1690,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1415,7 +1716,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1445,7 +1746,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetCertificateResponse>(String::from_utf8_lossy(&body)
@@ -1477,7 +1778,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ImportCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1507,7 +1808,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListCertificatesResponse>(String::from_utf8_lossy(&body)
@@ -1540,7 +1841,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsForCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1571,7 +1872,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1598,7 +1899,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RequestCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1628,7 +1929,7 @@ impl<P, D> Acm for AcmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -120,6 +116,38 @@ pub struct ApiKeys {
     pub warnings: Option<Vec<String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ApiKeysFormat {
+    Csv,
+}
+
+impl Into<String> for ApiKeysFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ApiKeysFormat {
+    fn into(self) -> &'static str {
+        match self {
+            ApiKeysFormat::Csv => "csv",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ApiKeysFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "csv" => Ok(ApiKeysFormat::Csv),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>API stage name of the associated API stage in a usage plan.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApiStage {
@@ -178,6 +206,41 @@ pub struct Authorizer {
     pub type_: Option<String>,
 }
 
+#[doc="<p>The authorizer type. the current value is <code>TOKEN</code> for a Lambda function or <code>COGNITO_USER_POOLS</code> for an Amazon Cognito Your User Pool.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AuthorizerType {
+    CognitoUserPools,
+    Token,
+}
+
+impl Into<String> for AuthorizerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AuthorizerType {
+    fn into(self) -> &'static str {
+        match self {
+            AuthorizerType::CognitoUserPools => "COGNITO_USER_POOLS",
+            AuthorizerType::Token => "TOKEN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AuthorizerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COGNITO_USER_POOLS" => Ok(AuthorizerType::CognitoUserPools),
+            "TOKEN" => Ok(AuthorizerType::Token),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents a collection of <a>Authorizer</a> resources.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html\">Enable custom authorization</a> </div>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Authorizers {
@@ -219,6 +282,103 @@ pub struct BasePathMappings {
     pub position: Option<String>,
 }
 
+#[doc="<p>Returns the size of the <b>CacheCluster</b>.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CacheClusterSize {
+    _0_5,
+    _1_6,
+    _118,
+    _13_5,
+    _237,
+    _28_4,
+    _58_2,
+    _6_1,
+}
+
+impl Into<String> for CacheClusterSize {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CacheClusterSize {
+    fn into(self) -> &'static str {
+        match self {
+            CacheClusterSize::_0_5 => "0.5",
+            CacheClusterSize::_1_6 => "1.6",
+            CacheClusterSize::_118 => "118",
+            CacheClusterSize::_13_5 => "13.5",
+            CacheClusterSize::_237 => "237",
+            CacheClusterSize::_28_4 => "28.4",
+            CacheClusterSize::_58_2 => "58.2",
+            CacheClusterSize::_6_1 => "6.1",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CacheClusterSize {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "0.5" => Ok(CacheClusterSize::_0_5),
+            "1.6" => Ok(CacheClusterSize::_1_6),
+            "118" => Ok(CacheClusterSize::_118),
+            "13.5" => Ok(CacheClusterSize::_13_5),
+            "237" => Ok(CacheClusterSize::_237),
+            "28.4" => Ok(CacheClusterSize::_28_4),
+            "58.2" => Ok(CacheClusterSize::_58_2),
+            "6.1" => Ok(CacheClusterSize::_6_1),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="<p>Returns the status of the <b>CacheCluster</b>.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CacheClusterStatus {
+    Available,
+    CreateInProgress,
+    DeleteInProgress,
+    FlushInProgress,
+    NotAvailable,
+}
+
+impl Into<String> for CacheClusterStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CacheClusterStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CacheClusterStatus::Available => "AVAILABLE",
+            CacheClusterStatus::CreateInProgress => "CREATE_IN_PROGRESS",
+            CacheClusterStatus::DeleteInProgress => "DELETE_IN_PROGRESS",
+            CacheClusterStatus::FlushInProgress => "FLUSH_IN_PROGRESS",
+            CacheClusterStatus::NotAvailable => "NOT_AVAILABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CacheClusterStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(CacheClusterStatus::Available),
+            "CREATE_IN_PROGRESS" => Ok(CacheClusterStatus::CreateInProgress),
+            "DELETE_IN_PROGRESS" => Ok(CacheClusterStatus::DeleteInProgress),
+            "FLUSH_IN_PROGRESS" => Ok(CacheClusterStatus::FlushInProgress),
+            "NOT_AVAILABLE" => Ok(CacheClusterStatus::NotAvailable),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents a client certificate used to configure client-side SSL authentication while sending requests to the integration endpoint.</p> <div class=\"remarks\">Client certificates are used authenticate an API by the back-end server. To authenticate an API client (or user), use a custom <a>Authorizer</a>.</div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html\">Use Client-Side Certificate</a> </div>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ClientCertificate {
@@ -254,6 +414,41 @@ pub struct ClientCertificates {
     #[serde(rename="position")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub position: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContentHandlingStrategy {
+    ConvertToBinary,
+    ConvertToText,
+}
+
+impl Into<String> for ContentHandlingStrategy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContentHandlingStrategy {
+    fn into(self) -> &'static str {
+        match self {
+            ContentHandlingStrategy::ConvertToBinary => "CONVERT_TO_BINARY",
+            ContentHandlingStrategy::ConvertToText => "CONVERT_TO_TEXT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContentHandlingStrategy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONVERT_TO_BINARY" => Ok(ContentHandlingStrategy::ConvertToBinary),
+            "CONVERT_TO_TEXT" => Ok(ContentHandlingStrategy::ConvertToText),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Request to create an <a>ApiKey</a> resource.</p>"]
@@ -906,6 +1101,71 @@ pub struct DocumentationPartLocation {
     pub type_: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentationPartType {
+    Api,
+    Authorizer,
+    Method,
+    Model,
+    PathParameter,
+    QueryParameter,
+    RequestBody,
+    RequestHeader,
+    Resource,
+    Response,
+    ResponseBody,
+    ResponseHeader,
+}
+
+impl Into<String> for DocumentationPartType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentationPartType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentationPartType::Api => "API",
+            DocumentationPartType::Authorizer => "AUTHORIZER",
+            DocumentationPartType::Method => "METHOD",
+            DocumentationPartType::Model => "MODEL",
+            DocumentationPartType::PathParameter => "PATH_PARAMETER",
+            DocumentationPartType::QueryParameter => "QUERY_PARAMETER",
+            DocumentationPartType::RequestBody => "REQUEST_BODY",
+            DocumentationPartType::RequestHeader => "REQUEST_HEADER",
+            DocumentationPartType::Resource => "RESOURCE",
+            DocumentationPartType::Response => "RESPONSE",
+            DocumentationPartType::ResponseBody => "RESPONSE_BODY",
+            DocumentationPartType::ResponseHeader => "RESPONSE_HEADER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentationPartType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "API" => Ok(DocumentationPartType::Api),
+            "AUTHORIZER" => Ok(DocumentationPartType::Authorizer),
+            "METHOD" => Ok(DocumentationPartType::Method),
+            "MODEL" => Ok(DocumentationPartType::Model),
+            "PATH_PARAMETER" => Ok(DocumentationPartType::PathParameter),
+            "QUERY_PARAMETER" => Ok(DocumentationPartType::QueryParameter),
+            "REQUEST_BODY" => Ok(DocumentationPartType::RequestBody),
+            "REQUEST_HEADER" => Ok(DocumentationPartType::RequestHeader),
+            "RESOURCE" => Ok(DocumentationPartType::Resource),
+            "RESPONSE" => Ok(DocumentationPartType::Response),
+            "RESPONSE_BODY" => Ok(DocumentationPartType::ResponseBody),
+            "RESPONSE_HEADER" => Ok(DocumentationPartType::ResponseHeader),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The collection of documentation parts of an API.</p> <div class=\"remarks\"/> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html\">Documenting an API</a>, <a>DocumentationPart</a> </div>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DocumentationParts {
@@ -1040,6 +1300,97 @@ pub struct GatewayResponse {
     #[serde(rename="statusCode")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status_code: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GatewayResponseType {
+    AccessDenied,
+    ApiConfigurationError,
+    AuthorizerConfigurationError,
+    AuthorizerFailure,
+    BadRequestBody,
+    BadRequestParameters,
+    Default4Xx,
+    Default5Xx,
+    ExpiredToken,
+    IntegrationFailure,
+    IntegrationTimeout,
+    InvalidApiKey,
+    InvalidSignature,
+    MissingAuthenticationToken,
+    QuotaExceeded,
+    RequestTooLarge,
+    ResourceNotFound,
+    Throttled,
+    Unauthorized,
+    UnsupportedMediaType,
+}
+
+impl Into<String> for GatewayResponseType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GatewayResponseType {
+    fn into(self) -> &'static str {
+        match self {
+            GatewayResponseType::AccessDenied => "ACCESS_DENIED",
+            GatewayResponseType::ApiConfigurationError => "API_CONFIGURATION_ERROR",
+            GatewayResponseType::AuthorizerConfigurationError => "AUTHORIZER_CONFIGURATION_ERROR",
+            GatewayResponseType::AuthorizerFailure => "AUTHORIZER_FAILURE",
+            GatewayResponseType::BadRequestBody => "BAD_REQUEST_BODY",
+            GatewayResponseType::BadRequestParameters => "BAD_REQUEST_PARAMETERS",
+            GatewayResponseType::Default4Xx => "DEFAULT_4XX",
+            GatewayResponseType::Default5Xx => "DEFAULT_5XX",
+            GatewayResponseType::ExpiredToken => "EXPIRED_TOKEN",
+            GatewayResponseType::IntegrationFailure => "INTEGRATION_FAILURE",
+            GatewayResponseType::IntegrationTimeout => "INTEGRATION_TIMEOUT",
+            GatewayResponseType::InvalidApiKey => "INVALID_API_KEY",
+            GatewayResponseType::InvalidSignature => "INVALID_SIGNATURE",
+            GatewayResponseType::MissingAuthenticationToken => "MISSING_AUTHENTICATION_TOKEN",
+            GatewayResponseType::QuotaExceeded => "QUOTA_EXCEEDED",
+            GatewayResponseType::RequestTooLarge => "REQUEST_TOO_LARGE",
+            GatewayResponseType::ResourceNotFound => "RESOURCE_NOT_FOUND",
+            GatewayResponseType::Throttled => "THROTTLED",
+            GatewayResponseType::Unauthorized => "UNAUTHORIZED",
+            GatewayResponseType::UnsupportedMediaType => "UNSUPPORTED_MEDIA_TYPE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GatewayResponseType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCESS_DENIED" => Ok(GatewayResponseType::AccessDenied),
+            "API_CONFIGURATION_ERROR" => Ok(GatewayResponseType::ApiConfigurationError),
+            "AUTHORIZER_CONFIGURATION_ERROR" => {
+                Ok(GatewayResponseType::AuthorizerConfigurationError)
+            }
+            "AUTHORIZER_FAILURE" => Ok(GatewayResponseType::AuthorizerFailure),
+            "BAD_REQUEST_BODY" => Ok(GatewayResponseType::BadRequestBody),
+            "BAD_REQUEST_PARAMETERS" => Ok(GatewayResponseType::BadRequestParameters),
+            "DEFAULT_4XX" => Ok(GatewayResponseType::Default4Xx),
+            "DEFAULT_5XX" => Ok(GatewayResponseType::Default5Xx),
+            "EXPIRED_TOKEN" => Ok(GatewayResponseType::ExpiredToken),
+            "INTEGRATION_FAILURE" => Ok(GatewayResponseType::IntegrationFailure),
+            "INTEGRATION_TIMEOUT" => Ok(GatewayResponseType::IntegrationTimeout),
+            "INVALID_API_KEY" => Ok(GatewayResponseType::InvalidApiKey),
+            "INVALID_SIGNATURE" => Ok(GatewayResponseType::InvalidSignature),
+            "MISSING_AUTHENTICATION_TOKEN" => Ok(GatewayResponseType::MissingAuthenticationToken),
+            "QUOTA_EXCEEDED" => Ok(GatewayResponseType::QuotaExceeded),
+            "REQUEST_TOO_LARGE" => Ok(GatewayResponseType::RequestTooLarge),
+            "RESOURCE_NOT_FOUND" => Ok(GatewayResponseType::ResourceNotFound),
+            "THROTTLED" => Ok(GatewayResponseType::Throttled),
+            "UNAUTHORIZED" => Ok(GatewayResponseType::Unauthorized),
+            "UNSUPPORTED_MEDIA_TYPE" => Ok(GatewayResponseType::UnsupportedMediaType),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The collection of the <a>GatewayResponse</a> instances of a <a>RestApi</a> as a <code>responseType</code>-to-<a>GatewayResponse</a> object map of key-value pairs. As such, pagination is not supported for querying this collection.</p> <div class=\"remarks\"> For more information about valid gateway response types, see <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/supported-gateway-response-types.html\">Gateway Response Types Supported by Amazon API Gateway</a> <div class=\"example\"> <h4>Example: Get the collection of gateway responses of an API</h4> <h5>Request</h5> <p>This example request shows how to retrieve the <a>GatewayResponses</a> collection from an API.</p> <pre><code>GET /restapis/o81lxisefl/gatewayresponses HTTP/1.1 Host: beta-apigateway.us-east-1.amazonaws.com Content-Type: application/json X-Amz-Date: 20170503T220604Z Authorization: AWS4-HMAC-SHA256 Credential={access-key-id}/20170503/us-east-1/apigateway/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=59b42fe54a76a5de8adf2c67baa6d39206f8e9ad49a1d77ccc6a5da3103a398a Cache-Control: no-cache Postman-Token: 5637af27-dc29-fc5c-9dfe-0645d52cb515 </code></pre> <p></p> <h5>Response</h5> <p>The successful operation returns the <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ \"_links\": { \"curies\": { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-gatewayresponse-{rel}.html\", \"name\": \"gatewayresponse\", \"templated\": true }, \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses\" }, \"first\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses\" }, \"gatewayresponse:by-type\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"item\": [ { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_FAILURE\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/RESOURCE_NOT_FOUND\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/REQUEST_TOO_LARGE\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/THROTTLED\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED_MEDIA_TYPE\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_CONFIGURATION_ERROR\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_5XX\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_4XX\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_PARAMETERS\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_BODY\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/EXPIRED_TOKEN\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/ACCESS_DENIED\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_API_KEY\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/API_CONFIGURATION_ERROR\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/QUOTA_EXCEEDED\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_TIMEOUT\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/MISSING_AUTHENTICATION_TOKEN\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_SIGNATURE\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_FAILURE\" } ] }, \"_embedded\": { \"item\": [ { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_FAILURE\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_FAILURE\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"INTEGRATION_FAILURE\", \"statusCode\": \"504\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/RESOURCE_NOT_FOUND\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/RESOURCE_NOT_FOUND\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"RESOURCE_NOT_FOUND\", \"statusCode\": \"404\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/REQUEST_TOO_LARGE\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/REQUEST_TOO_LARGE\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"REQUEST_TOO_LARGE\", \"statusCode\": \"413\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/THROTTLED\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/THROTTLED\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"THROTTLED\", \"statusCode\": \"429\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED_MEDIA_TYPE\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED_MEDIA_TYPE\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"UNSUPPORTED_MEDIA_TYPE\", \"statusCode\": \"415\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_CONFIGURATION_ERROR\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_CONFIGURATION_ERROR\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"AUTHORIZER_CONFIGURATION_ERROR\", \"statusCode\": \"500\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_5XX\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_5XX\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"DEFAULT_5XX\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_4XX\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_4XX\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"DEFAULT_4XX\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_PARAMETERS\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_PARAMETERS\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"BAD_REQUEST_PARAMETERS\", \"statusCode\": \"400\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_BODY\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_BODY\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"BAD_REQUEST_BODY\", \"statusCode\": \"400\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/EXPIRED_TOKEN\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/EXPIRED_TOKEN\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"EXPIRED_TOKEN\", \"statusCode\": \"403\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/ACCESS_DENIED\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/ACCESS_DENIED\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"ACCESS_DENIED\", \"statusCode\": \"403\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_API_KEY\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_API_KEY\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"INVALID_API_KEY\", \"statusCode\": \"403\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"UNAUTHORIZED\", \"statusCode\": \"401\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/API_CONFIGURATION_ERROR\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/API_CONFIGURATION_ERROR\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"API_CONFIGURATION_ERROR\", \"statusCode\": \"500\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/QUOTA_EXCEEDED\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/QUOTA_EXCEEDED\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"QUOTA_EXCEEDED\", \"statusCode\": \"429\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_TIMEOUT\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_TIMEOUT\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"INTEGRATION_TIMEOUT\", \"statusCode\": \"504\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/MISSING_AUTHENTICATION_TOKEN\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/MISSING_AUTHENTICATION_TOKEN\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"MISSING_AUTHENTICATION_TOKEN\", \"statusCode\": \"403\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_SIGNATURE\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_SIGNATURE\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"INVALID_SIGNATURE\", \"statusCode\": \"403\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_FAILURE\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_FAILURE\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"AUTHORIZER_FAILURE\", \"statusCode\": \"500\" } ] } }</code></pre> <p></p> </div> </div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/customize-gateway-responses.html\">Customize Gateway Responses</a> </div>"]
@@ -1816,6 +2167,50 @@ pub struct IntegrationResponse {
     pub status_code: Option<String>,
 }
 
+#[doc="<p>The integration type. The valid value is <code>HTTP</code> for integrating with an HTTP back end, <code>AWS</code> for any AWS service endpoints, <code>MOCK</code> for testing without actually invoking the back end, <code>HTTP_PROXY</code> for integrating with the HTTP proxy integration, or <code>AWS_PROXY</code> for integrating with the Lambda proxy integration type.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IntegrationType {
+    Aws,
+    AwsProxy,
+    Http,
+    HttpProxy,
+    Mock,
+}
+
+impl Into<String> for IntegrationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IntegrationType {
+    fn into(self) -> &'static str {
+        match self {
+            IntegrationType::Aws => "AWS",
+            IntegrationType::AwsProxy => "AWS_PROXY",
+            IntegrationType::Http => "HTTP",
+            IntegrationType::HttpProxy => "HTTP_PROXY",
+            IntegrationType::Mock => "MOCK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IntegrationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS" => Ok(IntegrationType::Aws),
+            "AWS_PROXY" => Ok(IntegrationType::AwsProxy),
+            "HTTP" => Ok(IntegrationType::Http),
+            "HTTP_PROXY" => Ok(IntegrationType::HttpProxy),
+            "MOCK" => Ok(IntegrationType::Mock),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p> Represents a client-facing interface by which the client calls the API to access back-end resources. A <b>Method</b> resource is integrated with an <a>Integration</a> resource. Both consist of a request and one or more responses. The method request takes the client input that is passed to the back end through the integration request. A method response returns the output from the back end to the client through an integration response. A method request is embodied in a <b>Method</b> resource, whereas an integration request is embodied in an <a>Integration</a> resource. On the other hand, a method response is represented by a <a>MethodResponse</a> resource, whereas an integration response is represented by an <a>IntegrationResponse</a> resource. </p> <div class=\"remarks\"> <p/> <h4>Example: Retrive the GET method on a specified resource</h4> <h5>Request</h5> <p>The following example request retrieves the information about the GET method on an API resource (<code>3kzxbg5sa2</code>) of an API (<code>fugvjdxtri</code>). </p> <pre><code>GET /restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET HTTP/1.1 Content-Type: application/json Host: apigateway.us-east-1.amazonaws.com X-Amz-Date: 20160603T210259Z Authorization: AWS4-HMAC-SHA256 Credential={access_key_ID}/20160603/us-east-1/apigateway/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature={sig4_hash}</code></pre> <h5>Response</h5> <p>The successful response returns a <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ \"_links\": { \"curies\": [ { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-integration-{rel}.html\", \"name\": \"integration\", \"templated\": true }, { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-integration-response-{rel}.html\", \"name\": \"integrationresponse\", \"templated\": true }, { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-{rel}.html\", \"name\": \"method\", \"templated\": true }, { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-response-{rel}.html\", \"name\": \"methodresponse\", \"templated\": true } ], \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET\", \"name\": \"GET\", \"title\": \"GET\" }, \"integration:put\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"method:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET\" }, \"method:integration\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"method:responses\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"method:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET\" }, \"methodresponse:put\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/{status_code}\", \"templated\": true } }, \"apiKeyRequired\": true, \"authorizationType\": \"NONE\", \"httpMethod\": \"GET\", \"_embedded\": { \"method:integration\": { \"_links\": { \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"integration:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"integration:responses\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"integration:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"integrationresponse:put\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/{status_code}\", \"templated\": true } }, \"cacheKeyParameters\": [], \"cacheNamespace\": \"3kzxbg5sa2\", \"credentials\": \"arn:aws:iam::123456789012:role/apigAwsProxyRole\", \"httpMethod\": \"POST\", \"passthroughBehavior\": \"WHEN_NO_MATCH\", \"requestParameters\": { \"integration.request.header.Content-Type\": \"'application/x-amz-json-1.1'\" }, \"requestTemplates\": { \"application/json\": \"{\\n}\" }, \"type\": \"AWS\", \"uri\": \"arn:aws:apigateway:us-east-1:kinesis:action/ListStreams\", \"_embedded\": { \"integration:responses\": { \"_links\": { \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"integrationresponse:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\" }, \"integrationresponse:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\" } }, \"responseParameters\": { \"method.response.header.Content-Type\": \"'application/xml'\" }, \"responseTemplates\": { \"application/json\": \"$util.urlDecode(\\\"%3CkinesisStreams%3E%23foreach(%24stream%20in%20%24input.path(%27%24.StreamNames%27))%3Cstream%3E%3Cname%3E%24stream%3C%2Fname%3E%3C%2Fstream%3E%23end%3C%2FkinesisStreams%3E\\\")\" }, \"statusCode\": \"200\" } } }, \"method:responses\": { \"_links\": { \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"methodresponse:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\" }, \"methodresponse:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\" } }, \"responseModels\": { \"application/json\": \"Empty\" }, \"responseParameters\": { \"method.response.header.Content-Type\": false }, \"statusCode\": \"200\" } } }</code></pre> <p>In the example above, the response template for the <code>200 OK</code> response maps the JSON output from the <code>ListStreams</code> action in the back end to an XML output. The mapping template is URL-encoded as <code>%3CkinesisStreams%3E%23foreach(%24stream%20in%20%24input.path(%27%24.StreamNames%27))%3Cstream%3E%3Cname%3E%24stream%3C%2Fname%3E%3C%2Fstream%3E%23end%3C%2FkinesisStreams%3E</code> and the output is decoded using the <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#util-templat-reference\">$util.urlDecode()</a> helper function.</p> </div> <div class=\"seeAlso\"> <a>MethodResponse</a>, <a>Integration</a>, <a>IntegrationResponse</a>, <a>Resource</a>, <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-method-settings.html\">Set up an API's method</a> </div>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Method {
@@ -1971,6 +2366,53 @@ pub struct Models {
     #[serde(rename="position")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub position: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Op {
+    Add,
+    Copy,
+    Move,
+    Remove,
+    Replace,
+    Test,
+}
+
+impl Into<String> for Op {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Op {
+    fn into(self) -> &'static str {
+        match self {
+            Op::Add => "add",
+            Op::Copy => "copy",
+            Op::Move => "move",
+            Op::Remove => "remove",
+            Op::Replace => "replace",
+            Op::Test => "test",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Op {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "add" => Ok(Op::Add),
+            "copy" => Ok(Op::Copy),
+            "move" => Ok(Op::Move),
+            "remove" => Ok(Op::Remove),
+            "replace" => Ok(Op::Replace),
+            "test" => Ok(Op::Test),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="A single patch operation to apply to the specified resource. Please refer to http://tools.ietf.org/html/rfc6902#section-4 for an explanation of how each operation is used."]
@@ -2169,6 +2611,41 @@ pub struct PutMethodResponseRequest {
     pub status_code: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PutMode {
+    Merge,
+    Overwrite,
+}
+
+impl Into<String> for PutMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PutMode {
+    fn into(self) -> &'static str {
+        match self {
+            PutMode::Merge => "merge",
+            PutMode::Overwrite => "overwrite",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PutMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "merge" => Ok(PutMode::Merge),
+            "overwrite" => Ok(PutMode::Overwrite),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A PUT request to update an existing API, with external API definitions specified as the request body.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutRestApiRequest {
@@ -2195,6 +2672,44 @@ pub struct PutRestApiRequest {
     #[doc="<p>The string identifier of the associated <a>RestApi</a>.</p>"]
     #[serde(rename="restApiId")]
     pub rest_api_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum QuotaPeriodType {
+    Day,
+    Month,
+    Week,
+}
+
+impl Into<String> for QuotaPeriodType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for QuotaPeriodType {
+    fn into(self) -> &'static str {
+        match self {
+            QuotaPeriodType::Day => "DAY",
+            QuotaPeriodType::Month => "MONTH",
+            QuotaPeriodType::Week => "WEEK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for QuotaPeriodType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DAY" => Ok(QuotaPeriodType::Day),
+            "MONTH" => Ok(QuotaPeriodType::Month),
+            "WEEK" => Ok(QuotaPeriodType::Week),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Quotas configured for a usage plan.</p>"]
@@ -2615,6 +3130,52 @@ pub struct ThrottleSettings {
     #[serde(rename="rateLimit")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub rate_limit: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UnauthorizedCacheControlHeaderStrategy {
+    FailWith403,
+    SucceedWithoutResponseHeader,
+    SucceedWithResponseHeader,
+}
+
+impl Into<String> for UnauthorizedCacheControlHeaderStrategy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UnauthorizedCacheControlHeaderStrategy {
+    fn into(self) -> &'static str {
+        match self {
+            UnauthorizedCacheControlHeaderStrategy::FailWith403 => "FAIL_WITH_403",
+            UnauthorizedCacheControlHeaderStrategy::SucceedWithoutResponseHeader => {
+                "SUCCEED_WITHOUT_RESPONSE_HEADER"
+            }
+            UnauthorizedCacheControlHeaderStrategy::SucceedWithResponseHeader => {
+                "SUCCEED_WITH_RESPONSE_HEADER"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for UnauthorizedCacheControlHeaderStrategy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAIL_WITH_403" => Ok(UnauthorizedCacheControlHeaderStrategy::FailWith403),
+            "SUCCEED_WITHOUT_RESPONSE_HEADER" => {
+                Ok(UnauthorizedCacheControlHeaderStrategy::SucceedWithoutResponseHeader)
+            }
+            "SUCCEED_WITH_RESPONSE_HEADER" => {
+                Ok(UnauthorizedCacheControlHeaderStrategy::SucceedWithResponseHeader)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Requests Amazon API Gateway to change information about the current <a>Account</a> resource.</p>"]
@@ -14716,7 +15277,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14762,7 +15323,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14808,7 +15369,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14854,7 +15415,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14900,7 +15461,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14948,7 +15509,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14994,7 +15555,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -15038,7 +15599,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -15084,7 +15645,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -15131,7 +15692,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -15174,7 +15735,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -15218,7 +15779,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -15263,7 +15824,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -15309,7 +15870,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -15351,7 +15912,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15386,7 +15947,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15421,7 +15982,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15455,7 +16016,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15491,7 +16052,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15526,7 +16087,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15562,7 +16123,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15597,7 +16158,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15632,7 +16193,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15668,7 +16229,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -15705,7 +16266,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -15740,7 +16301,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -15777,7 +16338,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -15810,7 +16371,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15845,7 +16406,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15878,7 +16439,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15909,7 +16470,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15942,7 +16503,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -15976,7 +16537,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -16011,7 +16572,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -16046,7 +16607,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -16082,7 +16643,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
                 let result = ();
 
 
@@ -16116,7 +16677,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16159,7 +16720,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16205,7 +16766,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16263,7 +16824,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16309,7 +16870,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16361,7 +16922,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16407,7 +16968,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16459,7 +17020,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16504,7 +17065,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16555,7 +17116,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16607,7 +17168,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16659,7 +17220,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16705,7 +17266,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16766,7 +17327,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16812,7 +17373,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16866,7 +17427,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16912,7 +17473,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -16963,7 +17524,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17017,7 +17578,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut result = ExportResponse::default();
 
@@ -17066,7 +17627,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17118,7 +17679,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17165,7 +17726,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17213,7 +17774,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17258,7 +17819,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17306,7 +17867,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17354,7 +17915,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17400,7 +17961,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17450,7 +18011,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17496,7 +18057,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17548,7 +18109,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17598,7 +18159,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17653,7 +18214,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17695,7 +18256,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17744,7 +18305,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17795,7 +18356,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut result = SdkResponse::default();
 
@@ -17840,7 +18401,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17889,7 +18450,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17933,7 +18494,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -17980,7 +18541,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18035,7 +18596,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18078,7 +18639,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18124,7 +18685,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18179,7 +18740,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18233,7 +18794,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18284,7 +18845,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18338,7 +18899,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18392,7 +18953,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18439,7 +19000,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18487,7 +19048,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18536,7 +19097,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18582,7 +19143,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18631,7 +19192,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18686,7 +19247,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18734,7 +19295,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18782,7 +19343,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18825,7 +19386,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18868,7 +19429,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18915,7 +19476,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -18962,7 +19523,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19008,7 +19569,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19056,7 +19617,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19103,7 +19664,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19152,7 +19713,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19199,7 +19760,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19246,7 +19807,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19294,7 +19855,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19344,7 +19905,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19391,7 +19952,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19440,7 +20001,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19485,7 +20046,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19532,7 +20093,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19579,7 +20140,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19622,7 +20183,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19667,7 +20228,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19712,7 +20273,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -19758,7 +20319,7 @@ impl<P, D> ApiGateway for ApiGatewayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/application-autoscaling/src/generated.rs
+++ b/rusoto/services/application-autoscaling/src/generated.rs
@@ -11,23 +11,57 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AdjustmentType {
+    ChangeInCapacity,
+    ExactCapacity,
+    PercentChangeInCapacity,
+}
+
+impl Into<String> for AdjustmentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AdjustmentType {
+    fn into(self) -> &'static str {
+        match self {
+            AdjustmentType::ChangeInCapacity => "ChangeInCapacity",
+            AdjustmentType::ExactCapacity => "ExactCapacity",
+            AdjustmentType::PercentChangeInCapacity => "PercentChangeInCapacity",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AdjustmentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ChangeInCapacity" => Ok(AdjustmentType::ChangeInCapacity),
+            "ExactCapacity" => Ok(AdjustmentType::ExactCapacity),
+            "PercentChangeInCapacity" => Ok(AdjustmentType::PercentChangeInCapacity),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents a CloudWatch alarm associated with a scaling policy.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Alarm {
@@ -205,6 +239,44 @@ pub struct DescribeScalingPoliciesResponse {
     pub scaling_policies: Option<Vec<ScalingPolicy>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricAggregationType {
+    Average,
+    Maximum,
+    Minimum,
+}
+
+impl Into<String> for MetricAggregationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricAggregationType {
+    fn into(self) -> &'static str {
+        match self {
+            MetricAggregationType::Average => "Average",
+            MetricAggregationType::Maximum => "Maximum",
+            MetricAggregationType::Minimum => "Minimum",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricAggregationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Average" => Ok(MetricAggregationType::Average),
+            "Maximum" => Ok(MetricAggregationType::Maximum),
+            "Minimum" => Ok(MetricAggregationType::Minimum),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the dimension of a metric.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MetricDimension {
@@ -214,6 +286,120 @@ pub struct MetricDimension {
     #[doc="<p>The value of the dimension.</p>"]
     #[serde(rename="Value")]
     pub value: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricStatistic {
+    Average,
+    Maximum,
+    Minimum,
+    SampleCount,
+    Sum,
+}
+
+impl Into<String> for MetricStatistic {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricStatistic {
+    fn into(self) -> &'static str {
+        match self {
+            MetricStatistic::Average => "Average",
+            MetricStatistic::Maximum => "Maximum",
+            MetricStatistic::Minimum => "Minimum",
+            MetricStatistic::SampleCount => "SampleCount",
+            MetricStatistic::Sum => "Sum",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricStatistic {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Average" => Ok(MetricStatistic::Average),
+            "Maximum" => Ok(MetricStatistic::Maximum),
+            "Minimum" => Ok(MetricStatistic::Minimum),
+            "SampleCount" => Ok(MetricStatistic::SampleCount),
+            "Sum" => Ok(MetricStatistic::Sum),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricType {
+    DynamoDBReadCapacityUtilization,
+    DynamoDBWriteCapacityUtilization,
+}
+
+impl Into<String> for MetricType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricType {
+    fn into(self) -> &'static str {
+        match self {
+            MetricType::DynamoDBReadCapacityUtilization => "DynamoDBReadCapacityUtilization",
+            MetricType::DynamoDBWriteCapacityUtilization => "DynamoDBWriteCapacityUtilization",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DynamoDBReadCapacityUtilization" => Ok(MetricType::DynamoDBReadCapacityUtilization),
+            "DynamoDBWriteCapacityUtilization" => Ok(MetricType::DynamoDBWriteCapacityUtilization),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PolicyType {
+    StepScaling,
+    TargetTrackingScaling,
+}
+
+impl Into<String> for PolicyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PolicyType {
+    fn into(self) -> &'static str {
+        match self {
+            PolicyType::StepScaling => "StepScaling",
+            PolicyType::TargetTrackingScaling => "TargetTrackingScaling",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PolicyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "StepScaling" => Ok(PolicyType::StepScaling),
+            "TargetTrackingScaling" => Ok(PolicyType::TargetTrackingScaling),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Configures a predefined metric for a target tracking policy.</p>"]
@@ -296,6 +482,81 @@ pub struct RegisterScalableTargetRequest {
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RegisterScalableTargetResponse;
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScalableDimension {
+    AppstreamFleetDesiredCapacity,
+    DynamodbIndexReadCapacityUnits,
+    DynamodbIndexWriteCapacityUnits,
+    DynamodbTableReadCapacityUnits,
+    DynamodbTableWriteCapacityUnits,
+    Ec2SpotFleetRequestTargetCapacity,
+    EcsServiceDesiredCount,
+    ElasticmapreduceInstancegroupInstanceCount,
+}
+
+impl Into<String> for ScalableDimension {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScalableDimension {
+    fn into(self) -> &'static str {
+        match self {
+            ScalableDimension::AppstreamFleetDesiredCapacity => "appstream:fleet:DesiredCapacity",
+            ScalableDimension::DynamodbIndexReadCapacityUnits => "dynamodb:index:ReadCapacityUnits",
+            ScalableDimension::DynamodbIndexWriteCapacityUnits => {
+                "dynamodb:index:WriteCapacityUnits"
+            }
+            ScalableDimension::DynamodbTableReadCapacityUnits => "dynamodb:table:ReadCapacityUnits",
+            ScalableDimension::DynamodbTableWriteCapacityUnits => {
+                "dynamodb:table:WriteCapacityUnits"
+            }
+            ScalableDimension::Ec2SpotFleetRequestTargetCapacity => {
+                "ec2:spot-fleet-request:TargetCapacity"
+            }
+            ScalableDimension::EcsServiceDesiredCount => "ecs:service:DesiredCount",
+            ScalableDimension::ElasticmapreduceInstancegroupInstanceCount => {
+                "elasticmapreduce:instancegroup:InstanceCount"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScalableDimension {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "appstream:fleet:DesiredCapacity" => {
+                Ok(ScalableDimension::AppstreamFleetDesiredCapacity)
+            }
+            "dynamodb:index:ReadCapacityUnits" => {
+                Ok(ScalableDimension::DynamodbIndexReadCapacityUnits)
+            }
+            "dynamodb:index:WriteCapacityUnits" => {
+                Ok(ScalableDimension::DynamodbIndexWriteCapacityUnits)
+            }
+            "dynamodb:table:ReadCapacityUnits" => {
+                Ok(ScalableDimension::DynamodbTableReadCapacityUnits)
+            }
+            "dynamodb:table:WriteCapacityUnits" => {
+                Ok(ScalableDimension::DynamodbTableWriteCapacityUnits)
+            }
+            "ec2:spot-fleet-request:TargetCapacity" => {
+                Ok(ScalableDimension::Ec2SpotFleetRequestTargetCapacity)
+            }
+            "ecs:service:DesiredCount" => Ok(ScalableDimension::EcsServiceDesiredCount),
+            "elasticmapreduce:instancegroup:InstanceCount" => {
+                Ok(ScalableDimension::ElasticmapreduceInstancegroupInstanceCount)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents a scalable target.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ScalableTarget {
@@ -363,6 +624,53 @@ pub struct ScalingActivity {
     pub status_message: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScalingActivityStatusCode {
+    Failed,
+    InProgress,
+    Overridden,
+    Pending,
+    Successful,
+    Unfulfilled,
+}
+
+impl Into<String> for ScalingActivityStatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScalingActivityStatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            ScalingActivityStatusCode::Failed => "Failed",
+            ScalingActivityStatusCode::InProgress => "InProgress",
+            ScalingActivityStatusCode::Overridden => "Overridden",
+            ScalingActivityStatusCode::Pending => "Pending",
+            ScalingActivityStatusCode::Successful => "Successful",
+            ScalingActivityStatusCode::Unfulfilled => "Unfulfilled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScalingActivityStatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(ScalingActivityStatusCode::Failed),
+            "InProgress" => Ok(ScalingActivityStatusCode::InProgress),
+            "Overridden" => Ok(ScalingActivityStatusCode::Overridden),
+            "Pending" => Ok(ScalingActivityStatusCode::Pending),
+            "Successful" => Ok(ScalingActivityStatusCode::Successful),
+            "Unfulfilled" => Ok(ScalingActivityStatusCode::Unfulfilled),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents a scaling policy.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ScalingPolicy {
@@ -400,6 +708,50 @@ pub struct ScalingPolicy {
     #[serde(skip_serializing_if="Option::is_none")]
     pub target_tracking_scaling_policy_configuration:
         Option<TargetTrackingScalingPolicyConfiguration>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ServiceNamespace {
+    Appstream,
+    Dynamodb,
+    Ec2,
+    Ecs,
+    Elasticmapreduce,
+}
+
+impl Into<String> for ServiceNamespace {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ServiceNamespace {
+    fn into(self) -> &'static str {
+        match self {
+            ServiceNamespace::Appstream => "appstream",
+            ServiceNamespace::Dynamodb => "dynamodb",
+            ServiceNamespace::Ec2 => "ec2",
+            ServiceNamespace::Ecs => "ecs",
+            ServiceNamespace::Elasticmapreduce => "elasticmapreduce",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ServiceNamespace {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "appstream" => Ok(ServiceNamespace::Appstream),
+            "dynamodb" => Ok(ServiceNamespace::Dynamodb),
+            "ec2" => Ok(ServiceNamespace::Ec2),
+            "ecs" => Ok(ServiceNamespace::Ecs),
+            "elasticmapreduce" => Ok(ServiceNamespace::Elasticmapreduce),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents a step adjustment for a <a>StepScalingPolicyConfiguration</a>. Describes an adjustment based on the difference between the value of the aggregated CloudWatch metric and the breach threshold that you've defined for the alarm. </p> <p>For the following examples, suppose that you have an alarm with a breach threshold of 50:</p> <ul> <li> <p>To trigger the adjustment when the metric is greater than or equal to 50 and less than 60, specify a lower bound of 0 and an upper bound of 10.</p> </li> <li> <p>To trigger the adjustment when the metric is greater than 40 and less than or equal to 50, specify a lower bound of -10 and an upper bound of 0.</p> </li> </ul> <p>There are a few rules for the step adjustments for your step policy:</p> <ul> <li> <p>The ranges of your step adjustments can't overlap or have a gap.</p> </li> <li> <p>At most one step adjustment can have a null lower bound. If one step adjustment has a negative lower bound, then there must be a step adjustment with a null lower bound.</p> </li> <li> <p>At most one step adjustment can have a null upper bound. If one step adjustment has a positive upper bound, then there must be a step adjustment with a null upper bound.</p> </li> <li> <p>The upper and lower bound can't be null in the same step adjustment.</p> </li> </ul>"]
@@ -1220,7 +1572,7 @@ impl<P, D> ApplicationAutoScaling for ApplicationAutoScalingClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteScalingPolicyResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1252,7 +1604,7 @@ impl<P, D> ApplicationAutoScaling for ApplicationAutoScalingClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeregisterScalableTargetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1285,7 +1637,7 @@ impl<P, D> ApplicationAutoScaling for ApplicationAutoScalingClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeScalableTargetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1318,7 +1670,7 @@ impl<P, D> ApplicationAutoScaling for ApplicationAutoScalingClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeScalingActivitiesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1351,7 +1703,7 @@ impl<P, D> ApplicationAutoScaling for ApplicationAutoScalingClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeScalingPoliciesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1382,7 +1734,7 @@ impl<P, D> ApplicationAutoScaling for ApplicationAutoScalingClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutScalingPolicyResponse>(String::from_utf8_lossy(&body)
@@ -1416,7 +1768,7 @@ impl<P, D> ApplicationAutoScaling for ApplicationAutoScalingClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterScalableTargetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -73,6 +69,44 @@ pub struct AssociateFleetRequest {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AssociateFleetResult;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AuthenticationType {
+    Api,
+    Saml,
+    Userpool,
+}
+
+impl Into<String> for AuthenticationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AuthenticationType {
+    fn into(self) -> &'static str {
+        match self {
+            AuthenticationType::Api => "API",
+            AuthenticationType::Saml => "SAML",
+            AuthenticationType::Userpool => "USERPOOL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AuthenticationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "API" => Ok(AuthenticationType::Api),
+            "SAML" => Ok(AuthenticationType::Saml),
+            "USERPOOL" => Ok(AuthenticationType::Userpool),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p>The capacity configuration for the fleet.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
@@ -515,6 +549,48 @@ pub struct Fleet {
     pub vpc_config: Option<VpcConfig>,
 }
 
+#[doc="<p>Fleet attribute.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FleetAttribute {
+    DomainJoinInfo,
+    VpcConfiguration,
+    VpcConfigurationSecurityGroupIds,
+}
+
+impl Into<String> for FleetAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FleetAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            FleetAttribute::DomainJoinInfo => "DOMAIN_JOIN_INFO",
+            FleetAttribute::VpcConfiguration => "VPC_CONFIGURATION",
+            FleetAttribute::VpcConfigurationSecurityGroupIds => {
+                "VPC_CONFIGURATION_SECURITY_GROUP_IDS"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for FleetAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DOMAIN_JOIN_INFO" => Ok(FleetAttribute::DomainJoinInfo),
+            "VPC_CONFIGURATION" => Ok(FleetAttribute::VpcConfiguration),
+            "VPC_CONFIGURATION_SECURITY_GROUP_IDS" => {
+                Ok(FleetAttribute::VpcConfigurationSecurityGroupIds)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The details of the fleet error.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct FleetError {
@@ -526,6 +602,195 @@ pub struct FleetError {
     #[serde(rename="ErrorMessage")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub error_message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FleetErrorCode {
+    DomainJoinErrorAccessDenied,
+    DomainJoinErrorDsMachineAccountQuotaExceeded,
+    DomainJoinErrorFileNotFound,
+    DomainJoinErrorInvalidParameter,
+    DomainJoinErrorLogonFailure,
+    DomainJoinErrorMoreData,
+    DomainJoinErrorNotSupported,
+    DomainJoinErrorNoSuchDomain,
+    DomainJoinInternalServiceError,
+    DomainJoinNerrInvalidWorkgroupName,
+    DomainJoinNerrPasswordExpired,
+    DomainJoinNerrWorkstationNotStarted,
+    IamServiceRoleIsMissing,
+    IamServiceRoleMissingDescribeSecurityGroupsAction,
+    IamServiceRoleMissingDescribeSubnetAction,
+    IamServiceRoleMissingEniCreateAction,
+    IamServiceRoleMissingEniDeleteAction,
+    IamServiceRoleMissingEniDescribeAction,
+    ImageNotFound,
+    InternalServiceError,
+    InvalidSubnetConfiguration,
+    NetworkInterfaceLimitExceeded,
+    SecurityGroupsNotFound,
+    SubnetHasInsufficientIpAddresses,
+    SubnetNotFound,
+}
+
+impl Into<String> for FleetErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FleetErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            FleetErrorCode::DomainJoinErrorAccessDenied => "DOMAIN_JOIN_ERROR_ACCESS_DENIED",
+            FleetErrorCode::DomainJoinErrorDsMachineAccountQuotaExceeded => {
+                "DOMAIN_JOIN_ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED"
+            }
+            FleetErrorCode::DomainJoinErrorFileNotFound => "DOMAIN_JOIN_ERROR_FILE_NOT_FOUND",
+            FleetErrorCode::DomainJoinErrorInvalidParameter => {
+                "DOMAIN_JOIN_ERROR_INVALID_PARAMETER"
+            }
+            FleetErrorCode::DomainJoinErrorLogonFailure => "DOMAIN_JOIN_ERROR_LOGON_FAILURE",
+            FleetErrorCode::DomainJoinErrorMoreData => "DOMAIN_JOIN_ERROR_MORE_DATA",
+            FleetErrorCode::DomainJoinErrorNotSupported => "DOMAIN_JOIN_ERROR_NOT_SUPPORTED",
+            FleetErrorCode::DomainJoinErrorNoSuchDomain => "DOMAIN_JOIN_ERROR_NO_SUCH_DOMAIN",
+            FleetErrorCode::DomainJoinInternalServiceError => "DOMAIN_JOIN_INTERNAL_SERVICE_ERROR",
+            FleetErrorCode::DomainJoinNerrInvalidWorkgroupName => {
+                "DOMAIN_JOIN_NERR_INVALID_WORKGROUP_NAME"
+            }
+            FleetErrorCode::DomainJoinNerrPasswordExpired => "DOMAIN_JOIN_NERR_PASSWORD_EXPIRED",
+            FleetErrorCode::DomainJoinNerrWorkstationNotStarted => {
+                "DOMAIN_JOIN_NERR_WORKSTATION_NOT_STARTED"
+            }
+            FleetErrorCode::IamServiceRoleIsMissing => "IAM_SERVICE_ROLE_IS_MISSING",
+            FleetErrorCode::IamServiceRoleMissingDescribeSecurityGroupsAction => {
+                "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SECURITY_GROUPS_ACTION"
+            }
+            FleetErrorCode::IamServiceRoleMissingDescribeSubnetAction => {
+                "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SUBNET_ACTION"
+            }
+            FleetErrorCode::IamServiceRoleMissingEniCreateAction => {
+                "IAM_SERVICE_ROLE_MISSING_ENI_CREATE_ACTION"
+            }
+            FleetErrorCode::IamServiceRoleMissingEniDeleteAction => {
+                "IAM_SERVICE_ROLE_MISSING_ENI_DELETE_ACTION"
+            }
+            FleetErrorCode::IamServiceRoleMissingEniDescribeAction => {
+                "IAM_SERVICE_ROLE_MISSING_ENI_DESCRIBE_ACTION"
+            }
+            FleetErrorCode::ImageNotFound => "IMAGE_NOT_FOUND",
+            FleetErrorCode::InternalServiceError => "INTERNAL_SERVICE_ERROR",
+            FleetErrorCode::InvalidSubnetConfiguration => "INVALID_SUBNET_CONFIGURATION",
+            FleetErrorCode::NetworkInterfaceLimitExceeded => "NETWORK_INTERFACE_LIMIT_EXCEEDED",
+            FleetErrorCode::SecurityGroupsNotFound => "SECURITY_GROUPS_NOT_FOUND",
+            FleetErrorCode::SubnetHasInsufficientIpAddresses => {
+                "SUBNET_HAS_INSUFFICIENT_IP_ADDRESSES"
+            }
+            FleetErrorCode::SubnetNotFound => "SUBNET_NOT_FOUND",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FleetErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DOMAIN_JOIN_ERROR_ACCESS_DENIED" => Ok(FleetErrorCode::DomainJoinErrorAccessDenied),
+            "DOMAIN_JOIN_ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED" => {
+                Ok(FleetErrorCode::DomainJoinErrorDsMachineAccountQuotaExceeded)
+            }
+            "DOMAIN_JOIN_ERROR_FILE_NOT_FOUND" => Ok(FleetErrorCode::DomainJoinErrorFileNotFound),
+            "DOMAIN_JOIN_ERROR_INVALID_PARAMETER" => {
+                Ok(FleetErrorCode::DomainJoinErrorInvalidParameter)
+            }
+            "DOMAIN_JOIN_ERROR_LOGON_FAILURE" => Ok(FleetErrorCode::DomainJoinErrorLogonFailure),
+            "DOMAIN_JOIN_ERROR_MORE_DATA" => Ok(FleetErrorCode::DomainJoinErrorMoreData),
+            "DOMAIN_JOIN_ERROR_NOT_SUPPORTED" => Ok(FleetErrorCode::DomainJoinErrorNotSupported),
+            "DOMAIN_JOIN_ERROR_NO_SUCH_DOMAIN" => Ok(FleetErrorCode::DomainJoinErrorNoSuchDomain),
+            "DOMAIN_JOIN_INTERNAL_SERVICE_ERROR" => {
+                Ok(FleetErrorCode::DomainJoinInternalServiceError)
+            }
+            "DOMAIN_JOIN_NERR_INVALID_WORKGROUP_NAME" => {
+                Ok(FleetErrorCode::DomainJoinNerrInvalidWorkgroupName)
+            }
+            "DOMAIN_JOIN_NERR_PASSWORD_EXPIRED" => {
+                Ok(FleetErrorCode::DomainJoinNerrPasswordExpired)
+            }
+            "DOMAIN_JOIN_NERR_WORKSTATION_NOT_STARTED" => {
+                Ok(FleetErrorCode::DomainJoinNerrWorkstationNotStarted)
+            }
+            "IAM_SERVICE_ROLE_IS_MISSING" => Ok(FleetErrorCode::IamServiceRoleIsMissing),
+            "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SECURITY_GROUPS_ACTION" => {
+                Ok(FleetErrorCode::IamServiceRoleMissingDescribeSecurityGroupsAction)
+            }
+            "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SUBNET_ACTION" => {
+                Ok(FleetErrorCode::IamServiceRoleMissingDescribeSubnetAction)
+            }
+            "IAM_SERVICE_ROLE_MISSING_ENI_CREATE_ACTION" => {
+                Ok(FleetErrorCode::IamServiceRoleMissingEniCreateAction)
+            }
+            "IAM_SERVICE_ROLE_MISSING_ENI_DELETE_ACTION" => {
+                Ok(FleetErrorCode::IamServiceRoleMissingEniDeleteAction)
+            }
+            "IAM_SERVICE_ROLE_MISSING_ENI_DESCRIBE_ACTION" => {
+                Ok(FleetErrorCode::IamServiceRoleMissingEniDescribeAction)
+            }
+            "IMAGE_NOT_FOUND" => Ok(FleetErrorCode::ImageNotFound),
+            "INTERNAL_SERVICE_ERROR" => Ok(FleetErrorCode::InternalServiceError),
+            "INVALID_SUBNET_CONFIGURATION" => Ok(FleetErrorCode::InvalidSubnetConfiguration),
+            "NETWORK_INTERFACE_LIMIT_EXCEEDED" => Ok(FleetErrorCode::NetworkInterfaceLimitExceeded),
+            "SECURITY_GROUPS_NOT_FOUND" => Ok(FleetErrorCode::SecurityGroupsNotFound),
+            "SUBNET_HAS_INSUFFICIENT_IP_ADDRESSES" => {
+                Ok(FleetErrorCode::SubnetHasInsufficientIpAddresses)
+            }
+            "SUBNET_NOT_FOUND" => Ok(FleetErrorCode::SubnetNotFound),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FleetState {
+    Running,
+    Starting,
+    Stopped,
+    Stopping,
+}
+
+impl Into<String> for FleetState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FleetState {
+    fn into(self) -> &'static str {
+        match self {
+            FleetState::Running => "RUNNING",
+            FleetState::Starting => "STARTING",
+            FleetState::Stopped => "STOPPED",
+            FleetState::Stopping => "STOPPING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FleetState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RUNNING" => Ok(FleetState::Running),
+            "STARTING" => Ok(FleetState::Starting),
+            "STOPPED" => Ok(FleetState::Stopped),
+            "STOPPING" => Ok(FleetState::Stopping),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>New streaming instances are booted from images. The image stores the application catalog and is connected to fleets.</p>"]
@@ -584,6 +849,47 @@ pub struct Image {
     pub visibility: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageState {
+    Available,
+    Deleting,
+    Failed,
+    Pending,
+}
+
+impl Into<String> for ImageState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageState {
+    fn into(self) -> &'static str {
+        match self {
+            ImageState::Available => "AVAILABLE",
+            ImageState::Deleting => "DELETING",
+            ImageState::Failed => "FAILED",
+            ImageState::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(ImageState::Available),
+            "DELETING" => Ok(ImageState::Deleting),
+            "FAILED" => Ok(ImageState::Failed),
+            "PENDING" => Ok(ImageState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The reason why the last state change occurred.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ImageStateChangeReason {
@@ -595,6 +901,43 @@ pub struct ImageStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageStateChangeReasonCode {
+    ImageBuilderNotAvailable,
+    InternalError,
+}
+
+impl Into<String> for ImageStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            ImageStateChangeReasonCode::ImageBuilderNotAvailable => "IMAGE_BUILDER_NOT_AVAILABLE",
+            ImageStateChangeReasonCode::InternalError => "INTERNAL_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IMAGE_BUILDER_NOT_AVAILABLE" => {
+                Ok(ImageStateChangeReasonCode::ImageBuilderNotAvailable)
+            }
+            "INTERNAL_ERROR" => Ok(ImageStateChangeReasonCode::InternalError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -645,6 +988,38 @@ pub struct ListAssociatedStacksResult {
     pub next_token: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlatformType {
+    Windows,
+}
+
+impl Into<String> for PlatformType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlatformType {
+    fn into(self) -> &'static str {
+        match self {
+            PlatformType::Windows => "WINDOWS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlatformType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "WINDOWS" => Ok(PlatformType::Windows),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The <i>AccountName</i> and <i>AccountPassword</i> of the service account, to be used by the streaming instance to connect to the directory.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ServiceAccountCredentials {
@@ -678,6 +1053,44 @@ pub struct Session {
     #[doc="<p>The identifier of the user for whom the session was created.</p>"]
     #[serde(rename="UserId")]
     pub user_id: String,
+}
+
+#[doc="<p>Possible values for the state of a streaming session.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SessionState {
+    Active,
+    Expired,
+    Pending,
+}
+
+impl Into<String> for SessionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SessionState {
+    fn into(self) -> &'static str {
+        match self {
+            SessionState::Active => "ACTIVE",
+            SessionState::Expired => "EXPIRED",
+            SessionState::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SessionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(SessionState::Active),
+            "EXPIRED" => Ok(SessionState::Expired),
+            "PENDING" => Ok(SessionState::Pending),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Details about a stack.</p>"]
@@ -725,6 +1138,41 @@ pub struct StackError {
     pub error_message: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StackErrorCode {
+    InternalServiceError,
+    StorageConnectorError,
+}
+
+impl Into<String> for StackErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StackErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            StackErrorCode::InternalServiceError => "INTERNAL_SERVICE_ERROR",
+            StackErrorCode::StorageConnectorError => "STORAGE_CONNECTOR_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StackErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INTERNAL_SERVICE_ERROR" => Ok(StackErrorCode::InternalServiceError),
+            "STORAGE_CONNECTOR_ERROR" => Ok(StackErrorCode::StorageConnectorError),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StartFleetRequest {
     #[doc="<p>The name of the fleet to start.</p>"]
@@ -755,6 +1203,38 @@ pub struct StorageConnector {
     #[serde(rename="ResourceIdentifier")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub resource_identifier: Option<String>,
+}
+
+#[doc="<p>The type of storage connector. The possible values include: HOMEFOLDERS.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StorageConnectorType {
+    Homefolders,
+}
+
+impl Into<String> for StorageConnectorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StorageConnectorType {
+    fn into(self) -> &'static str {
+        match self {
+            StorageConnectorType::Homefolders => "HOMEFOLDERS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StorageConnectorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HOMEFOLDERS" => Ok(StorageConnectorType::Homefolders),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -868,6 +1348,41 @@ pub struct UpdateStackResult {
     #[serde(rename="Stack")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub stack: Option<Stack>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VisibilityType {
+    Private,
+    Public,
+}
+
+impl Into<String> for VisibilityType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VisibilityType {
+    fn into(self) -> &'static str {
+        match self {
+            VisibilityType::Private => "PRIVATE",
+            VisibilityType::Public => "PUBLIC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VisibilityType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PRIVATE" => Ok(VisibilityType::Private),
+            "PUBLIC" => Ok(VisibilityType::Public),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>VPC configuration information.</p>"]
@@ -3059,7 +3574,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AssociateFleetResult>(String::from_utf8_lossy(&body)
@@ -3093,7 +3608,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDirectoryConfigResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3123,7 +3638,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateFleetResult>(String::from_utf8_lossy(&body)
@@ -3155,7 +3670,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateStackResult>(String::from_utf8_lossy(&body)
@@ -3187,7 +3702,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateStreamingURLResult>(String::from_utf8_lossy(&body)
@@ -3221,7 +3736,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteDirectoryConfigResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3251,7 +3766,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteFleetResult>(String::from_utf8_lossy(&body)
@@ -3283,7 +3798,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteStackResult>(String::from_utf8_lossy(&body)
@@ -3317,7 +3832,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeDirectoryConfigsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3348,7 +3863,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeFleetsResult>(String::from_utf8_lossy(&body)
@@ -3380,7 +3895,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeImagesResult>(String::from_utf8_lossy(&body)
@@ -3412,7 +3927,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeSessionsResult>(String::from_utf8_lossy(&body)
@@ -3444,7 +3959,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeStacksResult>(String::from_utf8_lossy(&body)
@@ -3476,7 +3991,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisassociateFleetResult>(String::from_utf8_lossy(&body)
@@ -3508,7 +4023,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ExpireSessionResult>(String::from_utf8_lossy(&body)
@@ -3541,7 +4056,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAssociatedFleetsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3572,7 +4087,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAssociatedStacksResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3600,7 +4115,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartFleetResult>(String::from_utf8_lossy(&body)
@@ -3630,7 +4145,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopFleetResult>(String::from_utf8_lossy(&body).as_ref())
@@ -3663,7 +4178,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDirectoryConfigResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3693,7 +4208,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateFleetResult>(String::from_utf8_lossy(&body)
@@ -3725,7 +4240,7 @@ impl<P, D> AppStream for AppStreamClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateStackResult>(String::from_utf8_lossy(&body)

--- a/rusoto/services/athena/src/generated.rs
+++ b/rusoto/services/athena/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -109,6 +105,44 @@ pub struct ColumnInfo {
     pub type_: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ColumnNullable {
+    NotNull,
+    Nullable,
+    Unknown,
+}
+
+impl Into<String> for ColumnNullable {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ColumnNullable {
+    fn into(self) -> &'static str {
+        match self {
+            ColumnNullable::NotNull => "NOT_NULL",
+            ColumnNullable::Nullable => "NULLABLE",
+            ColumnNullable::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ColumnNullable {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NOT_NULL" => Ok(ColumnNullable::NotNull),
+            "NULLABLE" => Ok(ColumnNullable::Nullable),
+            "UNKNOWN" => Ok(ColumnNullable::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct CreateNamedQueryInput {
     #[doc="<p>A unique case-sensitive string used to ensure the request to create the query is idempotent (executes only once). If another <code>CreateNamedQuery</code> request is received, the same response is returned and another query is not created. If a parameter has changed, for example, the <code>QueryString</code>, an error is returned.</p> <important> <p>This token is listed as not required because AWS SDKs (for example the AWS SDK for Java) auto-generate the token for users. If you are not using the AWS SDK or the AWS CLI, you must provide this token or the action will fail.</p> </important>"]
@@ -167,6 +201,44 @@ pub struct EncryptionConfiguration {
     #[serde(rename="KmsKey")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EncryptionOption {
+    CseKms,
+    SseKms,
+    SseS3,
+}
+
+impl Into<String> for EncryptionOption {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EncryptionOption {
+    fn into(self) -> &'static str {
+        match self {
+            EncryptionOption::CseKms => "CSE_KMS",
+            EncryptionOption::SseKms => "SSE_KMS",
+            EncryptionOption::SseS3 => "SSE_S3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EncryptionOption {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CSE_KMS" => Ok(EncryptionOption::CseKms),
+            "SSE_KMS" => Ok(EncryptionOption::SseKms),
+            "SSE_S3" => Ok(EncryptionOption::SseS3),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -334,6 +406,50 @@ pub struct QueryExecutionContext {
     pub database: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum QueryExecutionState {
+    Cancelled,
+    Failed,
+    Queued,
+    Running,
+    Succeeded,
+}
+
+impl Into<String> for QueryExecutionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for QueryExecutionState {
+    fn into(self) -> &'static str {
+        match self {
+            QueryExecutionState::Cancelled => "CANCELLED",
+            QueryExecutionState::Failed => "FAILED",
+            QueryExecutionState::Queued => "QUEUED",
+            QueryExecutionState::Running => "RUNNING",
+            QueryExecutionState::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for QueryExecutionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(QueryExecutionState::Cancelled),
+            "FAILED" => Ok(QueryExecutionState::Failed),
+            "QUEUED" => Ok(QueryExecutionState::Queued),
+            "RUNNING" => Ok(QueryExecutionState::Running),
+            "SUCCEEDED" => Ok(QueryExecutionState::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The amount of data scanned during the query execution and the amount of time that it took to execute.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct QueryExecutionStatistics {
@@ -446,6 +562,38 @@ pub struct StopQueryExecutionInput {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct StopQueryExecutionOutput;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ThrottleReason {
+    ConcurrentQueryLimitExceeded,
+}
+
+impl Into<String> for ThrottleReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ThrottleReason {
+    fn into(self) -> &'static str {
+        match self {
+            ThrottleReason::ConcurrentQueryLimitExceeded => "CONCURRENT_QUERY_LIMIT_EXCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ThrottleReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONCURRENT_QUERY_LIMIT_EXCEEDED" => Ok(ThrottleReason::ConcurrentQueryLimitExceeded),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p>Information about a named query ID that could not be processed.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
@@ -1545,7 +1693,7 @@ impl<P, D> Athena for AthenaClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchGetNamedQueryOutput>(String::from_utf8_lossy(&body)
@@ -1578,7 +1726,7 @@ impl<P, D> Athena for AthenaClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchGetQueryExecutionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1608,7 +1756,7 @@ impl<P, D> Athena for AthenaClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateNamedQueryOutput>(String::from_utf8_lossy(&body)
@@ -1640,7 +1788,7 @@ impl<P, D> Athena for AthenaClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteNamedQueryOutput>(String::from_utf8_lossy(&body)
@@ -1672,7 +1820,7 @@ impl<P, D> Athena for AthenaClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetNamedQueryOutput>(String::from_utf8_lossy(&body)
@@ -1704,7 +1852,7 @@ impl<P, D> Athena for AthenaClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetQueryExecutionOutput>(String::from_utf8_lossy(&body)
@@ -1736,7 +1884,7 @@ impl<P, D> Athena for AthenaClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetQueryResultsOutput>(String::from_utf8_lossy(&body)
@@ -1768,7 +1916,7 @@ impl<P, D> Athena for AthenaClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListNamedQueriesOutput>(String::from_utf8_lossy(&body)
@@ -1800,7 +1948,7 @@ impl<P, D> Athena for AthenaClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListQueryExecutionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1830,7 +1978,7 @@ impl<P, D> Athena for AthenaClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartQueryExecutionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1860,7 +2008,7 @@ impl<P, D> Athena for AthenaClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopQueryExecutionOutput>(String::from_utf8_lossy(&body)

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -513,7 +509,7 @@ impl AssociatePublicIpAddressDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1335,7 +1331,7 @@ impl BlockDeviceEbsDeleteOnTerminationDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1349,7 +1345,7 @@ impl BlockDeviceEbsEncryptedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3357,7 +3353,7 @@ impl DisableScaleInDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3488,7 +3484,7 @@ impl EbsOptimizedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4106,7 +4102,7 @@ impl InstanceProtectedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4668,6 +4664,74 @@ impl LifecycleHooksDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LifecycleState {
+    Detached,
+    Detaching,
+    EnteringStandby,
+    InService,
+    Pending,
+    PendingProceed,
+    PendingWait,
+    Quarantined,
+    Standby,
+    Terminated,
+    Terminating,
+    TerminatingProceed,
+    TerminatingWait,
+}
+
+impl Into<String> for LifecycleState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LifecycleState {
+    fn into(self) -> &'static str {
+        match self {
+            LifecycleState::Detached => "Detached",
+            LifecycleState::Detaching => "Detaching",
+            LifecycleState::EnteringStandby => "EnteringStandby",
+            LifecycleState::InService => "InService",
+            LifecycleState::Pending => "Pending",
+            LifecycleState::PendingProceed => "Pending:Proceed",
+            LifecycleState::PendingWait => "Pending:Wait",
+            LifecycleState::Quarantined => "Quarantined",
+            LifecycleState::Standby => "Standby",
+            LifecycleState::Terminated => "Terminated",
+            LifecycleState::Terminating => "Terminating",
+            LifecycleState::TerminatingProceed => "Terminating:Proceed",
+            LifecycleState::TerminatingWait => "Terminating:Wait",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LifecycleState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Detached" => Ok(LifecycleState::Detached),
+            "Detaching" => Ok(LifecycleState::Detaching),
+            "EnteringStandby" => Ok(LifecycleState::EnteringStandby),
+            "InService" => Ok(LifecycleState::InService),
+            "Pending" => Ok(LifecycleState::Pending),
+            "Pending:Proceed" => Ok(LifecycleState::PendingProceed),
+            "Pending:Wait" => Ok(LifecycleState::PendingWait),
+            "Quarantined" => Ok(LifecycleState::Quarantined),
+            "Standby" => Ok(LifecycleState::Standby),
+            "Terminated" => Ok(LifecycleState::Terminated),
+            "Terminating" => Ok(LifecycleState::Terminating),
+            "Terminating:Proceed" => Ok(LifecycleState::TerminatingProceed),
+            "Terminating:Wait" => Ok(LifecycleState::TerminatingWait),
+            _ => Err(()),
+        }
+    }
+}
+
 struct LifecycleStateDeserializer;
 impl LifecycleStateDeserializer {
     #[allow(unused_variables)]
@@ -5355,6 +5419,50 @@ impl MetricScaleDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricStatistic {
+    Average,
+    Maximum,
+    Minimum,
+    SampleCount,
+    Sum,
+}
+
+impl Into<String> for MetricStatistic {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricStatistic {
+    fn into(self) -> &'static str {
+        match self {
+            MetricStatistic::Average => "Average",
+            MetricStatistic::Maximum => "Maximum",
+            MetricStatistic::Minimum => "Minimum",
+            MetricStatistic::SampleCount => "SampleCount",
+            MetricStatistic::Sum => "Sum",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricStatistic {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Average" => Ok(MetricStatistic::Average),
+            "Maximum" => Ok(MetricStatistic::Maximum),
+            "Minimum" => Ok(MetricStatistic::Minimum),
+            "SampleCount" => Ok(MetricStatistic::SampleCount),
+            "Sum" => Ok(MetricStatistic::Sum),
+            _ => Err(()),
+        }
+    }
+}
+
 struct MetricStatisticDeserializer;
 impl MetricStatisticDeserializer {
     #[allow(unused_variables)]
@@ -5369,6 +5477,47 @@ impl MetricStatisticDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricType {
+    AlbrequestCountPerTarget,
+    AsgaverageCPUUtilization,
+    AsgaverageNetworkIn,
+    AsgaverageNetworkOut,
+}
+
+impl Into<String> for MetricType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricType {
+    fn into(self) -> &'static str {
+        match self {
+            MetricType::AlbrequestCountPerTarget => "ALBRequestCountPerTarget",
+            MetricType::AsgaverageCPUUtilization => "ASGAverageCPUUtilization",
+            MetricType::AsgaverageNetworkIn => "ASGAverageNetworkIn",
+            MetricType::AsgaverageNetworkOut => "ASGAverageNetworkOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALBRequestCountPerTarget" => Ok(MetricType::AlbrequestCountPerTarget),
+            "ASGAverageCPUUtilization" => Ok(MetricType::AsgaverageCPUUtilization),
+            "ASGAverageNetworkIn" => Ok(MetricType::AsgaverageNetworkIn),
+            "ASGAverageNetworkOut" => Ok(MetricType::AsgaverageNetworkOut),
+            _ => Err(()),
+        }
+    }
+}
+
 struct MetricTypeDeserializer;
 impl MetricTypeDeserializer {
     #[allow(unused_variables)]
@@ -5444,7 +5593,7 @@ impl MonitoringEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5458,7 +5607,7 @@ impl NoDeviceDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5999,7 +6148,7 @@ impl PropagateAtLaunchDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6357,6 +6506,79 @@ impl ResourceNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScalingActivityStatusCode {
+    Cancelled,
+    Failed,
+    InProgress,
+    MidLifecycleAction,
+    PendingSpotBidPlacement,
+    PreInService,
+    Successful,
+    WaitingForELBConnectionDraining,
+    WaitingForInstanceId,
+    WaitingForInstanceWarmup,
+    WaitingForSpotInstanceId,
+    WaitingForSpotInstanceRequestId,
+}
+
+impl Into<String> for ScalingActivityStatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScalingActivityStatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            ScalingActivityStatusCode::Cancelled => "Cancelled",
+            ScalingActivityStatusCode::Failed => "Failed",
+            ScalingActivityStatusCode::InProgress => "InProgress",
+            ScalingActivityStatusCode::MidLifecycleAction => "MidLifecycleAction",
+            ScalingActivityStatusCode::PendingSpotBidPlacement => "PendingSpotBidPlacement",
+            ScalingActivityStatusCode::PreInService => "PreInService",
+            ScalingActivityStatusCode::Successful => "Successful",
+            ScalingActivityStatusCode::WaitingForELBConnectionDraining => {
+                "WaitingForELBConnectionDraining"
+            }
+            ScalingActivityStatusCode::WaitingForInstanceId => "WaitingForInstanceId",
+            ScalingActivityStatusCode::WaitingForInstanceWarmup => "WaitingForInstanceWarmup",
+            ScalingActivityStatusCode::WaitingForSpotInstanceId => "WaitingForSpotInstanceId",
+            ScalingActivityStatusCode::WaitingForSpotInstanceRequestId => {
+                "WaitingForSpotInstanceRequestId"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScalingActivityStatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(ScalingActivityStatusCode::Cancelled),
+            "Failed" => Ok(ScalingActivityStatusCode::Failed),
+            "InProgress" => Ok(ScalingActivityStatusCode::InProgress),
+            "MidLifecycleAction" => Ok(ScalingActivityStatusCode::MidLifecycleAction),
+            "PendingSpotBidPlacement" => Ok(ScalingActivityStatusCode::PendingSpotBidPlacement),
+            "PreInService" => Ok(ScalingActivityStatusCode::PreInService),
+            "Successful" => Ok(ScalingActivityStatusCode::Successful),
+            "WaitingForELBConnectionDraining" => {
+                Ok(ScalingActivityStatusCode::WaitingForELBConnectionDraining)
+            }
+            "WaitingForInstanceId" => Ok(ScalingActivityStatusCode::WaitingForInstanceId),
+            "WaitingForInstanceWarmup" => Ok(ScalingActivityStatusCode::WaitingForInstanceWarmup),
+            "WaitingForSpotInstanceId" => Ok(ScalingActivityStatusCode::WaitingForSpotInstanceId),
+            "WaitingForSpotInstanceRequestId" => {
+                Ok(ScalingActivityStatusCode::WaitingForSpotInstanceRequestId)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 struct ScalingActivityStatusCodeDeserializer;
 impl ScalingActivityStatusCodeDeserializer {
     #[allow(unused_variables)]
@@ -12243,7 +12465,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12272,7 +12494,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12319,7 +12541,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12368,7 +12590,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12417,7 +12639,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12445,7 +12667,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12474,7 +12696,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12502,7 +12724,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12530,7 +12752,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12559,7 +12781,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12606,7 +12828,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12633,7 +12855,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12661,7 +12883,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12687,7 +12909,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12715,7 +12937,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12762,7 +12984,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12812,7 +13034,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12861,7 +13083,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12910,7 +13132,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12957,7 +13179,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13005,7 +13227,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13055,7 +13277,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13104,7 +13326,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13151,7 +13373,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13199,7 +13421,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13248,7 +13470,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13294,7 +13516,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13341,7 +13563,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13389,7 +13611,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13438,7 +13660,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13484,7 +13706,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13531,7 +13753,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13578,7 +13800,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13626,7 +13848,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13673,7 +13895,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13721,7 +13943,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13750,7 +13972,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13779,7 +14001,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13824,7 +14046,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13852,7 +14074,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13899,7 +14121,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13946,7 +14168,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13975,7 +14197,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14022,7 +14244,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -14052,7 +14274,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14097,7 +14319,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -14125,7 +14347,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -14153,7 +14375,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -14182,7 +14404,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14227,7 +14449,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -14256,7 +14478,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14303,7 +14525,7 @@ impl<P, D> Autoscaling for AutoscalingClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -71,6 +67,158 @@ pub struct AttemptDetail {
     #[serde(rename="stoppedAt")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub stopped_at: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CEState {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for CEState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CEState {
+    fn into(self) -> &'static str {
+        match self {
+            CEState::Disabled => "DISABLED",
+            CEState::Enabled => "ENABLED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CEState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLED" => Ok(CEState::Disabled),
+            "ENABLED" => Ok(CEState::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CEStatus {
+    Creating,
+    Deleted,
+    Deleting,
+    Invalid,
+    Updating,
+    Valid,
+}
+
+impl Into<String> for CEStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CEStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CEStatus::Creating => "CREATING",
+            CEStatus::Deleted => "DELETED",
+            CEStatus::Deleting => "DELETING",
+            CEStatus::Invalid => "INVALID",
+            CEStatus::Updating => "UPDATING",
+            CEStatus::Valid => "VALID",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CEStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATING" => Ok(CEStatus::Creating),
+            "DELETED" => Ok(CEStatus::Deleted),
+            "DELETING" => Ok(CEStatus::Deleting),
+            "INVALID" => Ok(CEStatus::Invalid),
+            "UPDATING" => Ok(CEStatus::Updating),
+            "VALID" => Ok(CEStatus::Valid),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CEType {
+    Managed,
+    Unmanaged,
+}
+
+impl Into<String> for CEType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CEType {
+    fn into(self) -> &'static str {
+        match self {
+            CEType::Managed => "MANAGED",
+            CEType::Unmanaged => "UNMANAGED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CEType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "MANAGED" => Ok(CEType::Managed),
+            "UNMANAGED" => Ok(CEType::Unmanaged),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CRType {
+    Ec2,
+    Spot,
+}
+
+impl Into<String> for CRType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CRType {
+    fn into(self) -> &'static str {
+        match self {
+            CRType::Ec2 => "EC2",
+            CRType::Spot => "SPOT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CRType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EC2" => Ok(CRType::Ec2),
+            "SPOT" => Ok(CRType::Spot),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -551,6 +699,88 @@ pub struct Host {
     pub source_path: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JQState {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for JQState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JQState {
+    fn into(self) -> &'static str {
+        match self {
+            JQState::Disabled => "DISABLED",
+            JQState::Enabled => "ENABLED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JQState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLED" => Ok(JQState::Disabled),
+            "ENABLED" => Ok(JQState::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JQStatus {
+    Creating,
+    Deleted,
+    Deleting,
+    Invalid,
+    Updating,
+    Valid,
+}
+
+impl Into<String> for JQStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JQStatus {
+    fn into(self) -> &'static str {
+        match self {
+            JQStatus::Creating => "CREATING",
+            JQStatus::Deleted => "DELETED",
+            JQStatus::Deleting => "DELETING",
+            JQStatus::Invalid => "INVALID",
+            JQStatus::Updating => "UPDATING",
+            JQStatus::Valid => "VALID",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JQStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATING" => Ok(JQStatus::Creating),
+            "DELETED" => Ok(JQStatus::Deleted),
+            "DELETING" => Ok(JQStatus::Deleting),
+            "INVALID" => Ok(JQStatus::Invalid),
+            "UPDATING" => Ok(JQStatus::Updating),
+            "VALID" => Ok(JQStatus::Valid),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An object representing an AWS Batch job definition.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct JobDefinition {
@@ -582,6 +812,38 @@ pub struct JobDefinition {
     #[doc="<p>The type of job definition.</p>"]
     #[serde(rename="type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobDefinitionType {
+    Container,
+}
+
+impl Into<String> for JobDefinitionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobDefinitionType {
+    fn into(self) -> &'static str {
+        match self {
+            JobDefinitionType::Container => "container",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobDefinitionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "container" => Ok(JobDefinitionType::Container),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>An object representing an AWS Batch job dependency.</p>"]
@@ -674,6 +936,56 @@ pub struct JobQueueDetail {
     #[serde(rename="statusReason")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status_reason: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobStatus {
+    Failed,
+    Pending,
+    Runnable,
+    Running,
+    Starting,
+    Submitted,
+    Succeeded,
+}
+
+impl Into<String> for JobStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobStatus {
+    fn into(self) -> &'static str {
+        match self {
+            JobStatus::Failed => "FAILED",
+            JobStatus::Pending => "PENDING",
+            JobStatus::Runnable => "RUNNABLE",
+            JobStatus::Running => "RUNNING",
+            JobStatus::Starting => "STARTING",
+            JobStatus::Submitted => "SUBMITTED",
+            JobStatus::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(JobStatus::Failed),
+            "PENDING" => Ok(JobStatus::Pending),
+            "RUNNABLE" => Ok(JobStatus::Runnable),
+            "RUNNING" => Ok(JobStatus::Running),
+            "STARTING" => Ok(JobStatus::Starting),
+            "SUBMITTED" => Ok(JobStatus::Submitted),
+            "SUCCEEDED" => Ok(JobStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>An object representing summary details of a job.</p>"]
@@ -2412,7 +2724,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2458,7 +2770,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2505,7 +2817,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2551,7 +2863,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2598,7 +2910,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2644,7 +2956,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2692,7 +3004,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2740,7 +3052,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2786,7 +3098,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2831,7 +3143,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2874,7 +3186,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2920,7 +3232,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2964,7 +3276,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3009,7 +3321,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3055,7 +3367,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3102,7 +3414,7 @@ impl<P, D> Batch for BatchClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/clouddirectory/src/generated.rs
+++ b/rusoto/services/clouddirectory/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -788,6 +784,80 @@ pub struct BatchReadException {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BatchReadExceptionType {
+    AccessDeniedException,
+    CannotListParentOfRootException,
+    DirectoryNotEnabledException,
+    FacetValidationException,
+    InternalServiceException,
+    InvalidArnException,
+    InvalidNextTokenException,
+    LimitExceededException,
+    NotIndexException,
+    NotNodeException,
+    NotPolicyException,
+    ResourceNotFoundException,
+    ValidationException,
+}
+
+impl Into<String> for BatchReadExceptionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BatchReadExceptionType {
+    fn into(self) -> &'static str {
+        match self {
+            BatchReadExceptionType::AccessDeniedException => "AccessDeniedException",
+            BatchReadExceptionType::CannotListParentOfRootException => {
+                "CannotListParentOfRootException"
+            }
+            BatchReadExceptionType::DirectoryNotEnabledException => "DirectoryNotEnabledException",
+            BatchReadExceptionType::FacetValidationException => "FacetValidationException",
+            BatchReadExceptionType::InternalServiceException => "InternalServiceException",
+            BatchReadExceptionType::InvalidArnException => "InvalidArnException",
+            BatchReadExceptionType::InvalidNextTokenException => "InvalidNextTokenException",
+            BatchReadExceptionType::LimitExceededException => "LimitExceededException",
+            BatchReadExceptionType::NotIndexException => "NotIndexException",
+            BatchReadExceptionType::NotNodeException => "NotNodeException",
+            BatchReadExceptionType::NotPolicyException => "NotPolicyException",
+            BatchReadExceptionType::ResourceNotFoundException => "ResourceNotFoundException",
+            BatchReadExceptionType::ValidationException => "ValidationException",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BatchReadExceptionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AccessDeniedException" => Ok(BatchReadExceptionType::AccessDeniedException),
+            "CannotListParentOfRootException" => {
+                Ok(BatchReadExceptionType::CannotListParentOfRootException)
+            }
+            "DirectoryNotEnabledException" => {
+                Ok(BatchReadExceptionType::DirectoryNotEnabledException)
+            }
+            "FacetValidationException" => Ok(BatchReadExceptionType::FacetValidationException),
+            "InternalServiceException" => Ok(BatchReadExceptionType::InternalServiceException),
+            "InvalidArnException" => Ok(BatchReadExceptionType::InvalidArnException),
+            "InvalidNextTokenException" => Ok(BatchReadExceptionType::InvalidNextTokenException),
+            "LimitExceededException" => Ok(BatchReadExceptionType::LimitExceededException),
+            "NotIndexException" => Ok(BatchReadExceptionType::NotIndexException),
+            "NotNodeException" => Ok(BatchReadExceptionType::NotNodeException),
+            "NotPolicyException" => Ok(BatchReadExceptionType::NotPolicyException),
+            "ResourceNotFoundException" => Ok(BatchReadExceptionType::ResourceNotFoundException),
+            "ValidationException" => Ok(BatchReadExceptionType::ValidationException),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the output of a <code>BatchRead</code> operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct BatchReadOperation {
@@ -956,6 +1026,106 @@ pub struct BatchUpdateObjectAttributesResponse {
     pub object_identifier: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BatchWriteExceptionType {
+    AccessDeniedException,
+    DirectoryNotEnabledException,
+    FacetValidationException,
+    IndexedAttributeMissingException,
+    InternalServiceException,
+    InvalidArnException,
+    InvalidAttachmentException,
+    LimitExceededException,
+    LinkNameAlreadyInUseException,
+    NotIndexException,
+    NotPolicyException,
+    ObjectAlreadyDetachedException,
+    ObjectNotDetachedException,
+    ResourceNotFoundException,
+    StillContainsLinksException,
+    UnsupportedIndexTypeException,
+    ValidationException,
+}
+
+impl Into<String> for BatchWriteExceptionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BatchWriteExceptionType {
+    fn into(self) -> &'static str {
+        match self {
+            BatchWriteExceptionType::AccessDeniedException => "AccessDeniedException",
+            BatchWriteExceptionType::DirectoryNotEnabledException => "DirectoryNotEnabledException",
+            BatchWriteExceptionType::FacetValidationException => "FacetValidationException",
+            BatchWriteExceptionType::IndexedAttributeMissingException => {
+                "IndexedAttributeMissingException"
+            }
+            BatchWriteExceptionType::InternalServiceException => "InternalServiceException",
+            BatchWriteExceptionType::InvalidArnException => "InvalidArnException",
+            BatchWriteExceptionType::InvalidAttachmentException => "InvalidAttachmentException",
+            BatchWriteExceptionType::LimitExceededException => "LimitExceededException",
+            BatchWriteExceptionType::LinkNameAlreadyInUseException => {
+                "LinkNameAlreadyInUseException"
+            }
+            BatchWriteExceptionType::NotIndexException => "NotIndexException",
+            BatchWriteExceptionType::NotPolicyException => "NotPolicyException",
+            BatchWriteExceptionType::ObjectAlreadyDetachedException => {
+                "ObjectAlreadyDetachedException"
+            }
+            BatchWriteExceptionType::ObjectNotDetachedException => "ObjectNotDetachedException",
+            BatchWriteExceptionType::ResourceNotFoundException => "ResourceNotFoundException",
+            BatchWriteExceptionType::StillContainsLinksException => "StillContainsLinksException",
+            BatchWriteExceptionType::UnsupportedIndexTypeException => {
+                "UnsupportedIndexTypeException"
+            }
+            BatchWriteExceptionType::ValidationException => "ValidationException",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BatchWriteExceptionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AccessDeniedException" => Ok(BatchWriteExceptionType::AccessDeniedException),
+            "DirectoryNotEnabledException" => {
+                Ok(BatchWriteExceptionType::DirectoryNotEnabledException)
+            }
+            "FacetValidationException" => Ok(BatchWriteExceptionType::FacetValidationException),
+            "IndexedAttributeMissingException" => {
+                Ok(BatchWriteExceptionType::IndexedAttributeMissingException)
+            }
+            "InternalServiceException" => Ok(BatchWriteExceptionType::InternalServiceException),
+            "InvalidArnException" => Ok(BatchWriteExceptionType::InvalidArnException),
+            "InvalidAttachmentException" => Ok(BatchWriteExceptionType::InvalidAttachmentException),
+            "LimitExceededException" => Ok(BatchWriteExceptionType::LimitExceededException),
+            "LinkNameAlreadyInUseException" => {
+                Ok(BatchWriteExceptionType::LinkNameAlreadyInUseException)
+            }
+            "NotIndexException" => Ok(BatchWriteExceptionType::NotIndexException),
+            "NotPolicyException" => Ok(BatchWriteExceptionType::NotPolicyException),
+            "ObjectAlreadyDetachedException" => {
+                Ok(BatchWriteExceptionType::ObjectAlreadyDetachedException)
+            }
+            "ObjectNotDetachedException" => Ok(BatchWriteExceptionType::ObjectNotDetachedException),
+            "ResourceNotFoundException" => Ok(BatchWriteExceptionType::ResourceNotFoundException),
+            "StillContainsLinksException" => {
+                Ok(BatchWriteExceptionType::StillContainsLinksException)
+            }
+            "UnsupportedIndexTypeException" => {
+                Ok(BatchWriteExceptionType::UnsupportedIndexTypeException)
+            }
+            "ValidationException" => Ok(BatchWriteExceptionType::ValidationException),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the output of a <code>BatchWrite</code> operation. </p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct BatchWriteOperation {
@@ -1094,6 +1264,41 @@ pub struct BatchWriteResponse {
     #[serde(rename="Responses")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub responses: Option<Vec<BatchWriteOperationResponse>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConsistencyLevel {
+    Eventual,
+    Serializable,
+}
+
+impl Into<String> for ConsistencyLevel {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConsistencyLevel {
+    fn into(self) -> &'static str {
+        match self {
+            ConsistencyLevel::Eventual => "EVENTUAL",
+            ConsistencyLevel::Serializable => "SERIALIZABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConsistencyLevel {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EVENTUAL" => Ok(ConsistencyLevel::Eventual),
+            "SERIALIZABLE" => Ok(ConsistencyLevel::Serializable),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1386,6 +1591,44 @@ pub struct Directory {
     pub state: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DirectoryState {
+    Deleted,
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for DirectoryState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DirectoryState {
+    fn into(self) -> &'static str {
+        match self {
+            DirectoryState::Deleted => "DELETED",
+            DirectoryState::Disabled => "DISABLED",
+            DirectoryState::Enabled => "ENABLED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DirectoryState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETED" => Ok(DirectoryState::Deleted),
+            "DISABLED" => Ok(DirectoryState::Disabled),
+            "ENABLED" => Ok(DirectoryState::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DisableDirectoryRequest {
     #[doc="<p>The ARN of the directory to disable.</p>"]
@@ -1476,6 +1719,50 @@ pub struct FacetAttributeReference {
     #[doc="<p>The target facet name that is associated with the facet reference. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences\">Attribute References</a> for more information.</p>"]
     #[serde(rename="TargetFacetName")]
     pub target_facet_name: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FacetAttributeType {
+    Binary,
+    Boolean,
+    Datetime,
+    Number,
+    String,
+}
+
+impl Into<String> for FacetAttributeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FacetAttributeType {
+    fn into(self) -> &'static str {
+        match self {
+            FacetAttributeType::Binary => "BINARY",
+            FacetAttributeType::Boolean => "BOOLEAN",
+            FacetAttributeType::Datetime => "DATETIME",
+            FacetAttributeType::Number => "NUMBER",
+            FacetAttributeType::String => "STRING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FacetAttributeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BINARY" => Ok(FacetAttributeType::Binary),
+            "BOOLEAN" => Ok(FacetAttributeType::Boolean),
+            "DATETIME" => Ok(FacetAttributeType::Datetime),
+            "NUMBER" => Ok(FacetAttributeType::Number),
+            "STRING" => Ok(FacetAttributeType::String),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A structure that contains information used to update an attribute.</p>"]
@@ -2280,6 +2567,47 @@ pub struct ObjectReference {
     pub selector: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ObjectType {
+    Index,
+    LeafNode,
+    Node,
+    Policy,
+}
+
+impl Into<String> for ObjectType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ObjectType {
+    fn into(self) -> &'static str {
+        match self {
+            ObjectType::Index => "INDEX",
+            ObjectType::LeafNode => "LEAF_NODE",
+            ObjectType::Node => "NODE",
+            ObjectType::Policy => "POLICY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ObjectType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INDEX" => Ok(ObjectType::Index),
+            "LEAF_NODE" => Ok(ObjectType::LeafNode),
+            "NODE" => Ok(ObjectType::Node),
+            "POLICY" => Ok(ObjectType::Policy),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Returns the path to the <code>ObjectIdentifiers</code> that is associated with the directory.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct PathToObjectIdentifiers {
@@ -2363,6 +2691,50 @@ pub struct PutSchemaFromJsonResponse {
     pub arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RangeMode {
+    Exclusive,
+    First,
+    Inclusive,
+    Last,
+    LastBeforeMissingValues,
+}
+
+impl Into<String> for RangeMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RangeMode {
+    fn into(self) -> &'static str {
+        match self {
+            RangeMode::Exclusive => "EXCLUSIVE",
+            RangeMode::First => "FIRST",
+            RangeMode::Inclusive => "INCLUSIVE",
+            RangeMode::Last => "LAST",
+            RangeMode::LastBeforeMissingValues => "LAST_BEFORE_MISSING_VALUES",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RangeMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EXCLUSIVE" => Ok(RangeMode::Exclusive),
+            "FIRST" => Ok(RangeMode::First),
+            "INCLUSIVE" => Ok(RangeMode::Inclusive),
+            "LAST" => Ok(RangeMode::Last),
+            "LAST_BEFORE_MISSING_VALUES" => Ok(RangeMode::LastBeforeMissingValues),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct RemoveFacetFromObjectRequest {
     #[doc="<p>The ARN of the directory in which the object resides.</p>"]
@@ -2379,6 +2751,41 @@ pub struct RemoveFacetFromObjectRequest {
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RemoveFacetFromObjectResponse;
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RequiredAttributeBehavior {
+    NotRequired,
+    RequiredAlways,
+}
+
+impl Into<String> for RequiredAttributeBehavior {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RequiredAttributeBehavior {
+    fn into(self) -> &'static str {
+        match self {
+            RequiredAttributeBehavior::NotRequired => "NOT_REQUIRED",
+            RequiredAttributeBehavior::RequiredAlways => "REQUIRED_ALWAYS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RequiredAttributeBehavior {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NOT_REQUIRED" => Ok(RequiredAttributeBehavior::NotRequired),
+            "REQUIRED_ALWAYS" => Ok(RequiredAttributeBehavior::RequiredAlways),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains an Amazon Resource Name (ARN) and parameters that are associated with the rule.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Rule {
@@ -2390,6 +2797,47 @@ pub struct Rule {
     #[serde(rename="Type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RuleType {
+    BinaryLength,
+    NumberComparison,
+    StringFromSet,
+    StringLength,
+}
+
+impl Into<String> for RuleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RuleType {
+    fn into(self) -> &'static str {
+        match self {
+            RuleType::BinaryLength => "BINARY_LENGTH",
+            RuleType::NumberComparison => "NUMBER_COMPARISON",
+            RuleType::StringFromSet => "STRING_FROM_SET",
+            RuleType::StringLength => "STRING_LENGTH",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RuleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BINARY_LENGTH" => Ok(RuleType::BinaryLength),
+            "NUMBER_COMPARISON" => Ok(RuleType::NumberComparison),
+            "STRING_FROM_SET" => Ok(RuleType::StringFromSet),
+            "STRING_LENGTH" => Ok(RuleType::StringLength),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A facet.</p>"]
@@ -2582,6 +3030,41 @@ pub struct UntagResourceRequest {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct UntagResourceResponse;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UpdateActionType {
+    CreateOrUpdate,
+    Delete,
+}
+
+impl Into<String> for UpdateActionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UpdateActionType {
+    fn into(self) -> &'static str {
+        match self {
+            UpdateActionType::CreateOrUpdate => "CREATE_OR_UPDATE",
+            UpdateActionType::Delete => "DELETE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UpdateActionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE_OR_UPDATE" => Ok(UpdateActionType::CreateOrUpdate),
+            "DELETE" => Ok(UpdateActionType::Delete),
+            _ => Err(()),
+        }
+    }
+}
 
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct UpdateFacetRequest {
@@ -10135,7 +10618,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10180,7 +10663,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10225,7 +10708,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10273,7 +10756,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10318,7 +10801,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10363,7 +10846,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10410,7 +10893,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10455,7 +10938,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10500,7 +10983,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10545,7 +11028,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10590,7 +11073,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10635,7 +11118,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10680,7 +11163,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10726,7 +11209,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10770,7 +11253,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10815,7 +11298,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10860,7 +11343,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10904,7 +11387,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10950,7 +11433,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10995,7 +11478,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11040,7 +11523,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11085,7 +11568,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11130,7 +11613,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -11163,7 +11646,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11207,7 +11690,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11251,7 +11734,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11294,7 +11777,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11344,7 +11827,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11388,7 +11871,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11434,7 +11917,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11482,7 +11965,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11532,7 +12015,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11578,7 +12061,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11625,7 +12108,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11670,7 +12153,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11715,7 +12198,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11761,7 +12244,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11809,7 +12292,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11859,7 +12342,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11908,7 +12391,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11954,7 +12437,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12004,7 +12487,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12053,7 +12536,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12099,7 +12582,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12150,7 +12633,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12197,7 +12680,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12244,7 +12727,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12290,7 +12773,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12338,7 +12821,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12385,7 +12868,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12430,7 +12913,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12475,7 +12958,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12521,7 +13004,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12567,7 +13050,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12612,7 +13095,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12657,7 +13140,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12703,7 +13186,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12749,7 +13232,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -12795,7 +13278,7 @@ impl<P, D> CloudDirectory for CloudDirectoryClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -110,6 +106,44 @@ impl AccountGateResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccountGateStatus {
+    Failed,
+    Skipped,
+    Succeeded,
+}
+
+impl Into<String> for AccountGateStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccountGateStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AccountGateStatus::Failed => "FAILED",
+            AccountGateStatus::Skipped => "SKIPPED",
+            AccountGateStatus::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccountGateStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(AccountGateStatus::Failed),
+            "SKIPPED" => Ok(AccountGateStatus::Skipped),
+            "SUCCEEDED" => Ok(AccountGateStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AccountGateStatusDeserializer;
 impl AccountGateStatusDeserializer {
     #[allow(unused_variables)]
@@ -411,6 +445,41 @@ impl CapabilitiesReasonDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Capability {
+    CapabilityIam,
+    CapabilityNamedIam,
+}
+
+impl Into<String> for Capability {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Capability {
+    fn into(self) -> &'static str {
+        match self {
+            Capability::CapabilityIam => "CAPABILITY_IAM",
+            Capability::CapabilityNamedIam => "CAPABILITY_NAMED_IAM",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Capability {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CAPABILITY_IAM" => Ok(Capability::CapabilityIam),
+            "CAPABILITY_NAMED_IAM" => Ok(Capability::CapabilityNamedIam),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CapabilityDeserializer;
 impl CapabilityDeserializer {
     #[allow(unused_variables)]
@@ -495,6 +564,44 @@ impl ChangeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeAction {
+    Add,
+    Modify,
+    Remove,
+}
+
+impl Into<String> for ChangeAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeAction {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeAction::Add => "Add",
+            ChangeAction::Modify => "Modify",
+            ChangeAction::Remove => "Remove",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Add" => Ok(ChangeAction::Add),
+            "Modify" => Ok(ChangeAction::Modify),
+            "Remove" => Ok(ChangeAction::Remove),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeActionDeserializer;
 impl ChangeActionDeserializer {
     #[allow(unused_variables)]
@@ -537,6 +644,50 @@ impl ChangeSetNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeSetStatus {
+    CreateComplete,
+    CreateInProgress,
+    CreatePending,
+    DeleteComplete,
+    Failed,
+}
+
+impl Into<String> for ChangeSetStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeSetStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeSetStatus::CreateComplete => "CREATE_COMPLETE",
+            ChangeSetStatus::CreateInProgress => "CREATE_IN_PROGRESS",
+            ChangeSetStatus::CreatePending => "CREATE_PENDING",
+            ChangeSetStatus::DeleteComplete => "DELETE_COMPLETE",
+            ChangeSetStatus::Failed => "FAILED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeSetStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE_COMPLETE" => Ok(ChangeSetStatus::CreateComplete),
+            "CREATE_IN_PROGRESS" => Ok(ChangeSetStatus::CreateInProgress),
+            "CREATE_PENDING" => Ok(ChangeSetStatus::CreatePending),
+            "DELETE_COMPLETE" => Ok(ChangeSetStatus::DeleteComplete),
+            "FAILED" => Ok(ChangeSetStatus::Failed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeSetStatusDeserializer;
 impl ChangeSetStatusDeserializer {
     #[allow(unused_variables)]
@@ -710,6 +861,85 @@ impl ChangeSetSummaryDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeSetType {
+    Create,
+    Update,
+}
+
+impl Into<String> for ChangeSetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeSetType {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeSetType::Create => "CREATE",
+            ChangeSetType::Update => "UPDATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeSetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE" => Ok(ChangeSetType::Create),
+            "UPDATE" => Ok(ChangeSetType::Update),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeSource {
+    Automatic,
+    DirectModification,
+    ParameterReference,
+    ResourceAttribute,
+    ResourceReference,
+}
+
+impl Into<String> for ChangeSource {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeSource {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeSource::Automatic => "Automatic",
+            ChangeSource::DirectModification => "DirectModification",
+            ChangeSource::ParameterReference => "ParameterReference",
+            ChangeSource::ResourceAttribute => "ResourceAttribute",
+            ChangeSource::ResourceReference => "ResourceReference",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeSource {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Automatic" => Ok(ChangeSource::Automatic),
+            "DirectModification" => Ok(ChangeSource::DirectModification),
+            "ParameterReference" => Ok(ChangeSource::ParameterReference),
+            "ResourceAttribute" => Ok(ChangeSource::ResourceAttribute),
+            "ResourceReference" => Ok(ChangeSource::ResourceReference),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeSourceDeserializer;
 impl ChangeSourceDeserializer {
     #[allow(unused_variables)]
@@ -724,6 +954,38 @@ impl ChangeSourceDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeType {
+    Resource,
+}
+
+impl Into<String> for ChangeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeType {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeType::Resource => "Resource",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Resource" => Ok(ChangeType::Resource),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeTypeDeserializer;
 impl ChangeTypeDeserializer {
     #[allow(unused_variables)]
@@ -2501,7 +2763,7 @@ impl DisableRollbackDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2594,6 +2856,41 @@ impl EstimateTemplateCostOutputDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EvaluationType {
+    Dynamic,
+    Static,
+}
+
+impl Into<String> for EvaluationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EvaluationType {
+    fn into(self) -> &'static str {
+        match self {
+            EvaluationType::Dynamic => "Dynamic",
+            EvaluationType::Static => "Static",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EvaluationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Dynamic" => Ok(EvaluationType::Dynamic),
+            "Static" => Ok(EvaluationType::Static),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EvaluationTypeDeserializer;
 impl EvaluationTypeDeserializer {
     #[allow(unused_variables)]
@@ -2677,6 +2974,53 @@ impl ExecuteChangeSetOutputDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExecutionStatus {
+    Available,
+    ExecuteComplete,
+    ExecuteFailed,
+    ExecuteInProgress,
+    Obsolete,
+    Unavailable,
+}
+
+impl Into<String> for ExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ExecutionStatus::Available => "AVAILABLE",
+            ExecutionStatus::ExecuteComplete => "EXECUTE_COMPLETE",
+            ExecutionStatus::ExecuteFailed => "EXECUTE_FAILED",
+            ExecutionStatus::ExecuteInProgress => "EXECUTE_IN_PROGRESS",
+            ExecutionStatus::Obsolete => "OBSOLETE",
+            ExecutionStatus::Unavailable => "UNAVAILABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(ExecutionStatus::Available),
+            "EXECUTE_COMPLETE" => Ok(ExecutionStatus::ExecuteComplete),
+            "EXECUTE_FAILED" => Ok(ExecutionStatus::ExecuteFailed),
+            "EXECUTE_IN_PROGRESS" => Ok(ExecutionStatus::ExecuteInProgress),
+            "OBSOLETE" => Ok(ExecutionStatus::Obsolete),
+            "UNAVAILABLE" => Ok(ExecutionStatus::Unavailable),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ExecutionStatusDeserializer;
 impl ExecutionStatusDeserializer {
     #[allow(unused_variables)]
@@ -4120,7 +4464,7 @@ impl NoEchoDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4190,6 +4534,44 @@ impl NotificationARNsSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OnFailure {
+    Delete,
+    DoNothing,
+    Rollback,
+}
+
+impl Into<String> for OnFailure {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OnFailure {
+    fn into(self) -> &'static str {
+        match self {
+            OnFailure::Delete => "DELETE",
+            OnFailure::DoNothing => "DO_NOTHING",
+            OnFailure::Rollback => "ROLLBACK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OnFailure {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETE" => Ok(OnFailure::Delete),
+            "DO_NOTHING" => Ok(OnFailure::DoNothing),
+            "ROLLBACK" => Ok(OnFailure::Rollback),
+            _ => Err(()),
         }
     }
 }
@@ -4803,6 +5185,44 @@ impl RegionListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Replacement {
+    Conditional,
+    False,
+    True,
+}
+
+impl Into<String> for Replacement {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Replacement {
+    fn into(self) -> &'static str {
+        match self {
+            Replacement::Conditional => "Conditional",
+            Replacement::False => "False",
+            Replacement::True => "True",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Replacement {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Conditional" => Ok(Replacement::Conditional),
+            "False" => Ok(Replacement::False),
+            "True" => Ok(Replacement::True),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReplacementDeserializer;
 impl ReplacementDeserializer {
     #[allow(unused_variables)]
@@ -4817,6 +5237,44 @@ impl ReplacementDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RequiresRecreation {
+    Always,
+    Conditionally,
+    Never,
+}
+
+impl Into<String> for RequiresRecreation {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RequiresRecreation {
+    fn into(self) -> &'static str {
+        match self {
+            RequiresRecreation::Always => "Always",
+            RequiresRecreation::Conditionally => "Conditionally",
+            RequiresRecreation::Never => "Never",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RequiresRecreation {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Always" => Ok(RequiresRecreation::Always),
+            "Conditionally" => Ok(RequiresRecreation::Conditionally),
+            "Never" => Ok(RequiresRecreation::Never),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RequiresRecreationDeserializer;
 impl RequiresRecreationDeserializer {
     #[allow(unused_variables)]
@@ -4831,6 +5289,53 @@ impl RequiresRecreationDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceAttribute {
+    CreationPolicy,
+    DeletionPolicy,
+    Metadata,
+    Properties,
+    Tags,
+    UpdatePolicy,
+}
+
+impl Into<String> for ResourceAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceAttribute::CreationPolicy => "CreationPolicy",
+            ResourceAttribute::DeletionPolicy => "DeletionPolicy",
+            ResourceAttribute::Metadata => "Metadata",
+            ResourceAttribute::Properties => "Properties",
+            ResourceAttribute::Tags => "Tags",
+            ResourceAttribute::UpdatePolicy => "UpdatePolicy",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreationPolicy" => Ok(ResourceAttribute::CreationPolicy),
+            "DeletionPolicy" => Ok(ResourceAttribute::DeletionPolicy),
+            "Metadata" => Ok(ResourceAttribute::Metadata),
+            "Properties" => Ok(ResourceAttribute::Properties),
+            "Tags" => Ok(ResourceAttribute::Tags),
+            "UpdatePolicy" => Ok(ResourceAttribute::UpdatePolicy),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ResourceAttributeDeserializer;
 impl ResourceAttributeDeserializer {
     #[allow(unused_variables)]
@@ -5059,6 +5564,100 @@ impl ResourcePropertiesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceSignalStatus {
+    Failure,
+    Success,
+}
+
+impl Into<String> for ResourceSignalStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceSignalStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceSignalStatus::Failure => "FAILURE",
+            ResourceSignalStatus::Success => "SUCCESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceSignalStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILURE" => Ok(ResourceSignalStatus::Failure),
+            "SUCCESS" => Ok(ResourceSignalStatus::Success),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceStatus {
+    CreateComplete,
+    CreateFailed,
+    CreateInProgress,
+    DeleteComplete,
+    DeleteFailed,
+    DeleteInProgress,
+    DeleteSkipped,
+    UpdateComplete,
+    UpdateFailed,
+    UpdateInProgress,
+}
+
+impl Into<String> for ResourceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceStatus::CreateComplete => "CREATE_COMPLETE",
+            ResourceStatus::CreateFailed => "CREATE_FAILED",
+            ResourceStatus::CreateInProgress => "CREATE_IN_PROGRESS",
+            ResourceStatus::DeleteComplete => "DELETE_COMPLETE",
+            ResourceStatus::DeleteFailed => "DELETE_FAILED",
+            ResourceStatus::DeleteInProgress => "DELETE_IN_PROGRESS",
+            ResourceStatus::DeleteSkipped => "DELETE_SKIPPED",
+            ResourceStatus::UpdateComplete => "UPDATE_COMPLETE",
+            ResourceStatus::UpdateFailed => "UPDATE_FAILED",
+            ResourceStatus::UpdateInProgress => "UPDATE_IN_PROGRESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE_COMPLETE" => Ok(ResourceStatus::CreateComplete),
+            "CREATE_FAILED" => Ok(ResourceStatus::CreateFailed),
+            "CREATE_IN_PROGRESS" => Ok(ResourceStatus::CreateInProgress),
+            "DELETE_COMPLETE" => Ok(ResourceStatus::DeleteComplete),
+            "DELETE_FAILED" => Ok(ResourceStatus::DeleteFailed),
+            "DELETE_IN_PROGRESS" => Ok(ResourceStatus::DeleteInProgress),
+            "DELETE_SKIPPED" => Ok(ResourceStatus::DeleteSkipped),
+            "UPDATE_COMPLETE" => Ok(ResourceStatus::UpdateComplete),
+            "UPDATE_FAILED" => Ok(ResourceStatus::UpdateFailed),
+            "UPDATE_IN_PROGRESS" => Ok(ResourceStatus::UpdateInProgress),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ResourceStatusDeserializer;
 impl ResourceStatusDeserializer {
     #[allow(unused_variables)]
@@ -5248,7 +5847,7 @@ impl RetainStacksNullableDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5987,6 +6586,44 @@ impl StackInstanceDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StackInstanceStatus {
+    Current,
+    Inoperable,
+    Outdated,
+}
+
+impl Into<String> for StackInstanceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StackInstanceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StackInstanceStatus::Current => "CURRENT",
+            StackInstanceStatus::Inoperable => "INOPERABLE",
+            StackInstanceStatus::Outdated => "OUTDATED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StackInstanceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CURRENT" => Ok(StackInstanceStatus::Current),
+            "INOPERABLE" => Ok(StackInstanceStatus::Inoperable),
+            "OUTDATED" => Ok(StackInstanceStatus::Outdated),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StackInstanceStatusDeserializer;
 impl StackInstanceStatusDeserializer {
     #[allow(unused_variables)]
@@ -6750,6 +7387,44 @@ impl StackSetOperationDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StackSetOperationAction {
+    Create,
+    Delete,
+    Update,
+}
+
+impl Into<String> for StackSetOperationAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StackSetOperationAction {
+    fn into(self) -> &'static str {
+        match self {
+            StackSetOperationAction::Create => "CREATE",
+            StackSetOperationAction::Delete => "DELETE",
+            StackSetOperationAction::Update => "UPDATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StackSetOperationAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE" => Ok(StackSetOperationAction::Create),
+            "DELETE" => Ok(StackSetOperationAction::Delete),
+            "UPDATE" => Ok(StackSetOperationAction::Update),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StackSetOperationActionDeserializer;
 impl StackSetOperationActionDeserializer {
     #[allow(unused_variables)]
@@ -6872,6 +7547,50 @@ impl StackSetOperationPreferencesSerializer {
                                             field_value);
         }
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StackSetOperationResultStatus {
+    Cancelled,
+    Failed,
+    Pending,
+    Running,
+    Succeeded,
+}
+
+impl Into<String> for StackSetOperationResultStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StackSetOperationResultStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StackSetOperationResultStatus::Cancelled => "CANCELLED",
+            StackSetOperationResultStatus::Failed => "FAILED",
+            StackSetOperationResultStatus::Pending => "PENDING",
+            StackSetOperationResultStatus::Running => "RUNNING",
+            StackSetOperationResultStatus::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StackSetOperationResultStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(StackSetOperationResultStatus::Cancelled),
+            "FAILED" => Ok(StackSetOperationResultStatus::Failed),
+            "PENDING" => Ok(StackSetOperationResultStatus::Pending),
+            "RUNNING" => Ok(StackSetOperationResultStatus::Running),
+            "SUCCEEDED" => Ok(StackSetOperationResultStatus::Succeeded),
+            _ => Err(()),
+        }
     }
 }
 
@@ -7004,6 +7723,50 @@ impl StackSetOperationResultSummaryDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StackSetOperationStatus {
+    Failed,
+    Running,
+    Stopped,
+    Stopping,
+    Succeeded,
+}
+
+impl Into<String> for StackSetOperationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StackSetOperationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StackSetOperationStatus::Failed => "FAILED",
+            StackSetOperationStatus::Running => "RUNNING",
+            StackSetOperationStatus::Stopped => "STOPPED",
+            StackSetOperationStatus::Stopping => "STOPPING",
+            StackSetOperationStatus::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StackSetOperationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(StackSetOperationStatus::Failed),
+            "RUNNING" => Ok(StackSetOperationStatus::Running),
+            "STOPPED" => Ok(StackSetOperationStatus::Stopped),
+            "STOPPING" => Ok(StackSetOperationStatus::Stopping),
+            "SUCCEEDED" => Ok(StackSetOperationStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StackSetOperationStatusDeserializer;
 impl StackSetOperationStatusDeserializer {
     #[allow(unused_variables)]
@@ -7138,6 +7901,41 @@ impl StackSetOperationSummaryDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StackSetStatus {
+    Active,
+    Deleted,
+}
+
+impl Into<String> for StackSetStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StackSetStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StackSetStatus::Active => "ACTIVE",
+            StackSetStatus::Deleted => "DELETED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StackSetStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(StackSetStatus::Active),
+            "DELETED" => Ok(StackSetStatus::Deleted),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StackSetStatusDeserializer;
 impl StackSetStatusDeserializer {
     #[allow(unused_variables)]
@@ -7263,6 +8061,92 @@ impl StackSetSummaryDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StackStatus {
+    CreateComplete,
+    CreateFailed,
+    CreateInProgress,
+    DeleteComplete,
+    DeleteFailed,
+    DeleteInProgress,
+    ReviewInProgress,
+    RollbackComplete,
+    RollbackFailed,
+    RollbackInProgress,
+    UpdateComplete,
+    UpdateCompleteCleanupInProgress,
+    UpdateInProgress,
+    UpdateRollbackComplete,
+    UpdateRollbackCompleteCleanupInProgress,
+    UpdateRollbackFailed,
+    UpdateRollbackInProgress,
+}
+
+impl Into<String> for StackStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StackStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StackStatus::CreateComplete => "CREATE_COMPLETE",
+            StackStatus::CreateFailed => "CREATE_FAILED",
+            StackStatus::CreateInProgress => "CREATE_IN_PROGRESS",
+            StackStatus::DeleteComplete => "DELETE_COMPLETE",
+            StackStatus::DeleteFailed => "DELETE_FAILED",
+            StackStatus::DeleteInProgress => "DELETE_IN_PROGRESS",
+            StackStatus::ReviewInProgress => "REVIEW_IN_PROGRESS",
+            StackStatus::RollbackComplete => "ROLLBACK_COMPLETE",
+            StackStatus::RollbackFailed => "ROLLBACK_FAILED",
+            StackStatus::RollbackInProgress => "ROLLBACK_IN_PROGRESS",
+            StackStatus::UpdateComplete => "UPDATE_COMPLETE",
+            StackStatus::UpdateCompleteCleanupInProgress => "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            StackStatus::UpdateInProgress => "UPDATE_IN_PROGRESS",
+            StackStatus::UpdateRollbackComplete => "UPDATE_ROLLBACK_COMPLETE",
+            StackStatus::UpdateRollbackCompleteCleanupInProgress => {
+                "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS"
+            }
+            StackStatus::UpdateRollbackFailed => "UPDATE_ROLLBACK_FAILED",
+            StackStatus::UpdateRollbackInProgress => "UPDATE_ROLLBACK_IN_PROGRESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StackStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE_COMPLETE" => Ok(StackStatus::CreateComplete),
+            "CREATE_FAILED" => Ok(StackStatus::CreateFailed),
+            "CREATE_IN_PROGRESS" => Ok(StackStatus::CreateInProgress),
+            "DELETE_COMPLETE" => Ok(StackStatus::DeleteComplete),
+            "DELETE_FAILED" => Ok(StackStatus::DeleteFailed),
+            "DELETE_IN_PROGRESS" => Ok(StackStatus::DeleteInProgress),
+            "REVIEW_IN_PROGRESS" => Ok(StackStatus::ReviewInProgress),
+            "ROLLBACK_COMPLETE" => Ok(StackStatus::RollbackComplete),
+            "ROLLBACK_FAILED" => Ok(StackStatus::RollbackFailed),
+            "ROLLBACK_IN_PROGRESS" => Ok(StackStatus::RollbackInProgress),
+            "UPDATE_COMPLETE" => Ok(StackStatus::UpdateComplete),
+            "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS" => {
+                Ok(StackStatus::UpdateCompleteCleanupInProgress)
+            }
+            "UPDATE_IN_PROGRESS" => Ok(StackStatus::UpdateInProgress),
+            "UPDATE_ROLLBACK_COMPLETE" => Ok(StackStatus::UpdateRollbackComplete),
+            "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS" => {
+                Ok(StackStatus::UpdateRollbackCompleteCleanupInProgress)
+            }
+            "UPDATE_ROLLBACK_FAILED" => Ok(StackStatus::UpdateRollbackFailed),
+            "UPDATE_ROLLBACK_IN_PROGRESS" => Ok(StackStatus::UpdateRollbackInProgress),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StackStatusDeserializer;
 impl StackStatusDeserializer {
     #[allow(unused_variables)]
@@ -7857,6 +8741,41 @@ impl TemplateParametersDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TemplateStage {
+    Original,
+    Processed,
+}
+
+impl Into<String> for TemplateStage {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TemplateStage {
+    fn into(self) -> &'static str {
+        match self {
+            TemplateStage::Original => "Original",
+            TemplateStage::Processed => "Processed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TemplateStage {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Original" => Ok(TemplateStage::Original),
+            "Processed" => Ok(TemplateStage::Processed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TemplateStageDeserializer;
 impl TemplateStageDeserializer {
     #[allow(unused_variables)]
@@ -8286,7 +9205,7 @@ impl UsePreviousValueDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -11599,7 +12518,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11628,7 +12547,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11676,7 +12595,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11723,7 +12642,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11770,7 +12689,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11817,7 +12736,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11864,7 +12783,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11909,7 +12828,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11937,7 +12856,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11984,7 +12903,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12032,7 +12951,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12079,7 +12998,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12126,7 +13045,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12174,7 +13093,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12222,7 +13141,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12270,7 +13189,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12318,7 +13237,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12366,7 +13285,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12415,7 +13334,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12462,7 +13381,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12509,7 +13428,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12556,7 +13475,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12603,7 +13522,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12650,7 +13569,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12697,7 +13616,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12744,7 +13663,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12791,7 +13710,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12838,7 +13757,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12885,7 +13804,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12933,7 +13852,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12981,7 +13900,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13029,7 +13948,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13074,7 +13993,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13119,7 +14038,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13145,7 +14064,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13174,7 +14093,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13221,7 +14140,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13268,7 +14187,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13315,7 +14234,7 @@ impl<P, D> CloudFormation for CloudFormationClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 
@@ -391,7 +387,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -819,6 +815,44 @@ impl CachedMethodsSerializer {
             .write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.quantity)))?;
         writer.write(xml::writer::XmlEvent::end_element())?;
         writer.write(xml::writer::XmlEvent::end_element())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CertificateSource {
+    Acm,
+    Cloudfront,
+    Iam,
+}
+
+impl Into<String> for CertificateSource {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CertificateSource {
+    fn into(self) -> &'static str {
+        match self {
+            CertificateSource::Acm => "acm",
+            CertificateSource::Cloudfront => "cloudfront",
+            CertificateSource::Iam => "iam",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CertificateSource {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "acm" => Ok(CertificateSource::Acm),
+            "cloudfront" => Ok(CertificateSource::Cloudfront),
+            "iam" => Ok(CertificateSource::Iam),
+            _ => Err(()),
+        }
     }
 }
 
@@ -2995,6 +3029,47 @@ impl DistributionSummaryListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventType {
+    OriginRequest,
+    OriginResponse,
+    ViewerRequest,
+    ViewerResponse,
+}
+
+impl Into<String> for EventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventType {
+    fn into(self) -> &'static str {
+        match self {
+            EventType::OriginRequest => "origin-request",
+            EventType::OriginResponse => "origin-response",
+            EventType::ViewerRequest => "viewer-request",
+            EventType::ViewerResponse => "viewer-response",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "origin-request" => Ok(EventType::OriginRequest),
+            "origin-response" => Ok(EventType::OriginResponse),
+            "viewer-request" => Ok(EventType::ViewerRequest),
+            "viewer-response" => Ok(EventType::ViewerResponse),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventTypeDeserializer;
 impl EventTypeDeserializer {
     #[allow(unused_variables)]
@@ -3211,6 +3286,44 @@ impl GeoRestrictionSerializer {
                                                              value = obj.restriction_type)))?;
         writer.write(xml::writer::XmlEvent::end_element())?;
         writer.write(xml::writer::XmlEvent::end_element())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GeoRestrictionType {
+    Blacklist,
+    None,
+    Whitelist,
+}
+
+impl Into<String> for GeoRestrictionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GeoRestrictionType {
+    fn into(self) -> &'static str {
+        match self {
+            GeoRestrictionType::Blacklist => "blacklist",
+            GeoRestrictionType::None => "none",
+            GeoRestrictionType::Whitelist => "whitelist",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GeoRestrictionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "blacklist" => Ok(GeoRestrictionType::Blacklist),
+            "none" => Ok(GeoRestrictionType::None),
+            "whitelist" => Ok(GeoRestrictionType::Whitelist),
+            _ => Err(()),
+        }
     }
 }
 
@@ -3794,6 +3907,41 @@ impl HeadersSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HttpVersion {
+    Http11,
+    Http2,
+}
+
+impl Into<String> for HttpVersion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HttpVersion {
+    fn into(self) -> &'static str {
+        match self {
+            HttpVersion::Http11 => "http1.1",
+            HttpVersion::Http2 => "http2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HttpVersion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "http1.1" => Ok(HttpVersion::Http11),
+            "http2" => Ok(HttpVersion::Http2),
+            _ => Err(()),
+        }
+    }
+}
+
 struct HttpVersionDeserializer;
 impl HttpVersionDeserializer {
     #[allow(unused_variables)]
@@ -4178,6 +4326,44 @@ impl InvalidationSummaryListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ItemSelection {
+    All,
+    None,
+    Whitelist,
+}
+
+impl Into<String> for ItemSelection {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ItemSelection {
+    fn into(self) -> &'static str {
+        match self {
+            ItemSelection::All => "all",
+            ItemSelection::None => "none",
+            ItemSelection::Whitelist => "whitelist",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ItemSelection {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(ItemSelection::All),
+            "none" => Ok(ItemSelection::None),
+            "whitelist" => Ok(ItemSelection::Whitelist),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ItemSelectionDeserializer;
 impl ItemSelectionDeserializer {
     #[allow(unused_variables)]
@@ -5073,6 +5259,56 @@ impl LongSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Method {
+    Delete,
+    Get,
+    Head,
+    Options,
+    Patch,
+    Post,
+    Put,
+}
+
+impl Into<String> for Method {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Method {
+    fn into(self) -> &'static str {
+        match self {
+            Method::Delete => "DELETE",
+            Method::Get => "GET",
+            Method::Head => "HEAD",
+            Method::Options => "OPTIONS",
+            Method::Patch => "PATCH",
+            Method::Post => "POST",
+            Method::Put => "PUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Method {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETE" => Ok(Method::Delete),
+            "GET" => Ok(Method::Get),
+            "HEAD" => Ok(Method::Head),
+            "OPTIONS" => Ok(Method::Options),
+            "PATCH" => Ok(Method::Patch),
+            "POST" => Ok(Method::Post),
+            "PUT" => Ok(Method::Put),
+            _ => Err(()),
+        }
+    }
+}
+
 struct MethodDeserializer;
 impl MethodDeserializer {
     #[allow(unused_variables)]
@@ -5162,6 +5398,41 @@ impl MethodsListSerializer {
         }
         writer.write(xml::writer::XmlEvent::end_element())?;
         Ok(())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MinimumProtocolVersion {
+    Sslv3,
+    Tlsv1,
+}
+
+impl Into<String> for MinimumProtocolVersion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MinimumProtocolVersion {
+    fn into(self) -> &'static str {
+        match self {
+            MinimumProtocolVersion::Sslv3 => "SSLv3",
+            MinimumProtocolVersion::Tlsv1 => "TLSv1",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MinimumProtocolVersion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SSLv3" => Ok(MinimumProtocolVersion::Sslv3),
+            "TLSv1" => Ok(MinimumProtocolVersion::Tlsv1),
+            _ => Err(()),
+        }
     }
 }
 
@@ -5516,6 +5787,44 @@ impl OriginListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OriginProtocolPolicy {
+    HttpOnly,
+    HttpsOnly,
+    MatchViewer,
+}
+
+impl Into<String> for OriginProtocolPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OriginProtocolPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            OriginProtocolPolicy::HttpOnly => "http-only",
+            OriginProtocolPolicy::HttpsOnly => "https-only",
+            OriginProtocolPolicy::MatchViewer => "match-viewer",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OriginProtocolPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "http-only" => Ok(OriginProtocolPolicy::HttpOnly),
+            "https-only" => Ok(OriginProtocolPolicy::HttpsOnly),
+            "match-viewer" => Ok(OriginProtocolPolicy::MatchViewer),
+            _ => Err(()),
+        }
+    }
+}
+
 struct OriginProtocolPolicyDeserializer;
 impl OriginProtocolPolicyDeserializer {
     #[allow(unused_variables)]
@@ -5837,6 +6146,44 @@ impl PathsSerializer {
             .write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.quantity)))?;
         writer.write(xml::writer::XmlEvent::end_element())?;
         writer.write(xml::writer::XmlEvent::end_element())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PriceClass {
+    PriceClass100,
+    PriceClass200,
+    PriceClassAll,
+}
+
+impl Into<String> for PriceClass {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PriceClass {
+    fn into(self) -> &'static str {
+        match self {
+            PriceClass::PriceClass100 => "PriceClass_100",
+            PriceClass::PriceClass200 => "PriceClass_200",
+            PriceClass::PriceClassAll => "PriceClass_All",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PriceClass {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PriceClass_100" => Ok(PriceClass::PriceClass100),
+            "PriceClass_200" => Ok(PriceClass::PriceClass200),
+            "PriceClass_All" => Ok(PriceClass::PriceClassAll),
+            _ => Err(()),
+        }
     }
 }
 
@@ -6243,6 +6590,41 @@ impl S3OriginConfigSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SSLSupportMethod {
+    SniOnly,
+    Vip,
+}
+
+impl Into<String> for SSLSupportMethod {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SSLSupportMethod {
+    fn into(self) -> &'static str {
+        match self {
+            SSLSupportMethod::SniOnly => "sni-only",
+            SSLSupportMethod::Vip => "vip",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SSLSupportMethod {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "sni-only" => Ok(SSLSupportMethod::SniOnly),
+            "vip" => Ok(SSLSupportMethod::Vip),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SSLSupportMethodDeserializer;
 impl SSLSupportMethodDeserializer {
     #[allow(unused_variables)]
@@ -6373,6 +6755,47 @@ impl SignerListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SslProtocol {
+    Sslv3,
+    Tlsv1,
+    Tlsv11,
+    Tlsv12,
+}
+
+impl Into<String> for SslProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SslProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            SslProtocol::Sslv3 => "SSLv3",
+            SslProtocol::Tlsv1 => "TLSv1",
+            SslProtocol::Tlsv11 => "TLSv1.1",
+            SslProtocol::Tlsv12 => "TLSv1.2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SslProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SSLv3" => Ok(SslProtocol::Sslv3),
+            "TLSv1" => Ok(SslProtocol::Tlsv1),
+            "TLSv1.1" => Ok(SslProtocol::Tlsv11),
+            "TLSv1.2" => Ok(SslProtocol::Tlsv12),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SslProtocolDeserializer;
 impl SslProtocolDeserializer {
     #[allow(unused_variables)]
@@ -7796,6 +8219,44 @@ impl ViewerCertificateSerializer {
             writer.write(xml::writer::XmlEvent::end_element())?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ViewerProtocolPolicy {
+    AllowAll,
+    HttpsOnly,
+    RedirectToHttps,
+}
+
+impl Into<String> for ViewerProtocolPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ViewerProtocolPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            ViewerProtocolPolicy::AllowAll => "allow-all",
+            ViewerProtocolPolicy::HttpsOnly => "https-only",
+            ViewerProtocolPolicy::RedirectToHttps => "redirect-to-https",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ViewerProtocolPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "allow-all" => Ok(ViewerProtocolPolicy::AllowAll),
+            "https-only" => Ok(ViewerProtocolPolicy::HttpsOnly),
+            "redirect-to-https" => Ok(ViewerProtocolPolicy::RedirectToHttps),
+            _ => Err(()),
+        }
     }
 }
 
@@ -10921,9 +11382,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -10983,9 +11444,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11050,9 +11511,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11114,9 +11575,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11175,9 +11636,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11240,9 +11701,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11300,9 +11761,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -11336,9 +11797,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -11372,9 +11833,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -11408,9 +11869,9 @@ impl<P, D> CloudFront for CloudFrontClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11458,9 +11919,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11509,9 +11970,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11562,9 +12023,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11615,9 +12076,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11665,9 +12126,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11719,9 +12180,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11780,9 +12241,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11835,9 +12296,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11894,9 +12355,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11951,9 +12412,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12009,9 +12470,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12060,9 +12521,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12116,9 +12577,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -12155,9 +12616,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -12199,9 +12660,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12260,9 +12721,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12325,9 +12786,9 @@ fn get_cloud_front_origin_access_identity_config(&self, input: &GetCloudFrontOri
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -43,6 +39,79 @@ pub struct AddTagsToResourceResponse {
     #[doc="<p>The status of the operation.</p>"]
     #[serde(rename="Status")]
     pub status: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ClientVersion {
+    _5_1,
+    _5_3,
+}
+
+impl Into<String> for ClientVersion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ClientVersion {
+    fn into(self) -> &'static str {
+        match self {
+            ClientVersion::_5_1 => "5.1",
+            ClientVersion::_5_3 => "5.3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ClientVersion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "5.1" => Ok(ClientVersion::_5_1),
+            "5.3" => Ok(ClientVersion::_5_3),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloudHsmObjectState {
+    Degraded,
+    Ready,
+    Updating,
+}
+
+impl Into<String> for CloudHsmObjectState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloudHsmObjectState {
+    fn into(self) -> &'static str {
+        match self {
+            CloudHsmObjectState::Degraded => "DEGRADED",
+            CloudHsmObjectState::Ready => "READY",
+            CloudHsmObjectState::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloudHsmObjectState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEGRADED" => Ok(CloudHsmObjectState::Degraded),
+            "READY" => Ok(CloudHsmObjectState::Ready),
+            "UPDATING" => Ok(CloudHsmObjectState::Updating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains the inputs for the <a>CreateHapgRequest</a> action.</p>"]
@@ -382,6 +451,56 @@ pub struct GetConfigResponse {
     pub config_type: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HsmStatus {
+    Degraded,
+    Pending,
+    Running,
+    Suspended,
+    Terminated,
+    Terminating,
+    Updating,
+}
+
+impl Into<String> for HsmStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HsmStatus {
+    fn into(self) -> &'static str {
+        match self {
+            HsmStatus::Degraded => "DEGRADED",
+            HsmStatus::Pending => "PENDING",
+            HsmStatus::Running => "RUNNING",
+            HsmStatus::Suspended => "SUSPENDED",
+            HsmStatus::Terminated => "TERMINATED",
+            HsmStatus::Terminating => "TERMINATING",
+            HsmStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HsmStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEGRADED" => Ok(HsmStatus::Degraded),
+            "PENDING" => Ok(HsmStatus::Pending),
+            "RUNNING" => Ok(HsmStatus::Running),
+            "SUSPENDED" => Ok(HsmStatus::Suspended),
+            "TERMINATED" => Ok(HsmStatus::Terminated),
+            "TERMINATING" => Ok(HsmStatus::Terminating),
+            "UPDATING" => Ok(HsmStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the inputs for the <a>ListAvailableZones</a> action.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListAvailableZonesRequest;
@@ -560,6 +679,38 @@ pub struct RemoveTagsFromResourceResponse {
     #[doc="<p>The status of the operation.</p>"]
     #[serde(rename="Status")]
     pub status: String,
+}
+
+#[doc="<p>Specifies the type of subscription for the HSM.</p> <ul> <li><b>PRODUCTION</b> - The HSM is being used in a production environment.</li> <li><b>TRIAL</b> - The HSM is being used in a product trial.</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SubscriptionType {
+    Production,
+}
+
+impl Into<String> for SubscriptionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SubscriptionType {
+    fn into(self) -> &'static str {
+        match self {
+            SubscriptionType::Production => "PRODUCTION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SubscriptionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PRODUCTION" => Ok(SubscriptionType::Production),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A key-value pair that identifies or specifies metadata about an AWS CloudHSM resource.</p>"]
@@ -2524,7 +2675,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddTagsToResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2554,7 +2705,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateHapgResponse>(String::from_utf8_lossy(&body)
@@ -2584,7 +2735,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateHsmResponse>(String::from_utf8_lossy(&body)
@@ -2616,7 +2767,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateLunaClientResponse>(String::from_utf8_lossy(&body)
@@ -2648,7 +2799,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteHapgResponse>(String::from_utf8_lossy(&body)
@@ -2678,7 +2829,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteHsmResponse>(String::from_utf8_lossy(&body)
@@ -2710,7 +2861,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteLunaClientResponse>(String::from_utf8_lossy(&body)
@@ -2742,7 +2893,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeHapgResponse>(String::from_utf8_lossy(&body)
@@ -2774,7 +2925,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeHsmResponse>(String::from_utf8_lossy(&body)
@@ -2806,7 +2957,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeLunaClientResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2834,7 +2985,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetConfigResponse>(String::from_utf8_lossy(&body)
@@ -2863,7 +3014,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAvailableZonesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2891,7 +3042,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListHapgsResponse>(String::from_utf8_lossy(&body)
@@ -2921,7 +3072,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListHsmsResponse>(String::from_utf8_lossy(&body)
@@ -2953,7 +3104,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListLunaClientsResponse>(String::from_utf8_lossy(&body)
@@ -2986,7 +3137,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3016,7 +3167,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ModifyHapgResponse>(String::from_utf8_lossy(&body)
@@ -3046,7 +3197,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ModifyHsmResponse>(String::from_utf8_lossy(&body)
@@ -3078,7 +3229,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ModifyLunaClientResponse>(String::from_utf8_lossy(&body)
@@ -3112,7 +3263,7 @@ impl<P, D> CloudHsm for CloudHsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveTagsFromResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/cloudhsmv2/src/generated.rs
+++ b/rusoto/services/cloudhsmv2/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -46,6 +42,76 @@ pub struct Backup {
     #[serde(rename="CreateTimestamp")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub create_timestamp: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BackupPolicy {
+    Default,
+}
+
+impl Into<String> for BackupPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BackupPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            BackupPolicy::Default => "DEFAULT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BackupPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEFAULT" => Ok(BackupPolicy::Default),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BackupState {
+    CreateInProgress,
+    Deleted,
+    Ready,
+}
+
+impl Into<String> for BackupState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BackupState {
+    fn into(self) -> &'static str {
+        match self {
+            BackupState::CreateInProgress => "CREATE_IN_PROGRESS",
+            BackupState::Deleted => "DELETED",
+            BackupState::Ready => "READY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BackupState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE_IN_PROGRESS" => Ok(BackupState::CreateInProgress),
+            "DELETED" => Ok(BackupState::Deleted),
+            "READY" => Ok(BackupState::Ready),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains one or more certificates or a certificate signing request (CSR).</p>"]
@@ -128,6 +194,62 @@ pub struct Cluster {
     #[serde(rename="VpcId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ClusterState {
+    Active,
+    CreateInProgress,
+    Degraded,
+    Deleted,
+    DeleteInProgress,
+    Initialized,
+    InitializeInProgress,
+    Uninitialized,
+    UpdateInProgress,
+}
+
+impl Into<String> for ClusterState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ClusterState {
+    fn into(self) -> &'static str {
+        match self {
+            ClusterState::Active => "ACTIVE",
+            ClusterState::CreateInProgress => "CREATE_IN_PROGRESS",
+            ClusterState::Degraded => "DEGRADED",
+            ClusterState::Deleted => "DELETED",
+            ClusterState::DeleteInProgress => "DELETE_IN_PROGRESS",
+            ClusterState::Initialized => "INITIALIZED",
+            ClusterState::InitializeInProgress => "INITIALIZE_IN_PROGRESS",
+            ClusterState::Uninitialized => "UNINITIALIZED",
+            ClusterState::UpdateInProgress => "UPDATE_IN_PROGRESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ClusterState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(ClusterState::Active),
+            "CREATE_IN_PROGRESS" => Ok(ClusterState::CreateInProgress),
+            "DEGRADED" => Ok(ClusterState::Degraded),
+            "DELETED" => Ok(ClusterState::Deleted),
+            "DELETE_IN_PROGRESS" => Ok(ClusterState::DeleteInProgress),
+            "INITIALIZED" => Ok(ClusterState::Initialized),
+            "INITIALIZE_IN_PROGRESS" => Ok(ClusterState::InitializeInProgress),
+            "UNINITIALIZED" => Ok(ClusterState::Uninitialized),
+            "UPDATE_IN_PROGRESS" => Ok(ClusterState::UpdateInProgress),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -306,6 +428,50 @@ pub struct Hsm {
     #[serde(rename="SubnetId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HsmState {
+    Active,
+    CreateInProgress,
+    Degraded,
+    Deleted,
+    DeleteInProgress,
+}
+
+impl Into<String> for HsmState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HsmState {
+    fn into(self) -> &'static str {
+        match self {
+            HsmState::Active => "ACTIVE",
+            HsmState::CreateInProgress => "CREATE_IN_PROGRESS",
+            HsmState::Degraded => "DEGRADED",
+            HsmState::Deleted => "DELETED",
+            HsmState::DeleteInProgress => "DELETE_IN_PROGRESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HsmState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(HsmState::Active),
+            "CREATE_IN_PROGRESS" => Ok(HsmState::CreateInProgress),
+            "DEGRADED" => Ok(HsmState::Degraded),
+            "DELETED" => Ok(HsmState::Deleted),
+            "DELETE_IN_PROGRESS" => Ok(HsmState::DeleteInProgress),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1512,7 +1678,7 @@ impl<P, D> CloudHsmv2 for CloudHsmv2Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateClusterResponse>(String::from_utf8_lossy(&body)
@@ -1542,7 +1708,7 @@ impl<P, D> CloudHsmv2 for CloudHsmv2Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateHsmResponse>(String::from_utf8_lossy(&body)
@@ -1574,7 +1740,7 @@ impl<P, D> CloudHsmv2 for CloudHsmv2Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteClusterResponse>(String::from_utf8_lossy(&body)
@@ -1604,7 +1770,7 @@ impl<P, D> CloudHsmv2 for CloudHsmv2Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteHsmResponse>(String::from_utf8_lossy(&body)
@@ -1636,7 +1802,7 @@ impl<P, D> CloudHsmv2 for CloudHsmv2Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeBackupsResponse>(String::from_utf8_lossy(&body)
@@ -1668,7 +1834,7 @@ impl<P, D> CloudHsmv2 for CloudHsmv2Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeClustersResponse>(String::from_utf8_lossy(&body)
@@ -1700,7 +1866,7 @@ impl<P, D> CloudHsmv2 for CloudHsmv2Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<InitializeClusterResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1728,7 +1894,7 @@ impl<P, D> CloudHsmv2 for CloudHsmv2Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsResponse>(String::from_utf8_lossy(&body)
@@ -1760,7 +1926,7 @@ impl<P, D> CloudHsmv2 for CloudHsmv2Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<TagResourceResponse>(String::from_utf8_lossy(&body)
@@ -1792,7 +1958,7 @@ impl<P, D> CloudHsmv2 for CloudHsmv2Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UntagResourceResponse>(String::from_utf8_lossy(&body)

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -120,6 +116,47 @@ impl AccessPoliciesStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AlgorithmicStemming {
+    Full,
+    Light,
+    Minimal,
+    None,
+}
+
+impl Into<String> for AlgorithmicStemming {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AlgorithmicStemming {
+    fn into(self) -> &'static str {
+        match self {
+            AlgorithmicStemming::Full => "full",
+            AlgorithmicStemming::Light => "light",
+            AlgorithmicStemming::Minimal => "minimal",
+            AlgorithmicStemming::None => "none",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AlgorithmicStemming {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "full" => Ok(AlgorithmicStemming::Full),
+            "light" => Ok(AlgorithmicStemming::Light),
+            "minimal" => Ok(AlgorithmicStemming::Minimal),
+            "none" => Ok(AlgorithmicStemming::None),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AlgorithmicStemmingDeserializer;
 impl AlgorithmicStemmingDeserializer {
     #[allow(unused_variables)]
@@ -328,6 +365,140 @@ impl AnalysisSchemeSerializer {
     }
 }
 
+#[doc="<p>An <a href=\"http://tools.ietf.org/html/rfc4646\" target=\"_blank\">IETF RFC 4646</a> language code or <code>mul</code> for multiple languages.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AnalysisSchemeLanguage {
+    Ar,
+    Bg,
+    Ca,
+    Cs,
+    Da,
+    De,
+    El,
+    En,
+    Es,
+    Eu,
+    Fa,
+    Fi,
+    Fr,
+    Ga,
+    Gl,
+    He,
+    Hi,
+    Hu,
+    Hy,
+    Id,
+    It,
+    Ja,
+    Ko,
+    Lv,
+    Mul,
+    Nl,
+    No,
+    Pt,
+    Ro,
+    Ru,
+    Sv,
+    Th,
+    Tr,
+    ZhHans,
+    ZhHant,
+}
+
+impl Into<String> for AnalysisSchemeLanguage {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AnalysisSchemeLanguage {
+    fn into(self) -> &'static str {
+        match self {
+            AnalysisSchemeLanguage::Ar => "ar",
+            AnalysisSchemeLanguage::Bg => "bg",
+            AnalysisSchemeLanguage::Ca => "ca",
+            AnalysisSchemeLanguage::Cs => "cs",
+            AnalysisSchemeLanguage::Da => "da",
+            AnalysisSchemeLanguage::De => "de",
+            AnalysisSchemeLanguage::El => "el",
+            AnalysisSchemeLanguage::En => "en",
+            AnalysisSchemeLanguage::Es => "es",
+            AnalysisSchemeLanguage::Eu => "eu",
+            AnalysisSchemeLanguage::Fa => "fa",
+            AnalysisSchemeLanguage::Fi => "fi",
+            AnalysisSchemeLanguage::Fr => "fr",
+            AnalysisSchemeLanguage::Ga => "ga",
+            AnalysisSchemeLanguage::Gl => "gl",
+            AnalysisSchemeLanguage::He => "he",
+            AnalysisSchemeLanguage::Hi => "hi",
+            AnalysisSchemeLanguage::Hu => "hu",
+            AnalysisSchemeLanguage::Hy => "hy",
+            AnalysisSchemeLanguage::Id => "id",
+            AnalysisSchemeLanguage::It => "it",
+            AnalysisSchemeLanguage::Ja => "ja",
+            AnalysisSchemeLanguage::Ko => "ko",
+            AnalysisSchemeLanguage::Lv => "lv",
+            AnalysisSchemeLanguage::Mul => "mul",
+            AnalysisSchemeLanguage::Nl => "nl",
+            AnalysisSchemeLanguage::No => "no",
+            AnalysisSchemeLanguage::Pt => "pt",
+            AnalysisSchemeLanguage::Ro => "ro",
+            AnalysisSchemeLanguage::Ru => "ru",
+            AnalysisSchemeLanguage::Sv => "sv",
+            AnalysisSchemeLanguage::Th => "th",
+            AnalysisSchemeLanguage::Tr => "tr",
+            AnalysisSchemeLanguage::ZhHans => "zh-Hans",
+            AnalysisSchemeLanguage::ZhHant => "zh-Hant",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AnalysisSchemeLanguage {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ar" => Ok(AnalysisSchemeLanguage::Ar),
+            "bg" => Ok(AnalysisSchemeLanguage::Bg),
+            "ca" => Ok(AnalysisSchemeLanguage::Ca),
+            "cs" => Ok(AnalysisSchemeLanguage::Cs),
+            "da" => Ok(AnalysisSchemeLanguage::Da),
+            "de" => Ok(AnalysisSchemeLanguage::De),
+            "el" => Ok(AnalysisSchemeLanguage::El),
+            "en" => Ok(AnalysisSchemeLanguage::En),
+            "es" => Ok(AnalysisSchemeLanguage::Es),
+            "eu" => Ok(AnalysisSchemeLanguage::Eu),
+            "fa" => Ok(AnalysisSchemeLanguage::Fa),
+            "fi" => Ok(AnalysisSchemeLanguage::Fi),
+            "fr" => Ok(AnalysisSchemeLanguage::Fr),
+            "ga" => Ok(AnalysisSchemeLanguage::Ga),
+            "gl" => Ok(AnalysisSchemeLanguage::Gl),
+            "he" => Ok(AnalysisSchemeLanguage::He),
+            "hi" => Ok(AnalysisSchemeLanguage::Hi),
+            "hu" => Ok(AnalysisSchemeLanguage::Hu),
+            "hy" => Ok(AnalysisSchemeLanguage::Hy),
+            "id" => Ok(AnalysisSchemeLanguage::Id),
+            "it" => Ok(AnalysisSchemeLanguage::It),
+            "ja" => Ok(AnalysisSchemeLanguage::Ja),
+            "ko" => Ok(AnalysisSchemeLanguage::Ko),
+            "lv" => Ok(AnalysisSchemeLanguage::Lv),
+            "mul" => Ok(AnalysisSchemeLanguage::Mul),
+            "nl" => Ok(AnalysisSchemeLanguage::Nl),
+            "no" => Ok(AnalysisSchemeLanguage::No),
+            "pt" => Ok(AnalysisSchemeLanguage::Pt),
+            "ro" => Ok(AnalysisSchemeLanguage::Ro),
+            "ru" => Ok(AnalysisSchemeLanguage::Ru),
+            "sv" => Ok(AnalysisSchemeLanguage::Sv),
+            "th" => Ok(AnalysisSchemeLanguage::Th),
+            "tr" => Ok(AnalysisSchemeLanguage::Tr),
+            "zh-Hans" => Ok(AnalysisSchemeLanguage::ZhHans),
+            "zh-Hant" => Ok(AnalysisSchemeLanguage::ZhHant),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AnalysisSchemeLanguageDeserializer;
 impl AnalysisSchemeLanguageDeserializer {
     #[allow(unused_variables)]
@@ -497,7 +668,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3413,6 +3584,68 @@ impl IndexFieldStatusListDeserializer {
 
     }
 }
+#[doc="<p>The type of field. The valid options for a field depend on the field type. For more information about the supported field types, see <a href=\"http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-index-fields.html\" target=\"_blank\">Configuring Index Fields</a> in the <i>Amazon CloudSearch Developer Guide</i>.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IndexFieldType {
+    Date,
+    DateArray,
+    Double,
+    DoubleArray,
+    Int,
+    IntArray,
+    Latlon,
+    Literal,
+    LiteralArray,
+    Text,
+    TextArray,
+}
+
+impl Into<String> for IndexFieldType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IndexFieldType {
+    fn into(self) -> &'static str {
+        match self {
+            IndexFieldType::Date => "date",
+            IndexFieldType::DateArray => "date-array",
+            IndexFieldType::Double => "double",
+            IndexFieldType::DoubleArray => "double-array",
+            IndexFieldType::Int => "int",
+            IndexFieldType::IntArray => "int-array",
+            IndexFieldType::Latlon => "latlon",
+            IndexFieldType::Literal => "literal",
+            IndexFieldType::LiteralArray => "literal-array",
+            IndexFieldType::Text => "text",
+            IndexFieldType::TextArray => "text-array",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IndexFieldType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "date" => Ok(IndexFieldType::Date),
+            "date-array" => Ok(IndexFieldType::DateArray),
+            "double" => Ok(IndexFieldType::Double),
+            "double-array" => Ok(IndexFieldType::DoubleArray),
+            "int" => Ok(IndexFieldType::Int),
+            "int-array" => Ok(IndexFieldType::IntArray),
+            "latlon" => Ok(IndexFieldType::Latlon),
+            "literal" => Ok(IndexFieldType::Literal),
+            "literal-array" => Ok(IndexFieldType::LiteralArray),
+            "text" => Ok(IndexFieldType::Text),
+            "text-array" => Ok(IndexFieldType::TextArray),
+            _ => Err(()),
+        }
+    }
+}
+
 struct IndexFieldTypeDeserializer;
 impl IndexFieldTypeDeserializer {
     #[allow(unused_variables)]
@@ -4175,13 +4408,54 @@ impl MultiAZDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
 
     }
 }
+#[doc="<p>The state of processing a change to an option. One of:</p> <ul> <li>RequiresIndexDocuments: The option's latest value will not be deployed until <a>IndexDocuments</a> has been called and indexing is complete.</li> <li>Processing: The option's latest value is in the process of being activated.</li> <li>Active: The option's latest value is fully deployed. </li> <li>FailedToValidate: The option value is not compatible with the domain's data and cannot be used to index the data. You must either modify the option value or update or remove the incompatible documents.</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OptionState {
+    Active,
+    FailedToValidate,
+    Processing,
+    RequiresIndexDocuments,
+}
+
+impl Into<String> for OptionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OptionState {
+    fn into(self) -> &'static str {
+        match self {
+            OptionState::Active => "Active",
+            OptionState::FailedToValidate => "FailedToValidate",
+            OptionState::Processing => "Processing",
+            OptionState::RequiresIndexDocuments => "RequiresIndexDocuments",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OptionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(OptionState::Active),
+            "FailedToValidate" => Ok(OptionState::FailedToValidate),
+            "Processing" => Ok(OptionState::Processing),
+            "RequiresIndexDocuments" => Ok(OptionState::RequiresIndexDocuments),
+            _ => Err(()),
+        }
+    }
+}
+
 struct OptionStateDeserializer;
 impl OptionStateDeserializer {
     #[allow(unused_variables)]
@@ -4285,6 +4559,59 @@ impl PartitionCountDeserializer {
 
     }
 }
+#[doc="<p>The instance type (such as <code>search.m1.small</code>) on which an index partition is hosted.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PartitionInstanceType {
+    SearchM1Large,
+    SearchM1Small,
+    SearchM22Xlarge,
+    SearchM2Xlarge,
+    SearchM32Xlarge,
+    SearchM3Large,
+    SearchM3Medium,
+    SearchM3Xlarge,
+}
+
+impl Into<String> for PartitionInstanceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PartitionInstanceType {
+    fn into(self) -> &'static str {
+        match self {
+            PartitionInstanceType::SearchM1Large => "search.m1.large",
+            PartitionInstanceType::SearchM1Small => "search.m1.small",
+            PartitionInstanceType::SearchM22Xlarge => "search.m2.2xlarge",
+            PartitionInstanceType::SearchM2Xlarge => "search.m2.xlarge",
+            PartitionInstanceType::SearchM32Xlarge => "search.m3.2xlarge",
+            PartitionInstanceType::SearchM3Large => "search.m3.large",
+            PartitionInstanceType::SearchM3Medium => "search.m3.medium",
+            PartitionInstanceType::SearchM3Xlarge => "search.m3.xlarge",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PartitionInstanceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "search.m1.large" => Ok(PartitionInstanceType::SearchM1Large),
+            "search.m1.small" => Ok(PartitionInstanceType::SearchM1Small),
+            "search.m2.2xlarge" => Ok(PartitionInstanceType::SearchM22Xlarge),
+            "search.m2.xlarge" => Ok(PartitionInstanceType::SearchM2Xlarge),
+            "search.m3.2xlarge" => Ok(PartitionInstanceType::SearchM32Xlarge),
+            "search.m3.large" => Ok(PartitionInstanceType::SearchM3Large),
+            "search.m3.medium" => Ok(PartitionInstanceType::SearchM3Medium),
+            "search.m3.xlarge" => Ok(PartitionInstanceType::SearchM3Xlarge),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PartitionInstanceTypeDeserializer;
 impl PartitionInstanceTypeDeserializer {
     #[allow(unused_variables)]
@@ -4644,6 +4971,44 @@ impl SuggesterSerializer {
         params.put(&format!("{}{}", prefix, "SuggesterName"),
                    &obj.suggester_name.replace("+", "%2B"));
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SuggesterFuzzyMatching {
+    High,
+    Low,
+    None,
+}
+
+impl Into<String> for SuggesterFuzzyMatching {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SuggesterFuzzyMatching {
+    fn into(self) -> &'static str {
+        match self {
+            SuggesterFuzzyMatching::High => "high",
+            SuggesterFuzzyMatching::Low => "low",
+            SuggesterFuzzyMatching::None => "none",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SuggesterFuzzyMatching {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "high" => Ok(SuggesterFuzzyMatching::High),
+            "low" => Ok(SuggesterFuzzyMatching::Low),
+            "none" => Ok(SuggesterFuzzyMatching::None),
+            _ => Err(()),
+        }
     }
 }
 
@@ -7568,7 +7933,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -7615,7 +7980,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -7663,7 +8028,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -7711,7 +8076,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -7758,7 +8123,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -7805,7 +8170,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -7853,7 +8218,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -7901,7 +8266,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -7948,7 +8313,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -7995,7 +8360,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8042,7 +8407,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8090,7 +8455,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8140,7 +8505,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8187,7 +8552,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8234,7 +8599,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8281,7 +8646,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8329,7 +8694,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8377,7 +8742,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8424,7 +8789,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8471,7 +8836,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8516,7 +8881,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8564,7 +8929,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8612,7 +8977,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8662,7 +9027,7 @@ impl<P, D> CloudSearch for CloudSearchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/cloudsearchdomain/src/generated.rs
+++ b/rusoto/services/cloudsearchdomain/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -49,6 +45,41 @@ pub struct BucketInfo {
     #[serde(rename="buckets")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub buckets: Option<Vec<Bucket>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContentType {
+    ApplicationJson,
+    ApplicationXml,
+}
+
+impl Into<String> for ContentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContentType {
+    fn into(self) -> &'static str {
+        match self {
+            ContentType::ApplicationJson => "application/json",
+            ContentType::ApplicationXml => "application/xml",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "application/json" => Ok(ContentType::ApplicationJson),
+            "application/xml" => Ok(ContentType::ApplicationXml),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A warning returned by the document service when an issue is discovered while processing an upload request.</p>"]
@@ -137,6 +168,47 @@ pub struct Hits {
     #[serde(rename="start")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub start: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum QueryParser {
+    Dismax,
+    Lucene,
+    Simple,
+    Structured,
+}
+
+impl Into<String> for QueryParser {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for QueryParser {
+    fn into(self) -> &'static str {
+        match self {
+            QueryParser::Dismax => "dismax",
+            QueryParser::Lucene => "lucene",
+            QueryParser::Simple => "simple",
+            QueryParser::Structured => "structured",
+        }
+    }
+}
+
+impl ::std::str::FromStr for QueryParser {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dismax" => Ok(QueryParser::Dismax),
+            "lucene" => Ok(QueryParser::Lucene),
+            "simple" => Ok(QueryParser::Simple),
+            "structured" => Ok(QueryParser::Structured),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Container for the parameters to the <code>Search</code> request.</p>"]
@@ -674,7 +746,7 @@ impl<P, D> CloudSearchDomain for CloudSearchDomainClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -723,7 +795,7 @@ impl<P, D> CloudSearchDomain for CloudSearchDomainClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -770,7 +842,7 @@ impl<P, D> CloudSearchDomain for CloudSearchDomainClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -399,6 +395,53 @@ pub struct LookupAttribute {
     pub attribute_value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LookupAttributeKey {
+    EventId,
+    EventName,
+    EventSource,
+    ResourceName,
+    ResourceType,
+    Username,
+}
+
+impl Into<String> for LookupAttributeKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LookupAttributeKey {
+    fn into(self) -> &'static str {
+        match self {
+            LookupAttributeKey::EventId => "EventId",
+            LookupAttributeKey::EventName => "EventName",
+            LookupAttributeKey::EventSource => "EventSource",
+            LookupAttributeKey::ResourceName => "ResourceName",
+            LookupAttributeKey::ResourceType => "ResourceType",
+            LookupAttributeKey::Username => "Username",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LookupAttributeKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EventId" => Ok(LookupAttributeKey::EventId),
+            "EventName" => Ok(LookupAttributeKey::EventName),
+            "EventSource" => Ok(LookupAttributeKey::EventSource),
+            "ResourceName" => Ok(LookupAttributeKey::ResourceName),
+            "ResourceType" => Ok(LookupAttributeKey::ResourceType),
+            "Username" => Ok(LookupAttributeKey::Username),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains a request for LookupEvents.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct LookupEventsRequest {
@@ -482,6 +525,44 @@ pub struct PutEventSelectorsResponse {
     #[serde(rename="TrailARN")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub trail_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReadWriteType {
+    All,
+    ReadOnly,
+    WriteOnly,
+}
+
+impl Into<String> for ReadWriteType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReadWriteType {
+    fn into(self) -> &'static str {
+        match self {
+            ReadWriteType::All => "All",
+            ReadWriteType::ReadOnly => "ReadOnly",
+            ReadWriteType::WriteOnly => "WriteOnly",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReadWriteType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(ReadWriteType::All),
+            "ReadOnly" => Ok(ReadWriteType::ReadOnly),
+            "WriteOnly" => Ok(ReadWriteType::WriteOnly),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Specifies the tags to remove from a trail.</p>"]
@@ -2413,7 +2494,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddTagsResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -2445,7 +2526,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateTrailResponse>(String::from_utf8_lossy(&body)
@@ -2478,7 +2559,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteTrailResponse>(String::from_utf8_lossy(&body)
@@ -2511,7 +2592,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTrailsResponse>(String::from_utf8_lossy(&body)
@@ -2543,7 +2624,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetEventSelectorsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2574,7 +2655,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetTrailStatusResponse>(String::from_utf8_lossy(&body)
@@ -2607,7 +2688,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListPublicKeysResponse>(String::from_utf8_lossy(&body)
@@ -2638,7 +2719,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsResponse>(String::from_utf8_lossy(&body)
@@ -2671,7 +2752,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<LookupEventsResponse>(String::from_utf8_lossy(&body)
@@ -2703,7 +2784,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutEventSelectorsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2734,7 +2815,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveTagsResponse>(String::from_utf8_lossy(&body)
@@ -2767,7 +2848,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartLoggingResponse>(String::from_utf8_lossy(&body)
@@ -2800,7 +2881,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopLoggingResponse>(String::from_utf8_lossy(&body)
@@ -2833,7 +2914,7 @@ impl<P, D> CloudTrail for CloudTrailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateTrailResponse>(String::from_utf8_lossy(&body)

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -46,7 +42,7 @@ impl ActionsEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -220,6 +216,49 @@ impl AlarmNamesSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperator {
+    GreaterThanOrEqualToThreshold,
+    GreaterThanThreshold,
+    LessThanOrEqualToThreshold,
+    LessThanThreshold,
+}
+
+impl Into<String> for ComparisonOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperator::GreaterThanOrEqualToThreshold => "GreaterThanOrEqualToThreshold",
+            ComparisonOperator::GreaterThanThreshold => "GreaterThanThreshold",
+            ComparisonOperator::LessThanOrEqualToThreshold => "LessThanOrEqualToThreshold",
+            ComparisonOperator::LessThanThreshold => "LessThanThreshold",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GreaterThanOrEqualToThreshold" => {
+                Ok(ComparisonOperator::GreaterThanOrEqualToThreshold)
+            }
+            "GreaterThanThreshold" => Ok(ComparisonOperator::GreaterThanThreshold),
+            "LessThanOrEqualToThreshold" => Ok(ComparisonOperator::LessThanOrEqualToThreshold),
+            "LessThanThreshold" => Ok(ComparisonOperator::LessThanThreshold),
+            _ => Err(()),
         }
     }
 }
@@ -1595,6 +1634,44 @@ impl HistoryDataDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HistoryItemType {
+    Action,
+    ConfigurationUpdate,
+    StateUpdate,
+}
+
+impl Into<String> for HistoryItemType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HistoryItemType {
+    fn into(self) -> &'static str {
+        match self {
+            HistoryItemType::Action => "Action",
+            HistoryItemType::ConfigurationUpdate => "ConfigurationUpdate",
+            HistoryItemType::StateUpdate => "StateUpdate",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HistoryItemType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Action" => Ok(HistoryItemType::Action),
+            "ConfigurationUpdate" => Ok(HistoryItemType::ConfigurationUpdate),
+            "StateUpdate" => Ok(HistoryItemType::StateUpdate),
+            _ => Err(()),
+        }
+    }
+}
+
 struct HistoryItemTypeDeserializer;
 impl HistoryItemTypeDeserializer {
     #[allow(unused_variables)]
@@ -2658,6 +2735,116 @@ impl SizeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StandardUnit {
+    Bits,
+    BitsSecond,
+    Bytes,
+    BytesSecond,
+    Count,
+    CountSecond,
+    Gigabits,
+    GigabitsSecond,
+    Gigabytes,
+    GigabytesSecond,
+    Kilobits,
+    KilobitsSecond,
+    Kilobytes,
+    KilobytesSecond,
+    Megabits,
+    MegabitsSecond,
+    Megabytes,
+    MegabytesSecond,
+    Microseconds,
+    Milliseconds,
+    None,
+    Percent,
+    Seconds,
+    Terabits,
+    TerabitsSecond,
+    Terabytes,
+    TerabytesSecond,
+}
+
+impl Into<String> for StandardUnit {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StandardUnit {
+    fn into(self) -> &'static str {
+        match self {
+            StandardUnit::Bits => "Bits",
+            StandardUnit::BitsSecond => "Bits/Second",
+            StandardUnit::Bytes => "Bytes",
+            StandardUnit::BytesSecond => "Bytes/Second",
+            StandardUnit::Count => "Count",
+            StandardUnit::CountSecond => "Count/Second",
+            StandardUnit::Gigabits => "Gigabits",
+            StandardUnit::GigabitsSecond => "Gigabits/Second",
+            StandardUnit::Gigabytes => "Gigabytes",
+            StandardUnit::GigabytesSecond => "Gigabytes/Second",
+            StandardUnit::Kilobits => "Kilobits",
+            StandardUnit::KilobitsSecond => "Kilobits/Second",
+            StandardUnit::Kilobytes => "Kilobytes",
+            StandardUnit::KilobytesSecond => "Kilobytes/Second",
+            StandardUnit::Megabits => "Megabits",
+            StandardUnit::MegabitsSecond => "Megabits/Second",
+            StandardUnit::Megabytes => "Megabytes",
+            StandardUnit::MegabytesSecond => "Megabytes/Second",
+            StandardUnit::Microseconds => "Microseconds",
+            StandardUnit::Milliseconds => "Milliseconds",
+            StandardUnit::None => "None",
+            StandardUnit::Percent => "Percent",
+            StandardUnit::Seconds => "Seconds",
+            StandardUnit::Terabits => "Terabits",
+            StandardUnit::TerabitsSecond => "Terabits/Second",
+            StandardUnit::Terabytes => "Terabytes",
+            StandardUnit::TerabytesSecond => "Terabytes/Second",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StandardUnit {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Bits" => Ok(StandardUnit::Bits),
+            "Bits/Second" => Ok(StandardUnit::BitsSecond),
+            "Bytes" => Ok(StandardUnit::Bytes),
+            "Bytes/Second" => Ok(StandardUnit::BytesSecond),
+            "Count" => Ok(StandardUnit::Count),
+            "Count/Second" => Ok(StandardUnit::CountSecond),
+            "Gigabits" => Ok(StandardUnit::Gigabits),
+            "Gigabits/Second" => Ok(StandardUnit::GigabitsSecond),
+            "Gigabytes" => Ok(StandardUnit::Gigabytes),
+            "Gigabytes/Second" => Ok(StandardUnit::GigabytesSecond),
+            "Kilobits" => Ok(StandardUnit::Kilobits),
+            "Kilobits/Second" => Ok(StandardUnit::KilobitsSecond),
+            "Kilobytes" => Ok(StandardUnit::Kilobytes),
+            "Kilobytes/Second" => Ok(StandardUnit::KilobytesSecond),
+            "Megabits" => Ok(StandardUnit::Megabits),
+            "Megabits/Second" => Ok(StandardUnit::MegabitsSecond),
+            "Megabytes" => Ok(StandardUnit::Megabytes),
+            "Megabytes/Second" => Ok(StandardUnit::MegabytesSecond),
+            "Microseconds" => Ok(StandardUnit::Microseconds),
+            "Milliseconds" => Ok(StandardUnit::Milliseconds),
+            "None" => Ok(StandardUnit::None),
+            "Percent" => Ok(StandardUnit::Percent),
+            "Seconds" => Ok(StandardUnit::Seconds),
+            "Terabits" => Ok(StandardUnit::Terabits),
+            "Terabits/Second" => Ok(StandardUnit::TerabitsSecond),
+            "Terabytes" => Ok(StandardUnit::Terabytes),
+            "Terabytes/Second" => Ok(StandardUnit::TerabytesSecond),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StandardUnitDeserializer;
 impl StandardUnitDeserializer {
     #[allow(unused_variables)]
@@ -2700,6 +2887,44 @@ impl StateReasonDataDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StateValue {
+    Alarm,
+    InsufficientData,
+    Ok,
+}
+
+impl Into<String> for StateValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StateValue {
+    fn into(self) -> &'static str {
+        match self {
+            StateValue::Alarm => "ALARM",
+            StateValue::InsufficientData => "INSUFFICIENT_DATA",
+            StateValue::Ok => "OK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StateValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALARM" => Ok(StateValue::Alarm),
+            "INSUFFICIENT_DATA" => Ok(StateValue::InsufficientData),
+            "OK" => Ok(StateValue::Ok),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StateValueDeserializer;
 impl StateValueDeserializer {
     #[allow(unused_variables)]
@@ -2714,6 +2939,50 @@ impl StateValueDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Statistic {
+    Average,
+    Maximum,
+    Minimum,
+    SampleCount,
+    Sum,
+}
+
+impl Into<String> for Statistic {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Statistic {
+    fn into(self) -> &'static str {
+        match self {
+            Statistic::Average => "Average",
+            Statistic::Maximum => "Maximum",
+            Statistic::Minimum => "Minimum",
+            Statistic::SampleCount => "SampleCount",
+            Statistic::Sum => "Sum",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Statistic {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Average" => Ok(Statistic::Average),
+            "Maximum" => Ok(Statistic::Maximum),
+            "Minimum" => Ok(Statistic::Minimum),
+            "SampleCount" => Ok(Statistic::SampleCount),
+            "Sum" => Ok(Statistic::Sum),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StatisticDeserializer;
 impl StatisticDeserializer {
     #[allow(unused_variables)]
@@ -4082,7 +4351,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -4110,7 +4379,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4157,7 +4426,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4204,7 +4473,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4252,7 +4521,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4301,7 +4570,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -4329,7 +4598,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -4357,7 +4626,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4404,7 +4673,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4451,7 +4720,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4498,7 +4767,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4545,7 +4814,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4590,7 +4859,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -4616,7 +4885,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -4642,7 +4911,7 @@ impl<P, D> CloudWatch for CloudWatchClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -77,6 +73,44 @@ pub struct BranchInfo {
     #[serde(rename="commitId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub commit_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeTypeEnum {
+    A,
+    D,
+    M,
+}
+
+impl Into<String> for ChangeTypeEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeTypeEnum {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeTypeEnum::A => "A",
+            ChangeTypeEnum::D => "D",
+            ChangeTypeEnum::M => "M",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeTypeEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "A" => Ok(ChangeTypeEnum::A),
+            "D" => Ok(ChangeTypeEnum::D),
+            "M" => Ok(ChangeTypeEnum::M),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Returns information about a specific commit.</p>"]
@@ -377,6 +411,41 @@ pub struct ListRepositoriesOutput {
     pub repositories: Option<Vec<RepositoryNameIdPair>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OrderEnum {
+    Ascending,
+    Descending,
+}
+
+impl Into<String> for OrderEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OrderEnum {
+    fn into(self) -> &'static str {
+        match self {
+            OrderEnum::Ascending => "ascending",
+            OrderEnum::Descending => "descending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OrderEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ascending" => Ok(OrderEnum::Ascending),
+            "descending" => Ok(OrderEnum::Descending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input ofa put repository triggers operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutRepositoryTriggersInput {
@@ -477,6 +546,47 @@ pub struct RepositoryTrigger {
     pub name: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RepositoryTriggerEventEnum {
+    All,
+    CreateReference,
+    DeleteReference,
+    UpdateReference,
+}
+
+impl Into<String> for RepositoryTriggerEventEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RepositoryTriggerEventEnum {
+    fn into(self) -> &'static str {
+        match self {
+            RepositoryTriggerEventEnum::All => "all",
+            RepositoryTriggerEventEnum::CreateReference => "createReference",
+            RepositoryTriggerEventEnum::DeleteReference => "deleteReference",
+            RepositoryTriggerEventEnum::UpdateReference => "updateReference",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RepositoryTriggerEventEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(RepositoryTriggerEventEnum::All),
+            "createReference" => Ok(RepositoryTriggerEventEnum::CreateReference),
+            "deleteReference" => Ok(RepositoryTriggerEventEnum::DeleteReference),
+            "updateReference" => Ok(RepositoryTriggerEventEnum::UpdateReference),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A trigger failed to run.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RepositoryTriggerExecutionFailure {
@@ -488,6 +598,41 @@ pub struct RepositoryTriggerExecutionFailure {
     #[serde(rename="trigger")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub trigger: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SortByEnum {
+    LastModifiedDate,
+    RepositoryName,
+}
+
+impl Into<String> for SortByEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SortByEnum {
+    fn into(self) -> &'static str {
+        match self {
+            SortByEnum::LastModifiedDate => "lastModifiedDate",
+            SortByEnum::RepositoryName => "repositoryName",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SortByEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "lastModifiedDate" => Ok(SortByEnum::LastModifiedDate),
+            "repositoryName" => Ok(SortByEnum::RepositoryName),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a test repository triggers operation.</p>"]
@@ -2889,7 +3034,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchGetRepositoriesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2917,7 +3062,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2943,7 +3088,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateRepositoryOutput>(String::from_utf8_lossy(&body)
@@ -2975,7 +3120,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteRepositoryOutput>(String::from_utf8_lossy(&body)
@@ -3005,7 +3150,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetBlobOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -3034,7 +3179,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetBranchOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -3063,7 +3208,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetCommitOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -3094,7 +3239,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDifferencesOutput>(String::from_utf8_lossy(&body)
@@ -3126,7 +3271,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRepositoryOutput>(String::from_utf8_lossy(&body)
@@ -3159,7 +3304,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRepositoryTriggersOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3189,7 +3334,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListBranchesOutput>(String::from_utf8_lossy(&body)
@@ -3221,7 +3366,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRepositoriesOutput>(String::from_utf8_lossy(&body)
@@ -3254,7 +3399,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutRepositoryTriggersOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3285,7 +3430,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<TestRepositoryTriggersOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3315,7 +3460,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3342,7 +3487,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3369,7 +3514,7 @@ impl<P, D> CodeCommit for CodeCommitClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -90,6 +86,44 @@ pub struct ApplicationInfo {
     pub linked_to_git_hub: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ApplicationRevisionSortBy {
+    FirstUsedTime,
+    LastUsedTime,
+    RegisterTime,
+}
+
+impl Into<String> for ApplicationRevisionSortBy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ApplicationRevisionSortBy {
+    fn into(self) -> &'static str {
+        match self {
+            ApplicationRevisionSortBy::FirstUsedTime => "firstUsedTime",
+            ApplicationRevisionSortBy::LastUsedTime => "lastUsedTime",
+            ApplicationRevisionSortBy::RegisterTime => "registerTime",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ApplicationRevisionSortBy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "firstUsedTime" => Ok(ApplicationRevisionSortBy::FirstUsedTime),
+            "lastUsedTime" => Ok(ApplicationRevisionSortBy::LastUsedTime),
+            "registerTime" => Ok(ApplicationRevisionSortBy::RegisterTime),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about a configuration for automatically rolling back to a previous version of an application revision when a deployment doesn't complete successfully.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoRollbackConfiguration {
@@ -101,6 +135,44 @@ pub struct AutoRollbackConfiguration {
     #[serde(rename="events")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<String>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoRollbackEvent {
+    DeploymentFailure,
+    DeploymentStopOnAlarm,
+    DeploymentStopOnRequest,
+}
+
+impl Into<String> for AutoRollbackEvent {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoRollbackEvent {
+    fn into(self) -> &'static str {
+        match self {
+            AutoRollbackEvent::DeploymentFailure => "DEPLOYMENT_FAILURE",
+            AutoRollbackEvent::DeploymentStopOnAlarm => "DEPLOYMENT_STOP_ON_ALARM",
+            AutoRollbackEvent::DeploymentStopOnRequest => "DEPLOYMENT_STOP_ON_REQUEST",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoRollbackEvent {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEPLOYMENT_FAILURE" => Ok(AutoRollbackEvent::DeploymentFailure),
+            "DEPLOYMENT_STOP_ON_ALARM" => Ok(AutoRollbackEvent::DeploymentStopOnAlarm),
+            "DEPLOYMENT_STOP_ON_REQUEST" => Ok(AutoRollbackEvent::DeploymentStopOnRequest),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about an Auto Scaling group.</p>"]
@@ -274,6 +346,44 @@ pub struct BlueInstanceTerminationOption {
     #[serde(rename="terminationWaitTimeInMinutes")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub termination_wait_time_in_minutes: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BundleType {
+    Tar,
+    Tgz,
+    Zip,
+}
+
+impl Into<String> for BundleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BundleType {
+    fn into(self) -> &'static str {
+        match self {
+            BundleType::Tar => "tar",
+            BundleType::Tgz => "tgz",
+            BundleType::Zip => "zip",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BundleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "tar" => Ok(BundleType::Tar),
+            "tgz" => Ok(BundleType::Tgz),
+            "zip" => Ok(BundleType::Zip),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -502,6 +612,44 @@ pub struct DeploymentConfigInfo {
     pub minimum_healthy_hosts: Option<MinimumHealthyHosts>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentCreator {
+    Autoscaling,
+    CodeDeployRollback,
+    User,
+}
+
+impl Into<String> for DeploymentCreator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentCreator {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentCreator::Autoscaling => "autoscaling",
+            DeploymentCreator::CodeDeployRollback => "codeDeployRollback",
+            DeploymentCreator::User => "user",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentCreator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "autoscaling" => Ok(DeploymentCreator::Autoscaling),
+            "codeDeployRollback" => Ok(DeploymentCreator::CodeDeployRollback),
+            "user" => Ok(DeploymentCreator::User),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about a deployment group.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DeploymentGroupInfo {
@@ -688,6 +836,41 @@ pub struct DeploymentInfo {
     pub update_outdated_instances_only: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentOption {
+    WithoutTrafficControl,
+    WithTrafficControl,
+}
+
+impl Into<String> for DeploymentOption {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentOption {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentOption::WithoutTrafficControl => "WITHOUT_TRAFFIC_CONTROL",
+            DeploymentOption::WithTrafficControl => "WITH_TRAFFIC_CONTROL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentOption {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "WITHOUT_TRAFFIC_CONTROL" => Ok(DeploymentOption::WithoutTrafficControl),
+            "WITH_TRAFFIC_CONTROL" => Ok(DeploymentOption::WithTrafficControl),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the deployment status of the instances in the deployment.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DeploymentOverview {
@@ -717,6 +900,41 @@ pub struct DeploymentOverview {
     pub succeeded: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentReadyAction {
+    ContinueDeployment,
+    StopDeployment,
+}
+
+impl Into<String> for DeploymentReadyAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentReadyAction {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentReadyAction::ContinueDeployment => "CONTINUE_DEPLOYMENT",
+            DeploymentReadyAction::StopDeployment => "STOP_DEPLOYMENT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentReadyAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONTINUE_DEPLOYMENT" => Ok(DeploymentReadyAction::ContinueDeployment),
+            "STOP_DEPLOYMENT" => Ok(DeploymentReadyAction::StopDeployment),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about how traffic is rerouted to instances in a replacement environment in a blue/green deployment.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeploymentReadyOption {
@@ -730,6 +948,56 @@ pub struct DeploymentReadyOption {
     pub wait_time_in_minutes: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentStatus {
+    Created,
+    Failed,
+    InProgress,
+    Queued,
+    Ready,
+    Stopped,
+    Succeeded,
+}
+
+impl Into<String> for DeploymentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentStatus::Created => "Created",
+            DeploymentStatus::Failed => "Failed",
+            DeploymentStatus::InProgress => "InProgress",
+            DeploymentStatus::Queued => "Queued",
+            DeploymentStatus::Ready => "Ready",
+            DeploymentStatus::Stopped => "Stopped",
+            DeploymentStatus::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Created" => Ok(DeploymentStatus::Created),
+            "Failed" => Ok(DeploymentStatus::Failed),
+            "InProgress" => Ok(DeploymentStatus::InProgress),
+            "Queued" => Ok(DeploymentStatus::Queued),
+            "Ready" => Ok(DeploymentStatus::Ready),
+            "Stopped" => Ok(DeploymentStatus::Stopped),
+            "Succeeded" => Ok(DeploymentStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the type of deployment, either in-place or blue/green, you want to run and whether to route deployment traffic behind a load balancer.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeploymentStyle {
@@ -741,6 +1009,41 @@ pub struct DeploymentStyle {
     #[serde(rename="deploymentType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub deployment_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentType {
+    BlueGreen,
+    InPlace,
+}
+
+impl Into<String> for DeploymentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentType {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentType::BlueGreen => "BLUE_GREEN",
+            DeploymentType::InPlace => "IN_PLACE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BLUE_GREEN" => Ok(DeploymentType::BlueGreen),
+            "IN_PLACE" => Ok(DeploymentType::InPlace),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a DeregisterOnPremisesInstance operation.</p>"]
@@ -789,6 +1092,44 @@ pub struct EC2TagFilter {
     pub value: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EC2TagFilterType {
+    KeyAndValue,
+    KeyOnly,
+    ValueOnly,
+}
+
+impl Into<String> for EC2TagFilterType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EC2TagFilterType {
+    fn into(self) -> &'static str {
+        match self {
+            EC2TagFilterType::KeyAndValue => "KEY_AND_VALUE",
+            EC2TagFilterType::KeyOnly => "KEY_ONLY",
+            EC2TagFilterType::ValueOnly => "VALUE_ONLY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EC2TagFilterType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KEY_AND_VALUE" => Ok(EC2TagFilterType::KeyAndValue),
+            "KEY_ONLY" => Ok(EC2TagFilterType::KeyOnly),
+            "VALUE_ONLY" => Ok(EC2TagFilterType::ValueOnly),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about groups of EC2 instance tags.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EC2TagSet {
@@ -807,6 +1148,89 @@ pub struct ELBInfo {
     pub name: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ErrorCode {
+    AgentIssue,
+    AlarmActive,
+    ApplicationMissing,
+    AutoScalingConfiguration,
+    AutoScalingIamRolePermissions,
+    DeploymentGroupMissing,
+    HealthConstraints,
+    HealthConstraintsInvalid,
+    IamRoleMissing,
+    IamRolePermissions,
+    InternalError,
+    ManualStop,
+    NoEc2Subscription,
+    NoInstances,
+    OverMaxInstances,
+    RevisionMissing,
+    Throttled,
+    Timeout,
+}
+
+impl Into<String> for ErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            ErrorCode::AgentIssue => "AGENT_ISSUE",
+            ErrorCode::AlarmActive => "ALARM_ACTIVE",
+            ErrorCode::ApplicationMissing => "APPLICATION_MISSING",
+            ErrorCode::AutoScalingConfiguration => "AUTO_SCALING_CONFIGURATION",
+            ErrorCode::AutoScalingIamRolePermissions => "AUTO_SCALING_IAM_ROLE_PERMISSIONS",
+            ErrorCode::DeploymentGroupMissing => "DEPLOYMENT_GROUP_MISSING",
+            ErrorCode::HealthConstraints => "HEALTH_CONSTRAINTS",
+            ErrorCode::HealthConstraintsInvalid => "HEALTH_CONSTRAINTS_INVALID",
+            ErrorCode::IamRoleMissing => "IAM_ROLE_MISSING",
+            ErrorCode::IamRolePermissions => "IAM_ROLE_PERMISSIONS",
+            ErrorCode::InternalError => "INTERNAL_ERROR",
+            ErrorCode::ManualStop => "MANUAL_STOP",
+            ErrorCode::NoEc2Subscription => "NO_EC2_SUBSCRIPTION",
+            ErrorCode::NoInstances => "NO_INSTANCES",
+            ErrorCode::OverMaxInstances => "OVER_MAX_INSTANCES",
+            ErrorCode::RevisionMissing => "REVISION_MISSING",
+            ErrorCode::Throttled => "THROTTLED",
+            ErrorCode::Timeout => "TIMEOUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AGENT_ISSUE" => Ok(ErrorCode::AgentIssue),
+            "ALARM_ACTIVE" => Ok(ErrorCode::AlarmActive),
+            "APPLICATION_MISSING" => Ok(ErrorCode::ApplicationMissing),
+            "AUTO_SCALING_CONFIGURATION" => Ok(ErrorCode::AutoScalingConfiguration),
+            "AUTO_SCALING_IAM_ROLE_PERMISSIONS" => Ok(ErrorCode::AutoScalingIamRolePermissions),
+            "DEPLOYMENT_GROUP_MISSING" => Ok(ErrorCode::DeploymentGroupMissing),
+            "HEALTH_CONSTRAINTS" => Ok(ErrorCode::HealthConstraints),
+            "HEALTH_CONSTRAINTS_INVALID" => Ok(ErrorCode::HealthConstraintsInvalid),
+            "IAM_ROLE_MISSING" => Ok(ErrorCode::IamRoleMissing),
+            "IAM_ROLE_PERMISSIONS" => Ok(ErrorCode::IamRolePermissions),
+            "INTERNAL_ERROR" => Ok(ErrorCode::InternalError),
+            "MANUAL_STOP" => Ok(ErrorCode::ManualStop),
+            "NO_EC2_SUBSCRIPTION" => Ok(ErrorCode::NoEc2Subscription),
+            "NO_INSTANCES" => Ok(ErrorCode::NoInstances),
+            "OVER_MAX_INSTANCES" => Ok(ErrorCode::OverMaxInstances),
+            "REVISION_MISSING" => Ok(ErrorCode::RevisionMissing),
+            "THROTTLED" => Ok(ErrorCode::Throttled),
+            "TIMEOUT" => Ok(ErrorCode::Timeout),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about a deployment error.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ErrorInformation {
@@ -818,6 +1242,44 @@ pub struct ErrorInformation {
     #[serde(rename="message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FileExistsBehavior {
+    Disallow,
+    Overwrite,
+    Retain,
+}
+
+impl Into<String> for FileExistsBehavior {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FileExistsBehavior {
+    fn into(self) -> &'static str {
+        match self {
+            FileExistsBehavior::Disallow => "DISALLOW",
+            FileExistsBehavior::Overwrite => "OVERWRITE",
+            FileExistsBehavior::Retain => "RETAIN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FileExistsBehavior {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISALLOW" => Ok(FileExistsBehavior::Disallow),
+            "OVERWRITE" => Ok(FileExistsBehavior::Overwrite),
+            "RETAIN" => Ok(FileExistsBehavior::Retain),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about an application revision.</p>"]
@@ -994,6 +1456,41 @@ pub struct GitHubLocation {
     pub repository: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GreenFleetProvisioningAction {
+    CopyAutoScalingGroup,
+    DiscoverExisting,
+}
+
+impl Into<String> for GreenFleetProvisioningAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GreenFleetProvisioningAction {
+    fn into(self) -> &'static str {
+        match self {
+            GreenFleetProvisioningAction::CopyAutoScalingGroup => "COPY_AUTO_SCALING_GROUP",
+            GreenFleetProvisioningAction::DiscoverExisting => "DISCOVER_EXISTING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GreenFleetProvisioningAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COPY_AUTO_SCALING_GROUP" => Ok(GreenFleetProvisioningAction::CopyAutoScalingGroup),
+            "DISCOVER_EXISTING" => Ok(GreenFleetProvisioningAction::DiscoverExisting),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the instances that belong to the replacement environment in a blue/green deployment.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GreenFleetProvisioningOption {
@@ -1001,6 +1498,41 @@ pub struct GreenFleetProvisioningOption {
     #[serde(rename="action")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub action: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceAction {
+    KeepAlive,
+    Terminate,
+}
+
+impl Into<String> for InstanceAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceAction {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceAction::KeepAlive => "KEEP_ALIVE",
+            InstanceAction::Terminate => "TERMINATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KEEP_ALIVE" => Ok(InstanceAction::KeepAlive),
+            "TERMINATE" => Ok(InstanceAction::Terminate),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about an on-premises instance.</p>"]
@@ -1036,6 +1568,56 @@ pub struct InstanceInfo {
     pub tags: Option<Vec<Tag>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceStatus {
+    Failed,
+    InProgress,
+    Pending,
+    Ready,
+    Skipped,
+    Succeeded,
+    Unknown,
+}
+
+impl Into<String> for InstanceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceStatus::Failed => "Failed",
+            InstanceStatus::InProgress => "InProgress",
+            InstanceStatus::Pending => "Pending",
+            InstanceStatus::Ready => "Ready",
+            InstanceStatus::Skipped => "Skipped",
+            InstanceStatus::Succeeded => "Succeeded",
+            InstanceStatus::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(InstanceStatus::Failed),
+            "InProgress" => Ok(InstanceStatus::InProgress),
+            "Pending" => Ok(InstanceStatus::Pending),
+            "Ready" => Ok(InstanceStatus::Ready),
+            "Skipped" => Ok(InstanceStatus::Skipped),
+            "Succeeded" => Ok(InstanceStatus::Succeeded),
+            "Unknown" => Ok(InstanceStatus::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about an instance in a deployment.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceSummary {
@@ -1065,6 +1647,41 @@ pub struct InstanceSummary {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceType {
+    Blue,
+    Green,
+}
+
+impl Into<String> for InstanceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceType::Blue => "Blue",
+            InstanceType::Green => "Green",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Blue" => Ok(InstanceType::Blue),
+            "Green" => Ok(InstanceType::Green),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the most recent attempted or successful deployment to a deployment group.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct LastDeploymentInfo {
@@ -1084,6 +1701,53 @@ pub struct LastDeploymentInfo {
     #[serde(rename="status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LifecycleErrorCode {
+    ScriptFailed,
+    ScriptMissing,
+    ScriptNotExecutable,
+    ScriptTimedOut,
+    Success,
+    UnknownError,
+}
+
+impl Into<String> for LifecycleErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LifecycleErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            LifecycleErrorCode::ScriptFailed => "ScriptFailed",
+            LifecycleErrorCode::ScriptMissing => "ScriptMissing",
+            LifecycleErrorCode::ScriptNotExecutable => "ScriptNotExecutable",
+            LifecycleErrorCode::ScriptTimedOut => "ScriptTimedOut",
+            LifecycleErrorCode::Success => "Success",
+            LifecycleErrorCode::UnknownError => "UnknownError",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LifecycleErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ScriptFailed" => Ok(LifecycleErrorCode::ScriptFailed),
+            "ScriptMissing" => Ok(LifecycleErrorCode::ScriptMissing),
+            "ScriptNotExecutable" => Ok(LifecycleErrorCode::ScriptNotExecutable),
+            "ScriptTimedOut" => Ok(LifecycleErrorCode::ScriptTimedOut),
+            "Success" => Ok(LifecycleErrorCode::Success),
+            "UnknownError" => Ok(LifecycleErrorCode::UnknownError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about a deployment lifecycle event.</p>"]
@@ -1109,6 +1773,53 @@ pub struct LifecycleEvent {
     #[serde(rename="status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LifecycleEventStatus {
+    Failed,
+    InProgress,
+    Pending,
+    Skipped,
+    Succeeded,
+    Unknown,
+}
+
+impl Into<String> for LifecycleEventStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LifecycleEventStatus {
+    fn into(self) -> &'static str {
+        match self {
+            LifecycleEventStatus::Failed => "Failed",
+            LifecycleEventStatus::InProgress => "InProgress",
+            LifecycleEventStatus::Pending => "Pending",
+            LifecycleEventStatus::Skipped => "Skipped",
+            LifecycleEventStatus::Succeeded => "Succeeded",
+            LifecycleEventStatus::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LifecycleEventStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(LifecycleEventStatus::Failed),
+            "InProgress" => Ok(LifecycleEventStatus::InProgress),
+            "Pending" => Ok(LifecycleEventStatus::Pending),
+            "Skipped" => Ok(LifecycleEventStatus::Skipped),
+            "Succeeded" => Ok(LifecycleEventStatus::Succeeded),
+            "Unknown" => Ok(LifecycleEventStatus::Unknown),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a ListApplicationRevisions operation.</p>"]
@@ -1352,6 +2063,44 @@ pub struct ListOnPremisesInstancesOutput {
     pub next_token: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ListStateFilterAction {
+    Exclude,
+    Ignore,
+    Include,
+}
+
+impl Into<String> for ListStateFilterAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ListStateFilterAction {
+    fn into(self) -> &'static str {
+        match self {
+            ListStateFilterAction::Exclude => "exclude",
+            ListStateFilterAction::Ignore => "ignore",
+            ListStateFilterAction::Include => "include",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ListStateFilterAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "exclude" => Ok(ListStateFilterAction::Exclude),
+            "ignore" => Ok(ListStateFilterAction::Ignore),
+            "include" => Ok(ListStateFilterAction::Include),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the Elastic Load Balancing load balancer or target group used in a deployment.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBalancerInfo {
@@ -1376,6 +2125,41 @@ pub struct MinimumHealthyHosts {
     #[serde(rename="value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MinimumHealthyHostsType {
+    FleetPercent,
+    HostCount,
+}
+
+impl Into<String> for MinimumHealthyHostsType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MinimumHealthyHostsType {
+    fn into(self) -> &'static str {
+        match self {
+            MinimumHealthyHostsType::FleetPercent => "FLEET_PERCENT",
+            MinimumHealthyHostsType::HostCount => "HOST_COUNT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MinimumHealthyHostsType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FLEET_PERCENT" => Ok(MinimumHealthyHostsType::FleetPercent),
+            "HOST_COUNT" => Ok(MinimumHealthyHostsType::HostCount),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about groups of on-premises instance tags.</p>"]
@@ -1418,6 +2202,41 @@ pub struct RegisterOnPremisesInstanceInput {
     pub instance_name: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RegistrationStatus {
+    Deregistered,
+    Registered,
+}
+
+impl Into<String> for RegistrationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RegistrationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RegistrationStatus::Deregistered => "Deregistered",
+            RegistrationStatus::Registered => "Registered",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RegistrationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Deregistered" => Ok(RegistrationStatus::Deregistered),
+            "Registered" => Ok(RegistrationStatus::Registered),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input of a RemoveTagsFromOnPremisesInstances operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct RemoveTagsFromOnPremisesInstancesInput {
@@ -1457,6 +2276,41 @@ pub struct RevisionLocation {
     #[serde(rename="s3Location")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub s_3_location: Option<S3Location>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RevisionLocationType {
+    GitHub,
+    S3,
+}
+
+impl Into<String> for RevisionLocationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RevisionLocationType {
+    fn into(self) -> &'static str {
+        match self {
+            RevisionLocationType::GitHub => "GitHub",
+            RevisionLocationType::S3 => "S3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RevisionLocationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GitHub" => Ok(RevisionLocationType::GitHub),
+            "S3" => Ok(RevisionLocationType::S3),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about a deployment rollback.</p>"]
@@ -1509,6 +2363,41 @@ pub struct SkipWaitTimeForInstanceTerminationInput {
     pub deployment_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SortOrder {
+    Ascending,
+    Descending,
+}
+
+impl Into<String> for SortOrder {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SortOrder {
+    fn into(self) -> &'static str {
+        match self {
+            SortOrder::Ascending => "ascending",
+            SortOrder::Descending => "descending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SortOrder {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ascending" => Ok(SortOrder::Ascending),
+            "descending" => Ok(SortOrder::Descending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input of a StopDeployment operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StopDeploymentInput {
@@ -1532,6 +2421,41 @@ pub struct StopDeploymentOutput {
     #[serde(rename="statusMessage")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StopStatus {
+    Pending,
+    Succeeded,
+}
+
+impl Into<String> for StopStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StopStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StopStatus::Pending => "Pending",
+            StopStatus::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StopStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Pending" => Ok(StopStatus::Pending),
+            "Succeeded" => Ok(StopStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about a tag.</p>"]
@@ -1562,6 +2486,44 @@ pub struct TagFilter {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TagFilterType {
+    KeyAndValue,
+    KeyOnly,
+    ValueOnly,
+}
+
+impl Into<String> for TagFilterType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TagFilterType {
+    fn into(self) -> &'static str {
+        match self {
+            TagFilterType::KeyAndValue => "KEY_AND_VALUE",
+            TagFilterType::KeyOnly => "KEY_ONLY",
+            TagFilterType::ValueOnly => "VALUE_ONLY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TagFilterType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KEY_AND_VALUE" => Ok(TagFilterType::KeyAndValue),
+            "KEY_ONLY" => Ok(TagFilterType::KeyOnly),
+            "VALUE_ONLY" => Ok(TagFilterType::ValueOnly),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about a target group in Elastic Load Balancing to use in a deployment. Instances are registered as targets in a target group, and traffic is routed to the target group.</p>"]
@@ -1618,6 +2580,65 @@ pub struct TriggerConfig {
     #[serde(rename="triggerTargetArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub trigger_target_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TriggerEventType {
+    DeploymentFailure,
+    DeploymentReady,
+    DeploymentRollback,
+    DeploymentStart,
+    DeploymentStop,
+    DeploymentSuccess,
+    InstanceFailure,
+    InstanceReady,
+    InstanceStart,
+    InstanceSuccess,
+}
+
+impl Into<String> for TriggerEventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TriggerEventType {
+    fn into(self) -> &'static str {
+        match self {
+            TriggerEventType::DeploymentFailure => "DeploymentFailure",
+            TriggerEventType::DeploymentReady => "DeploymentReady",
+            TriggerEventType::DeploymentRollback => "DeploymentRollback",
+            TriggerEventType::DeploymentStart => "DeploymentStart",
+            TriggerEventType::DeploymentStop => "DeploymentStop",
+            TriggerEventType::DeploymentSuccess => "DeploymentSuccess",
+            TriggerEventType::InstanceFailure => "InstanceFailure",
+            TriggerEventType::InstanceReady => "InstanceReady",
+            TriggerEventType::InstanceStart => "InstanceStart",
+            TriggerEventType::InstanceSuccess => "InstanceSuccess",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TriggerEventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DeploymentFailure" => Ok(TriggerEventType::DeploymentFailure),
+            "DeploymentReady" => Ok(TriggerEventType::DeploymentReady),
+            "DeploymentRollback" => Ok(TriggerEventType::DeploymentRollback),
+            "DeploymentStart" => Ok(TriggerEventType::DeploymentStart),
+            "DeploymentStop" => Ok(TriggerEventType::DeploymentStop),
+            "DeploymentSuccess" => Ok(TriggerEventType::DeploymentSuccess),
+            "InstanceFailure" => Ok(TriggerEventType::InstanceFailure),
+            "InstanceReady" => Ok(TriggerEventType::InstanceReady),
+            "InstanceStart" => Ok(TriggerEventType::InstanceStart),
+            "InstanceSuccess" => Ok(TriggerEventType::InstanceSuccess),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of an UpdateApplication operation.</p>"]
@@ -5920,7 +6941,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5949,7 +6970,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchGetApplicationRevisionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5980,7 +7001,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchGetApplicationsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6012,7 +7033,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchGetDeploymentGroupsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6045,7 +7066,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchGetDeploymentInstancesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6076,7 +7097,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchGetDeploymentsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6108,7 +7129,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchGetOnPremisesInstancesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6139,7 +7160,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6165,7 +7186,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateApplicationOutput>(String::from_utf8_lossy(&body)
@@ -6197,7 +7218,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDeploymentOutput>(String::from_utf8_lossy(&body)
@@ -6230,7 +7251,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDeploymentConfigOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6261,7 +7282,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDeploymentGroupOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6291,7 +7312,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6317,7 +7338,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6344,7 +7365,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteDeploymentGroupOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6375,7 +7396,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6402,7 +7423,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetApplicationOutput>(String::from_utf8_lossy(&body)
@@ -6435,7 +7456,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetApplicationRevisionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6465,7 +7486,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDeploymentOutput>(String::from_utf8_lossy(&body)
@@ -6497,7 +7518,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDeploymentConfigOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6527,7 +7548,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDeploymentGroupOutput>(String::from_utf8_lossy(&body)
@@ -6560,7 +7581,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDeploymentInstanceOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6591,7 +7612,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetOnPremisesInstanceOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6623,7 +7644,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListApplicationRevisionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6654,7 +7675,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListApplicationsOutput>(String::from_utf8_lossy(&body)
@@ -6687,7 +7708,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListDeploymentConfigsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6717,7 +7738,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListDeploymentGroupsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6749,7 +7770,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListDeploymentInstancesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6780,7 +7801,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListDeploymentsOutput>(String::from_utf8_lossy(&body)
@@ -6814,7 +7835,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListGitHubAccountTokenNamesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6847,7 +7868,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListOnPremisesInstancesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6879,7 +7900,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6907,7 +7928,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6936,7 +7957,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6964,7 +7985,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6990,7 +8011,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopDeploymentOutput>(String::from_utf8_lossy(&body)
@@ -7022,7 +8043,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7049,7 +8070,7 @@ impl<P, D> CodeDeploy for CodeDeployClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDeploymentGroupOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -85,6 +81,53 @@ pub struct AcknowledgeThirdPartyJobOutput {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionCategory {
+    Approval,
+    Build,
+    Deploy,
+    Invoke,
+    Source,
+    Test,
+}
+
+impl Into<String> for ActionCategory {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionCategory {
+    fn into(self) -> &'static str {
+        match self {
+            ActionCategory::Approval => "Approval",
+            ActionCategory::Build => "Build",
+            ActionCategory::Deploy => "Deploy",
+            ActionCategory::Invoke => "Invoke",
+            ActionCategory::Source => "Source",
+            ActionCategory::Test => "Test",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionCategory {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Approval" => Ok(ActionCategory::Approval),
+            "Build" => Ok(ActionCategory::Build),
+            "Deploy" => Ok(ActionCategory::Deploy),
+            "Invoke" => Ok(ActionCategory::Invoke),
+            "Source" => Ok(ActionCategory::Source),
+            "Test" => Ok(ActionCategory::Test),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about an action configuration.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ActionConfiguration {
@@ -121,6 +164,44 @@ pub struct ActionConfigurationProperty {
     #[serde(rename="type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionConfigurationPropertyType {
+    Boolean,
+    Number,
+    String,
+}
+
+impl Into<String> for ActionConfigurationPropertyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionConfigurationPropertyType {
+    fn into(self) -> &'static str {
+        match self {
+            ActionConfigurationPropertyType::Boolean => "Boolean",
+            ActionConfigurationPropertyType::Number => "Number",
+            ActionConfigurationPropertyType::String => "String",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionConfigurationPropertyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Boolean" => Ok(ActionConfigurationPropertyType::Boolean),
+            "Number" => Ok(ActionConfigurationPropertyType::Number),
+            "String" => Ok(ActionConfigurationPropertyType::String),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the context of an action within the stage of a pipeline to a job worker.</p>"]
@@ -202,6 +283,82 @@ pub struct ActionExecution {
     #[serde(rename="token")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub token: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionExecutionStatus {
+    Failed,
+    InProgress,
+    Succeeded,
+}
+
+impl Into<String> for ActionExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ActionExecutionStatus::Failed => "Failed",
+            ActionExecutionStatus::InProgress => "InProgress",
+            ActionExecutionStatus::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(ActionExecutionStatus::Failed),
+            "InProgress" => Ok(ActionExecutionStatus::InProgress),
+            "Succeeded" => Ok(ActionExecutionStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionOwner {
+    Aws,
+    Custom,
+    ThirdParty,
+}
+
+impl Into<String> for ActionOwner {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionOwner {
+    fn into(self) -> &'static str {
+        match self {
+            ActionOwner::Aws => "AWS",
+            ActionOwner::Custom => "Custom",
+            ActionOwner::ThirdParty => "ThirdParty",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionOwner {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS" => Ok(ActionOwner::Aws),
+            "Custom" => Ok(ActionOwner::Custom),
+            "ThirdParty" => Ok(ActionOwner::ThirdParty),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents information about the version (or revision) of an action.</p>"]
@@ -314,6 +471,41 @@ pub struct ApprovalResult {
     pub summary: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ApprovalStatus {
+    Approved,
+    Rejected,
+}
+
+impl Into<String> for ApprovalStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ApprovalStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ApprovalStatus::Approved => "Approved",
+            ApprovalStatus::Rejected => "Rejected",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ApprovalStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Approved" => Ok(ApprovalStatus::Approved),
+            "Rejected" => Ok(ApprovalStatus::Rejected),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about an artifact that will be worked upon by actions in the pipeline.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Artifact {
@@ -353,6 +545,38 @@ pub struct ArtifactLocation {
     #[serde(rename="type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArtifactLocationType {
+    S3,
+}
+
+impl Into<String> for ArtifactLocationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArtifactLocationType {
+    fn into(self) -> &'static str {
+        match self {
+            ArtifactLocationType::S3 => "S3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArtifactLocationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "S3" => Ok(ArtifactLocationType::S3),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents revision details of an artifact. </p>"]
@@ -399,6 +623,38 @@ pub struct ArtifactStore {
     pub type_: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArtifactStoreType {
+    S3,
+}
+
+impl Into<String> for ArtifactStoreType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArtifactStoreType {
+    fn into(self) -> &'static str {
+        match self {
+            ArtifactStoreType::S3 => "S3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArtifactStoreType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "S3" => Ok(ArtifactStoreType::S3),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Reserved for future use.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BlockerDeclaration {
@@ -408,6 +664,38 @@ pub struct BlockerDeclaration {
     #[doc="<p>Reserved for future use.</p>"]
     #[serde(rename="type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BlockerType {
+    Schedule,
+}
+
+impl Into<String> for BlockerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BlockerType {
+    fn into(self) -> &'static str {
+        match self {
+            BlockerType::Schedule => "Schedule",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BlockerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Schedule" => Ok(BlockerType::Schedule),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a create custom action operation.</p>"]
@@ -546,6 +834,38 @@ pub struct EncryptionKey {
     pub type_: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EncryptionKeyType {
+    Kms,
+}
+
+impl Into<String> for EncryptionKeyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EncryptionKeyType {
+    fn into(self) -> &'static str {
+        match self {
+            EncryptionKeyType::Kms => "KMS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EncryptionKeyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KMS" => Ok(EncryptionKeyType::Kms),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about an error in AWS CodePipeline.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ErrorDetails {
@@ -589,6 +909,53 @@ pub struct FailureDetails {
     #[doc="<p>The type of the failure.</p>"]
     #[serde(rename="type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FailureType {
+    ConfigurationError,
+    JobFailed,
+    PermissionError,
+    RevisionOutOfSync,
+    RevisionUnavailable,
+    SystemUnavailable,
+}
+
+impl Into<String> for FailureType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FailureType {
+    fn into(self) -> &'static str {
+        match self {
+            FailureType::ConfigurationError => "ConfigurationError",
+            FailureType::JobFailed => "JobFailed",
+            FailureType::PermissionError => "PermissionError",
+            FailureType::RevisionOutOfSync => "RevisionOutOfSync",
+            FailureType::RevisionUnavailable => "RevisionUnavailable",
+            FailureType::SystemUnavailable => "SystemUnavailable",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FailureType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ConfigurationError" => Ok(FailureType::ConfigurationError),
+            "JobFailed" => Ok(FailureType::JobFailed),
+            "PermissionError" => Ok(FailureType::PermissionError),
+            "RevisionOutOfSync" => Ok(FailureType::RevisionOutOfSync),
+            "RevisionUnavailable" => Ok(FailureType::RevisionUnavailable),
+            "SystemUnavailable" => Ok(FailureType::SystemUnavailable),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a get job details action.</p>"]
@@ -785,6 +1152,56 @@ pub struct JobDetails {
     pub id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobStatus {
+    Created,
+    Dispatched,
+    Failed,
+    InProgress,
+    Queued,
+    Succeeded,
+    TimedOut,
+}
+
+impl Into<String> for JobStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobStatus {
+    fn into(self) -> &'static str {
+        match self {
+            JobStatus::Created => "Created",
+            JobStatus::Dispatched => "Dispatched",
+            JobStatus::Failed => "Failed",
+            JobStatus::InProgress => "InProgress",
+            JobStatus::Queued => "Queued",
+            JobStatus::Succeeded => "Succeeded",
+            JobStatus::TimedOut => "TimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Created" => Ok(JobStatus::Created),
+            "Dispatched" => Ok(JobStatus::Dispatched),
+            "Failed" => Ok(JobStatus::Failed),
+            "InProgress" => Ok(JobStatus::InProgress),
+            "Queued" => Ok(JobStatus::Queued),
+            "Succeeded" => Ok(JobStatus::Succeeded),
+            "TimedOut" => Ok(JobStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input of a list action types action.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListActionTypesInput {
@@ -930,6 +1347,47 @@ pub struct PipelineExecution {
     #[serde(rename="status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PipelineExecutionStatus {
+    Failed,
+    InProgress,
+    Succeeded,
+    Superseded,
+}
+
+impl Into<String> for PipelineExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PipelineExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PipelineExecutionStatus::Failed => "Failed",
+            PipelineExecutionStatus::InProgress => "InProgress",
+            PipelineExecutionStatus::Succeeded => "Succeeded",
+            PipelineExecutionStatus::Superseded => "Superseded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PipelineExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(PipelineExecutionStatus::Failed),
+            "InProgress" => Ok(PipelineExecutionStatus::InProgress),
+            "Succeeded" => Ok(PipelineExecutionStatus::Succeeded),
+            "Superseded" => Ok(PipelineExecutionStatus::Superseded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Summary information about a pipeline execution.</p>"]
@@ -1219,6 +1677,76 @@ pub struct StageExecution {
     pub status: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StageExecutionStatus {
+    Failed,
+    InProgress,
+    Succeeded,
+}
+
+impl Into<String> for StageExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StageExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StageExecutionStatus::Failed => "Failed",
+            StageExecutionStatus::InProgress => "InProgress",
+            StageExecutionStatus::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StageExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(StageExecutionStatus::Failed),
+            "InProgress" => Ok(StageExecutionStatus::InProgress),
+            "Succeeded" => Ok(StageExecutionStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StageRetryMode {
+    FailedActions,
+}
+
+impl Into<String> for StageRetryMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StageRetryMode {
+    fn into(self) -> &'static str {
+        match self {
+            StageRetryMode::FailedActions => "FAILED_ACTIONS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StageRetryMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED_ACTIONS" => Ok(StageRetryMode::FailedActions),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about the state of the stage.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct StageState {
@@ -1238,6 +1766,41 @@ pub struct StageState {
     #[serde(rename="stageName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub stage_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StageTransitionType {
+    Inbound,
+    Outbound,
+}
+
+impl Into<String> for StageTransitionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StageTransitionType {
+    fn into(self) -> &'static str {
+        match self {
+            StageTransitionType::Inbound => "Inbound",
+            StageTransitionType::Outbound => "Outbound",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StageTransitionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Inbound" => Ok(StageTransitionType::Inbound),
+            "Outbound" => Ok(StageTransitionType::Outbound),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input of a start pipeline execution action.</p>"]
@@ -3907,7 +4470,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AcknowledgeJobOutput>(String::from_utf8_lossy(&body)
@@ -3941,7 +4504,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AcknowledgeThirdPartyJobOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3974,7 +4537,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateCustomActionTypeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4004,7 +4567,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreatePipelineOutput>(String::from_utf8_lossy(&body)
@@ -4037,7 +4600,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4061,7 +4624,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4088,7 +4651,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4115,7 +4678,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4141,7 +4704,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetJobDetailsOutput>(String::from_utf8_lossy(&body)
@@ -4173,7 +4736,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetPipelineOutput>(String::from_utf8_lossy(&body)
@@ -4205,7 +4768,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetPipelineExecutionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4235,7 +4798,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetPipelineStateOutput>(String::from_utf8_lossy(&body)
@@ -4269,7 +4832,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetThirdPartyJobDetailsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4300,7 +4863,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListActionTypesOutput>(String::from_utf8_lossy(&body)
@@ -4334,7 +4897,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListPipelineExecutionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4364,7 +4927,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListPipelinesOutput>(String::from_utf8_lossy(&body)
@@ -4396,7 +4959,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PollForJobsOutput>(String::from_utf8_lossy(&body)
@@ -4430,7 +4993,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PollForThirdPartyJobsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4460,7 +5023,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutActionRevisionOutput>(String::from_utf8_lossy(&body)
@@ -4492,7 +5055,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutApprovalResultOutput>(String::from_utf8_lossy(&body)
@@ -4524,7 +5087,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4550,7 +5113,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4577,7 +5140,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4605,7 +5168,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4632,7 +5195,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RetryStageExecutionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4664,7 +5227,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartPipelineExecutionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4694,7 +5257,7 @@ impl<P, D> CodePipeline for CodePipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdatePipelineOutput>(String::from_utf8_lossy(&body)

--- a/rusoto/services/codestar/src/generated.rs
+++ b/rusoto/services/codestar/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -1976,7 +1972,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AssociateTeamMemberResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2006,7 +2002,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateProjectResult>(String::from_utf8_lossy(&body)
@@ -2038,7 +2034,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateUserProfileResult>(String::from_utf8_lossy(&body)
@@ -2070,7 +2066,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteProjectResult>(String::from_utf8_lossy(&body)
@@ -2102,7 +2098,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteUserProfileResult>(String::from_utf8_lossy(&body)
@@ -2134,7 +2130,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeProjectResult>(String::from_utf8_lossy(&body)
@@ -2166,7 +2162,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeUserProfileResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2197,7 +2193,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisassociateTeamMemberResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2227,7 +2223,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListProjectsResult>(String::from_utf8_lossy(&body)
@@ -2259,7 +2255,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListResourcesResult>(String::from_utf8_lossy(&body)
@@ -2291,7 +2287,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTeamMembersResult>(String::from_utf8_lossy(&body)
@@ -2323,7 +2319,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListUserProfilesResult>(String::from_utf8_lossy(&body)
@@ -2355,7 +2351,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateProjectResult>(String::from_utf8_lossy(&body)
@@ -2387,7 +2383,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateTeamMemberResult>(String::from_utf8_lossy(&body)
@@ -2419,7 +2415,7 @@ impl<P, D> CodeStar for CodeStarClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateUserProfileResult>(String::from_utf8_lossy(&body)

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -11,23 +11,54 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AmbiguousRoleResolutionType {
+    AuthenticatedRole,
+    Deny,
+}
+
+impl Into<String> for AmbiguousRoleResolutionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AmbiguousRoleResolutionType {
+    fn into(self) -> &'static str {
+        match self {
+            AmbiguousRoleResolutionType::AuthenticatedRole => "AuthenticatedRole",
+            AmbiguousRoleResolutionType::Deny => "Deny",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AmbiguousRoleResolutionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AuthenticatedRole" => Ok(AmbiguousRoleResolutionType::AuthenticatedRole),
+            "Deny" => Ok(AmbiguousRoleResolutionType::Deny),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A provider representing an Amazon Cognito Identity User Pool and its client ID.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CognitoIdentityProvider {
@@ -136,6 +167,41 @@ pub struct DescribeIdentityPoolInput {
     #[doc="<p>An identity pool ID in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityPoolId")]
     pub identity_pool_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ErrorCode {
+    AccessDenied,
+    InternalServerError,
+}
+
+impl Into<String> for ErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            ErrorCode::AccessDenied => "AccessDenied",
+            ErrorCode::InternalServerError => "InternalServerError",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AccessDenied" => Ok(ErrorCode::AccessDenied),
+            "InternalServerError" => Ok(ErrorCode::InternalServerError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Input to the <code>GetCredentialsForIdentity</code> action.</p>"]
@@ -461,6 +527,47 @@ pub struct MappingRule {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MappingRuleMatchType {
+    Contains,
+    Equals,
+    NotEqual,
+    StartsWith,
+}
+
+impl Into<String> for MappingRuleMatchType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MappingRuleMatchType {
+    fn into(self) -> &'static str {
+        match self {
+            MappingRuleMatchType::Contains => "Contains",
+            MappingRuleMatchType::Equals => "Equals",
+            MappingRuleMatchType::NotEqual => "NotEqual",
+            MappingRuleMatchType::StartsWith => "StartsWith",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MappingRuleMatchType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Contains" => Ok(MappingRuleMatchType::Contains),
+            "Equals" => Ok(MappingRuleMatchType::Equals),
+            "NotEqual" => Ok(MappingRuleMatchType::NotEqual),
+            "StartsWith" => Ok(MappingRuleMatchType::StartsWith),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Input to the <code>MergeDeveloperIdentities</code> action.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct MergeDeveloperIdentitiesInput {
@@ -501,6 +608,41 @@ pub struct RoleMapping {
     #[doc="<p>The role mapping type. Token will use <code>cognito:roles</code> and <code>cognito:preferred_role</code> claims from the Cognito identity provider token to map groups to roles. Rules will attempt to match claims from the token to map to a role.</p>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RoleMappingType {
+    Rules,
+    Token,
+}
+
+impl Into<String> for RoleMappingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RoleMappingType {
+    fn into(self) -> &'static str {
+        match self {
+            RoleMappingType::Rules => "Rules",
+            RoleMappingType::Token => "Token",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RoleMappingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Rules" => Ok(RoleMappingType::Rules),
+            "Token" => Ok(RoleMappingType::Token),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A container for rules.</p>"]
@@ -2694,7 +2836,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&body).as_ref())
@@ -2725,7 +2867,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteIdentitiesResponse>(String::from_utf8_lossy(&body)
@@ -2758,7 +2900,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2784,7 +2926,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<IdentityDescription>(String::from_utf8_lossy(&body)
@@ -2817,7 +2959,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&body).as_ref())
@@ -2850,7 +2992,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetCredentialsForIdentityResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2879,7 +3021,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetIdResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -2912,7 +3054,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetIdentityPoolRolesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2942,7 +3084,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetOpenIdTokenResponse>(String::from_utf8_lossy(&body)
@@ -2977,7 +3119,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetOpenIdTokenForDeveloperIdentityResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3007,7 +3149,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListIdentitiesResponse>(String::from_utf8_lossy(&body)
@@ -3040,7 +3182,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListIdentityPoolsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3072,7 +3214,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<LookupDeveloperIdentityResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3105,7 +3247,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<MergeDeveloperIdentitiesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3137,7 +3279,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3164,7 +3306,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3189,7 +3331,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3216,7 +3358,7 @@ impl<P, D> CognitoIdentity for CognitoIdentityClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<IdentityPool>(String::from_utf8_lossy(&body).as_ref())

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -548,6 +544,85 @@ pub struct AdminUserGlobalSignOutRequest {
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AdminUserGlobalSignOutResponse;
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AliasAttributeType {
+    Email,
+    PhoneNumber,
+    PreferredUsername,
+}
+
+impl Into<String> for AliasAttributeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AliasAttributeType {
+    fn into(self) -> &'static str {
+        match self {
+            AliasAttributeType::Email => "email",
+            AliasAttributeType::PhoneNumber => "phone_number",
+            AliasAttributeType::PreferredUsername => "preferred_username",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AliasAttributeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "email" => Ok(AliasAttributeType::Email),
+            "phone_number" => Ok(AliasAttributeType::PhoneNumber),
+            "preferred_username" => Ok(AliasAttributeType::PreferredUsername),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AttributeDataType {
+    Boolean,
+    DateTime,
+    Number,
+    String,
+}
+
+impl Into<String> for AttributeDataType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AttributeDataType {
+    fn into(self) -> &'static str {
+        match self {
+            AttributeDataType::Boolean => "Boolean",
+            AttributeDataType::DateTime => "DateTime",
+            AttributeDataType::Number => "Number",
+            AttributeDataType::String => "String",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AttributeDataType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Boolean" => Ok(AttributeDataType::Boolean),
+            "DateTime" => Ok(AttributeDataType::DateTime),
+            "Number" => Ok(AttributeDataType::Number),
+            "String" => Ok(AttributeDataType::String),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies whether the attribute is standard or custom.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttributeType {
@@ -558,6 +633,50 @@ pub struct AttributeType {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AuthFlowType {
+    AdminNoSrpAuth,
+    CustomAuth,
+    RefreshToken,
+    RefreshTokenAuth,
+    UserSrpAuth,
+}
+
+impl Into<String> for AuthFlowType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AuthFlowType {
+    fn into(self) -> &'static str {
+        match self {
+            AuthFlowType::AdminNoSrpAuth => "ADMIN_NO_SRP_AUTH",
+            AuthFlowType::CustomAuth => "CUSTOM_AUTH",
+            AuthFlowType::RefreshToken => "REFRESH_TOKEN",
+            AuthFlowType::RefreshTokenAuth => "REFRESH_TOKEN_AUTH",
+            AuthFlowType::UserSrpAuth => "USER_SRP_AUTH",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AuthFlowType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADMIN_NO_SRP_AUTH" => Ok(AuthFlowType::AdminNoSrpAuth),
+            "CUSTOM_AUTH" => Ok(AuthFlowType::CustomAuth),
+            "REFRESH_TOKEN" => Ok(AuthFlowType::RefreshToken),
+            "REFRESH_TOKEN_AUTH" => Ok(AuthFlowType::RefreshTokenAuth),
+            "USER_SRP_AUTH" => Ok(AuthFlowType::UserSrpAuth),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The result type of the authentication result.</p>"]
@@ -587,6 +706,56 @@ pub struct AuthenticationResultType {
     #[serde(rename="TokenType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub token_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChallengeNameType {
+    AdminNoSrpAuth,
+    CustomChallenge,
+    DevicePasswordVerifier,
+    DeviceSrpAuth,
+    NewPasswordRequired,
+    PasswordVerifier,
+    SmsMfa,
+}
+
+impl Into<String> for ChallengeNameType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChallengeNameType {
+    fn into(self) -> &'static str {
+        match self {
+            ChallengeNameType::AdminNoSrpAuth => "ADMIN_NO_SRP_AUTH",
+            ChallengeNameType::CustomChallenge => "CUSTOM_CHALLENGE",
+            ChallengeNameType::DevicePasswordVerifier => "DEVICE_PASSWORD_VERIFIER",
+            ChallengeNameType::DeviceSrpAuth => "DEVICE_SRP_AUTH",
+            ChallengeNameType::NewPasswordRequired => "NEW_PASSWORD_REQUIRED",
+            ChallengeNameType::PasswordVerifier => "PASSWORD_VERIFIER",
+            ChallengeNameType::SmsMfa => "SMS_MFA",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChallengeNameType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADMIN_NO_SRP_AUTH" => Ok(ChallengeNameType::AdminNoSrpAuth),
+            "CUSTOM_CHALLENGE" => Ok(ChallengeNameType::CustomChallenge),
+            "DEVICE_PASSWORD_VERIFIER" => Ok(ChallengeNameType::DevicePasswordVerifier),
+            "DEVICE_SRP_AUTH" => Ok(ChallengeNameType::DeviceSrpAuth),
+            "NEW_PASSWORD_REQUIRED" => Ok(ChallengeNameType::NewPasswordRequired),
+            "PASSWORD_VERIFIER" => Ok(ChallengeNameType::PasswordVerifier),
+            "SMS_MFA" => Ok(ChallengeNameType::SmsMfa),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the request to change a user password.</p>"]
@@ -977,6 +1146,41 @@ pub struct CreateUserPoolResponse {
     pub user_pool: Option<UserPoolType>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DefaultEmailOptionType {
+    ConfirmWithCode,
+    ConfirmWithLink,
+}
+
+impl Into<String> for DefaultEmailOptionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DefaultEmailOptionType {
+    fn into(self) -> &'static str {
+        match self {
+            DefaultEmailOptionType::ConfirmWithCode => "CONFIRM_WITH_CODE",
+            DefaultEmailOptionType::ConfirmWithLink => "CONFIRM_WITH_LINK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DefaultEmailOptionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONFIRM_WITH_CODE" => Ok(DefaultEmailOptionType::ConfirmWithCode),
+            "CONFIRM_WITH_LINK" => Ok(DefaultEmailOptionType::ConfirmWithLink),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DeleteGroupRequest {
     #[doc="<p>The name of the group.</p>"]
@@ -1060,6 +1264,41 @@ pub struct DeleteUserRequest {
     #[doc="<p>The access token from a request to delete a user.</p>"]
     #[serde(rename="AccessToken")]
     pub access_token: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeliveryMediumType {
+    Email,
+    Sms,
+}
+
+impl Into<String> for DeliveryMediumType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeliveryMediumType {
+    fn into(self) -> &'static str {
+        match self {
+            DeliveryMediumType::Email => "EMAIL",
+            DeliveryMediumType::Sms => "SMS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeliveryMediumType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EMAIL" => Ok(DeliveryMediumType::Email),
+            "SMS" => Ok(DeliveryMediumType::Sms),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1181,6 +1420,41 @@ pub struct DeviceConfigurationType {
     pub device_only_remembered_on_user_prompt: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeviceRememberedStatusType {
+    NotRemembered,
+    Remembered,
+}
+
+impl Into<String> for DeviceRememberedStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeviceRememberedStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            DeviceRememberedStatusType::NotRemembered => "not_remembered",
+            DeviceRememberedStatusType::Remembered => "remembered",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeviceRememberedStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "not_remembered" => Ok(DeviceRememberedStatusType::NotRemembered),
+            "remembered" => Ok(DeviceRememberedStatusType::Remembered),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The device verifier against which it will be authenticated.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DeviceSecretVerifierConfigType {
@@ -1252,6 +1526,50 @@ pub struct DomainDescriptionType {
     pub version: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DomainStatusType {
+    Active,
+    Creating,
+    Deleting,
+    Failed,
+    Updating,
+}
+
+impl Into<String> for DomainStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DomainStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            DomainStatusType::Active => "ACTIVE",
+            DomainStatusType::Creating => "CREATING",
+            DomainStatusType::Deleting => "DELETING",
+            DomainStatusType::Failed => "FAILED",
+            DomainStatusType::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DomainStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(DomainStatusType::Active),
+            "CREATING" => Ok(DomainStatusType::Creating),
+            "DELETING" => Ok(DomainStatusType::Deleting),
+            "FAILED" => Ok(DomainStatusType::Failed),
+            "UPDATING" => Ok(DomainStatusType::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The email configuration type.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EmailConfigurationType {
@@ -1263,6 +1581,41 @@ pub struct EmailConfigurationType {
     #[serde(rename="SourceArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub source_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExplicitAuthFlowsType {
+    AdminNoSrpAuth,
+    CustomAuthFlowOnly,
+}
+
+impl Into<String> for ExplicitAuthFlowsType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExplicitAuthFlowsType {
+    fn into(self) -> &'static str {
+        match self {
+            ExplicitAuthFlowsType::AdminNoSrpAuth => "ADMIN_NO_SRP_AUTH",
+            ExplicitAuthFlowsType::CustomAuthFlowOnly => "CUSTOM_AUTH_FLOW_ONLY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExplicitAuthFlowsType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADMIN_NO_SRP_AUTH" => Ok(ExplicitAuthFlowsType::AdminNoSrpAuth),
+            "CUSTOM_AUTH_FLOW_ONLY" => Ok(ExplicitAuthFlowsType::CustomAuthFlowOnly),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the request to forget the device.</p>"]
@@ -1518,6 +1871,47 @@ pub struct IdentityProviderType {
     #[serde(rename="UserPoolId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub user_pool_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IdentityProviderTypeType {
+    Facebook,
+    Google,
+    LoginWithAmazon,
+    Saml,
+}
+
+impl Into<String> for IdentityProviderTypeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IdentityProviderTypeType {
+    fn into(self) -> &'static str {
+        match self {
+            IdentityProviderTypeType::Facebook => "Facebook",
+            IdentityProviderTypeType::Google => "Google",
+            IdentityProviderTypeType::LoginWithAmazon => "LoginWithAmazon",
+            IdentityProviderTypeType::Saml => "SAML",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IdentityProviderTypeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Facebook" => Ok(IdentityProviderTypeType::Facebook),
+            "Google" => Ok(IdentityProviderTypeType::Google),
+            "LoginWithAmazon" => Ok(IdentityProviderTypeType::LoginWithAmazon),
+            "SAML" => Ok(IdentityProviderTypeType::Saml),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Initiates the authentication request.</p>"]
@@ -1867,6 +2261,41 @@ pub struct MFAOptionType {
     pub delivery_medium: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MessageActionType {
+    Resend,
+    Suppress,
+}
+
+impl Into<String> for MessageActionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MessageActionType {
+    fn into(self) -> &'static str {
+        match self {
+            MessageActionType::Resend => "RESEND",
+            MessageActionType::Suppress => "SUPPRESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MessageActionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RESEND" => Ok(MessageActionType::Resend),
+            "SUPPRESS" => Ok(MessageActionType::Suppress),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The message template structure.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MessageTemplateType {
@@ -1908,6 +2337,44 @@ pub struct NumberAttributeConstraintsType {
     #[serde(rename="MinValue")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub min_value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OAuthFlowType {
+    ClientCredentials,
+    Code,
+    Implicit,
+}
+
+impl Into<String> for OAuthFlowType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OAuthFlowType {
+    fn into(self) -> &'static str {
+        match self {
+            OAuthFlowType::ClientCredentials => "client_credentials",
+            OAuthFlowType::Code => "code",
+            OAuthFlowType::Implicit => "implicit",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OAuthFlowType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "client_credentials" => Ok(OAuthFlowType::ClientCredentials),
+            "code" => Ok(OAuthFlowType::Code),
+            "implicit" => Ok(OAuthFlowType::Implicit),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The password policy type.</p>"]
@@ -2218,6 +2685,41 @@ pub struct StartUserImportJobResponse {
     #[serde(rename="UserImportJob")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub user_import_job: Option<UserImportJobType>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusType {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for StatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusType {
+    fn into(self) -> &'static str {
+        match self {
+            StatusType::Disabled => "Disabled",
+            StatusType::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(StatusType::Disabled),
+            "Enabled" => Ok(StatusType::Enabled),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the request to stop the user import job.</p>"]
@@ -2544,6 +3046,59 @@ pub struct UpdateUserPoolRequest {
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct UpdateUserPoolResponse;
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UserImportJobStatusType {
+    Created,
+    Expired,
+    Failed,
+    InProgress,
+    Pending,
+    Stopped,
+    Stopping,
+    Succeeded,
+}
+
+impl Into<String> for UserImportJobStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UserImportJobStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            UserImportJobStatusType::Created => "Created",
+            UserImportJobStatusType::Expired => "Expired",
+            UserImportJobStatusType::Failed => "Failed",
+            UserImportJobStatusType::InProgress => "InProgress",
+            UserImportJobStatusType::Pending => "Pending",
+            UserImportJobStatusType::Stopped => "Stopped",
+            UserImportJobStatusType::Stopping => "Stopping",
+            UserImportJobStatusType::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UserImportJobStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Created" => Ok(UserImportJobStatusType::Created),
+            "Expired" => Ok(UserImportJobStatusType::Expired),
+            "Failed" => Ok(UserImportJobStatusType::Failed),
+            "InProgress" => Ok(UserImportJobStatusType::InProgress),
+            "Pending" => Ok(UserImportJobStatusType::Pending),
+            "Stopped" => Ok(UserImportJobStatusType::Stopped),
+            "Stopping" => Ok(UserImportJobStatusType::Stopping),
+            "Succeeded" => Ok(UserImportJobStatusType::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The user import job type.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct UserImportJobType {
@@ -2720,6 +3275,44 @@ pub struct UserPoolDescriptionType {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UserPoolMfaType {
+    Off,
+    On,
+    Optional,
+}
+
+impl Into<String> for UserPoolMfaType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UserPoolMfaType {
+    fn into(self) -> &'static str {
+        match self {
+            UserPoolMfaType::Off => "OFF",
+            UserPoolMfaType::On => "ON",
+            UserPoolMfaType::Optional => "OPTIONAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UserPoolMfaType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OFF" => Ok(UserPoolMfaType::Off),
+            "ON" => Ok(UserPoolMfaType::On),
+            "OPTIONAL" => Ok(UserPoolMfaType::Optional),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The type of policy in a user pool.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserPoolPolicyType {
@@ -2834,6 +3427,56 @@ pub struct UserPoolType {
     pub verification_message_template: Option<VerificationMessageTemplateType>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UserStatusType {
+    Archived,
+    Compromised,
+    Confirmed,
+    ForceChangePassword,
+    ResetRequired,
+    Unconfirmed,
+    Unknown,
+}
+
+impl Into<String> for UserStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UserStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            UserStatusType::Archived => "ARCHIVED",
+            UserStatusType::Compromised => "COMPROMISED",
+            UserStatusType::Confirmed => "CONFIRMED",
+            UserStatusType::ForceChangePassword => "FORCE_CHANGE_PASSWORD",
+            UserStatusType::ResetRequired => "RESET_REQUIRED",
+            UserStatusType::Unconfirmed => "UNCONFIRMED",
+            UserStatusType::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UserStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ARCHIVED" => Ok(UserStatusType::Archived),
+            "COMPROMISED" => Ok(UserStatusType::Compromised),
+            "CONFIRMED" => Ok(UserStatusType::Confirmed),
+            "FORCE_CHANGE_PASSWORD" => Ok(UserStatusType::ForceChangePassword),
+            "RESET_REQUIRED" => Ok(UserStatusType::ResetRequired),
+            "UNCONFIRMED" => Ok(UserStatusType::Unconfirmed),
+            "UNKNOWN" => Ok(UserStatusType::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The user type.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct UserType {
@@ -2867,6 +3510,41 @@ pub struct UserType {
     pub username: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UsernameAttributeType {
+    Email,
+    PhoneNumber,
+}
+
+impl Into<String> for UsernameAttributeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UsernameAttributeType {
+    fn into(self) -> &'static str {
+        match self {
+            UsernameAttributeType::Email => "email",
+            UsernameAttributeType::PhoneNumber => "phone_number",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UsernameAttributeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "email" => Ok(UsernameAttributeType::Email),
+            "phone_number" => Ok(UsernameAttributeType::PhoneNumber),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The template for verification messages.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerificationMessageTemplateType {
@@ -2894,6 +3572,41 @@ pub struct VerificationMessageTemplateType {
     #[serde(rename="SmsMessage")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub sms_message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VerifiedAttributeType {
+    Email,
+    PhoneNumber,
+}
+
+impl Into<String> for VerifiedAttributeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VerifiedAttributeType {
+    fn into(self) -> &'static str {
+        match self {
+            VerifiedAttributeType::Email => "email",
+            VerifiedAttributeType::PhoneNumber => "phone_number",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VerifiedAttributeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "email" => Ok(VerifiedAttributeType::Email),
+            "phone_number" => Ok(VerifiedAttributeType::PhoneNumber),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the request to verify user attributes.</p>"]
@@ -13351,7 +14064,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddCustomAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -13382,7 +14095,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -13409,7 +14122,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminConfirmSignUpResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -13440,7 +14153,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminCreateUserResponse>(String::from_utf8_lossy(&body)
@@ -13473,7 +14186,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -13501,7 +14214,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminDeleteUserAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -13534,7 +14247,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminDisableProviderForUserResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -13566,7 +14279,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminDisableUserResponse>(String::from_utf8_lossy(&body)
@@ -13599,7 +14312,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminEnableUserResponse>(String::from_utf8_lossy(&body)
@@ -13632,7 +14345,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -13659,7 +14372,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminGetDeviceResponse>(String::from_utf8_lossy(&body)
@@ -13692,7 +14405,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminGetUserResponse>(String::from_utf8_lossy(&body)
@@ -13725,7 +14438,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminInitiateAuthResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -13757,7 +14470,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminLinkProviderForUserResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -13789,7 +14502,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminListDevicesResponse>(String::from_utf8_lossy(&body)
@@ -13823,7 +14536,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminListGroupsForUserResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -13854,7 +14567,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -13883,7 +14596,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminResetUserPasswordResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -13915,7 +14628,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminRespondToAuthChallengeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -13948,7 +14661,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminSetUserSettingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -13980,7 +14693,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminUpdateDeviceStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14013,7 +14726,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminUpdateUserAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14046,7 +14759,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AdminUserGlobalSignOutResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14077,7 +14790,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ChangePasswordResponse>(String::from_utf8_lossy(&body)
@@ -14110,7 +14823,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ConfirmDeviceResponse>(String::from_utf8_lossy(&body)
@@ -14144,7 +14857,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ConfirmForgotPasswordResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14175,7 +14888,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ConfirmSignUpResponse>(String::from_utf8_lossy(&body)
@@ -14208,7 +14921,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateGroupResponse>(String::from_utf8_lossy(&body)
@@ -14242,7 +14955,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateIdentityProviderResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14274,7 +14987,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateResourceServerResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14305,7 +15018,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateUserImportJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14336,7 +15049,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateUserPoolResponse>(String::from_utf8_lossy(&body)
@@ -14370,7 +15083,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateUserPoolClientResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14402,7 +15115,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateUserPoolDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14431,7 +15144,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14458,7 +15171,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14485,7 +15198,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14510,7 +15223,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14538,7 +15251,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteUserAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14567,7 +15280,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14594,7 +15307,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14622,7 +15335,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteUserPoolDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14654,7 +15367,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeIdentityProviderResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14687,7 +15400,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeResourceServerResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14719,7 +15432,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeUserImportJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14750,7 +15463,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeUserPoolResponse>(String::from_utf8_lossy(&body)
@@ -14784,7 +15497,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeUserPoolClientResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14816,7 +15529,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeUserPoolDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -14845,7 +15558,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -14872,7 +15585,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ForgotPasswordResponse>(String::from_utf8_lossy(&body)
@@ -14905,7 +15618,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetCSVHeaderResponse>(String::from_utf8_lossy(&body)
@@ -14936,7 +15649,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDeviceResponse>(String::from_utf8_lossy(&body)
@@ -14966,7 +15679,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetGroupResponse>(String::from_utf8_lossy(&body)
@@ -15000,7 +15713,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetIdentityProviderByIdentifierResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15032,7 +15745,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetUICustomizationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15060,7 +15773,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetUserResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -15093,7 +15806,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetUserAttributeVerificationCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15124,7 +15837,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GlobalSignOutResponse>(String::from_utf8_lossy(&body)
@@ -15157,7 +15870,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<InitiateAuthResponse>(String::from_utf8_lossy(&body)
@@ -15190,7 +15903,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListDevicesResponse>(String::from_utf8_lossy(&body)
@@ -15223,7 +15936,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListGroupsResponse>(String::from_utf8_lossy(&body)
@@ -15257,7 +15970,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListIdentityProvidersResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15288,7 +16001,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListResourceServersResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15319,7 +16032,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListUserImportJobsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15350,7 +16063,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListUserPoolClientsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15381,7 +16094,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListUserPoolsResponse>(String::from_utf8_lossy(&body)
@@ -15412,7 +16125,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListUsersResponse>(String::from_utf8_lossy(&body)
@@ -15445,7 +16158,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListUsersInGroupResponse>(String::from_utf8_lossy(&body)
@@ -15479,7 +16192,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ResendConfirmationCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15511,7 +16224,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RespondToAuthChallengeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15542,7 +16255,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SetUICustomizationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15573,7 +16286,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SetUserSettingsResponse>(String::from_utf8_lossy(&body)
@@ -15603,7 +16316,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SignUpResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -15635,7 +16348,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartUserImportJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15666,7 +16379,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopUserImportJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15697,7 +16410,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDeviceStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15728,7 +16441,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateGroupResponse>(String::from_utf8_lossy(&body)
@@ -15762,7 +16475,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateIdentityProviderResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15794,7 +16507,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateResourceServerResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15826,7 +16539,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateUserAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15857,7 +16570,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateUserPoolResponse>(String::from_utf8_lossy(&body)
@@ -15891,7 +16604,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateUserPoolClientResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15922,7 +16635,7 @@ impl<P, D> CognitoIdentityProvider for CognitoIdentityProviderClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<VerifyUserAttributeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -11,23 +11,142 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+#[doc="Region of customer S3 bucket."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AWSRegion {
+    ApNortheast1,
+    ApSoutheast1,
+    ApSoutheast2,
+    EuCentral1,
+    EuWest1,
+    UsEast1,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for AWSRegion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AWSRegion {
+    fn into(self) -> &'static str {
+        match self {
+            AWSRegion::ApNortheast1 => "ap-northeast-1",
+            AWSRegion::ApSoutheast1 => "ap-southeast-1",
+            AWSRegion::ApSoutheast2 => "ap-southeast-2",
+            AWSRegion::EuCentral1 => "eu-central-1",
+            AWSRegion::EuWest1 => "eu-west-1",
+            AWSRegion::UsEast1 => "us-east-1",
+            AWSRegion::UsWest1 => "us-west-1",
+            AWSRegion::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AWSRegion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(AWSRegion::ApNortheast1),
+            "ap-southeast-1" => Ok(AWSRegion::ApSoutheast1),
+            "ap-southeast-2" => Ok(AWSRegion::ApSoutheast2),
+            "eu-central-1" => Ok(AWSRegion::EuCentral1),
+            "eu-west-1" => Ok(AWSRegion::EuWest1),
+            "us-east-1" => Ok(AWSRegion::UsEast1),
+            "us-west-1" => Ok(AWSRegion::UsWest1),
+            "us-west-2" => Ok(AWSRegion::UsWest2),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Enable support for Redshift and/or QuickSight."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AdditionalArtifact {
+    Quicksight,
+    Redshift,
+}
+
+impl Into<String> for AdditionalArtifact {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AdditionalArtifact {
+    fn into(self) -> &'static str {
+        match self {
+            AdditionalArtifact::Quicksight => "QUICKSIGHT",
+            AdditionalArtifact::Redshift => "REDSHIFT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AdditionalArtifact {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "QUICKSIGHT" => Ok(AdditionalArtifact::Quicksight),
+            "REDSHIFT" => Ok(AdditionalArtifact::Redshift),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Preferred compression format for report."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CompressionFormat {
+    Gzip,
+    Zip,
+}
+
+impl Into<String> for CompressionFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CompressionFormat {
+    fn into(self) -> &'static str {
+        match self {
+            CompressionFormat::Gzip => "GZIP",
+            CompressionFormat::Zip => "ZIP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CompressionFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GZIP" => Ok(CompressionFormat::Gzip),
+            "ZIP" => Ok(CompressionFormat::Zip),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="Request of DeleteReportDefinition"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DeleteReportDefinitionRequest {
@@ -99,6 +218,105 @@ pub struct ReportDefinition {
     pub s3_region: String,
     #[serde(rename="TimeUnit")]
     pub time_unit: String,
+}
+
+#[doc="Preferred format for report."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportFormat {
+    TextORcsv,
+}
+
+impl Into<String> for ReportFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportFormat {
+    fn into(self) -> &'static str {
+        match self {
+            ReportFormat::TextORcsv => "textORcsv",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "textORcsv" => Ok(ReportFormat::TextORcsv),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Preference of including Resource IDs. You can include additional details about individual resource IDs in your report."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SchemaElement {
+    Resources,
+}
+
+impl Into<String> for SchemaElement {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SchemaElement {
+    fn into(self) -> &'static str {
+        match self {
+            SchemaElement::Resources => "RESOURCES",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SchemaElement {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RESOURCES" => Ok(SchemaElement::Resources),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="The frequency on which report data are measured and displayed."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TimeUnit {
+    Daily,
+    Hourly,
+}
+
+impl Into<String> for TimeUnit {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TimeUnit {
+    fn into(self) -> &'static str {
+        match self {
+            TimeUnit::Daily => "DAILY",
+            TimeUnit::Hourly => "HOURLY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TimeUnit {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DAILY" => Ok(TimeUnit::Daily),
+            "HOURLY" => Ok(TimeUnit::Hourly),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by DeleteReportDefinition
@@ -422,7 +640,7 @@ impl<P, D> CostAndUsageReport for CostAndUsageReportClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteReportDefinitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -454,7 +672,7 @@ impl<P, D> CostAndUsageReport for CostAndUsageReportClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeReportDefinitionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -486,7 +704,7 @@ impl<P, D> CostAndUsageReport for CostAndUsageReportClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutReportDefinitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -281,6 +277,50 @@ pub struct Operator {
     #[serde(rename="values")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub values: Option<Vec<String>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperatorType {
+    Between,
+    Eq,
+    Ge,
+    Le,
+    RefEq,
+}
+
+impl Into<String> for OperatorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperatorType {
+    fn into(self) -> &'static str {
+        match self {
+            OperatorType::Between => "BETWEEN",
+            OperatorType::Eq => "EQ",
+            OperatorType::Ge => "GE",
+            OperatorType::Le => "LE",
+            OperatorType::RefEq => "REF_EQ",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperatorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BETWEEN" => Ok(OperatorType::Between),
+            "EQ" => Ok(OperatorType::Eq),
+            "GE" => Ok(OperatorType::Ge),
+            "LE" => Ok(OperatorType::Le),
+            "REF_EQ" => Ok(OperatorType::RefEq),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The attributes allowed or specified with a parameter object.</p>"]
@@ -616,6 +656,44 @@ pub struct TaskObject {
     #[serde(rename="taskId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub task_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaskStatus {
+    Failed,
+    False,
+    Finished,
+}
+
+impl Into<String> for TaskStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaskStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TaskStatus::Failed => "FAILED",
+            TaskStatus::False => "FALSE",
+            TaskStatus::Finished => "FINISHED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaskStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(TaskStatus::Failed),
+            "FALSE" => Ok(TaskStatus::False),
+            "FINISHED" => Ok(TaskStatus::Finished),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains the parameters for ValidatePipelineDefinition.</p>"]
@@ -2644,7 +2722,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ActivatePipelineOutput>(String::from_utf8_lossy(&body)
@@ -2674,7 +2752,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -2705,7 +2783,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreatePipelineOutput>(String::from_utf8_lossy(&body)
@@ -2737,7 +2815,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeactivatePipelineOutput>(String::from_utf8_lossy(&body)
@@ -2767,7 +2845,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2793,7 +2871,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeObjectsOutput>(String::from_utf8_lossy(&body)
@@ -2825,7 +2903,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribePipelinesOutput>(String::from_utf8_lossy(&body)
@@ -2857,7 +2935,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<EvaluateExpressionOutput>(String::from_utf8_lossy(&body)
@@ -2890,7 +2968,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetPipelineDefinitionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2920,7 +2998,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListPipelinesOutput>(String::from_utf8_lossy(&body)
@@ -2952,7 +3030,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PollForTaskOutput>(String::from_utf8_lossy(&body)
@@ -2985,7 +3063,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutPipelineDefinitionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3015,7 +3093,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<QueryObjectsOutput>(String::from_utf8_lossy(&body)
@@ -3045,7 +3123,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveTagsOutput>(String::from_utf8_lossy(&body)
@@ -3077,7 +3155,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ReportTaskProgressOutput>(String::from_utf8_lossy(&body)
@@ -3110,7 +3188,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ReportTaskRunnerHeartbeatOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3139,7 +3217,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3165,7 +3243,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SetTaskStatusOutput>(String::from_utf8_lossy(&body)
@@ -3198,7 +3276,7 @@ impl<P, D> DataPipeline for DataPipelineClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ValidatePipelineDefinitionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -84,6 +80,183 @@ pub struct Artifact {
     #[serde(rename="url")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArtifactCategory {
+    File,
+    Log,
+    Screenshot,
+}
+
+impl Into<String> for ArtifactCategory {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArtifactCategory {
+    fn into(self) -> &'static str {
+        match self {
+            ArtifactCategory::File => "FILE",
+            ArtifactCategory::Log => "LOG",
+            ArtifactCategory::Screenshot => "SCREENSHOT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArtifactCategory {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FILE" => Ok(ArtifactCategory::File),
+            "LOG" => Ok(ArtifactCategory::Log),
+            "SCREENSHOT" => Ok(ArtifactCategory::Screenshot),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArtifactType {
+    AppiumJavaOutput,
+    AppiumJavaXmlOutput,
+    AppiumPythonOutput,
+    AppiumPythonXmlOutput,
+    AppiumServerOutput,
+    ApplicationCrashReport,
+    AutomationOutput,
+    CalabashJavaXmlOutput,
+    CalabashJsonOutput,
+    CalabashPrettyOutput,
+    CalabashStandardOutput,
+    DeviceLog,
+    ExerciserMonkeyOutput,
+    ExplorerEventLog,
+    ExplorerSummaryLog,
+    InstrumentationOutput,
+    MessageLog,
+    ResultLog,
+    Screenshot,
+    ServiceLog,
+    Unknown,
+    Video,
+    VideoLog,
+    WebkitLog,
+    XctestLog,
+}
+
+impl Into<String> for ArtifactType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArtifactType {
+    fn into(self) -> &'static str {
+        match self {
+            ArtifactType::AppiumJavaOutput => "APPIUM_JAVA_OUTPUT",
+            ArtifactType::AppiumJavaXmlOutput => "APPIUM_JAVA_XML_OUTPUT",
+            ArtifactType::AppiumPythonOutput => "APPIUM_PYTHON_OUTPUT",
+            ArtifactType::AppiumPythonXmlOutput => "APPIUM_PYTHON_XML_OUTPUT",
+            ArtifactType::AppiumServerOutput => "APPIUM_SERVER_OUTPUT",
+            ArtifactType::ApplicationCrashReport => "APPLICATION_CRASH_REPORT",
+            ArtifactType::AutomationOutput => "AUTOMATION_OUTPUT",
+            ArtifactType::CalabashJavaXmlOutput => "CALABASH_JAVA_XML_OUTPUT",
+            ArtifactType::CalabashJsonOutput => "CALABASH_JSON_OUTPUT",
+            ArtifactType::CalabashPrettyOutput => "CALABASH_PRETTY_OUTPUT",
+            ArtifactType::CalabashStandardOutput => "CALABASH_STANDARD_OUTPUT",
+            ArtifactType::DeviceLog => "DEVICE_LOG",
+            ArtifactType::ExerciserMonkeyOutput => "EXERCISER_MONKEY_OUTPUT",
+            ArtifactType::ExplorerEventLog => "EXPLORER_EVENT_LOG",
+            ArtifactType::ExplorerSummaryLog => "EXPLORER_SUMMARY_LOG",
+            ArtifactType::InstrumentationOutput => "INSTRUMENTATION_OUTPUT",
+            ArtifactType::MessageLog => "MESSAGE_LOG",
+            ArtifactType::ResultLog => "RESULT_LOG",
+            ArtifactType::Screenshot => "SCREENSHOT",
+            ArtifactType::ServiceLog => "SERVICE_LOG",
+            ArtifactType::Unknown => "UNKNOWN",
+            ArtifactType::Video => "VIDEO",
+            ArtifactType::VideoLog => "VIDEO_LOG",
+            ArtifactType::WebkitLog => "WEBKIT_LOG",
+            ArtifactType::XctestLog => "XCTEST_LOG",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArtifactType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "APPIUM_JAVA_OUTPUT" => Ok(ArtifactType::AppiumJavaOutput),
+            "APPIUM_JAVA_XML_OUTPUT" => Ok(ArtifactType::AppiumJavaXmlOutput),
+            "APPIUM_PYTHON_OUTPUT" => Ok(ArtifactType::AppiumPythonOutput),
+            "APPIUM_PYTHON_XML_OUTPUT" => Ok(ArtifactType::AppiumPythonXmlOutput),
+            "APPIUM_SERVER_OUTPUT" => Ok(ArtifactType::AppiumServerOutput),
+            "APPLICATION_CRASH_REPORT" => Ok(ArtifactType::ApplicationCrashReport),
+            "AUTOMATION_OUTPUT" => Ok(ArtifactType::AutomationOutput),
+            "CALABASH_JAVA_XML_OUTPUT" => Ok(ArtifactType::CalabashJavaXmlOutput),
+            "CALABASH_JSON_OUTPUT" => Ok(ArtifactType::CalabashJsonOutput),
+            "CALABASH_PRETTY_OUTPUT" => Ok(ArtifactType::CalabashPrettyOutput),
+            "CALABASH_STANDARD_OUTPUT" => Ok(ArtifactType::CalabashStandardOutput),
+            "DEVICE_LOG" => Ok(ArtifactType::DeviceLog),
+            "EXERCISER_MONKEY_OUTPUT" => Ok(ArtifactType::ExerciserMonkeyOutput),
+            "EXPLORER_EVENT_LOG" => Ok(ArtifactType::ExplorerEventLog),
+            "EXPLORER_SUMMARY_LOG" => Ok(ArtifactType::ExplorerSummaryLog),
+            "INSTRUMENTATION_OUTPUT" => Ok(ArtifactType::InstrumentationOutput),
+            "MESSAGE_LOG" => Ok(ArtifactType::MessageLog),
+            "RESULT_LOG" => Ok(ArtifactType::ResultLog),
+            "SCREENSHOT" => Ok(ArtifactType::Screenshot),
+            "SERVICE_LOG" => Ok(ArtifactType::ServiceLog),
+            "UNKNOWN" => Ok(ArtifactType::Unknown),
+            "VIDEO" => Ok(ArtifactType::Video),
+            "VIDEO_LOG" => Ok(ArtifactType::VideoLog),
+            "WEBKIT_LOG" => Ok(ArtifactType::WebkitLog),
+            "XCTEST_LOG" => Ok(ArtifactType::XctestLog),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BillingMethod {
+    Metered,
+    Unmetered,
+}
+
+impl Into<String> for BillingMethod {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BillingMethod {
+    fn into(self) -> &'static str {
+        match self {
+            BillingMethod::Metered => "METERED",
+            BillingMethod::Unmetered => "UNMETERED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BillingMethod {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "METERED" => Ok(BillingMethod::Metered),
+            "UNMETERED" => Ok(BillingMethod::Unmetered),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the amount of CPU that an app is using on a physical device.</p> <p>Note that this does not represent system-wide CPU usage.</p>"]
@@ -306,6 +479,38 @@ pub struct CreateUploadResult {
     pub upload: Option<Upload>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CurrencyCode {
+    Usd,
+}
+
+impl Into<String> for CurrencyCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CurrencyCode {
+    fn into(self) -> &'static str {
+        match self {
+            CurrencyCode::Usd => "USD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CurrencyCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "USD" => Ok(CurrencyCode::Usd),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents a request to the delete device pool operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DeleteDevicePoolRequest {
@@ -449,6 +654,88 @@ pub struct Device {
     pub resolution: Option<Resolution>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeviceAttribute {
+    AppiumVersion,
+    Arn,
+    FormFactor,
+    Manufacturer,
+    Platform,
+    RemoteAccessEnabled,
+}
+
+impl Into<String> for DeviceAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeviceAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            DeviceAttribute::AppiumVersion => "APPIUM_VERSION",
+            DeviceAttribute::Arn => "ARN",
+            DeviceAttribute::FormFactor => "FORM_FACTOR",
+            DeviceAttribute::Manufacturer => "MANUFACTURER",
+            DeviceAttribute::Platform => "PLATFORM",
+            DeviceAttribute::RemoteAccessEnabled => "REMOTE_ACCESS_ENABLED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeviceAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "APPIUM_VERSION" => Ok(DeviceAttribute::AppiumVersion),
+            "ARN" => Ok(DeviceAttribute::Arn),
+            "FORM_FACTOR" => Ok(DeviceAttribute::FormFactor),
+            "MANUFACTURER" => Ok(DeviceAttribute::Manufacturer),
+            "PLATFORM" => Ok(DeviceAttribute::Platform),
+            "REMOTE_ACCESS_ENABLED" => Ok(DeviceAttribute::RemoteAccessEnabled),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeviceFormFactor {
+    Phone,
+    Tablet,
+}
+
+impl Into<String> for DeviceFormFactor {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeviceFormFactor {
+    fn into(self) -> &'static str {
+        match self {
+            DeviceFormFactor::Phone => "PHONE",
+            DeviceFormFactor::Tablet => "TABLET",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeviceFormFactor {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PHONE" => Ok(DeviceFormFactor::Phone),
+            "TABLET" => Ok(DeviceFormFactor::Tablet),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the total (metered or unmetered) minutes used by the resource to run tests. Contains the sum of minutes consumed by all children.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DeviceMinutes {
@@ -464,6 +751,41 @@ pub struct DeviceMinutes {
     #[serde(rename="unmetered")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub unmetered: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DevicePlatform {
+    Android,
+    Ios,
+}
+
+impl Into<String> for DevicePlatform {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DevicePlatform {
+    fn into(self) -> &'static str {
+        match self {
+            DevicePlatform::Android => "ANDROID",
+            DevicePlatform::Ios => "IOS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DevicePlatform {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ANDROID" => Ok(DevicePlatform::Android),
+            "IOS" => Ok(DevicePlatform::Ios),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents a collection of device types.</p>"]
@@ -508,6 +830,41 @@ pub struct DevicePoolCompatibilityResult {
     pub incompatibility_messages: Option<Vec<IncompatibilityMessage>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DevicePoolType {
+    Curated,
+    Private,
+}
+
+impl Into<String> for DevicePoolType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DevicePoolType {
+    fn into(self) -> &'static str {
+        match self {
+            DevicePoolType::Curated => "CURATED",
+            DevicePoolType::Private => "PRIVATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DevicePoolType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CURATED" => Ok(DevicePoolType::Curated),
+            "PRIVATE" => Ok(DevicePoolType::Private),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents configuration information about a test run, such as the execution timeout (in minutes).</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ExecutionConfiguration {
@@ -523,6 +880,112 @@ pub struct ExecutionConfiguration {
     #[serde(rename="jobTimeoutMinutes")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub job_timeout_minutes: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExecutionResult {
+    Errored,
+    Failed,
+    Passed,
+    Pending,
+    Skipped,
+    Stopped,
+    Warned,
+}
+
+impl Into<String> for ExecutionResult {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExecutionResult {
+    fn into(self) -> &'static str {
+        match self {
+            ExecutionResult::Errored => "ERRORED",
+            ExecutionResult::Failed => "FAILED",
+            ExecutionResult::Passed => "PASSED",
+            ExecutionResult::Pending => "PENDING",
+            ExecutionResult::Skipped => "SKIPPED",
+            ExecutionResult::Stopped => "STOPPED",
+            ExecutionResult::Warned => "WARNED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExecutionResult {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ERRORED" => Ok(ExecutionResult::Errored),
+            "FAILED" => Ok(ExecutionResult::Failed),
+            "PASSED" => Ok(ExecutionResult::Passed),
+            "PENDING" => Ok(ExecutionResult::Pending),
+            "SKIPPED" => Ok(ExecutionResult::Skipped),
+            "STOPPED" => Ok(ExecutionResult::Stopped),
+            "WARNED" => Ok(ExecutionResult::Warned),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExecutionStatus {
+    Completed,
+    Pending,
+    PendingConcurrency,
+    PendingDevice,
+    Preparing,
+    Processing,
+    Running,
+    Scheduling,
+    Stopping,
+}
+
+impl Into<String> for ExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ExecutionStatus::Completed => "COMPLETED",
+            ExecutionStatus::Pending => "PENDING",
+            ExecutionStatus::PendingConcurrency => "PENDING_CONCURRENCY",
+            ExecutionStatus::PendingDevice => "PENDING_DEVICE",
+            ExecutionStatus::Preparing => "PREPARING",
+            ExecutionStatus::Processing => "PROCESSING",
+            ExecutionStatus::Running => "RUNNING",
+            ExecutionStatus::Scheduling => "SCHEDULING",
+            ExecutionStatus::Stopping => "STOPPING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLETED" => Ok(ExecutionStatus::Completed),
+            "PENDING" => Ok(ExecutionStatus::Pending),
+            "PENDING_CONCURRENCY" => Ok(ExecutionStatus::PendingConcurrency),
+            "PENDING_DEVICE" => Ok(ExecutionStatus::PendingDevice),
+            "PREPARING" => Ok(ExecutionStatus::Preparing),
+            "PROCESSING" => Ok(ExecutionStatus::Processing),
+            "RUNNING" => Ok(ExecutionStatus::Running),
+            "SCHEDULING" => Ok(ExecutionStatus::Scheduling),
+            "STOPPING" => Ok(ExecutionStatus::Stopping),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the request sent to retrieve the account settings.</p>"]
@@ -1328,6 +1791,41 @@ pub struct NetworkProfile {
     pub uplink_loss_percent: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkProfileType {
+    Curated,
+    Private,
+}
+
+impl Into<String> for NetworkProfileType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkProfileType {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkProfileType::Curated => "CURATED",
+            NetworkProfileType::Private => "PRIVATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkProfileType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CURATED" => Ok(NetworkProfileType::Curated),
+            "PRIVATE" => Ok(NetworkProfileType::Private),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the metadata of a device offering.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Offering {
@@ -1410,6 +1908,76 @@ pub struct OfferingTransaction {
     #[serde(rename="transactionId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub transaction_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OfferingTransactionType {
+    Purchase,
+    Renew,
+    System,
+}
+
+impl Into<String> for OfferingTransactionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OfferingTransactionType {
+    fn into(self) -> &'static str {
+        match self {
+            OfferingTransactionType::Purchase => "PURCHASE",
+            OfferingTransactionType::Renew => "RENEW",
+            OfferingTransactionType::System => "SYSTEM",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OfferingTransactionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PURCHASE" => Ok(OfferingTransactionType::Purchase),
+            "RENEW" => Ok(OfferingTransactionType::Renew),
+            "SYSTEM" => Ok(OfferingTransactionType::System),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OfferingType {
+    Recurring,
+}
+
+impl Into<String> for OfferingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OfferingType {
+    fn into(self) -> &'static str {
+        match self {
+            OfferingType::Recurring => "RECURRING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OfferingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RECURRING" => Ok(OfferingType::Recurring),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents a specific warning or failure.</p>"]
@@ -1539,6 +2107,38 @@ pub struct RecurringCharge {
     pub frequency: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RecurringChargeFrequency {
+    Monthly,
+}
+
+impl Into<String> for RecurringChargeFrequency {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RecurringChargeFrequency {
+    fn into(self) -> &'static str {
+        match self {
+            RecurringChargeFrequency::Monthly => "MONTHLY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RecurringChargeFrequency {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "MONTHLY" => Ok(RecurringChargeFrequency::Monthly),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about the remote access session.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RemoteAccessSession {
@@ -1644,6 +2244,53 @@ pub struct Rule {
     pub value: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RuleOperator {
+    Contains,
+    Equals,
+    GreaterThan,
+    In,
+    LessThan,
+    NotIn,
+}
+
+impl Into<String> for RuleOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RuleOperator {
+    fn into(self) -> &'static str {
+        match self {
+            RuleOperator::Contains => "CONTAINS",
+            RuleOperator::Equals => "EQUALS",
+            RuleOperator::GreaterThan => "GREATER_THAN",
+            RuleOperator::In => "IN",
+            RuleOperator::LessThan => "LESS_THAN",
+            RuleOperator::NotIn => "NOT_IN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RuleOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONTAINS" => Ok(RuleOperator::Contains),
+            "EQUALS" => Ok(RuleOperator::Equals),
+            "GREATER_THAN" => Ok(RuleOperator::GreaterThan),
+            "IN" => Ok(RuleOperator::In),
+            "LESS_THAN" => Ok(RuleOperator::LessThan),
+            "NOT_IN" => Ok(RuleOperator::NotIn),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents an app on a set of devices with a specific test and configuration.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Run {
@@ -1728,6 +2375,86 @@ pub struct Sample {
     #[serde(rename="url")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SampleType {
+    Cpu,
+    Memory,
+    NativeAvgDrawtime,
+    NativeFps,
+    NativeFrames,
+    NativeMaxDrawtime,
+    NativeMinDrawtime,
+    OpenglAvgDrawtime,
+    OpenglFps,
+    OpenglFrames,
+    OpenglMaxDrawtime,
+    OpenglMinDrawtime,
+    Rx,
+    RxRate,
+    Threads,
+    Tx,
+    TxRate,
+}
+
+impl Into<String> for SampleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SampleType {
+    fn into(self) -> &'static str {
+        match self {
+            SampleType::Cpu => "CPU",
+            SampleType::Memory => "MEMORY",
+            SampleType::NativeAvgDrawtime => "NATIVE_AVG_DRAWTIME",
+            SampleType::NativeFps => "NATIVE_FPS",
+            SampleType::NativeFrames => "NATIVE_FRAMES",
+            SampleType::NativeMaxDrawtime => "NATIVE_MAX_DRAWTIME",
+            SampleType::NativeMinDrawtime => "NATIVE_MIN_DRAWTIME",
+            SampleType::OpenglAvgDrawtime => "OPENGL_AVG_DRAWTIME",
+            SampleType::OpenglFps => "OPENGL_FPS",
+            SampleType::OpenglFrames => "OPENGL_FRAMES",
+            SampleType::OpenglMaxDrawtime => "OPENGL_MAX_DRAWTIME",
+            SampleType::OpenglMinDrawtime => "OPENGL_MIN_DRAWTIME",
+            SampleType::Rx => "RX",
+            SampleType::RxRate => "RX_RATE",
+            SampleType::Threads => "THREADS",
+            SampleType::Tx => "TX",
+            SampleType::TxRate => "TX_RATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SampleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CPU" => Ok(SampleType::Cpu),
+            "MEMORY" => Ok(SampleType::Memory),
+            "NATIVE_AVG_DRAWTIME" => Ok(SampleType::NativeAvgDrawtime),
+            "NATIVE_FPS" => Ok(SampleType::NativeFps),
+            "NATIVE_FRAMES" => Ok(SampleType::NativeFrames),
+            "NATIVE_MAX_DRAWTIME" => Ok(SampleType::NativeMaxDrawtime),
+            "NATIVE_MIN_DRAWTIME" => Ok(SampleType::NativeMinDrawtime),
+            "OPENGL_AVG_DRAWTIME" => Ok(SampleType::OpenglAvgDrawtime),
+            "OPENGL_FPS" => Ok(SampleType::OpenglFps),
+            "OPENGL_FRAMES" => Ok(SampleType::OpenglFrames),
+            "OPENGL_MAX_DRAWTIME" => Ok(SampleType::OpenglMaxDrawtime),
+            "OPENGL_MIN_DRAWTIME" => Ok(SampleType::OpenglMinDrawtime),
+            "RX" => Ok(SampleType::Rx),
+            "RX_RATE" => Ok(SampleType::RxRate),
+            "THREADS" => Ok(SampleType::Threads),
+            "TX" => Ok(SampleType::Tx),
+            "TX_RATE" => Ok(SampleType::TxRate),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the settings for a run. Includes things like location, radio states, auxiliary apps, and network profiles.</p>"]
@@ -1954,6 +2681,77 @@ pub struct Test {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TestType {
+    AppiumJavaJunit,
+    AppiumJavaTestng,
+    AppiumPython,
+    AppiumWebJavaJunit,
+    AppiumWebJavaTestng,
+    AppiumWebPython,
+    BuiltinExplorer,
+    BuiltinFuzz,
+    Calabash,
+    Instrumentation,
+    Uiautomation,
+    Uiautomator,
+    Xctest,
+    XctestUi,
+}
+
+impl Into<String> for TestType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TestType {
+    fn into(self) -> &'static str {
+        match self {
+            TestType::AppiumJavaJunit => "APPIUM_JAVA_JUNIT",
+            TestType::AppiumJavaTestng => "APPIUM_JAVA_TESTNG",
+            TestType::AppiumPython => "APPIUM_PYTHON",
+            TestType::AppiumWebJavaJunit => "APPIUM_WEB_JAVA_JUNIT",
+            TestType::AppiumWebJavaTestng => "APPIUM_WEB_JAVA_TESTNG",
+            TestType::AppiumWebPython => "APPIUM_WEB_PYTHON",
+            TestType::BuiltinExplorer => "BUILTIN_EXPLORER",
+            TestType::BuiltinFuzz => "BUILTIN_FUZZ",
+            TestType::Calabash => "CALABASH",
+            TestType::Instrumentation => "INSTRUMENTATION",
+            TestType::Uiautomation => "UIAUTOMATION",
+            TestType::Uiautomator => "UIAUTOMATOR",
+            TestType::Xctest => "XCTEST",
+            TestType::XctestUi => "XCTEST_UI",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TestType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "APPIUM_JAVA_JUNIT" => Ok(TestType::AppiumJavaJunit),
+            "APPIUM_JAVA_TESTNG" => Ok(TestType::AppiumJavaTestng),
+            "APPIUM_PYTHON" => Ok(TestType::AppiumPython),
+            "APPIUM_WEB_JAVA_JUNIT" => Ok(TestType::AppiumWebJavaJunit),
+            "APPIUM_WEB_JAVA_TESTNG" => Ok(TestType::AppiumWebJavaTestng),
+            "APPIUM_WEB_PYTHON" => Ok(TestType::AppiumWebPython),
+            "BUILTIN_EXPLORER" => Ok(TestType::BuiltinExplorer),
+            "BUILTIN_FUZZ" => Ok(TestType::BuiltinFuzz),
+            "CALABASH" => Ok(TestType::Calabash),
+            "INSTRUMENTATION" => Ok(TestType::Instrumentation),
+            "UIAUTOMATION" => Ok(TestType::Uiautomation),
+            "UIAUTOMATOR" => Ok(TestType::Uiautomator),
+            "XCTEST" => Ok(TestType::Xctest),
+            "XCTEST_UI" => Ok(TestType::XctestUi),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents information about free trial device minutes for an AWS account.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct TrialMinutes {
@@ -2132,6 +2930,124 @@ pub struct Upload {
     #[serde(rename="url")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UploadStatus {
+    Failed,
+    Initialized,
+    Processing,
+    Succeeded,
+}
+
+impl Into<String> for UploadStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UploadStatus {
+    fn into(self) -> &'static str {
+        match self {
+            UploadStatus::Failed => "FAILED",
+            UploadStatus::Initialized => "INITIALIZED",
+            UploadStatus::Processing => "PROCESSING",
+            UploadStatus::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UploadStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(UploadStatus::Failed),
+            "INITIALIZED" => Ok(UploadStatus::Initialized),
+            "PROCESSING" => Ok(UploadStatus::Processing),
+            "SUCCEEDED" => Ok(UploadStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UploadType {
+    AndroidApp,
+    AppiumJavaJunitTestPackage,
+    AppiumJavaTestngTestPackage,
+    AppiumPythonTestPackage,
+    AppiumWebJavaJunitTestPackage,
+    AppiumWebJavaTestngTestPackage,
+    AppiumWebPythonTestPackage,
+    CalabashTestPackage,
+    ExternalData,
+    InstrumentationTestPackage,
+    IosApp,
+    UiautomationTestPackage,
+    UiautomatorTestPackage,
+    WebApp,
+    XctestTestPackage,
+    XctestUiTestPackage,
+}
+
+impl Into<String> for UploadType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UploadType {
+    fn into(self) -> &'static str {
+        match self {
+            UploadType::AndroidApp => "ANDROID_APP",
+            UploadType::AppiumJavaJunitTestPackage => "APPIUM_JAVA_JUNIT_TEST_PACKAGE",
+            UploadType::AppiumJavaTestngTestPackage => "APPIUM_JAVA_TESTNG_TEST_PACKAGE",
+            UploadType::AppiumPythonTestPackage => "APPIUM_PYTHON_TEST_PACKAGE",
+            UploadType::AppiumWebJavaJunitTestPackage => "APPIUM_WEB_JAVA_JUNIT_TEST_PACKAGE",
+            UploadType::AppiumWebJavaTestngTestPackage => "APPIUM_WEB_JAVA_TESTNG_TEST_PACKAGE",
+            UploadType::AppiumWebPythonTestPackage => "APPIUM_WEB_PYTHON_TEST_PACKAGE",
+            UploadType::CalabashTestPackage => "CALABASH_TEST_PACKAGE",
+            UploadType::ExternalData => "EXTERNAL_DATA",
+            UploadType::InstrumentationTestPackage => "INSTRUMENTATION_TEST_PACKAGE",
+            UploadType::IosApp => "IOS_APP",
+            UploadType::UiautomationTestPackage => "UIAUTOMATION_TEST_PACKAGE",
+            UploadType::UiautomatorTestPackage => "UIAUTOMATOR_TEST_PACKAGE",
+            UploadType::WebApp => "WEB_APP",
+            UploadType::XctestTestPackage => "XCTEST_TEST_PACKAGE",
+            UploadType::XctestUiTestPackage => "XCTEST_UI_TEST_PACKAGE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UploadType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ANDROID_APP" => Ok(UploadType::AndroidApp),
+            "APPIUM_JAVA_JUNIT_TEST_PACKAGE" => Ok(UploadType::AppiumJavaJunitTestPackage),
+            "APPIUM_JAVA_TESTNG_TEST_PACKAGE" => Ok(UploadType::AppiumJavaTestngTestPackage),
+            "APPIUM_PYTHON_TEST_PACKAGE" => Ok(UploadType::AppiumPythonTestPackage),
+            "APPIUM_WEB_JAVA_JUNIT_TEST_PACKAGE" => Ok(UploadType::AppiumWebJavaJunitTestPackage),
+            "APPIUM_WEB_JAVA_TESTNG_TEST_PACKAGE" => Ok(UploadType::AppiumWebJavaTestngTestPackage),
+            "APPIUM_WEB_PYTHON_TEST_PACKAGE" => Ok(UploadType::AppiumWebPythonTestPackage),
+            "CALABASH_TEST_PACKAGE" => Ok(UploadType::CalabashTestPackage),
+            "EXTERNAL_DATA" => Ok(UploadType::ExternalData),
+            "INSTRUMENTATION_TEST_PACKAGE" => Ok(UploadType::InstrumentationTestPackage),
+            "IOS_APP" => Ok(UploadType::IosApp),
+            "UIAUTOMATION_TEST_PACKAGE" => Ok(UploadType::UiautomationTestPackage),
+            "UIAUTOMATOR_TEST_PACKAGE" => Ok(UploadType::UiautomatorTestPackage),
+            "WEB_APP" => Ok(UploadType::WebApp),
+            "XCTEST_TEST_PACKAGE" => Ok(UploadType::XctestTestPackage),
+            "XCTEST_UI_TEST_PACKAGE" => Ok(UploadType::XctestUiTestPackage),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by CreateDevicePool
@@ -7172,7 +8088,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDevicePoolResult>(String::from_utf8_lossy(&body)
@@ -7204,7 +8120,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateNetworkProfileResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7234,7 +8150,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateProjectResult>(String::from_utf8_lossy(&body)
@@ -7268,7 +8184,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateRemoteAccessSessionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7299,7 +8215,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateUploadResult>(String::from_utf8_lossy(&body)
@@ -7331,7 +8247,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteDevicePoolResult>(String::from_utf8_lossy(&body)
@@ -7363,7 +8279,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteNetworkProfileResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7393,7 +8309,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteProjectResult>(String::from_utf8_lossy(&body)
@@ -7427,7 +8343,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteRemoteAccessSessionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7456,7 +8372,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteRunResult>(String::from_utf8_lossy(&body).as_ref())
@@ -7487,7 +8403,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteUploadResult>(String::from_utf8_lossy(&body)
@@ -7516,7 +8432,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetAccountSettingsResult>(String::from_utf8_lossy(&body)
@@ -7546,7 +8462,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDeviceResult>(String::from_utf8_lossy(&body).as_ref())
@@ -7577,7 +8493,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDevicePoolResult>(String::from_utf8_lossy(&body)
@@ -7611,7 +8527,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDevicePoolCompatibilityResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7640,7 +8556,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetJobResult>(String::from_utf8_lossy(&body).as_ref())
@@ -7671,7 +8587,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetNetworkProfileResult>(String::from_utf8_lossy(&body)
@@ -7703,7 +8619,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetOfferingStatusResult>(String::from_utf8_lossy(&body)
@@ -7733,7 +8649,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetProjectResult>(String::from_utf8_lossy(&body)
@@ -7766,7 +8682,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRemoteAccessSessionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7794,7 +8710,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRunResult>(String::from_utf8_lossy(&body).as_ref())
@@ -7823,7 +8739,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetSuiteResult>(String::from_utf8_lossy(&body).as_ref())
@@ -7852,7 +8768,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetTestResult>(String::from_utf8_lossy(&body).as_ref())
@@ -7881,7 +8797,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetUploadResult>(String::from_utf8_lossy(&body).as_ref())
@@ -7914,7 +8830,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<InstallToRemoteAccessSessionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7945,7 +8861,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListArtifactsResult>(String::from_utf8_lossy(&body)
@@ -7977,7 +8893,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListDevicePoolsResult>(String::from_utf8_lossy(&body)
@@ -8009,7 +8925,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListDevicesResult>(String::from_utf8_lossy(&body)
@@ -8039,7 +8955,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListJobsResult>(String::from_utf8_lossy(&body).as_ref())
@@ -8070,7 +8986,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListNetworkProfilesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8101,7 +9017,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListOfferingPromotionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8133,7 +9049,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListOfferingTransactionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8164,7 +9080,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListOfferingsResult>(String::from_utf8_lossy(&body)
@@ -8196,7 +9112,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListProjectsResult>(String::from_utf8_lossy(&body)
@@ -8230,7 +9146,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRemoteAccessSessionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8259,7 +9175,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRunsResult>(String::from_utf8_lossy(&body).as_ref())
@@ -8290,7 +9206,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListSamplesResult>(String::from_utf8_lossy(&body)
@@ -8320,7 +9236,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListSuitesResult>(String::from_utf8_lossy(&body)
@@ -8350,7 +9266,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTestsResult>(String::from_utf8_lossy(&body).as_ref())
@@ -8381,7 +9297,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListUniqueProblemsResult>(String::from_utf8_lossy(&body)
@@ -8413,7 +9329,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListUploadsResult>(String::from_utf8_lossy(&body)
@@ -8445,7 +9361,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PurchaseOfferingResult>(String::from_utf8_lossy(&body)
@@ -8477,7 +9393,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RenewOfferingResult>(String::from_utf8_lossy(&body)
@@ -8509,7 +9425,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ScheduleRunResult>(String::from_utf8_lossy(&body)
@@ -8543,7 +9459,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopRemoteAccessSessionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8572,7 +9488,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopRunResult>(String::from_utf8_lossy(&body).as_ref())
@@ -8603,7 +9519,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDevicePoolResult>(String::from_utf8_lossy(&body)
@@ -8635,7 +9551,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateNetworkProfileResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8665,7 +9581,7 @@ impl<P, D> DeviceFarm for DeviceFarmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateProjectResult>(String::from_utf8_lossy(&body)

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -11,23 +11,54 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+#[doc="<p>Indicates the address family for the BGP peer.</p> <ul> <li> <p> <b>ipv4</b>: IPv4 address family</p> </li> <li> <p> <b>ipv6</b>: IPv6 address family</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AddressFamily {
+    Ipv4,
+    Ipv6,
+}
+
+impl Into<String> for AddressFamily {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AddressFamily {
+    fn into(self) -> &'static str {
+        match self {
+            AddressFamily::Ipv4 => "ipv4",
+            AddressFamily::Ipv6 => "ipv6",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AddressFamily {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ipv4" => Ok(AddressFamily::Ipv4),
+            "ipv6" => Ok(AddressFamily::Ipv6),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Container for the parameters to the AllocateConnectionOnInterconnect operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AllocateConnectionOnInterconnectRequest {
@@ -155,6 +186,85 @@ pub struct BGPPeer {
     pub customer_address: Option<String>,
 }
 
+#[doc="<p>The state of the BGP peer.</p> <ul> <li> <p> <b>Verifying</b>: The BGP peering addresses or ASN require validation before the BGP peer can be created. This state only applies to BGP peers on a public virtual interface. </p> </li> <li> <p> <b>Pending</b>: The BGP peer has been created, and is in this state until it is ready to be established.</p> </li> <li> <p> <b>Available</b>: The BGP peer can be established.</p> </li> <li> <p> <b>Deleting</b>: The BGP peer is in the process of being deleted.</p> </li> <li> <p> <b>Deleted</b>: The BGP peer has been deleted and cannot be established.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BGPPeerState {
+    Available,
+    Deleted,
+    Deleting,
+    Pending,
+    Verifying,
+}
+
+impl Into<String> for BGPPeerState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BGPPeerState {
+    fn into(self) -> &'static str {
+        match self {
+            BGPPeerState::Available => "available",
+            BGPPeerState::Deleted => "deleted",
+            BGPPeerState::Deleting => "deleting",
+            BGPPeerState::Pending => "pending",
+            BGPPeerState::Verifying => "verifying",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BGPPeerState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(BGPPeerState::Available),
+            "deleted" => Ok(BGPPeerState::Deleted),
+            "deleting" => Ok(BGPPeerState::Deleting),
+            "pending" => Ok(BGPPeerState::Pending),
+            "verifying" => Ok(BGPPeerState::Verifying),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="<p>The Up/Down state of the BGP peer.</p> <ul> <li> <p> <b>Up</b>: The BGP peer is established.</p> </li> <li> <p> <b>Down</b>: The BGP peer is down.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BGPStatus {
+    Down,
+    Up,
+}
+
+impl Into<String> for BGPStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BGPStatus {
+    fn into(self) -> &'static str {
+        match self {
+            BGPStatus::Down => "down",
+            BGPStatus::Up => "up",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BGPStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "down" => Ok(BGPStatus::Down),
+            "up" => Ok(BGPStatus::Up),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Container for the parameters to the ConfirmConnection operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ConfirmConnectionRequest {
@@ -247,6 +357,59 @@ pub struct Connection {
     #[serde(rename="vlan")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vlan: Option<i64>,
+}
+
+#[doc="<p>State of the connection.</p> <ul> <li> <p> <b>Ordering</b>: The initial state of a hosted connection provisioned on an interconnect. The connection stays in the ordering state until the owner of the hosted connection confirms or declines the connection order.</p> </li> <li> <p> <b>Requested</b>: The initial state of a standard connection. The connection stays in the requested state until the Letter of Authorization (LOA) is sent to the customer.</p> </li> <li> <p> <b>Pending</b>: The connection has been approved, and is being initialized.</p> </li> <li> <p> <b>Available</b>: The network link is up, and the connection is ready for use.</p> </li> <li> <p> <b>Down</b>: The network link is down.</p> </li> <li> <p> <b>Deleting</b>: The connection is in the process of being deleted.</p> </li> <li> <p> <b>Deleted</b>: The connection has been deleted.</p> </li> <li> <p> <b>Rejected</b>: A hosted connection in the 'Ordering' state will enter the 'Rejected' state if it is deleted by the end customer.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConnectionState {
+    Available,
+    Deleted,
+    Deleting,
+    Down,
+    Ordering,
+    Pending,
+    Rejected,
+    Requested,
+}
+
+impl Into<String> for ConnectionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConnectionState {
+    fn into(self) -> &'static str {
+        match self {
+            ConnectionState::Available => "available",
+            ConnectionState::Deleted => "deleted",
+            ConnectionState::Deleting => "deleting",
+            ConnectionState::Down => "down",
+            ConnectionState::Ordering => "ordering",
+            ConnectionState::Pending => "pending",
+            ConnectionState::Rejected => "rejected",
+            ConnectionState::Requested => "requested",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConnectionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(ConnectionState::Available),
+            "deleted" => Ok(ConnectionState::Deleted),
+            "deleting" => Ok(ConnectionState::Deleting),
+            "down" => Ok(ConnectionState::Down),
+            "ordering" => Ok(ConnectionState::Ordering),
+            "pending" => Ok(ConnectionState::Pending),
+            "rejected" => Ok(ConnectionState::Rejected),
+            "requested" => Ok(ConnectionState::Requested),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A structure containing a list of connections.</p>"]
@@ -593,6 +756,53 @@ pub struct Interconnect {
     pub region: Option<String>,
 }
 
+#[doc="<p>State of the interconnect.</p> <ul> <li> <p> <b>Requested</b>: The initial state of an interconnect. The interconnect stays in the requested state until the Letter of Authorization (LOA) is sent to the customer.</p> </li> <li> <p> <b>Pending</b>: The interconnect has been approved, and is being initialized.</p> </li> <li> <p> <b>Available</b>: The network link is up, and the interconnect is ready for use.</p> </li> <li> <p> <b>Down</b>: The network link is down.</p> </li> <li> <p> <b>Deleting</b>: The interconnect is in the process of being deleted.</p> </li> <li> <p> <b>Deleted</b>: The interconnect has been deleted.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InterconnectState {
+    Available,
+    Deleted,
+    Deleting,
+    Down,
+    Pending,
+    Requested,
+}
+
+impl Into<String> for InterconnectState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InterconnectState {
+    fn into(self) -> &'static str {
+        match self {
+            InterconnectState::Available => "available",
+            InterconnectState::Deleted => "deleted",
+            InterconnectState::Deleting => "deleting",
+            InterconnectState::Down => "down",
+            InterconnectState::Pending => "pending",
+            InterconnectState::Requested => "requested",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InterconnectState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(InterconnectState::Available),
+            "deleted" => Ok(InterconnectState::Deleted),
+            "deleting" => Ok(InterconnectState::Deleting),
+            "down" => Ok(InterconnectState::Down),
+            "pending" => Ok(InterconnectState::Pending),
+            "requested" => Ok(InterconnectState::Requested),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A structure containing a list of interconnects.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Interconnects {
@@ -651,6 +861,53 @@ pub struct Lag {
     pub region: Option<String>,
 }
 
+#[doc="<p>The state of the LAG.</p> <ul> <li> <p> <b>Requested</b>: The initial state of a LAG. The LAG stays in the requested state until the Letter of Authorization (LOA) is available.</p> </li> <li> <p> <b>Pending</b>: The LAG has been approved, and is being initialized.</p> </li> <li> <p> <b>Available</b>: The network link is established, and the LAG is ready for use.</p> </li> <li> <p> <b>Down</b>: The network link is down.</p> </li> <li> <p> <b>Deleting</b>: The LAG is in the process of being deleted.</p> </li> <li> <p> <b>Deleted</b>: The LAG has been deleted.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LagState {
+    Available,
+    Deleted,
+    Deleting,
+    Down,
+    Pending,
+    Requested,
+}
+
+impl Into<String> for LagState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LagState {
+    fn into(self) -> &'static str {
+        match self {
+            LagState::Available => "available",
+            LagState::Deleted => "deleted",
+            LagState::Deleting => "deleting",
+            LagState::Down => "down",
+            LagState::Pending => "pending",
+            LagState::Requested => "requested",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LagState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(LagState::Available),
+            "deleted" => Ok(LagState::Deleted),
+            "deleting" => Ok(LagState::Deleting),
+            "down" => Ok(LagState::Down),
+            "pending" => Ok(LagState::Pending),
+            "requested" => Ok(LagState::Requested),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A structure containing a list of LAGs.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Lags {
@@ -673,6 +930,38 @@ pub struct Loa {
     #[serde(rename="loaContentType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub loa_content_type: Option<String>,
+}
+
+#[doc="<p>A standard media type indicating the content type of the LOA-CFA document. Currently, the only supported value is \"application/pdf\".</p> <p>Default: application/pdf</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LoaContentType {
+    ApplicationPdf,
+}
+
+impl Into<String> for LoaContentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LoaContentType {
+    fn into(self) -> &'static str {
+        match self {
+            LoaContentType::ApplicationPdf => "application/pdf",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LoaContentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "application/pdf" => Ok(LoaContentType::ApplicationPdf),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>An AWS Direct Connect location where connections and interconnects can be requested.</p>"]
@@ -973,6 +1262,59 @@ pub struct VirtualInterface {
     #[serde(rename="vlan")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vlan: Option<i64>,
+}
+
+#[doc="<p>State of the virtual interface.</p> <ul> <li> <p> <b>Confirming</b>: The creation of the virtual interface is pending confirmation from the virtual interface owner. If the owner of the virtual interface is different from the owner of the connection on which it is provisioned, then the virtual interface will remain in this state until it is confirmed by the virtual interface owner.</p> </li> <li> <p> <b>Verifying</b>: This state only applies to public virtual interfaces. Each public virtual interface needs validation before the virtual interface can be created.</p> </li> <li> <p> <b>Pending</b>: A virtual interface is in this state from the time that it is created until the virtual interface is ready to forward traffic.</p> </li> <li> <p> <b>Available</b>: A virtual interface that is able to forward traffic.</p> </li> <li> <p> <b>Down</b>: A virtual interface that is BGP down.</p> </li> <li> <p> <b>Deleting</b>: A virtual interface is in this state immediately after calling <a>DeleteVirtualInterface</a> until it can no longer forward traffic.</p> </li> <li> <p> <b>Deleted</b>: A virtual interface that cannot forward traffic.</p> </li> <li> <p> <b>Rejected</b>: The virtual interface owner has declined creation of the virtual interface. If a virtual interface in the 'Confirming' state is deleted by the virtual interface owner, the virtual interface will enter the 'Rejected' state.</p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VirtualInterfaceState {
+    Available,
+    Confirming,
+    Deleted,
+    Deleting,
+    Down,
+    Pending,
+    Rejected,
+    Verifying,
+}
+
+impl Into<String> for VirtualInterfaceState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VirtualInterfaceState {
+    fn into(self) -> &'static str {
+        match self {
+            VirtualInterfaceState::Available => "available",
+            VirtualInterfaceState::Confirming => "confirming",
+            VirtualInterfaceState::Deleted => "deleted",
+            VirtualInterfaceState::Deleting => "deleting",
+            VirtualInterfaceState::Down => "down",
+            VirtualInterfaceState::Pending => "pending",
+            VirtualInterfaceState::Rejected => "rejected",
+            VirtualInterfaceState::Verifying => "verifying",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VirtualInterfaceState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(VirtualInterfaceState::Available),
+            "confirming" => Ok(VirtualInterfaceState::Confirming),
+            "deleted" => Ok(VirtualInterfaceState::Deleted),
+            "deleting" => Ok(VirtualInterfaceState::Deleting),
+            "down" => Ok(VirtualInterfaceState::Down),
+            "pending" => Ok(VirtualInterfaceState::Pending),
+            "rejected" => Ok(VirtualInterfaceState::Rejected),
+            "verifying" => Ok(VirtualInterfaceState::Verifying),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A structure containing a list of virtual interfaces.</p>"]
@@ -4380,7 +4722,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
@@ -4411,7 +4753,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
@@ -4445,7 +4787,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&body)
@@ -4480,7 +4822,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&body)
@@ -4513,7 +4855,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
@@ -4545,7 +4887,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
@@ -4577,7 +4919,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&body)
@@ -4610,7 +4952,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ConfirmConnectionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4642,7 +4984,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ConfirmPrivateVirtualInterfaceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4675,7 +5017,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ConfirmPublicVirtualInterfaceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4706,7 +5048,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateBGPPeerResponse>(String::from_utf8_lossy(&body)
@@ -4738,7 +5080,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
@@ -4769,7 +5111,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Interconnect>(String::from_utf8_lossy(&body).as_ref())
@@ -4798,7 +5140,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4830,7 +5172,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&body)
@@ -4865,7 +5207,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<VirtualInterface>(String::from_utf8_lossy(&body)
@@ -4898,7 +5240,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteBGPPeerResponse>(String::from_utf8_lossy(&body)
@@ -4930,7 +5272,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
@@ -4961,7 +5303,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteInterconnectResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4989,7 +5331,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5020,7 +5362,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteVirtualInterfaceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5051,7 +5393,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeConnectionLoaResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5081,7 +5423,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&body).as_ref())
@@ -5114,7 +5456,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&body).as_ref())
@@ -5145,7 +5487,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Connections>(String::from_utf8_lossy(&body).as_ref())
@@ -5178,7 +5520,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeInterconnectLoaResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5209,7 +5551,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Interconnects>(String::from_utf8_lossy(&body).as_ref())
@@ -5238,7 +5580,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Lags>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5266,7 +5608,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Loa>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5293,7 +5635,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Locations>(String::from_utf8_lossy(&body).as_ref())
@@ -5324,7 +5666,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTagsResponse>(String::from_utf8_lossy(&body)
@@ -5353,7 +5695,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<VirtualGateways>(String::from_utf8_lossy(&body).as_ref())
@@ -5385,7 +5727,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<VirtualInterfaces>(String::from_utf8_lossy(&body)
@@ -5420,7 +5762,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Connection>(String::from_utf8_lossy(&body).as_ref())
@@ -5452,7 +5794,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<TagResourceResponse>(String::from_utf8_lossy(&body)
@@ -5484,7 +5826,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UntagResourceResponse>(String::from_utf8_lossy(&body)
@@ -5514,7 +5856,7 @@ impl<P, D> DirectConnect for DirectConnectClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Lag>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/discovery/src/generated.rs
+++ b/rusoto/services/discovery/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -103,6 +99,53 @@ pub struct AgentNetworkInfo {
     pub mac_address: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AgentStatus {
+    Blacklisted,
+    Healthy,
+    Running,
+    Shutdown,
+    Unhealthy,
+    Unknown,
+}
+
+impl Into<String> for AgentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AgentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AgentStatus::Blacklisted => "BLACKLISTED",
+            AgentStatus::Healthy => "HEALTHY",
+            AgentStatus::Running => "RUNNING",
+            AgentStatus::Shutdown => "SHUTDOWN",
+            AgentStatus::Unhealthy => "UNHEALTHY",
+            AgentStatus::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AgentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BLACKLISTED" => Ok(AgentStatus::Blacklisted),
+            "HEALTHY" => Ok(AgentStatus::Healthy),
+            "RUNNING" => Ok(AgentStatus::Running),
+            "SHUTDOWN" => Ok(AgentStatus::Shutdown),
+            "UNHEALTHY" => Ok(AgentStatus::Unhealthy),
+            "UNKNOWN" => Ok(AgentStatus::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AssociateConfigurationItemsToApplicationRequest {
     #[doc="<p>The configuration ID of an application with which items are to be associated.</p>"]
@@ -115,6 +158,47 @@ pub struct AssociateConfigurationItemsToApplicationRequest {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AssociateConfigurationItemsToApplicationResponse;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConfigurationItemType {
+    Application,
+    Connection,
+    Process,
+    Server,
+}
+
+impl Into<String> for ConfigurationItemType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConfigurationItemType {
+    fn into(self) -> &'static str {
+        match self {
+            ConfigurationItemType::Application => "APPLICATION",
+            ConfigurationItemType::Connection => "CONNECTION",
+            ConfigurationItemType::Process => "PROCESS",
+            ConfigurationItemType::Server => "SERVER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConfigurationItemType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "APPLICATION" => Ok(ConfigurationItemType::Application),
+            "CONNECTION" => Ok(ConfigurationItemType::Connection),
+            "PROCESS" => Ok(ConfigurationItemType::Process),
+            "SERVER" => Ok(ConfigurationItemType::Server),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p>Tags for a configuration item. Tags are metadata that help you categorize IT assets.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
@@ -405,6 +489,41 @@ pub struct ExportConfigurationsResponse {
     pub export_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExportDataFormat {
+    Csv,
+    Graphml,
+}
+
+impl Into<String> for ExportDataFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExportDataFormat {
+    fn into(self) -> &'static str {
+        match self {
+            ExportDataFormat::Csv => "CSV",
+            ExportDataFormat::Graphml => "GRAPHML",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExportDataFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CSV" => Ok(ExportDataFormat::Csv),
+            "GRAPHML" => Ok(ExportDataFormat::Graphml),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Used to select which agent's data is to be exported. A single agent ID may be selected for export using the <a href=\"http://docs.aws.amazon.com/application-discovery/latest/APIReference/API_StartExportTask.html\">StartExportTask</a> action.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ExportFilter {
@@ -450,6 +569,44 @@ pub struct ExportInfo {
     #[doc="<p>A status message provided for API callers.</p>"]
     #[serde(rename="statusMessage")]
     pub status_message: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExportStatus {
+    Failed,
+    InProgress,
+    Succeeded,
+}
+
+impl Into<String> for ExportStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExportStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ExportStatus::Failed => "FAILED",
+            ExportStatus::InProgress => "IN_PROGRESS",
+            ExportStatus::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExportStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(ExportStatus::Failed),
+            "IN_PROGRESS" => Ok(ExportStatus::InProgress),
+            "SUCCEEDED" => Ok(ExportStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A filter that can use conditional operators.</p> <p>For more information about filters, see <a href=\"http://docs.aws.amazon.com/application-discovery/latest/APIReference/discovery-api-queries.html\">Querying Discovered Configuration Items</a>. </p>"]
@@ -602,6 +759,41 @@ pub struct OrderByElement {
     #[serde(rename="sortOrder")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub sort_order: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OrderString {
+    Asc,
+    Desc,
+}
+
+impl Into<String> for OrderString {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OrderString {
+    fn into(self) -> &'static str {
+        match self {
+            OrderString::Asc => "ASC",
+            OrderString::Desc => "DESC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OrderString {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASC" => Ok(OrderString::Asc),
+            "DESC" => Ok(OrderString::Desc),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -2723,7 +2915,7 @@ fn associate_configuration_items_to_application(&self, input: &AssociateConfigur
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AssociateConfigurationItemsToApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2754,7 +2946,7 @@ fn associate_configuration_items_to_application(&self, input: &AssociateConfigur
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2784,7 +2976,7 @@ fn associate_configuration_items_to_application(&self, input: &AssociateConfigur
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateTagsResponse>(String::from_utf8_lossy(&body)
@@ -2817,7 +3009,7 @@ fn associate_configuration_items_to_application(&self, input: &AssociateConfigur
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteApplicationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2847,7 +3039,7 @@ fn associate_configuration_items_to_application(&self, input: &AssociateConfigur
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteTagsResponse>(String::from_utf8_lossy(&body)
@@ -2880,7 +3072,7 @@ fn associate_configuration_items_to_application(&self, input: &AssociateConfigur
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAgentsResponse>(String::from_utf8_lossy(&body)
@@ -2914,7 +3106,7 @@ fn associate_configuration_items_to_application(&self, input: &AssociateConfigur
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeConfigurationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2946,7 +3138,7 @@ fn associate_configuration_items_to_application(&self, input: &AssociateConfigur
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeExportConfigurationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2978,7 +3170,7 @@ fn associate_configuration_items_to_application(&self, input: &AssociateConfigur
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeExportTasksResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3009,7 +3201,7 @@ fn associate_configuration_items_to_application(&self, input: &AssociateConfigur
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTagsResponse>(String::from_utf8_lossy(&body)
@@ -3039,7 +3231,7 @@ fn disassociate_configuration_items_from_application(&self, input: &Disassociate
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisassociateConfigurationItemsFromApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3068,7 +3260,7 @@ fn disassociate_configuration_items_from_application(&self, input: &Disassociate
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ExportConfigurationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3097,7 +3289,7 @@ fn disassociate_configuration_items_from_application(&self, input: &Disassociate
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDiscoverySummaryResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3128,7 +3320,7 @@ fn disassociate_configuration_items_from_application(&self, input: &Disassociate
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListConfigurationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3159,7 +3351,7 @@ fn disassociate_configuration_items_from_application(&self, input: &Disassociate
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListServerNeighborsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3191,7 +3383,7 @@ fn disassociate_configuration_items_from_application(&self, input: &Disassociate
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartDataCollectionByAgentIdsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3223,7 +3415,7 @@ fn disassociate_configuration_items_from_application(&self, input: &Disassociate
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartExportTaskResponse>(String::from_utf8_lossy(&body)
@@ -3257,7 +3449,7 @@ fn disassociate_configuration_items_from_application(&self, input: &Disassociate
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopDataCollectionByAgentIdsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3289,7 +3481,7 @@ fn disassociate_configuration_items_from_application(&self, input: &Disassociate
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -59,6 +55,79 @@ pub struct AddTagsToResourceMessage {
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AddTagsToResourceResponse;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AuthMechanismValue {
+    Default,
+    MongodbCr,
+    ScramSha1,
+}
+
+impl Into<String> for AuthMechanismValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AuthMechanismValue {
+    fn into(self) -> &'static str {
+        match self {
+            AuthMechanismValue::Default => "default",
+            AuthMechanismValue::MongodbCr => "mongodb_cr",
+            AuthMechanismValue::ScramSha1 => "scram_sha_1",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AuthMechanismValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default" => Ok(AuthMechanismValue::Default),
+            "mongodb_cr" => Ok(AuthMechanismValue::MongodbCr),
+            "scram_sha_1" => Ok(AuthMechanismValue::ScramSha1),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AuthTypeValue {
+    No,
+    Password,
+}
+
+impl Into<String> for AuthTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AuthTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            AuthTypeValue::No => "no",
+            AuthTypeValue::Password => "password",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AuthTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "no" => Ok(AuthTypeValue::No),
+            "password" => Ok(AuthTypeValue::Password),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Deserialize)]
@@ -116,6 +185,41 @@ pub struct Certificate {
     #[serde(rename="ValidToDate")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub valid_to_date: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CompressionTypeValue {
+    Gzip,
+    None,
+}
+
+impl Into<String> for CompressionTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CompressionTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            CompressionTypeValue::Gzip => "gzip",
+            CompressionTypeValue::None => "none",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CompressionTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "gzip" => Ok(CompressionTypeValue::Gzip),
+            "none" => Ok(CompressionTypeValue::None),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p/>"]
@@ -928,6 +1032,47 @@ pub struct DescribeTableStatisticsResponse {
     pub table_statistics: Option<Vec<TableStatistics>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DmsSslModeValue {
+    None,
+    Require,
+    VerifyCa,
+    VerifyFull,
+}
+
+impl Into<String> for DmsSslModeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DmsSslModeValue {
+    fn into(self) -> &'static str {
+        match self {
+            DmsSslModeValue::None => "none",
+            DmsSslModeValue::Require => "require",
+            DmsSslModeValue::VerifyCa => "verify-ca",
+            DmsSslModeValue::VerifyFull => "verify-full",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DmsSslModeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "none" => Ok(DmsSslModeValue::None),
+            "require" => Ok(DmsSslModeValue::Require),
+            "verify-ca" => Ok(DmsSslModeValue::VerifyCa),
+            "verify-full" => Ok(DmsSslModeValue::VerifyFull),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DynamoDbSettings {
@@ -1145,6 +1290,44 @@ pub struct ListTagsForResourceResponse {
     #[serde(rename="TagList")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tag_list: Option<Vec<Tag>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MigrationTypeValue {
+    Cdc,
+    FullLoad,
+    FullLoadAndCdc,
+}
+
+impl Into<String> for MigrationTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MigrationTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            MigrationTypeValue::Cdc => "cdc",
+            MigrationTypeValue::FullLoad => "full-load",
+            MigrationTypeValue::FullLoadAndCdc => "full-load-and-cdc",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MigrationTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cdc" => Ok(MigrationTypeValue::Cdc),
+            "full-load" => Ok(MigrationTypeValue::FullLoad),
+            "full-load-and-cdc" => Ok(MigrationTypeValue::FullLoadAndCdc),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p/>"]
@@ -1420,6 +1603,41 @@ pub struct MongoDbSettings {
     pub username: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NestingLevelValue {
+    None,
+    One,
+}
+
+impl Into<String> for NestingLevelValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NestingLevelValue {
+    fn into(self) -> &'static str {
+        match self {
+            NestingLevelValue::None => "none",
+            NestingLevelValue::One => "one",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NestingLevelValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "none" => Ok(NestingLevelValue::None),
+            "one" => Ok(NestingLevelValue::One),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct OrderableReplicationInstance {
@@ -1498,6 +1716,44 @@ pub struct RefreshSchemasStatus {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RefreshSchemasStatusTypeValue {
+    Failed,
+    Refreshing,
+    Successful,
+}
+
+impl Into<String> for RefreshSchemasStatusTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RefreshSchemasStatusTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            RefreshSchemasStatusTypeValue::Failed => "failed",
+            RefreshSchemasStatusTypeValue::Refreshing => "refreshing",
+            RefreshSchemasStatusTypeValue::Successful => "successful",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RefreshSchemasStatusTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "failed" => Ok(RefreshSchemasStatusTypeValue::Failed),
+            "refreshing" => Ok(RefreshSchemasStatusTypeValue::Refreshing),
+            "successful" => Ok(RefreshSchemasStatusTypeValue::Successful),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ReloadTablesMessage {
     #[doc="<p>The Amazon Resource Name (ARN) of the replication instance. </p>"]
@@ -1530,6 +1786,41 @@ pub struct RemoveTagsFromResourceMessage {
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RemoveTagsFromResourceResponse;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationEndpointTypeValue {
+    Source,
+    Target,
+}
+
+impl Into<String> for ReplicationEndpointTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationEndpointTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationEndpointTypeValue::Source => "source",
+            ReplicationEndpointTypeValue::Target => "target",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationEndpointTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "source" => Ok(ReplicationEndpointTypeValue::Source),
+            "target" => Ok(ReplicationEndpointTypeValue::Target),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Deserialize)]
@@ -1781,6 +2072,38 @@ pub struct S3Settings {
     pub service_access_role_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    ReplicationInstance,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::ReplicationInstance => "replication-instance",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "replication-instance" => Ok(SourceType::ReplicationInstance),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StartReplicationTaskMessage {
@@ -1803,6 +2126,44 @@ pub struct StartReplicationTaskResponse {
     #[serde(rename="ReplicationTask")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub replication_task: Option<ReplicationTask>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StartReplicationTaskTypeValue {
+    ReloadTarget,
+    ResumeProcessing,
+    StartReplication,
+}
+
+impl Into<String> for StartReplicationTaskTypeValue {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StartReplicationTaskTypeValue {
+    fn into(self) -> &'static str {
+        match self {
+            StartReplicationTaskTypeValue::ReloadTarget => "reload-target",
+            StartReplicationTaskTypeValue::ResumeProcessing => "resume-processing",
+            StartReplicationTaskTypeValue::StartReplication => "start-replication",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StartReplicationTaskTypeValue {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "reload-target" => Ok(StartReplicationTaskTypeValue::ReloadTarget),
+            "resume-processing" => Ok(StartReplicationTaskTypeValue::ResumeProcessing),
+            "start-replication" => Ok(StartReplicationTaskTypeValue::StartReplication),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p/>"]
@@ -5729,7 +6090,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddTagsToResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5759,7 +6120,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateEndpointResponse>(String::from_utf8_lossy(&body)
@@ -5792,7 +6153,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateEventSubscriptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5825,7 +6186,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateReplicationInstanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5858,7 +6219,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateReplicationSubnetGroupResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5890,7 +6251,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateReplicationTaskResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5920,7 +6281,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5950,7 +6311,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteEndpointResponse>(String::from_utf8_lossy(&body)
@@ -5983,7 +6344,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteEventSubscriptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6016,7 +6377,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteReplicationInstanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6049,7 +6410,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteReplicationSubnetGroupResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6081,7 +6442,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteReplicationTaskResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6111,7 +6472,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAccountAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6142,7 +6503,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeCertificatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6172,7 +6533,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeConnectionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6203,7 +6564,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEndpointTypesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6233,7 +6594,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEndpointsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6264,7 +6625,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEventCategoriesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6297,7 +6658,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEventSubscriptionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6328,7 +6689,7 @@ impl<P, D> DatabaseMigrationService for DatabaseMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&body)
@@ -6359,7 +6720,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeOrderableReplicationInstancesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6391,7 +6752,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeRefreshSchemasStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6424,7 +6785,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeReplicationInstancesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6457,7 +6818,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeReplicationSubnetGroupsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6490,7 +6851,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeReplicationTasksResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6521,7 +6882,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeSchemasResponse>(String::from_utf8_lossy(&body)
@@ -6554,7 +6915,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTableStatisticsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6585,7 +6946,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ImportCertificateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6615,7 +6976,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6645,7 +7006,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ModifyEndpointResponse>(String::from_utf8_lossy(&body)
@@ -6678,7 +7039,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ModifyEventSubscriptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6711,7 +7072,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ModifyReplicationInstanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6744,7 +7105,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ModifyReplicationSubnetGroupResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6776,7 +7137,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ModifyReplicationTaskResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6806,7 +7167,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RefreshSchemasResponse>(String::from_utf8_lossy(&body)
@@ -6838,7 +7199,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ReloadTablesResponse>(String::from_utf8_lossy(&body)
@@ -6871,7 +7232,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveTagsFromResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6902,7 +7263,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartReplicationTaskResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6932,7 +7293,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopReplicationTaskResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6962,7 +7323,7 @@ fn describe_orderable_replication_instances(&self, input: &DescribeOrderableRepl
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<TestConnectionResponse>(String::from_utf8_lossy(&body)

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -771,6 +767,141 @@ pub struct DirectoryLimits {
     pub connected_directories_limit_reached: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DirectorySize {
+    Large,
+    Small,
+}
+
+impl Into<String> for DirectorySize {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DirectorySize {
+    fn into(self) -> &'static str {
+        match self {
+            DirectorySize::Large => "Large",
+            DirectorySize::Small => "Small",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DirectorySize {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Large" => Ok(DirectorySize::Large),
+            "Small" => Ok(DirectorySize::Small),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DirectoryStage {
+    Active,
+    Created,
+    Creating,
+    Deleted,
+    Deleting,
+    Failed,
+    Impaired,
+    Inoperable,
+    Requested,
+    RestoreFailed,
+    Restoring,
+}
+
+impl Into<String> for DirectoryStage {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DirectoryStage {
+    fn into(self) -> &'static str {
+        match self {
+            DirectoryStage::Active => "Active",
+            DirectoryStage::Created => "Created",
+            DirectoryStage::Creating => "Creating",
+            DirectoryStage::Deleted => "Deleted",
+            DirectoryStage::Deleting => "Deleting",
+            DirectoryStage::Failed => "Failed",
+            DirectoryStage::Impaired => "Impaired",
+            DirectoryStage::Inoperable => "Inoperable",
+            DirectoryStage::Requested => "Requested",
+            DirectoryStage::RestoreFailed => "RestoreFailed",
+            DirectoryStage::Restoring => "Restoring",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DirectoryStage {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(DirectoryStage::Active),
+            "Created" => Ok(DirectoryStage::Created),
+            "Creating" => Ok(DirectoryStage::Creating),
+            "Deleted" => Ok(DirectoryStage::Deleted),
+            "Deleting" => Ok(DirectoryStage::Deleting),
+            "Failed" => Ok(DirectoryStage::Failed),
+            "Impaired" => Ok(DirectoryStage::Impaired),
+            "Inoperable" => Ok(DirectoryStage::Inoperable),
+            "Requested" => Ok(DirectoryStage::Requested),
+            "RestoreFailed" => Ok(DirectoryStage::RestoreFailed),
+            "Restoring" => Ok(DirectoryStage::Restoring),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DirectoryType {
+    Adconnector,
+    MicrosoftAD,
+    SimpleAD,
+}
+
+impl Into<String> for DirectoryType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DirectoryType {
+    fn into(self) -> &'static str {
+        match self {
+            DirectoryType::Adconnector => "ADConnector",
+            DirectoryType::MicrosoftAD => "MicrosoftAD",
+            DirectoryType::SimpleAD => "SimpleAD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DirectoryType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADConnector" => Ok(DirectoryType::Adconnector),
+            "MicrosoftAD" => Ok(DirectoryType::MicrosoftAD),
+            "SimpleAD" => Ok(DirectoryType::SimpleAD),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains VPC information for the <a>CreateDirectory</a> or <a>CreateMicrosoftAD</a> operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DirectoryVpcSettings {
@@ -878,6 +1009,56 @@ pub struct DomainController {
     #[serde(rename="VpcId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DomainControllerStatus {
+    Active,
+    Creating,
+    Deleted,
+    Deleting,
+    Failed,
+    Impaired,
+    Restoring,
+}
+
+impl Into<String> for DomainControllerStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DomainControllerStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DomainControllerStatus::Active => "Active",
+            DomainControllerStatus::Creating => "Creating",
+            DomainControllerStatus::Deleted => "Deleted",
+            DomainControllerStatus::Deleting => "Deleting",
+            DomainControllerStatus::Failed => "Failed",
+            DomainControllerStatus::Impaired => "Impaired",
+            DomainControllerStatus::Restoring => "Restoring",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DomainControllerStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(DomainControllerStatus::Active),
+            "Creating" => Ok(DomainControllerStatus::Creating),
+            "Deleted" => Ok(DomainControllerStatus::Deleted),
+            "Deleting" => Ok(DomainControllerStatus::Deleting),
+            "Failed" => Ok(DomainControllerStatus::Failed),
+            "Impaired" => Ok(DomainControllerStatus::Impaired),
+            "Restoring" => Ok(DomainControllerStatus::Restoring),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains the inputs for the <a>EnableRadius</a> operation.</p>"]
@@ -1012,6 +1193,53 @@ pub struct IpRouteInfo {
     pub ip_route_status_reason: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IpRouteStatusMsg {
+    AddFailed,
+    Added,
+    Adding,
+    RemoveFailed,
+    Removed,
+    Removing,
+}
+
+impl Into<String> for IpRouteStatusMsg {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IpRouteStatusMsg {
+    fn into(self) -> &'static str {
+        match self {
+            IpRouteStatusMsg::AddFailed => "AddFailed",
+            IpRouteStatusMsg::Added => "Added",
+            IpRouteStatusMsg::Adding => "Adding",
+            IpRouteStatusMsg::RemoveFailed => "RemoveFailed",
+            IpRouteStatusMsg::Removed => "Removed",
+            IpRouteStatusMsg::Removing => "Removing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IpRouteStatusMsg {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AddFailed" => Ok(IpRouteStatusMsg::AddFailed),
+            "Added" => Ok(IpRouteStatusMsg::Added),
+            "Adding" => Ok(IpRouteStatusMsg::Adding),
+            "RemoveFailed" => Ok(IpRouteStatusMsg::RemoveFailed),
+            "Removed" => Ok(IpRouteStatusMsg::Removed),
+            "Removing" => Ok(IpRouteStatusMsg::Removing),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListIpRoutesRequest {
     #[doc="<p>Identifier (ID) of the directory for which you want to retrieve the IP addresses.</p>"]
@@ -1093,6 +1321,47 @@ pub struct ListTagsForResourceResult {
     pub tags: Option<Vec<Tag>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RadiusAuthenticationProtocol {
+    Chap,
+    MsChapv1,
+    MsChapv2,
+    Pap,
+}
+
+impl Into<String> for RadiusAuthenticationProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RadiusAuthenticationProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            RadiusAuthenticationProtocol::Chap => "CHAP",
+            RadiusAuthenticationProtocol::MsChapv1 => "MS-CHAPv1",
+            RadiusAuthenticationProtocol::MsChapv2 => "MS-CHAPv2",
+            RadiusAuthenticationProtocol::Pap => "PAP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RadiusAuthenticationProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHAP" => Ok(RadiusAuthenticationProtocol::Chap),
+            "MS-CHAPv1" => Ok(RadiusAuthenticationProtocol::MsChapv1),
+            "MS-CHAPv2" => Ok(RadiusAuthenticationProtocol::MsChapv2),
+            "PAP" => Ok(RadiusAuthenticationProtocol::Pap),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about a Remote Authentication Dial In User Service (RADIUS) server.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RadiusSettings {
@@ -1128,6 +1397,44 @@ pub struct RadiusSettings {
     #[serde(rename="UseSameUsername")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub use_same_username: Option<bool>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RadiusStatus {
+    Completed,
+    Creating,
+    Failed,
+}
+
+impl Into<String> for RadiusStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RadiusStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RadiusStatus::Completed => "Completed",
+            RadiusStatus::Creating => "Creating",
+            RadiusStatus::Failed => "Failed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RadiusStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Completed" => Ok(RadiusStatus::Completed),
+            "Creating" => Ok(RadiusStatus::Creating),
+            "Failed" => Ok(RadiusStatus::Failed),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Registers a new event topic.</p>"]
@@ -1170,6 +1477,38 @@ pub struct RemoveTagsFromResourceRequest {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RemoveTagsFromResourceResult;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationScope {
+    Domain,
+}
+
+impl Into<String> for ReplicationScope {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationScope {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationScope::Domain => "Domain",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationScope {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Domain" => Ok(ReplicationScope::Domain),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p>An object representing the inputs for the <a>RestoreFromSnapshot</a> operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1214,6 +1553,62 @@ pub struct SchemaExtensionInfo {
     #[serde(rename="StartDateTime")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub start_date_time: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SchemaExtensionStatus {
+    CancelInProgress,
+    Cancelled,
+    Completed,
+    CreatingSnapshot,
+    Failed,
+    Initializing,
+    Replicating,
+    RollbackInProgress,
+    UpdatingSchema,
+}
+
+impl Into<String> for SchemaExtensionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SchemaExtensionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            SchemaExtensionStatus::CancelInProgress => "CancelInProgress",
+            SchemaExtensionStatus::Cancelled => "Cancelled",
+            SchemaExtensionStatus::Completed => "Completed",
+            SchemaExtensionStatus::CreatingSnapshot => "CreatingSnapshot",
+            SchemaExtensionStatus::Failed => "Failed",
+            SchemaExtensionStatus::Initializing => "Initializing",
+            SchemaExtensionStatus::Replicating => "Replicating",
+            SchemaExtensionStatus::RollbackInProgress => "RollbackInProgress",
+            SchemaExtensionStatus::UpdatingSchema => "UpdatingSchema",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SchemaExtensionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CancelInProgress" => Ok(SchemaExtensionStatus::CancelInProgress),
+            "Cancelled" => Ok(SchemaExtensionStatus::Cancelled),
+            "Completed" => Ok(SchemaExtensionStatus::Completed),
+            "CreatingSnapshot" => Ok(SchemaExtensionStatus::CreatingSnapshot),
+            "Failed" => Ok(SchemaExtensionStatus::Failed),
+            "Initializing" => Ok(SchemaExtensionStatus::Initializing),
+            "Replicating" => Ok(SchemaExtensionStatus::Replicating),
+            "RollbackInProgress" => Ok(SchemaExtensionStatus::RollbackInProgress),
+            "UpdatingSchema" => Ok(SchemaExtensionStatus::UpdatingSchema),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a directory snapshot.</p>"]
@@ -1262,6 +1657,79 @@ pub struct SnapshotLimits {
     pub manual_snapshots_limit_reached: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnapshotStatus {
+    Completed,
+    Creating,
+    Failed,
+}
+
+impl Into<String> for SnapshotStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnapshotStatus {
+    fn into(self) -> &'static str {
+        match self {
+            SnapshotStatus::Completed => "Completed",
+            SnapshotStatus::Creating => "Creating",
+            SnapshotStatus::Failed => "Failed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnapshotStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Completed" => Ok(SnapshotStatus::Completed),
+            "Creating" => Ok(SnapshotStatus::Creating),
+            "Failed" => Ok(SnapshotStatus::Failed),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnapshotType {
+    Auto,
+    Manual,
+}
+
+impl Into<String> for SnapshotType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnapshotType {
+    fn into(self) -> &'static str {
+        match self {
+            SnapshotType::Auto => "Auto",
+            SnapshotType::Manual => "Manual",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnapshotType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Auto" => Ok(SnapshotType::Auto),
+            "Manual" => Ok(SnapshotType::Manual),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StartSchemaExtensionRequest {
     #[doc="<p>If true, creates a snapshot of the directory before applying the schema extension.</p>"]
@@ -1295,6 +1763,47 @@ pub struct Tag {
     #[doc="<p>The optional value of the tag. The string value can be Unicode characters. The string can contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: \"^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=+\\\\-]*)$\").</p>"]
     #[serde(rename="Value")]
     pub value: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TopicStatus {
+    Deleted,
+    Failed,
+    Registered,
+    TopicNotFound,
+}
+
+impl Into<String> for TopicStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TopicStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TopicStatus::Deleted => "Deleted",
+            TopicStatus::Failed => "Failed",
+            TopicStatus::Registered => "Registered",
+            TopicStatus::TopicNotFound => "Topic not found",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TopicStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Deleted" => Ok(TopicStatus::Deleted),
+            "Failed" => Ok(TopicStatus::Failed),
+            "Registered" => Ok(TopicStatus::Registered),
+            "Topic not found" => Ok(TopicStatus::TopicNotFound),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a trust relationship between an Microsoft AD in the AWS cloud and an external domain.</p>"]
@@ -1340,6 +1849,129 @@ pub struct Trust {
     #[serde(rename="TrustType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub trust_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TrustDirection {
+    OneWayIncoming,
+    OneWayOutgoing,
+    TwoWay,
+}
+
+impl Into<String> for TrustDirection {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TrustDirection {
+    fn into(self) -> &'static str {
+        match self {
+            TrustDirection::OneWayIncoming => "One-Way: Incoming",
+            TrustDirection::OneWayOutgoing => "One-Way: Outgoing",
+            TrustDirection::TwoWay => "Two-Way",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TrustDirection {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "One-Way: Incoming" => Ok(TrustDirection::OneWayIncoming),
+            "One-Way: Outgoing" => Ok(TrustDirection::OneWayOutgoing),
+            "Two-Way" => Ok(TrustDirection::TwoWay),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TrustState {
+    Created,
+    Creating,
+    Deleted,
+    Deleting,
+    Failed,
+    Verified,
+    VerifyFailed,
+    Verifying,
+}
+
+impl Into<String> for TrustState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TrustState {
+    fn into(self) -> &'static str {
+        match self {
+            TrustState::Created => "Created",
+            TrustState::Creating => "Creating",
+            TrustState::Deleted => "Deleted",
+            TrustState::Deleting => "Deleting",
+            TrustState::Failed => "Failed",
+            TrustState::Verified => "Verified",
+            TrustState::VerifyFailed => "VerifyFailed",
+            TrustState::Verifying => "Verifying",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TrustState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Created" => Ok(TrustState::Created),
+            "Creating" => Ok(TrustState::Creating),
+            "Deleted" => Ok(TrustState::Deleted),
+            "Deleting" => Ok(TrustState::Deleting),
+            "Failed" => Ok(TrustState::Failed),
+            "Verified" => Ok(TrustState::Verified),
+            "VerifyFailed" => Ok(TrustState::VerifyFailed),
+            "Verifying" => Ok(TrustState::Verifying),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TrustType {
+    Forest,
+}
+
+impl Into<String> for TrustType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TrustType {
+    fn into(self) -> &'static str {
+        match self {
+            TrustType::Forest => "Forest",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TrustType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Forest" => Ok(TrustType::Forest),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Updates a conditional forwarder.</p>"]
@@ -5701,7 +6333,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddIpRoutesResult>(String::from_utf8_lossy(&body)
@@ -5734,7 +6366,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddTagsToResourceResult>(String::from_utf8_lossy(&body)
@@ -5768,7 +6400,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CancelSchemaExtensionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5798,7 +6430,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ConnectDirectoryResult>(String::from_utf8_lossy(&body)
@@ -5830,7 +6462,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateAliasResult>(String::from_utf8_lossy(&body)
@@ -5862,7 +6494,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateComputerResult>(String::from_utf8_lossy(&body)
@@ -5896,7 +6528,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateConditionalForwarderResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5927,7 +6559,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDirectoryResult>(String::from_utf8_lossy(&body)
@@ -5960,7 +6592,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateMicrosoftADResult>(String::from_utf8_lossy(&body)
@@ -5992,7 +6624,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateSnapshotResult>(String::from_utf8_lossy(&body)
@@ -6024,7 +6656,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateTrustResult>(String::from_utf8_lossy(&body)
@@ -6058,7 +6690,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteConditionalForwarderResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6089,7 +6721,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteDirectoryResult>(String::from_utf8_lossy(&body)
@@ -6121,7 +6753,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteSnapshotResult>(String::from_utf8_lossy(&body)
@@ -6153,7 +6785,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteTrustResult>(String::from_utf8_lossy(&body)
@@ -6186,7 +6818,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeregisterEventTopicResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6218,7 +6850,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeConditionalForwardersResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6250,7 +6882,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeDirectoriesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6282,7 +6914,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeDomainControllersResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6314,7 +6946,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEventTopicsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6345,7 +6977,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeSnapshotsResult>(String::from_utf8_lossy(&body)
@@ -6377,7 +7009,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTrustsResult>(String::from_utf8_lossy(&body)
@@ -6409,7 +7041,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisableRadiusResult>(String::from_utf8_lossy(&body)
@@ -6439,7 +7071,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisableSsoResult>(String::from_utf8_lossy(&body)
@@ -6471,7 +7103,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<EnableRadiusResult>(String::from_utf8_lossy(&body)
@@ -6501,7 +7133,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<EnableSsoResult>(String::from_utf8_lossy(&body).as_ref())
@@ -6530,7 +7162,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDirectoryLimitsResult>(String::from_utf8_lossy(&body)
@@ -6563,7 +7195,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetSnapshotLimitsResult>(String::from_utf8_lossy(&body)
@@ -6595,7 +7227,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListIpRoutesResult>(String::from_utf8_lossy(&body)
@@ -6628,7 +7260,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListSchemaExtensionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6659,7 +7291,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsForResourceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6690,7 +7322,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterEventTopicResult>(String::from_utf8_lossy(&body)
@@ -6722,7 +7354,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveIpRoutesResult>(String::from_utf8_lossy(&body)
@@ -6756,7 +7388,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveTagsFromResourceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6787,7 +7419,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RestoreFromSnapshotResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6818,7 +7450,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartSchemaExtensionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6850,7 +7482,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateConditionalForwarderResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6883,7 +7515,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateNumberOfDomainControllersResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6914,7 +7546,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateRadiusResult>(String::from_utf8_lossy(&body)
@@ -6946,7 +7578,7 @@ impl<P, D> DirectoryService for DirectoryServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<VerifyTrustResult>(String::from_utf8_lossy(&body)

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -178,6 +174,41 @@ pub struct KeySchemaElement {
     pub key_type: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum KeyType {
+    Hash,
+    Range,
+}
+
+impl Into<String> for KeyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for KeyType {
+    fn into(self) -> &'static str {
+        match self {
+            KeyType::Hash => "HASH",
+            KeyType::Range => "RANGE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for KeyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HASH" => Ok(KeyType::Hash),
+            "RANGE" => Ok(KeyType::Range),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input of a <code>ListStreams</code> operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListStreamsInput {
@@ -206,6 +237,44 @@ pub struct ListStreamsOutput {
     #[serde(rename="Streams")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub streams: Option<Vec<Stream>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationType {
+    Insert,
+    Modify,
+    Remove,
+}
+
+impl Into<String> for OperationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationType {
+    fn into(self) -> &'static str {
+        match self {
+            OperationType::Insert => "INSERT",
+            OperationType::Modify => "MODIFY",
+            OperationType::Remove => "REMOVE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSERT" => Ok(OperationType::Insert),
+            "MODIFY" => Ok(OperationType::Modify),
+            "REMOVE" => Ok(OperationType::Remove),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A description of a unique event within a stream.</p>"]
@@ -269,6 +338,47 @@ pub struct Shard {
     #[serde(rename="ShardId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub shard_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ShardIteratorType {
+    AfterSequenceNumber,
+    AtSequenceNumber,
+    Latest,
+    TrimHorizon,
+}
+
+impl Into<String> for ShardIteratorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ShardIteratorType {
+    fn into(self) -> &'static str {
+        match self {
+            ShardIteratorType::AfterSequenceNumber => "AFTER_SEQUENCE_NUMBER",
+            ShardIteratorType::AtSequenceNumber => "AT_SEQUENCE_NUMBER",
+            ShardIteratorType::Latest => "LATEST",
+            ShardIteratorType::TrimHorizon => "TRIM_HORIZON",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ShardIteratorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AFTER_SEQUENCE_NUMBER" => Ok(ShardIteratorType::AfterSequenceNumber),
+            "AT_SEQUENCE_NUMBER" => Ok(ShardIteratorType::AtSequenceNumber),
+            "LATEST" => Ok(ShardIteratorType::Latest),
+            "TRIM_HORIZON" => Ok(ShardIteratorType::TrimHorizon),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents all of the data describing a particular stream.</p>"]
@@ -360,6 +470,88 @@ pub struct StreamRecord {
     #[serde(rename="StreamViewType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub stream_view_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StreamStatus {
+    Disabled,
+    Disabling,
+    Enabled,
+    Enabling,
+}
+
+impl Into<String> for StreamStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StreamStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StreamStatus::Disabled => "DISABLED",
+            StreamStatus::Disabling => "DISABLING",
+            StreamStatus::Enabled => "ENABLED",
+            StreamStatus::Enabling => "ENABLING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StreamStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLED" => Ok(StreamStatus::Disabled),
+            "DISABLING" => Ok(StreamStatus::Disabling),
+            "ENABLED" => Ok(StreamStatus::Enabled),
+            "ENABLING" => Ok(StreamStatus::Enabling),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StreamViewType {
+    KeysOnly,
+    NewAndOldImages,
+    NewImage,
+    OldImage,
+}
+
+impl Into<String> for StreamViewType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StreamViewType {
+    fn into(self) -> &'static str {
+        match self {
+            StreamViewType::KeysOnly => "KEYS_ONLY",
+            StreamViewType::NewAndOldImages => "NEW_AND_OLD_IMAGES",
+            StreamViewType::NewImage => "NEW_IMAGE",
+            StreamViewType::OldImage => "OLD_IMAGE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StreamViewType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KEYS_ONLY" => Ok(StreamViewType::KeysOnly),
+            "NEW_AND_OLD_IMAGES" => Ok(StreamViewType::NewAndOldImages),
+            "NEW_IMAGE" => Ok(StreamViewType::NewImage),
+            "OLD_IMAGE" => Ok(StreamViewType::OldImage),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by DescribeStream
@@ -790,7 +982,7 @@ impl<P, D> DynamoDbStreams for DynamoDbStreamsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeStreamOutput>(String::from_utf8_lossy(&body)
@@ -820,7 +1012,7 @@ impl<P, D> DynamoDbStreams for DynamoDbStreamsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRecordsOutput>(String::from_utf8_lossy(&body)
@@ -852,7 +1044,7 @@ impl<P, D> DynamoDbStreams for DynamoDbStreamsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetShardIteratorOutput>(String::from_utf8_lossy(&body)
@@ -884,7 +1076,7 @@ impl<P, D> DynamoDbStreams for DynamoDbStreamsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListStreamsOutput>(String::from_utf8_lossy(&body)

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -308,6 +304,41 @@ impl AccountAttributeListDeserializer {
     }
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccountAttributeName {
+    DefaultVpc,
+    SupportedPlatforms,
+}
+
+impl Into<String> for AccountAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccountAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            AccountAttributeName::DefaultVpc => "default-vpc",
+            AccountAttributeName::SupportedPlatforms => "supported-platforms",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccountAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default-vpc" => Ok(AccountAttributeName::DefaultVpc),
+            "supported-platforms" => Ok(AccountAttributeName::SupportedPlatforms),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `AccountAttributeNameStringList` contents to a `SignedRequest`.
 struct AccountAttributeNameStringListSerializer;
 impl AccountAttributeNameStringListSerializer {
@@ -521,6 +552,47 @@ impl ActiveInstanceSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActivityStatus {
+    Error,
+    Fulfilled,
+    PendingFulfillment,
+    PendingTermination,
+}
+
+impl Into<String> for ActivityStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActivityStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ActivityStatus::Error => "error",
+            ActivityStatus::Fulfilled => "fulfilled",
+            ActivityStatus::PendingFulfillment => "pending_fulfillment",
+            ActivityStatus::PendingTermination => "pending_termination",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActivityStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "error" => Ok(ActivityStatus::Error),
+            "fulfilled" => Ok(ActivityStatus::Fulfilled),
+            "pending_fulfillment" => Ok(ActivityStatus::PendingFulfillment),
+            "pending_termination" => Ok(ActivityStatus::PendingTermination),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ActivityStatusDeserializer;
 impl ActivityStatusDeserializer {
     #[allow(unused_variables)]
@@ -670,6 +742,41 @@ impl AddressListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Affinity {
+    Default,
+    Host,
+}
+
+impl Into<String> for Affinity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Affinity {
+    fn into(self) -> &'static str {
+        match self {
+            Affinity::Default => "default",
+            Affinity::Host => "host",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Affinity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default" => Ok(Affinity::Default),
+            "host" => Ok(Affinity::Host),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the parameters for AllocateAddress.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct AllocateAddressRequest {
@@ -873,6 +980,50 @@ impl AllocationIdListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AllocationState {
+    Available,
+    PermanentFailure,
+    Released,
+    ReleasedPermanentFailure,
+    UnderAssessment,
+}
+
+impl Into<String> for AllocationState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AllocationState {
+    fn into(self) -> &'static str {
+        match self {
+            AllocationState::Available => "available",
+            AllocationState::PermanentFailure => "permanent-failure",
+            AllocationState::Released => "released",
+            AllocationState::ReleasedPermanentFailure => "released-permanent-failure",
+            AllocationState::UnderAssessment => "under-assessment",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AllocationState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(AllocationState::Available),
+            "permanent-failure" => Ok(AllocationState::PermanentFailure),
+            "released" => Ok(AllocationState::Released),
+            "released-permanent-failure" => Ok(AllocationState::ReleasedPermanentFailure),
+            "under-assessment" => Ok(AllocationState::UnderAssessment),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AllocationStateDeserializer;
 impl AllocationStateDeserializer {
     #[allow(unused_variables)]
@@ -887,6 +1038,41 @@ impl AllocationStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AllocationStrategy {
+    Diversified,
+    LowestPrice,
+}
+
+impl Into<String> for AllocationStrategy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AllocationStrategy {
+    fn into(self) -> &'static str {
+        match self {
+            AllocationStrategy::Diversified => "diversified",
+            AllocationStrategy::LowestPrice => "lowestPrice",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AllocationStrategy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "diversified" => Ok(AllocationStrategy::Diversified),
+            "lowestPrice" => Ok(AllocationStrategy::LowestPrice),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AllocationStrategyDeserializer;
 impl AllocationStrategyDeserializer {
     #[allow(unused_variables)]
@@ -901,6 +1087,41 @@ impl AllocationStrategyDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ArchitectureValues {
+    I386,
+    X8664,
+}
+
+impl Into<String> for ArchitectureValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ArchitectureValues {
+    fn into(self) -> &'static str {
+        match self {
+            ArchitectureValues::I386 => "i386",
+            ArchitectureValues::X8664 => "x86_64",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ArchitectureValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "i386" => Ok(ArchitectureValues::I386),
+            "x86_64" => Ok(ArchitectureValues::X8664),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ArchitectureValuesDeserializer;
 impl ArchitectureValuesDeserializer {
     #[allow(unused_variables)]
@@ -1850,6 +2071,47 @@ impl AttachVpnGatewayResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AttachmentStatus {
+    Attached,
+    Attaching,
+    Detached,
+    Detaching,
+}
+
+impl Into<String> for AttachmentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AttachmentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AttachmentStatus::Attached => "attached",
+            AttachmentStatus::Attaching => "attaching",
+            AttachmentStatus::Detached => "detached",
+            AttachmentStatus::Detaching => "detaching",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AttachmentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "attached" => Ok(AttachmentStatus::Attached),
+            "attaching" => Ok(AttachmentStatus::Attaching),
+            "detached" => Ok(AttachmentStatus::Detached),
+            "detaching" => Ok(AttachmentStatus::Detaching),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AttachmentStatusDeserializer;
 impl AttachmentStatusDeserializer {
     #[allow(unused_variables)]
@@ -2149,6 +2411,41 @@ impl AuthorizeSecurityGroupIngressRequestSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoPlacement {
+    Off,
+    On,
+}
+
+impl Into<String> for AutoPlacement {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoPlacement {
+    fn into(self) -> &'static str {
+        match self {
+            AutoPlacement::Off => "off",
+            AutoPlacement::On => "on",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoPlacement {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "off" => Ok(AutoPlacement::Off),
+            "on" => Ok(AutoPlacement::On),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AutoPlacementDeserializer;
 impl AutoPlacementDeserializer {
     #[allow(unused_variables)]
@@ -2362,6 +2659,47 @@ impl AvailabilityZoneMessageListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AvailabilityZoneState {
+    Available,
+    Impaired,
+    Information,
+    Unavailable,
+}
+
+impl Into<String> for AvailabilityZoneState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AvailabilityZoneState {
+    fn into(self) -> &'static str {
+        match self {
+            AvailabilityZoneState::Available => "available",
+            AvailabilityZoneState::Impaired => "impaired",
+            AvailabilityZoneState::Information => "information",
+            AvailabilityZoneState::Unavailable => "unavailable",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AvailabilityZoneState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(AvailabilityZoneState::Available),
+            "impaired" => Ok(AvailabilityZoneState::Impaired),
+            "information" => Ok(AvailabilityZoneState::Information),
+            "unavailable" => Ok(AvailabilityZoneState::Unavailable),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AvailabilityZoneStateDeserializer;
 impl AvailabilityZoneStateDeserializer {
     #[allow(unused_variables)]
@@ -2472,6 +2810,56 @@ impl AvailableInstanceCapacityListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BatchState {
+    Active,
+    Cancelled,
+    CancelledRunning,
+    CancelledTerminating,
+    Failed,
+    Modifying,
+    Submitted,
+}
+
+impl Into<String> for BatchState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BatchState {
+    fn into(self) -> &'static str {
+        match self {
+            BatchState::Active => "active",
+            BatchState::Cancelled => "cancelled",
+            BatchState::CancelledRunning => "cancelled_running",
+            BatchState::CancelledTerminating => "cancelled_terminating",
+            BatchState::Failed => "failed",
+            BatchState::Modifying => "modifying",
+            BatchState::Submitted => "submitted",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BatchState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(BatchState::Active),
+            "cancelled" => Ok(BatchState::Cancelled),
+            "cancelled_running" => Ok(BatchState::CancelledRunning),
+            "cancelled_terminating" => Ok(BatchState::CancelledTerminating),
+            "failed" => Ok(BatchState::Failed),
+            "modifying" => Ok(BatchState::Modifying),
+            "submitted" => Ok(BatchState::Submitted),
+            _ => Err(()),
+        }
+    }
+}
+
 struct BatchStateDeserializer;
 impl BatchStateDeserializer {
     #[allow(unused_variables)]
@@ -2707,7 +3095,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2995,6 +3383,56 @@ impl BundleTaskListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BundleTaskState {
+    Bundling,
+    Cancelling,
+    Complete,
+    Failed,
+    Pending,
+    Storing,
+    WaitingForShutdown,
+}
+
+impl Into<String> for BundleTaskState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BundleTaskState {
+    fn into(self) -> &'static str {
+        match self {
+            BundleTaskState::Bundling => "bundling",
+            BundleTaskState::Cancelling => "cancelling",
+            BundleTaskState::Complete => "complete",
+            BundleTaskState::Failed => "failed",
+            BundleTaskState::Pending => "pending",
+            BundleTaskState::Storing => "storing",
+            BundleTaskState::WaitingForShutdown => "waiting-for-shutdown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BundleTaskState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bundling" => Ok(BundleTaskState::Bundling),
+            "cancelling" => Ok(BundleTaskState::Cancelling),
+            "complete" => Ok(BundleTaskState::Complete),
+            "failed" => Ok(BundleTaskState::Failed),
+            "pending" => Ok(BundleTaskState::Pending),
+            "storing" => Ok(BundleTaskState::Storing),
+            "waiting-for-shutdown" => Ok(BundleTaskState::WaitingForShutdown),
+            _ => Err(()),
+        }
+    }
+}
+
 struct BundleTaskStateDeserializer;
 impl BundleTaskStateDeserializer {
     #[allow(unused_variables)]
@@ -3009,6 +3447,51 @@ impl BundleTaskStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CancelBatchErrorCode {
+    FleetRequestIdDoesNotExist,
+    FleetRequestIdMalformed,
+    FleetRequestNotInCancellableState,
+    UnexpectedError,
+}
+
+impl Into<String> for CancelBatchErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CancelBatchErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            CancelBatchErrorCode::FleetRequestIdDoesNotExist => "fleetRequestIdDoesNotExist",
+            CancelBatchErrorCode::FleetRequestIdMalformed => "fleetRequestIdMalformed",
+            CancelBatchErrorCode::FleetRequestNotInCancellableState => {
+                "fleetRequestNotInCancellableState"
+            }
+            CancelBatchErrorCode::UnexpectedError => "unexpectedError",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CancelBatchErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "fleetRequestIdDoesNotExist" => Ok(CancelBatchErrorCode::FleetRequestIdDoesNotExist),
+            "fleetRequestIdMalformed" => Ok(CancelBatchErrorCode::FleetRequestIdMalformed),
+            "fleetRequestNotInCancellableState" => {
+                Ok(CancelBatchErrorCode::FleetRequestNotInCancellableState)
+            }
+            "unexpectedError" => Ok(CancelBatchErrorCode::UnexpectedError),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CancelBatchErrorCodeDeserializer;
 impl CancelBatchErrorCodeDeserializer {
     #[allow(unused_variables)]
@@ -3676,6 +4159,50 @@ impl CancelSpotFleetRequestsSuccessSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CancelSpotInstanceRequestState {
+    Active,
+    Cancelled,
+    Closed,
+    Completed,
+    Open,
+}
+
+impl Into<String> for CancelSpotInstanceRequestState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CancelSpotInstanceRequestState {
+    fn into(self) -> &'static str {
+        match self {
+            CancelSpotInstanceRequestState::Active => "active",
+            CancelSpotInstanceRequestState::Cancelled => "cancelled",
+            CancelSpotInstanceRequestState::Closed => "closed",
+            CancelSpotInstanceRequestState::Completed => "completed",
+            CancelSpotInstanceRequestState::Open => "open",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CancelSpotInstanceRequestState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(CancelSpotInstanceRequestState::Active),
+            "cancelled" => Ok(CancelSpotInstanceRequestState::Cancelled),
+            "closed" => Ok(CancelSpotInstanceRequestState::Closed),
+            "completed" => Ok(CancelSpotInstanceRequestState::Completed),
+            "open" => Ok(CancelSpotInstanceRequestState::Open),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CancelSpotInstanceRequestStateDeserializer;
 impl CancelSpotInstanceRequestStateDeserializer {
     #[allow(unused_variables)]
@@ -4206,6 +4733,38 @@ impl ConfirmProductInstanceResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContainerFormat {
+    Ova,
+}
+
+impl Into<String> for ContainerFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContainerFormat {
+    fn into(self) -> &'static str {
+        match self {
+            ContainerFormat::Ova => "ova",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContainerFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ova" => Ok(ContainerFormat::Ova),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ContainerFormatDeserializer;
 impl ContainerFormatDeserializer {
     #[allow(unused_variables)]
@@ -4318,6 +4877,47 @@ impl ConversionTaskDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConversionTaskState {
+    Active,
+    Cancelled,
+    Cancelling,
+    Completed,
+}
+
+impl Into<String> for ConversionTaskState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConversionTaskState {
+    fn into(self) -> &'static str {
+        match self {
+            ConversionTaskState::Active => "active",
+            ConversionTaskState::Cancelled => "cancelled",
+            ConversionTaskState::Cancelling => "cancelling",
+            ConversionTaskState::Completed => "completed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConversionTaskState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(ConversionTaskState::Active),
+            "cancelled" => Ok(ConversionTaskState::Cancelled),
+            "cancelling" => Ok(ConversionTaskState::Cancelling),
+            "completed" => Ok(ConversionTaskState::Completed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ConversionTaskStateDeserializer;
 impl ConversionTaskStateDeserializer {
     #[allow(unused_variables)]
@@ -7258,6 +7858,38 @@ impl CreateVpnGatewayResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CurrencyCodeValues {
+    Usd,
+}
+
+impl Into<String> for CurrencyCodeValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CurrencyCodeValues {
+    fn into(self) -> &'static str {
+        match self {
+            CurrencyCodeValues::Usd => "USD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CurrencyCodeValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "USD" => Ok(CurrencyCodeValues::Usd),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CurrencyCodeValuesDeserializer;
 impl CurrencyCodeValuesDeserializer {
     #[allow(unused_variables)]
@@ -7403,6 +8035,41 @@ impl CustomerGatewayListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DatafeedSubscriptionState {
+    Active,
+    Inactive,
+}
+
+impl Into<String> for DatafeedSubscriptionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DatafeedSubscriptionState {
+    fn into(self) -> &'static str {
+        match self {
+            DatafeedSubscriptionState::Active => "Active",
+            DatafeedSubscriptionState::Inactive => "Inactive",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DatafeedSubscriptionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(DatafeedSubscriptionState::Active),
+            "Inactive" => Ok(DatafeedSubscriptionState::Inactive),
+            _ => Err(()),
+        }
+    }
+}
+
 struct DatafeedSubscriptionStateDeserializer;
 impl DatafeedSubscriptionStateDeserializer {
     #[allow(unused_variables)]
@@ -15620,6 +16287,41 @@ impl DetachVpnGatewayRequestSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeviceType {
+    Ebs,
+    InstanceStore,
+}
+
+impl Into<String> for DeviceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeviceType {
+    fn into(self) -> &'static str {
+        match self {
+            DeviceType::Ebs => "ebs",
+            DeviceType::InstanceStore => "instance-store",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeviceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ebs" => Ok(DeviceType::Ebs),
+            "instance-store" => Ok(DeviceType::InstanceStore),
+            _ => Err(()),
+        }
+    }
+}
+
 struct DeviceTypeDeserializer;
 impl DeviceTypeDeserializer {
     #[allow(unused_variables)]
@@ -16487,6 +17189,44 @@ impl DiskImageDetailSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DiskImageFormat {
+    Raw,
+    Vhd,
+    Vmdk,
+}
+
+impl Into<String> for DiskImageFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DiskImageFormat {
+    fn into(self) -> &'static str {
+        match self {
+            DiskImageFormat::Raw => "RAW",
+            DiskImageFormat::Vhd => "VHD",
+            DiskImageFormat::Vmdk => "VMDK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DiskImageFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RAW" => Ok(DiskImageFormat::Raw),
+            "VHD" => Ok(DiskImageFormat::Vhd),
+            "VMDK" => Ok(DiskImageFormat::Vmdk),
+            _ => Err(()),
+        }
+    }
+}
+
 struct DiskImageFormatDeserializer;
 impl DiskImageFormatDeserializer {
     #[allow(unused_variables)]
@@ -16566,6 +17306,41 @@ impl DiskImageVolumeDescriptionDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DomainType {
+    Standard,
+    Vpc,
+}
+
+impl Into<String> for DomainType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DomainType {
+    fn into(self) -> &'static str {
+        match self {
+            DomainType::Standard => "standard",
+            DomainType::Vpc => "vpc",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DomainType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "standard" => Ok(DomainType::Standard),
+            "vpc" => Ok(DomainType::Vpc),
+            _ => Err(()),
+        }
+    }
+}
+
 struct DomainTypeDeserializer;
 impl DomainTypeDeserializer {
     #[allow(unused_variables)]
@@ -17183,6 +17958,38 @@ impl ElasticGpuSpecificationsSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ElasticGpuState {
+    Attached,
+}
+
+impl Into<String> for ElasticGpuState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ElasticGpuState {
+    fn into(self) -> &'static str {
+        match self {
+            ElasticGpuState::Attached => "ATTACHED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ElasticGpuState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ATTACHED" => Ok(ElasticGpuState::Attached),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ElasticGpuStateDeserializer;
 impl ElasticGpuStateDeserializer {
     #[allow(unused_variables)]
@@ -17197,6 +18004,41 @@ impl ElasticGpuStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ElasticGpuStatus {
+    Impaired,
+    Ok,
+}
+
+impl Into<String> for ElasticGpuStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ElasticGpuStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ElasticGpuStatus::Impaired => "IMPAIRED",
+            ElasticGpuStatus::Ok => "OK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ElasticGpuStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IMPAIRED" => Ok(ElasticGpuStatus::Impaired),
+            "OK" => Ok(ElasticGpuStatus::Ok),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ElasticGpuStatusDeserializer;
 impl ElasticGpuStatusDeserializer {
     #[allow(unused_variables)]
@@ -17503,6 +18345,50 @@ impl EnableVpcClassicLinkResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventCode {
+    InstanceReboot,
+    InstanceRetirement,
+    InstanceStop,
+    SystemMaintenance,
+    SystemReboot,
+}
+
+impl Into<String> for EventCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventCode {
+    fn into(self) -> &'static str {
+        match self {
+            EventCode::InstanceReboot => "instance-reboot",
+            EventCode::InstanceRetirement => "instance-retirement",
+            EventCode::InstanceStop => "instance-stop",
+            EventCode::SystemMaintenance => "system-maintenance",
+            EventCode::SystemReboot => "system-reboot",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "instance-reboot" => Ok(EventCode::InstanceReboot),
+            "instance-retirement" => Ok(EventCode::InstanceRetirement),
+            "instance-stop" => Ok(EventCode::InstanceStop),
+            "system-maintenance" => Ok(EventCode::SystemMaintenance),
+            "system-reboot" => Ok(EventCode::SystemReboot),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventCodeDeserializer;
 impl EventCodeDeserializer {
     #[allow(unused_variables)]
@@ -17579,6 +18465,44 @@ impl EventInformationDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventType {
+    Error,
+    FleetRequestChange,
+    InstanceChange,
+}
+
+impl Into<String> for EventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventType {
+    fn into(self) -> &'static str {
+        match self {
+            EventType::Error => "error",
+            EventType::FleetRequestChange => "fleetRequestChange",
+            EventType::InstanceChange => "instanceChange",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "error" => Ok(EventType::Error),
+            "fleetRequestChange" => Ok(EventType::FleetRequestChange),
+            "instanceChange" => Ok(EventType::InstanceChange),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventTypeDeserializer;
 impl EventTypeDeserializer {
     #[allow(unused_variables)]
@@ -17593,6 +18517,41 @@ impl EventTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExcessCapacityTerminationPolicy {
+    Default,
+    NoTermination,
+}
+
+impl Into<String> for ExcessCapacityTerminationPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExcessCapacityTerminationPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            ExcessCapacityTerminationPolicy::Default => "default",
+            ExcessCapacityTerminationPolicy::NoTermination => "noTermination",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExcessCapacityTerminationPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default" => Ok(ExcessCapacityTerminationPolicy::Default),
+            "noTermination" => Ok(ExcessCapacityTerminationPolicy::NoTermination),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ExcessCapacityTerminationPolicyDeserializer;
 impl ExcessCapacityTerminationPolicyDeserializer {
     #[allow(unused_variables)]
@@ -17615,6 +18574,44 @@ impl ExecutableByStringListSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExportEnvironment {
+    Citrix,
+    Microsoft,
+    Vmware,
+}
+
+impl Into<String> for ExportEnvironment {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExportEnvironment {
+    fn into(self) -> &'static str {
+        match self {
+            ExportEnvironment::Citrix => "citrix",
+            ExportEnvironment::Microsoft => "microsoft",
+            ExportEnvironment::Vmware => "vmware",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExportEnvironment {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "citrix" => Ok(ExportEnvironment::Citrix),
+            "microsoft" => Ok(ExportEnvironment::Microsoft),
+            "vmware" => Ok(ExportEnvironment::Vmware),
+            _ => Err(()),
         }
     }
 }
@@ -17767,6 +18764,47 @@ impl ExportTaskListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExportTaskState {
+    Active,
+    Cancelled,
+    Cancelling,
+    Completed,
+}
+
+impl Into<String> for ExportTaskState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExportTaskState {
+    fn into(self) -> &'static str {
+        match self {
+            ExportTaskState::Active => "active",
+            ExportTaskState::Cancelled => "cancelled",
+            ExportTaskState::Cancelling => "cancelling",
+            ExportTaskState::Completed => "completed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExportTaskState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(ExportTaskState::Active),
+            "cancelled" => Ok(ExportTaskState::Cancelled),
+            "cancelling" => Ok(ExportTaskState::Cancelling),
+            "completed" => Ok(ExportTaskState::Completed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ExportTaskStateDeserializer;
 impl ExportTaskStateDeserializer {
     #[allow(unused_variables)]
@@ -17933,6 +18971,41 @@ impl FilterListSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.{}", name, index + 1);
             FilterSerializer::serialize(params, &key, obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FleetType {
+    Maintain,
+    Request,
+}
+
+impl Into<String> for FleetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FleetType {
+    fn into(self) -> &'static str {
+        match self {
+            FleetType::Maintain => "maintain",
+            FleetType::Request => "request",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FleetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "maintain" => Ok(FleetType::Maintain),
+            "request" => Ok(FleetType::Request),
+            _ => Err(()),
         }
     }
 }
@@ -18108,6 +19181,44 @@ impl FlowLogSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FlowLogsResourceType {
+    NetworkInterface,
+    Subnet,
+    Vpc,
+}
+
+impl Into<String> for FlowLogsResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FlowLogsResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            FlowLogsResourceType::NetworkInterface => "NetworkInterface",
+            FlowLogsResourceType::Subnet => "Subnet",
+            FlowLogsResourceType::Vpc => "VPC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FlowLogsResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NetworkInterface" => Ok(FlowLogsResourceType::NetworkInterface),
+            "Subnet" => Ok(FlowLogsResourceType::Subnet),
+            "VPC" => Ok(FlowLogsResourceType::Vpc),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes an Amazon FPGA image (AFI).</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct FpgaImage {
@@ -18337,6 +19448,47 @@ impl FpgaImageStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FpgaImageStateCode {
+    Available,
+    Failed,
+    Pending,
+    Unavailable,
+}
+
+impl Into<String> for FpgaImageStateCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FpgaImageStateCode {
+    fn into(self) -> &'static str {
+        match self {
+            FpgaImageStateCode::Available => "available",
+            FpgaImageStateCode::Failed => "failed",
+            FpgaImageStateCode::Pending => "pending",
+            FpgaImageStateCode::Unavailable => "unavailable",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FpgaImageStateCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(FpgaImageStateCode::Available),
+            "failed" => Ok(FpgaImageStateCode::Failed),
+            "pending" => Ok(FpgaImageStateCode::Pending),
+            "unavailable" => Ok(FpgaImageStateCode::Unavailable),
+            _ => Err(()),
+        }
+    }
+}
+
 struct FpgaImageStateCodeDeserializer;
 impl FpgaImageStateCodeDeserializer {
     #[allow(unused_variables)]
@@ -18351,6 +19503,38 @@ impl FpgaImageStateCodeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GatewayType {
+    Ipsec1,
+}
+
+impl Into<String> for GatewayType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GatewayType {
+    fn into(self) -> &'static str {
+        match self {
+            GatewayType::Ipsec1 => "ipsec.1",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GatewayType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ipsec.1" => Ok(GatewayType::Ipsec1),
+            _ => Err(()),
+        }
+    }
+}
+
 struct GatewayTypeDeserializer;
 impl GatewayTypeDeserializer {
     #[allow(unused_variables)]
@@ -19756,6 +20940,76 @@ impl HostReservationSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HostTenancy {
+    Dedicated,
+    Host,
+}
+
+impl Into<String> for HostTenancy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HostTenancy {
+    fn into(self) -> &'static str {
+        match self {
+            HostTenancy::Dedicated => "dedicated",
+            HostTenancy::Host => "host",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HostTenancy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dedicated" => Ok(HostTenancy::Dedicated),
+            "host" => Ok(HostTenancy::Host),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HypervisorType {
+    Ovm,
+    Xen,
+}
+
+impl Into<String> for HypervisorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HypervisorType {
+    fn into(self) -> &'static str {
+        match self {
+            HypervisorType::Ovm => "ovm",
+            HypervisorType::Xen => "xen",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HypervisorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ovm" => Ok(HypervisorType::Ovm),
+            "xen" => Ok(HypervisorType::Xen),
+            _ => Err(()),
+        }
+    }
+}
+
 struct HypervisorTypeDeserializer;
 impl HypervisorTypeDeserializer {
     #[allow(unused_variables)]
@@ -19938,6 +21192,47 @@ impl IamInstanceProfileAssociationSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IamInstanceProfileAssociationState {
+    Associated,
+    Associating,
+    Disassociated,
+    Disassociating,
+}
+
+impl Into<String> for IamInstanceProfileAssociationState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IamInstanceProfileAssociationState {
+    fn into(self) -> &'static str {
+        match self {
+            IamInstanceProfileAssociationState::Associated => "associated",
+            IamInstanceProfileAssociationState::Associating => "associating",
+            IamInstanceProfileAssociationState::Disassociated => "disassociated",
+            IamInstanceProfileAssociationState::Disassociating => "disassociating",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IamInstanceProfileAssociationState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "associated" => Ok(IamInstanceProfileAssociationState::Associated),
+            "associating" => Ok(IamInstanceProfileAssociationState::Associating),
+            "disassociated" => Ok(IamInstanceProfileAssociationState::Disassociated),
+            "disassociating" => Ok(IamInstanceProfileAssociationState::Disassociating),
+            _ => Err(()),
+        }
+    }
+}
+
 struct IamInstanceProfileAssociationStateDeserializer;
 impl IamInstanceProfileAssociationStateDeserializer {
     #[allow(unused_variables)]
@@ -20501,6 +21796,56 @@ impl ImageAttributeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageAttributeName {
+    BlockDeviceMapping,
+    Description,
+    Kernel,
+    LaunchPermission,
+    ProductCodes,
+    Ramdisk,
+    SriovNetSupport,
+}
+
+impl Into<String> for ImageAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            ImageAttributeName::BlockDeviceMapping => "blockDeviceMapping",
+            ImageAttributeName::Description => "description",
+            ImageAttributeName::Kernel => "kernel",
+            ImageAttributeName::LaunchPermission => "launchPermission",
+            ImageAttributeName::ProductCodes => "productCodes",
+            ImageAttributeName::Ramdisk => "ramdisk",
+            ImageAttributeName::SriovNetSupport => "sriovNetSupport",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "blockDeviceMapping" => Ok(ImageAttributeName::BlockDeviceMapping),
+            "description" => Ok(ImageAttributeName::Description),
+            "kernel" => Ok(ImageAttributeName::Kernel),
+            "launchPermission" => Ok(ImageAttributeName::LaunchPermission),
+            "productCodes" => Ok(ImageAttributeName::ProductCodes),
+            "ramdisk" => Ok(ImageAttributeName::Ramdisk),
+            "sriovNetSupport" => Ok(ImageAttributeName::SriovNetSupport),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the disk container object for an import image task.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct ImageDiskContainer {
@@ -20622,6 +21967,56 @@ impl ImageListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageState {
+    Available,
+    Deregistered,
+    Error,
+    Failed,
+    Invalid,
+    Pending,
+    Transient,
+}
+
+impl Into<String> for ImageState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageState {
+    fn into(self) -> &'static str {
+        match self {
+            ImageState::Available => "available",
+            ImageState::Deregistered => "deregistered",
+            ImageState::Error => "error",
+            ImageState::Failed => "failed",
+            ImageState::Invalid => "invalid",
+            ImageState::Pending => "pending",
+            ImageState::Transient => "transient",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(ImageState::Available),
+            "deregistered" => Ok(ImageState::Deregistered),
+            "error" => Ok(ImageState::Error),
+            "failed" => Ok(ImageState::Failed),
+            "invalid" => Ok(ImageState::Invalid),
+            "pending" => Ok(ImageState::Pending),
+            "transient" => Ok(ImageState::Transient),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ImageStateDeserializer;
 impl ImageStateDeserializer {
     #[allow(unused_variables)]
@@ -20636,6 +22031,44 @@ impl ImageStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageTypeValues {
+    Kernel,
+    Machine,
+    Ramdisk,
+}
+
+impl Into<String> for ImageTypeValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageTypeValues {
+    fn into(self) -> &'static str {
+        match self {
+            ImageTypeValues::Kernel => "kernel",
+            ImageTypeValues::Machine => "machine",
+            ImageTypeValues::Ramdisk => "ramdisk",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageTypeValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "kernel" => Ok(ImageTypeValues::Kernel),
+            "machine" => Ok(ImageTypeValues::Machine),
+            "ramdisk" => Ok(ImageTypeValues::Ramdisk),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ImageTypeValuesDeserializer;
 impl ImageTypeValuesDeserializer {
     #[allow(unused_variables)]
@@ -22305,6 +23738,81 @@ impl InstanceAttributeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceAttributeName {
+    BlockDeviceMapping,
+    DisableApiTermination,
+    EbsOptimized,
+    EnaSupport,
+    GroupSet,
+    InstanceInitiatedShutdownBehavior,
+    InstanceType,
+    Kernel,
+    ProductCodes,
+    Ramdisk,
+    RootDeviceName,
+    SourceDestCheck,
+    SriovNetSupport,
+    UserData,
+}
+
+impl Into<String> for InstanceAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceAttributeName::BlockDeviceMapping => "blockDeviceMapping",
+            InstanceAttributeName::DisableApiTermination => "disableApiTermination",
+            InstanceAttributeName::EbsOptimized => "ebsOptimized",
+            InstanceAttributeName::EnaSupport => "enaSupport",
+            InstanceAttributeName::GroupSet => "groupSet",
+            InstanceAttributeName::InstanceInitiatedShutdownBehavior => {
+                "instanceInitiatedShutdownBehavior"
+            }
+            InstanceAttributeName::InstanceType => "instanceType",
+            InstanceAttributeName::Kernel => "kernel",
+            InstanceAttributeName::ProductCodes => "productCodes",
+            InstanceAttributeName::Ramdisk => "ramdisk",
+            InstanceAttributeName::RootDeviceName => "rootDeviceName",
+            InstanceAttributeName::SourceDestCheck => "sourceDestCheck",
+            InstanceAttributeName::SriovNetSupport => "sriovNetSupport",
+            InstanceAttributeName::UserData => "userData",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "blockDeviceMapping" => Ok(InstanceAttributeName::BlockDeviceMapping),
+            "disableApiTermination" => Ok(InstanceAttributeName::DisableApiTermination),
+            "ebsOptimized" => Ok(InstanceAttributeName::EbsOptimized),
+            "enaSupport" => Ok(InstanceAttributeName::EnaSupport),
+            "groupSet" => Ok(InstanceAttributeName::GroupSet),
+            "instanceInitiatedShutdownBehavior" => {
+                Ok(InstanceAttributeName::InstanceInitiatedShutdownBehavior)
+            }
+            "instanceType" => Ok(InstanceAttributeName::InstanceType),
+            "kernel" => Ok(InstanceAttributeName::Kernel),
+            "productCodes" => Ok(InstanceAttributeName::ProductCodes),
+            "ramdisk" => Ok(InstanceAttributeName::Ramdisk),
+            "rootDeviceName" => Ok(InstanceAttributeName::RootDeviceName),
+            "sourceDestCheck" => Ok(InstanceAttributeName::SourceDestCheck),
+            "sriovNetSupport" => Ok(InstanceAttributeName::SriovNetSupport),
+            "userData" => Ok(InstanceAttributeName::UserData),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes a block device mapping.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct InstanceBlockDeviceMapping {
@@ -22680,6 +24188,41 @@ impl InstanceExportDetailsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceHealthStatus {
+    Healthy,
+    Unhealthy,
+}
+
+impl Into<String> for InstanceHealthStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceHealthStatus {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceHealthStatus::Healthy => "healthy",
+            InstanceHealthStatus::Unhealthy => "unhealthy",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceHealthStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "healthy" => Ok(InstanceHealthStatus::Healthy),
+            "unhealthy" => Ok(InstanceHealthStatus::Unhealthy),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InstanceHealthStatusDeserializer;
 impl InstanceHealthStatusDeserializer {
     #[allow(unused_variables)]
@@ -22863,6 +24406,41 @@ impl InstanceIpv6AddressListSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.{}", name, index + 1);
             InstanceIpv6AddressSerializer::serialize(params, &key, obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceLifecycleType {
+    Scheduled,
+    Spot,
+}
+
+impl Into<String> for InstanceLifecycleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceLifecycleType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceLifecycleType::Scheduled => "scheduled",
+            InstanceLifecycleType::Spot => "spot",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceLifecycleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "scheduled" => Ok(InstanceLifecycleType::Scheduled),
+            "spot" => Ok(InstanceLifecycleType::Spot),
+            _ => Err(()),
         }
     }
 }
@@ -23852,6 +25430,53 @@ impl InstanceStateChangeListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceStateName {
+    Pending,
+    Running,
+    ShuttingDown,
+    Stopped,
+    Stopping,
+    Terminated,
+}
+
+impl Into<String> for InstanceStateName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceStateName {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceStateName::Pending => "pending",
+            InstanceStateName::Running => "running",
+            InstanceStateName::ShuttingDown => "shutting-down",
+            InstanceStateName::Stopped => "stopped",
+            InstanceStateName::Stopping => "stopping",
+            InstanceStateName::Terminated => "terminated",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceStateName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(InstanceStateName::Pending),
+            "running" => Ok(InstanceStateName::Running),
+            "shutting-down" => Ok(InstanceStateName::ShuttingDown),
+            "stopped" => Ok(InstanceStateName::Stopped),
+            "stopping" => Ok(InstanceStateName::Stopping),
+            "terminated" => Ok(InstanceStateName::Terminated),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InstanceStateNameDeserializer;
 impl InstanceStateNameDeserializer {
     #[allow(unused_variables)]
@@ -24257,6 +25882,275 @@ impl InstanceStatusSummaryDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceType {
+    C1Medium,
+    C1Xlarge,
+    C32Xlarge,
+    C34Xlarge,
+    C38Xlarge,
+    C3Large,
+    C3Xlarge,
+    C42Xlarge,
+    C44Xlarge,
+    C48Xlarge,
+    C4Large,
+    C4Xlarge,
+    Cc14Xlarge,
+    Cc28Xlarge,
+    Cg14Xlarge,
+    Cr18Xlarge,
+    D22Xlarge,
+    D24Xlarge,
+    D28Xlarge,
+    D2Xlarge,
+    F116Xlarge,
+    F12Xlarge,
+    G22Xlarge,
+    G28Xlarge,
+    G316Xlarge,
+    G34Xlarge,
+    G38Xlarge,
+    Hi14Xlarge,
+    Hs18Xlarge,
+    I22Xlarge,
+    I24Xlarge,
+    I28Xlarge,
+    I2Xlarge,
+    I316Xlarge,
+    I32Xlarge,
+    I34Xlarge,
+    I38Xlarge,
+    I3Large,
+    I3Xlarge,
+    M1Large,
+    M1Medium,
+    M1Small,
+    M1Xlarge,
+    M22Xlarge,
+    M24Xlarge,
+    M2Xlarge,
+    M32Xlarge,
+    M3Large,
+    M3Medium,
+    M3Xlarge,
+    M410Xlarge,
+    M416Xlarge,
+    M42Xlarge,
+    M44Xlarge,
+    M4Large,
+    M4Xlarge,
+    P216Xlarge,
+    P28Xlarge,
+    P2Xlarge,
+    R32Xlarge,
+    R34Xlarge,
+    R38Xlarge,
+    R3Large,
+    R3Xlarge,
+    R416Xlarge,
+    R42Xlarge,
+    R44Xlarge,
+    R48Xlarge,
+    R4Large,
+    R4Xlarge,
+    T1Micro,
+    T22Xlarge,
+    T2Large,
+    T2Medium,
+    T2Micro,
+    T2Nano,
+    T2Small,
+    T2Xlarge,
+    X116Xlarge,
+    X132Xlarge,
+}
+
+impl Into<String> for InstanceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceType::C1Medium => "c1.medium",
+            InstanceType::C1Xlarge => "c1.xlarge",
+            InstanceType::C32Xlarge => "c3.2xlarge",
+            InstanceType::C34Xlarge => "c3.4xlarge",
+            InstanceType::C38Xlarge => "c3.8xlarge",
+            InstanceType::C3Large => "c3.large",
+            InstanceType::C3Xlarge => "c3.xlarge",
+            InstanceType::C42Xlarge => "c4.2xlarge",
+            InstanceType::C44Xlarge => "c4.4xlarge",
+            InstanceType::C48Xlarge => "c4.8xlarge",
+            InstanceType::C4Large => "c4.large",
+            InstanceType::C4Xlarge => "c4.xlarge",
+            InstanceType::Cc14Xlarge => "cc1.4xlarge",
+            InstanceType::Cc28Xlarge => "cc2.8xlarge",
+            InstanceType::Cg14Xlarge => "cg1.4xlarge",
+            InstanceType::Cr18Xlarge => "cr1.8xlarge",
+            InstanceType::D22Xlarge => "d2.2xlarge",
+            InstanceType::D24Xlarge => "d2.4xlarge",
+            InstanceType::D28Xlarge => "d2.8xlarge",
+            InstanceType::D2Xlarge => "d2.xlarge",
+            InstanceType::F116Xlarge => "f1.16xlarge",
+            InstanceType::F12Xlarge => "f1.2xlarge",
+            InstanceType::G22Xlarge => "g2.2xlarge",
+            InstanceType::G28Xlarge => "g2.8xlarge",
+            InstanceType::G316Xlarge => "g3.16xlarge",
+            InstanceType::G34Xlarge => "g3.4xlarge",
+            InstanceType::G38Xlarge => "g3.8xlarge",
+            InstanceType::Hi14Xlarge => "hi1.4xlarge",
+            InstanceType::Hs18Xlarge => "hs1.8xlarge",
+            InstanceType::I22Xlarge => "i2.2xlarge",
+            InstanceType::I24Xlarge => "i2.4xlarge",
+            InstanceType::I28Xlarge => "i2.8xlarge",
+            InstanceType::I2Xlarge => "i2.xlarge",
+            InstanceType::I316Xlarge => "i3.16xlarge",
+            InstanceType::I32Xlarge => "i3.2xlarge",
+            InstanceType::I34Xlarge => "i3.4xlarge",
+            InstanceType::I38Xlarge => "i3.8xlarge",
+            InstanceType::I3Large => "i3.large",
+            InstanceType::I3Xlarge => "i3.xlarge",
+            InstanceType::M1Large => "m1.large",
+            InstanceType::M1Medium => "m1.medium",
+            InstanceType::M1Small => "m1.small",
+            InstanceType::M1Xlarge => "m1.xlarge",
+            InstanceType::M22Xlarge => "m2.2xlarge",
+            InstanceType::M24Xlarge => "m2.4xlarge",
+            InstanceType::M2Xlarge => "m2.xlarge",
+            InstanceType::M32Xlarge => "m3.2xlarge",
+            InstanceType::M3Large => "m3.large",
+            InstanceType::M3Medium => "m3.medium",
+            InstanceType::M3Xlarge => "m3.xlarge",
+            InstanceType::M410Xlarge => "m4.10xlarge",
+            InstanceType::M416Xlarge => "m4.16xlarge",
+            InstanceType::M42Xlarge => "m4.2xlarge",
+            InstanceType::M44Xlarge => "m4.4xlarge",
+            InstanceType::M4Large => "m4.large",
+            InstanceType::M4Xlarge => "m4.xlarge",
+            InstanceType::P216Xlarge => "p2.16xlarge",
+            InstanceType::P28Xlarge => "p2.8xlarge",
+            InstanceType::P2Xlarge => "p2.xlarge",
+            InstanceType::R32Xlarge => "r3.2xlarge",
+            InstanceType::R34Xlarge => "r3.4xlarge",
+            InstanceType::R38Xlarge => "r3.8xlarge",
+            InstanceType::R3Large => "r3.large",
+            InstanceType::R3Xlarge => "r3.xlarge",
+            InstanceType::R416Xlarge => "r4.16xlarge",
+            InstanceType::R42Xlarge => "r4.2xlarge",
+            InstanceType::R44Xlarge => "r4.4xlarge",
+            InstanceType::R48Xlarge => "r4.8xlarge",
+            InstanceType::R4Large => "r4.large",
+            InstanceType::R4Xlarge => "r4.xlarge",
+            InstanceType::T1Micro => "t1.micro",
+            InstanceType::T22Xlarge => "t2.2xlarge",
+            InstanceType::T2Large => "t2.large",
+            InstanceType::T2Medium => "t2.medium",
+            InstanceType::T2Micro => "t2.micro",
+            InstanceType::T2Nano => "t2.nano",
+            InstanceType::T2Small => "t2.small",
+            InstanceType::T2Xlarge => "t2.xlarge",
+            InstanceType::X116Xlarge => "x1.16xlarge",
+            InstanceType::X132Xlarge => "x1.32xlarge",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "c1.medium" => Ok(InstanceType::C1Medium),
+            "c1.xlarge" => Ok(InstanceType::C1Xlarge),
+            "c3.2xlarge" => Ok(InstanceType::C32Xlarge),
+            "c3.4xlarge" => Ok(InstanceType::C34Xlarge),
+            "c3.8xlarge" => Ok(InstanceType::C38Xlarge),
+            "c3.large" => Ok(InstanceType::C3Large),
+            "c3.xlarge" => Ok(InstanceType::C3Xlarge),
+            "c4.2xlarge" => Ok(InstanceType::C42Xlarge),
+            "c4.4xlarge" => Ok(InstanceType::C44Xlarge),
+            "c4.8xlarge" => Ok(InstanceType::C48Xlarge),
+            "c4.large" => Ok(InstanceType::C4Large),
+            "c4.xlarge" => Ok(InstanceType::C4Xlarge),
+            "cc1.4xlarge" => Ok(InstanceType::Cc14Xlarge),
+            "cc2.8xlarge" => Ok(InstanceType::Cc28Xlarge),
+            "cg1.4xlarge" => Ok(InstanceType::Cg14Xlarge),
+            "cr1.8xlarge" => Ok(InstanceType::Cr18Xlarge),
+            "d2.2xlarge" => Ok(InstanceType::D22Xlarge),
+            "d2.4xlarge" => Ok(InstanceType::D24Xlarge),
+            "d2.8xlarge" => Ok(InstanceType::D28Xlarge),
+            "d2.xlarge" => Ok(InstanceType::D2Xlarge),
+            "f1.16xlarge" => Ok(InstanceType::F116Xlarge),
+            "f1.2xlarge" => Ok(InstanceType::F12Xlarge),
+            "g2.2xlarge" => Ok(InstanceType::G22Xlarge),
+            "g2.8xlarge" => Ok(InstanceType::G28Xlarge),
+            "g3.16xlarge" => Ok(InstanceType::G316Xlarge),
+            "g3.4xlarge" => Ok(InstanceType::G34Xlarge),
+            "g3.8xlarge" => Ok(InstanceType::G38Xlarge),
+            "hi1.4xlarge" => Ok(InstanceType::Hi14Xlarge),
+            "hs1.8xlarge" => Ok(InstanceType::Hs18Xlarge),
+            "i2.2xlarge" => Ok(InstanceType::I22Xlarge),
+            "i2.4xlarge" => Ok(InstanceType::I24Xlarge),
+            "i2.8xlarge" => Ok(InstanceType::I28Xlarge),
+            "i2.xlarge" => Ok(InstanceType::I2Xlarge),
+            "i3.16xlarge" => Ok(InstanceType::I316Xlarge),
+            "i3.2xlarge" => Ok(InstanceType::I32Xlarge),
+            "i3.4xlarge" => Ok(InstanceType::I34Xlarge),
+            "i3.8xlarge" => Ok(InstanceType::I38Xlarge),
+            "i3.large" => Ok(InstanceType::I3Large),
+            "i3.xlarge" => Ok(InstanceType::I3Xlarge),
+            "m1.large" => Ok(InstanceType::M1Large),
+            "m1.medium" => Ok(InstanceType::M1Medium),
+            "m1.small" => Ok(InstanceType::M1Small),
+            "m1.xlarge" => Ok(InstanceType::M1Xlarge),
+            "m2.2xlarge" => Ok(InstanceType::M22Xlarge),
+            "m2.4xlarge" => Ok(InstanceType::M24Xlarge),
+            "m2.xlarge" => Ok(InstanceType::M2Xlarge),
+            "m3.2xlarge" => Ok(InstanceType::M32Xlarge),
+            "m3.large" => Ok(InstanceType::M3Large),
+            "m3.medium" => Ok(InstanceType::M3Medium),
+            "m3.xlarge" => Ok(InstanceType::M3Xlarge),
+            "m4.10xlarge" => Ok(InstanceType::M410Xlarge),
+            "m4.16xlarge" => Ok(InstanceType::M416Xlarge),
+            "m4.2xlarge" => Ok(InstanceType::M42Xlarge),
+            "m4.4xlarge" => Ok(InstanceType::M44Xlarge),
+            "m4.large" => Ok(InstanceType::M4Large),
+            "m4.xlarge" => Ok(InstanceType::M4Xlarge),
+            "p2.16xlarge" => Ok(InstanceType::P216Xlarge),
+            "p2.8xlarge" => Ok(InstanceType::P28Xlarge),
+            "p2.xlarge" => Ok(InstanceType::P2Xlarge),
+            "r3.2xlarge" => Ok(InstanceType::R32Xlarge),
+            "r3.4xlarge" => Ok(InstanceType::R34Xlarge),
+            "r3.8xlarge" => Ok(InstanceType::R38Xlarge),
+            "r3.large" => Ok(InstanceType::R3Large),
+            "r3.xlarge" => Ok(InstanceType::R3Xlarge),
+            "r4.16xlarge" => Ok(InstanceType::R416Xlarge),
+            "r4.2xlarge" => Ok(InstanceType::R42Xlarge),
+            "r4.4xlarge" => Ok(InstanceType::R44Xlarge),
+            "r4.8xlarge" => Ok(InstanceType::R48Xlarge),
+            "r4.large" => Ok(InstanceType::R4Large),
+            "r4.xlarge" => Ok(InstanceType::R4Xlarge),
+            "t1.micro" => Ok(InstanceType::T1Micro),
+            "t2.2xlarge" => Ok(InstanceType::T22Xlarge),
+            "t2.large" => Ok(InstanceType::T2Large),
+            "t2.medium" => Ok(InstanceType::T2Medium),
+            "t2.micro" => Ok(InstanceType::T2Micro),
+            "t2.nano" => Ok(InstanceType::T2Nano),
+            "t2.small" => Ok(InstanceType::T2Small),
+            "t2.xlarge" => Ok(InstanceType::T2Xlarge),
+            "x1.16xlarge" => Ok(InstanceType::X116Xlarge),
+            "x1.32xlarge" => Ok(InstanceType::X132Xlarge),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InstanceTypeDeserializer;
 impl InstanceTypeDeserializer {
     #[allow(unused_variables)]
@@ -24297,6 +26191,41 @@ impl IntegerDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InterfacePermissionType {
+    EipAssociate,
+    InstanceAttach,
+}
+
+impl Into<String> for InterfacePermissionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InterfacePermissionType {
+    fn into(self) -> &'static str {
+        match self {
+            InterfacePermissionType::EipAssociate => "EIP-ASSOCIATE",
+            InterfacePermissionType::InstanceAttach => "INSTANCE-ATTACH",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InterfacePermissionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EIP-ASSOCIATE" => Ok(InterfacePermissionType::EipAssociate),
+            "INSTANCE-ATTACH" => Ok(InterfacePermissionType::InstanceAttach),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InterfacePermissionTypeDeserializer;
 impl InterfacePermissionTypeDeserializer {
     #[allow(unused_variables)]
@@ -25644,6 +27573,47 @@ impl LaunchSpecsListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ListingState {
+    Available,
+    Cancelled,
+    Pending,
+    Sold,
+}
+
+impl Into<String> for ListingState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ListingState {
+    fn into(self) -> &'static str {
+        match self {
+            ListingState::Available => "available",
+            ListingState::Cancelled => "cancelled",
+            ListingState::Pending => "pending",
+            ListingState::Sold => "sold",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ListingState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(ListingState::Available),
+            "cancelled" => Ok(ListingState::Cancelled),
+            "pending" => Ok(ListingState::Pending),
+            "sold" => Ok(ListingState::Sold),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ListingStateDeserializer;
 impl ListingStateDeserializer {
     #[allow(unused_variables)]
@@ -25658,6 +27628,47 @@ impl ListingStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ListingStatus {
+    Active,
+    Cancelled,
+    Closed,
+    Pending,
+}
+
+impl Into<String> for ListingStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ListingStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ListingStatus::Active => "active",
+            ListingStatus::Cancelled => "cancelled",
+            ListingStatus::Closed => "closed",
+            ListingStatus::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ListingStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(ListingStatus::Active),
+            "cancelled" => Ok(ListingStatus::Cancelled),
+            "closed" => Ok(ListingStatus::Closed),
+            "pending" => Ok(ListingStatus::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ListingStatusDeserializer;
 impl ListingStatusDeserializer {
     #[allow(unused_variables)]
@@ -26976,6 +28987,47 @@ impl MonitoringDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MonitoringState {
+    Disabled,
+    Disabling,
+    Enabled,
+    Pending,
+}
+
+impl Into<String> for MonitoringState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MonitoringState {
+    fn into(self) -> &'static str {
+        match self {
+            MonitoringState::Disabled => "disabled",
+            MonitoringState::Disabling => "disabling",
+            MonitoringState::Enabled => "enabled",
+            MonitoringState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MonitoringState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "disabled" => Ok(MonitoringState::Disabled),
+            "disabling" => Ok(MonitoringState::Disabling),
+            "enabled" => Ok(MonitoringState::Enabled),
+            "pending" => Ok(MonitoringState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct MonitoringStateDeserializer;
 impl MonitoringStateDeserializer {
     #[allow(unused_variables)]
@@ -27074,6 +29126,41 @@ impl MoveAddressToVpcResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MoveStatus {
+    MovingToVpc,
+    RestoringToClassic,
+}
+
+impl Into<String> for MoveStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MoveStatus {
+    fn into(self) -> &'static str {
+        match self {
+            MoveStatus::MovingToVpc => "movingToVpc",
+            MoveStatus::RestoringToClassic => "restoringToClassic",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MoveStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "movingToVpc" => Ok(MoveStatus::MovingToVpc),
+            "restoringToClassic" => Ok(MoveStatus::RestoringToClassic),
+            _ => Err(()),
+        }
+    }
+}
+
 struct MoveStatusDeserializer;
 impl MoveStatusDeserializer {
     #[allow(unused_variables)]
@@ -27441,6 +29528,50 @@ impl NatGatewayListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NatGatewayState {
+    Available,
+    Deleted,
+    Deleting,
+    Failed,
+    Pending,
+}
+
+impl Into<String> for NatGatewayState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NatGatewayState {
+    fn into(self) -> &'static str {
+        match self {
+            NatGatewayState::Available => "available",
+            NatGatewayState::Deleted => "deleted",
+            NatGatewayState::Deleting => "deleting",
+            NatGatewayState::Failed => "failed",
+            NatGatewayState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NatGatewayState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(NatGatewayState::Available),
+            "deleted" => Ok(NatGatewayState::Deleted),
+            "deleting" => Ok(NatGatewayState::Deleting),
+            "failed" => Ok(NatGatewayState::Failed),
+            "pending" => Ok(NatGatewayState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct NatGatewayStateDeserializer;
 impl NatGatewayStateDeserializer {
     #[allow(unused_variables)]
@@ -28174,6 +30305,47 @@ impl NetworkInterfaceAttachmentChangesSerializer {
 }
 
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkInterfaceAttribute {
+    Attachment,
+    Description,
+    GroupSet,
+    SourceDestCheck,
+}
+
+impl Into<String> for NetworkInterfaceAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkInterfaceAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkInterfaceAttribute::Attachment => "attachment",
+            NetworkInterfaceAttribute::Description => "description",
+            NetworkInterfaceAttribute::GroupSet => "groupSet",
+            NetworkInterfaceAttribute::SourceDestCheck => "sourceDestCheck",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkInterfaceAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "attachment" => Ok(NetworkInterfaceAttribute::Attachment),
+            "description" => Ok(NetworkInterfaceAttribute::Description),
+            "groupSet" => Ok(NetworkInterfaceAttribute::GroupSet),
+            "sourceDestCheck" => Ok(NetworkInterfaceAttribute::SourceDestCheck),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `NetworkInterfaceIdList` contents to a `SignedRequest`.
 struct NetworkInterfaceIdListSerializer;
 impl NetworkInterfaceIdListSerializer {
@@ -28509,6 +30681,47 @@ impl NetworkInterfacePermissionStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkInterfacePermissionStateCode {
+    Granted,
+    Pending,
+    Revoked,
+    Revoking,
+}
+
+impl Into<String> for NetworkInterfacePermissionStateCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkInterfacePermissionStateCode {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkInterfacePermissionStateCode::Granted => "granted",
+            NetworkInterfacePermissionStateCode::Pending => "pending",
+            NetworkInterfacePermissionStateCode::Revoked => "revoked",
+            NetworkInterfacePermissionStateCode::Revoking => "revoking",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkInterfacePermissionStateCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "granted" => Ok(NetworkInterfacePermissionStateCode::Granted),
+            "pending" => Ok(NetworkInterfacePermissionStateCode::Pending),
+            "revoked" => Ok(NetworkInterfacePermissionStateCode::Revoked),
+            "revoking" => Ok(NetworkInterfacePermissionStateCode::Revoking),
+            _ => Err(()),
+        }
+    }
+}
+
 struct NetworkInterfacePermissionStateCodeDeserializer;
 impl NetworkInterfacePermissionStateCodeDeserializer {
     #[allow(unused_variables)]
@@ -28634,6 +30847,47 @@ impl NetworkInterfacePrivateIpAddressListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkInterfaceStatus {
+    Attaching,
+    Available,
+    Detaching,
+    InUse,
+}
+
+impl Into<String> for NetworkInterfaceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkInterfaceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkInterfaceStatus::Attaching => "attaching",
+            NetworkInterfaceStatus::Available => "available",
+            NetworkInterfaceStatus::Detaching => "detaching",
+            NetworkInterfaceStatus::InUse => "in-use",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkInterfaceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "attaching" => Ok(NetworkInterfaceStatus::Attaching),
+            "available" => Ok(NetworkInterfaceStatus::Available),
+            "detaching" => Ok(NetworkInterfaceStatus::Detaching),
+            "in-use" => Ok(NetworkInterfaceStatus::InUse),
+            _ => Err(()),
+        }
+    }
+}
+
 struct NetworkInterfaceStatusDeserializer;
 impl NetworkInterfaceStatusDeserializer {
     #[allow(unused_variables)]
@@ -28648,6 +30902,41 @@ impl NetworkInterfaceStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkInterfaceType {
+    Interface,
+    NatGateway,
+}
+
+impl Into<String> for NetworkInterfaceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkInterfaceType {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkInterfaceType::Interface => "interface",
+            NetworkInterfaceType::NatGateway => "natGateway",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkInterfaceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "interface" => Ok(NetworkInterfaceType::Interface),
+            "natGateway" => Ok(NetworkInterfaceType::NatGateway),
+            _ => Err(()),
+        }
+    }
+}
+
 struct NetworkInterfaceTypeDeserializer;
 impl NetworkInterfaceTypeDeserializer {
     #[allow(unused_variables)]
@@ -28770,6 +31059,41 @@ impl OccurrenceDaySetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OfferingClassType {
+    Convertible,
+    Standard,
+}
+
+impl Into<String> for OfferingClassType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OfferingClassType {
+    fn into(self) -> &'static str {
+        match self {
+            OfferingClassType::Convertible => "convertible",
+            OfferingClassType::Standard => "standard",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OfferingClassType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "convertible" => Ok(OfferingClassType::Convertible),
+            "standard" => Ok(OfferingClassType::Standard),
+            _ => Err(()),
+        }
+    }
+}
+
 struct OfferingClassTypeDeserializer;
 impl OfferingClassTypeDeserializer {
     #[allow(unused_variables)]
@@ -28784,6 +31108,53 @@ impl OfferingClassTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OfferingTypeValues {
+    AllUpfront,
+    HeavyUtilization,
+    LightUtilization,
+    MediumUtilization,
+    NoUpfront,
+    PartialUpfront,
+}
+
+impl Into<String> for OfferingTypeValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OfferingTypeValues {
+    fn into(self) -> &'static str {
+        match self {
+            OfferingTypeValues::AllUpfront => "All Upfront",
+            OfferingTypeValues::HeavyUtilization => "Heavy Utilization",
+            OfferingTypeValues::LightUtilization => "Light Utilization",
+            OfferingTypeValues::MediumUtilization => "Medium Utilization",
+            OfferingTypeValues::NoUpfront => "No Upfront",
+            OfferingTypeValues::PartialUpfront => "Partial Upfront",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OfferingTypeValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All Upfront" => Ok(OfferingTypeValues::AllUpfront),
+            "Heavy Utilization" => Ok(OfferingTypeValues::HeavyUtilization),
+            "Light Utilization" => Ok(OfferingTypeValues::LightUtilization),
+            "Medium Utilization" => Ok(OfferingTypeValues::MediumUtilization),
+            "No Upfront" => Ok(OfferingTypeValues::NoUpfront),
+            "Partial Upfront" => Ok(OfferingTypeValues::PartialUpfront),
+            _ => Err(()),
+        }
+    }
+}
+
 struct OfferingTypeValuesDeserializer;
 impl OfferingTypeValuesDeserializer {
     #[allow(unused_variables)]
@@ -28799,6 +31170,41 @@ impl OfferingTypeValuesDeserializer {
     }
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationType {
+    Add,
+    Remove,
+}
+
+impl Into<String> for OperationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationType {
+    fn into(self) -> &'static str {
+        match self {
+            OperationType::Add => "add",
+            OperationType::Remove => "remove",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "add" => Ok(OperationType::Add),
+            "remove" => Ok(OperationType::Remove),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `OwnerStringList` contents to a `SignedRequest`.
 struct OwnerStringListSerializer;
 impl OwnerStringListSerializer {
@@ -28806,6 +31212,44 @@ impl OwnerStringListSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PaymentOption {
+    AllUpfront,
+    NoUpfront,
+    PartialUpfront,
+}
+
+impl Into<String> for PaymentOption {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PaymentOption {
+    fn into(self) -> &'static str {
+        match self {
+            PaymentOption::AllUpfront => "AllUpfront",
+            PaymentOption::NoUpfront => "NoUpfront",
+            PaymentOption::PartialUpfront => "PartialUpfront",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PaymentOption {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AllUpfront" => Ok(PaymentOption::AllUpfront),
+            "NoUpfront" => Ok(PaymentOption::NoUpfront),
+            "PartialUpfront" => Ok(PaymentOption::PartialUpfront),
+            _ => Err(()),
         }
     }
 }
@@ -28990,6 +31434,38 @@ impl PeeringConnectionOptionsRequestSerializer {
                        &field_value.to_string().replace("+", "%2B"));
         }
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PermissionGroup {
+    All,
+}
+
+impl Into<String> for PermissionGroup {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PermissionGroup {
+    fn into(self) -> &'static str {
+        match self {
+            PermissionGroup::All => "all",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PermissionGroup {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(PermissionGroup::All),
+            _ => Err(()),
+        }
     }
 }
 
@@ -29229,6 +31705,47 @@ impl PlacementGroupListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlacementGroupState {
+    Available,
+    Deleted,
+    Deleting,
+    Pending,
+}
+
+impl Into<String> for PlacementGroupState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlacementGroupState {
+    fn into(self) -> &'static str {
+        match self {
+            PlacementGroupState::Available => "available",
+            PlacementGroupState::Deleted => "deleted",
+            PlacementGroupState::Deleting => "deleting",
+            PlacementGroupState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlacementGroupState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(PlacementGroupState::Available),
+            "deleted" => Ok(PlacementGroupState::Deleted),
+            "deleting" => Ok(PlacementGroupState::Deleting),
+            "pending" => Ok(PlacementGroupState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PlacementGroupStateDeserializer;
 impl PlacementGroupStateDeserializer {
     #[allow(unused_variables)]
@@ -29255,6 +31772,38 @@ impl PlacementGroupStringListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlacementStrategy {
+    Cluster,
+}
+
+impl Into<String> for PlacementStrategy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlacementStrategy {
+    fn into(self) -> &'static str {
+        match self {
+            PlacementStrategy::Cluster => "cluster",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlacementStrategy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cluster" => Ok(PlacementStrategy::Cluster),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PlacementStrategyDeserializer;
 impl PlacementStrategyDeserializer {
     #[allow(unused_variables)]
@@ -29269,6 +31818,38 @@ impl PlacementStrategyDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlatformValues {
+    Windows,
+}
+
+impl Into<String> for PlatformValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlatformValues {
+    fn into(self) -> &'static str {
+        match self {
+            PlatformValues::Windows => "Windows",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlatformValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Windows" => Ok(PlatformValues::Windows),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PlatformValuesDeserializer;
 impl PlatformValuesDeserializer {
     #[allow(unused_variables)]
@@ -30137,6 +32718,41 @@ impl ProductCodeStringListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProductCodeValues {
+    Devpay,
+    Marketplace,
+}
+
+impl Into<String> for ProductCodeValues {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProductCodeValues {
+    fn into(self) -> &'static str {
+        match self {
+            ProductCodeValues::Devpay => "devpay",
+            ProductCodeValues::Marketplace => "marketplace",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProductCodeValues {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "devpay" => Ok(ProductCodeValues::Devpay),
+            "marketplace" => Ok(ProductCodeValues::Marketplace),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ProductCodeValuesDeserializer;
 impl ProductCodeValuesDeserializer {
     #[allow(unused_variables)]
@@ -30852,6 +33468,47 @@ impl PurchasedScheduledInstanceSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RIProductDescription {
+    LinuxUNIX,
+    LinuxUNIXAmazonVPC,
+    Windows,
+    WindowsAmazonVPC,
+}
+
+impl Into<String> for RIProductDescription {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RIProductDescription {
+    fn into(self) -> &'static str {
+        match self {
+            RIProductDescription::LinuxUNIX => "Linux/UNIX",
+            RIProductDescription::LinuxUNIXAmazonVPC => "Linux/UNIX (Amazon VPC)",
+            RIProductDescription::Windows => "Windows",
+            RIProductDescription::WindowsAmazonVPC => "Windows (Amazon VPC)",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RIProductDescription {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Linux/UNIX" => Ok(RIProductDescription::LinuxUNIX),
+            "Linux/UNIX (Amazon VPC)" => Ok(RIProductDescription::LinuxUNIXAmazonVPC),
+            "Windows" => Ok(RIProductDescription::Windows),
+            "Windows (Amazon VPC)" => Ok(RIProductDescription::WindowsAmazonVPC),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RIProductDescriptionDeserializer;
 impl RIProductDescriptionDeserializer {
     #[allow(unused_variables)]
@@ -30962,6 +33619,38 @@ impl RecurringChargeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RecurringChargeFrequency {
+    Hourly,
+}
+
+impl Into<String> for RecurringChargeFrequency {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RecurringChargeFrequency {
+    fn into(self) -> &'static str {
+        match self {
+            RecurringChargeFrequency::Hourly => "Hourly",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RecurringChargeFrequency {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Hourly" => Ok(RecurringChargeFrequency::Hourly),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RecurringChargeFrequencyDeserializer;
 impl RecurringChargeFrequencyDeserializer {
     #[allow(unused_variables)]
@@ -31865,6 +34554,62 @@ impl ReplaceRouteTableAssociationResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportInstanceReasonCodes {
+    InstanceStuckInState,
+    NotAcceptingCredentials,
+    Other,
+    PasswordNotAvailable,
+    PerformanceEbsVolume,
+    PerformanceInstanceStore,
+    PerformanceNetwork,
+    PerformanceOther,
+    Unresponsive,
+}
+
+impl Into<String> for ReportInstanceReasonCodes {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportInstanceReasonCodes {
+    fn into(self) -> &'static str {
+        match self {
+            ReportInstanceReasonCodes::InstanceStuckInState => "instance-stuck-in-state",
+            ReportInstanceReasonCodes::NotAcceptingCredentials => "not-accepting-credentials",
+            ReportInstanceReasonCodes::Other => "other",
+            ReportInstanceReasonCodes::PasswordNotAvailable => "password-not-available",
+            ReportInstanceReasonCodes::PerformanceEbsVolume => "performance-ebs-volume",
+            ReportInstanceReasonCodes::PerformanceInstanceStore => "performance-instance-store",
+            ReportInstanceReasonCodes::PerformanceNetwork => "performance-network",
+            ReportInstanceReasonCodes::PerformanceOther => "performance-other",
+            ReportInstanceReasonCodes::Unresponsive => "unresponsive",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportInstanceReasonCodes {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "instance-stuck-in-state" => Ok(ReportInstanceReasonCodes::InstanceStuckInState),
+            "not-accepting-credentials" => Ok(ReportInstanceReasonCodes::NotAcceptingCredentials),
+            "other" => Ok(ReportInstanceReasonCodes::Other),
+            "password-not-available" => Ok(ReportInstanceReasonCodes::PasswordNotAvailable),
+            "performance-ebs-volume" => Ok(ReportInstanceReasonCodes::PerformanceEbsVolume),
+            "performance-instance-store" => Ok(ReportInstanceReasonCodes::PerformanceInstanceStore),
+            "performance-network" => Ok(ReportInstanceReasonCodes::PerformanceNetwork),
+            "performance-other" => Ok(ReportInstanceReasonCodes::PerformanceOther),
+            "unresponsive" => Ok(ReportInstanceReasonCodes::Unresponsive),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the parameters for ReportInstanceStatus.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct ReportInstanceStatusRequest {
@@ -31919,6 +34664,41 @@ impl ReportInstanceStatusRequestSerializer {
         params.put(&format!("{}{}", prefix, "Status"),
                    &obj.status.replace("+", "%2B"));
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportStatusType {
+    Impaired,
+    Ok,
+}
+
+impl Into<String> for ReportStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            ReportStatusType::Impaired => "impaired",
+            ReportStatusType::Ok => "ok",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "impaired" => Ok(ReportStatusType::Impaired),
+            "ok" => Ok(ReportStatusType::Ok),
+            _ => Err(()),
+        }
     }
 }
 
@@ -32409,6 +35189,47 @@ impl ReservationListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReservationState {
+    Active,
+    PaymentFailed,
+    PaymentPending,
+    Retired,
+}
+
+impl Into<String> for ReservationState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReservationState {
+    fn into(self) -> &'static str {
+        match self {
+            ReservationState::Active => "active",
+            ReservationState::PaymentFailed => "payment-failed",
+            ReservationState::PaymentPending => "payment-pending",
+            ReservationState::Retired => "retired",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReservationState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(ReservationState::Active),
+            "payment-failed" => Ok(ReservationState::PaymentFailed),
+            "payment-pending" => Ok(ReservationState::PaymentPending),
+            "retired" => Ok(ReservationState::Retired),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReservationStateDeserializer;
 impl ReservationStateDeserializer {
     #[allow(unused_variables)]
@@ -32629,6 +35450,47 @@ impl ReservedInstanceReservationValueSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReservedInstanceState {
+    Active,
+    PaymentFailed,
+    PaymentPending,
+    Retired,
+}
+
+impl Into<String> for ReservedInstanceState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReservedInstanceState {
+    fn into(self) -> &'static str {
+        match self {
+            ReservedInstanceState::Active => "active",
+            ReservedInstanceState::PaymentFailed => "payment-failed",
+            ReservedInstanceState::PaymentPending => "payment-pending",
+            ReservedInstanceState::Retired => "retired",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReservedInstanceState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(ReservedInstanceState::Active),
+            "payment-failed" => Ok(ReservedInstanceState::PaymentFailed),
+            "payment-pending" => Ok(ReservedInstanceState::PaymentPending),
+            "retired" => Ok(ReservedInstanceState::Retired),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReservedInstanceStateDeserializer;
 impl ReservedInstanceStateDeserializer {
     #[allow(unused_variables)]
@@ -33664,6 +36526,38 @@ impl ReservedIntancesIdsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResetImageAttributeName {
+    LaunchPermission,
+}
+
+impl Into<String> for ResetImageAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResetImageAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            ResetImageAttributeName::LaunchPermission => "launchPermission",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResetImageAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "launchPermission" => Ok(ResetImageAttributeName::LaunchPermission),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the parameters for ResetImageAttribute.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct ResetImageAttributeRequest {
@@ -33806,6 +36700,86 @@ impl ResourceIdListSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceType {
+    CustomerGateway,
+    DhcpOptions,
+    Image,
+    Instance,
+    InternetGateway,
+    NetworkAcl,
+    NetworkInterface,
+    ReservedInstances,
+    RouteTable,
+    SecurityGroup,
+    Snapshot,
+    SpotInstancesRequest,
+    Subnet,
+    Volume,
+    Vpc,
+    VpnConnection,
+    VpnGateway,
+}
+
+impl Into<String> for ResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceType::CustomerGateway => "customer-gateway",
+            ResourceType::DhcpOptions => "dhcp-options",
+            ResourceType::Image => "image",
+            ResourceType::Instance => "instance",
+            ResourceType::InternetGateway => "internet-gateway",
+            ResourceType::NetworkAcl => "network-acl",
+            ResourceType::NetworkInterface => "network-interface",
+            ResourceType::ReservedInstances => "reserved-instances",
+            ResourceType::RouteTable => "route-table",
+            ResourceType::SecurityGroup => "security-group",
+            ResourceType::Snapshot => "snapshot",
+            ResourceType::SpotInstancesRequest => "spot-instances-request",
+            ResourceType::Subnet => "subnet",
+            ResourceType::Volume => "volume",
+            ResourceType::Vpc => "vpc",
+            ResourceType::VpnConnection => "vpn-connection",
+            ResourceType::VpnGateway => "vpn-gateway",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "customer-gateway" => Ok(ResourceType::CustomerGateway),
+            "dhcp-options" => Ok(ResourceType::DhcpOptions),
+            "image" => Ok(ResourceType::Image),
+            "instance" => Ok(ResourceType::Instance),
+            "internet-gateway" => Ok(ResourceType::InternetGateway),
+            "network-acl" => Ok(ResourceType::NetworkAcl),
+            "network-interface" => Ok(ResourceType::NetworkInterface),
+            "reserved-instances" => Ok(ResourceType::ReservedInstances),
+            "route-table" => Ok(ResourceType::RouteTable),
+            "security-group" => Ok(ResourceType::SecurityGroup),
+            "snapshot" => Ok(ResourceType::Snapshot),
+            "spot-instances-request" => Ok(ResourceType::SpotInstancesRequest),
+            "subnet" => Ok(ResourceType::Subnet),
+            "volume" => Ok(ResourceType::Volume),
+            "vpc" => Ok(ResourceType::Vpc),
+            "vpn-connection" => Ok(ResourceType::VpnConnection),
+            "vpn-gateway" => Ok(ResourceType::VpnGateway),
+            _ => Err(()),
         }
     }
 }
@@ -34317,6 +37291,44 @@ impl RouteListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RouteOrigin {
+    CreateRoute,
+    CreateRouteTable,
+    EnableVgwRoutePropagation,
+}
+
+impl Into<String> for RouteOrigin {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RouteOrigin {
+    fn into(self) -> &'static str {
+        match self {
+            RouteOrigin::CreateRoute => "CreateRoute",
+            RouteOrigin::CreateRouteTable => "CreateRouteTable",
+            RouteOrigin::EnableVgwRoutePropagation => "EnableVgwRoutePropagation",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RouteOrigin {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreateRoute" => Ok(RouteOrigin::CreateRoute),
+            "CreateRouteTable" => Ok(RouteOrigin::CreateRouteTable),
+            "EnableVgwRoutePropagation" => Ok(RouteOrigin::EnableVgwRoutePropagation),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RouteOriginDeserializer;
 impl RouteOriginDeserializer {
     #[allow(unused_variables)]
@@ -34331,6 +37343,41 @@ impl RouteOriginDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RouteState {
+    Active,
+    Blackhole,
+}
+
+impl Into<String> for RouteState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RouteState {
+    fn into(self) -> &'static str {
+        match self {
+            RouteState::Active => "active",
+            RouteState::Blackhole => "blackhole",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RouteState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(RouteState::Active),
+            "blackhole" => Ok(RouteState::Blackhole),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RouteStateDeserializer;
 impl RouteStateDeserializer {
     #[allow(unused_variables)]
@@ -34574,6 +37621,41 @@ impl RouteTableListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RuleAction {
+    Allow,
+    Deny,
+}
+
+impl Into<String> for RuleAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RuleAction {
+    fn into(self) -> &'static str {
+        match self {
+            RuleAction::Allow => "allow",
+            RuleAction::Deny => "deny",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RuleAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "allow" => Ok(RuleAction::Allow),
+            "deny" => Ok(RuleAction::Deny),
+            _ => Err(()),
+        }
+    }
+}
+
 struct RuleActionDeserializer;
 impl RuleActionDeserializer {
     #[allow(unused_variables)]
@@ -36057,6 +39139,41 @@ impl ScheduledInstancesSecurityGroupIdSetSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Scope {
+    AvailabilityZone,
+    Region,
+}
+
+impl Into<String> for Scope {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Scope {
+    fn into(self) -> &'static str {
+        match self {
+            Scope::AvailabilityZone => "Availability Zone",
+            Scope::Region => "Region",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Scope {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Availability Zone" => Ok(Scope::AvailabilityZone),
+            "Region" => Ok(Scope::Region),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ScopeDeserializer;
 impl ScopeDeserializer {
     #[allow(unused_variables)]
@@ -36373,6 +39490,41 @@ impl SecurityGroupStringListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ShutdownBehavior {
+    Stop,
+    Terminate,
+}
+
+impl Into<String> for ShutdownBehavior {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ShutdownBehavior {
+    fn into(self) -> &'static str {
+        match self {
+            ShutdownBehavior::Stop => "stop",
+            ShutdownBehavior::Terminate => "terminate",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ShutdownBehavior {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "stop" => Ok(ShutdownBehavior::Stop),
+            "terminate" => Ok(ShutdownBehavior::Terminate),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the time period for a Scheduled Instance to start its first schedule. The time period must span less than one day.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct SlotDateTimeRangeRequest {
@@ -36559,6 +39711,41 @@ impl SnapshotDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnapshotAttributeName {
+    CreateVolumePermission,
+    ProductCodes,
+}
+
+impl Into<String> for SnapshotAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnapshotAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            SnapshotAttributeName::CreateVolumePermission => "createVolumePermission",
+            SnapshotAttributeName::ProductCodes => "productCodes",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnapshotAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "createVolumePermission" => Ok(SnapshotAttributeName::CreateVolumePermission),
+            "productCodes" => Ok(SnapshotAttributeName::ProductCodes),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the snapshot created from the imported disk.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct SnapshotDetail {
@@ -36800,6 +39987,44 @@ impl SnapshotListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnapshotState {
+    Completed,
+    Error,
+    Pending,
+}
+
+impl Into<String> for SnapshotState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnapshotState {
+    fn into(self) -> &'static str {
+        match self {
+            SnapshotState::Completed => "completed",
+            SnapshotState::Error => "error",
+            SnapshotState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnapshotState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "completed" => Ok(SnapshotState::Completed),
+            "error" => Ok(SnapshotState::Error),
+            "pending" => Ok(SnapshotState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SnapshotStateDeserializer;
 impl SnapshotStateDeserializer {
     #[allow(unused_variables)]
@@ -37954,6 +41179,50 @@ impl SpotInstanceRequestListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SpotInstanceState {
+    Active,
+    Cancelled,
+    Closed,
+    Failed,
+    Open,
+}
+
+impl Into<String> for SpotInstanceState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SpotInstanceState {
+    fn into(self) -> &'static str {
+        match self {
+            SpotInstanceState::Active => "active",
+            SpotInstanceState::Cancelled => "cancelled",
+            SpotInstanceState::Closed => "closed",
+            SpotInstanceState::Failed => "failed",
+            SpotInstanceState::Open => "open",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SpotInstanceState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(SpotInstanceState::Active),
+            "cancelled" => Ok(SpotInstanceState::Cancelled),
+            "closed" => Ok(SpotInstanceState::Closed),
+            "failed" => Ok(SpotInstanceState::Failed),
+            "open" => Ok(SpotInstanceState::Open),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SpotInstanceStateDeserializer;
 impl SpotInstanceStateDeserializer {
     #[allow(unused_variables)]
@@ -38082,6 +41351,41 @@ impl SpotInstanceStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SpotInstanceType {
+    OneTime,
+    Persistent,
+}
+
+impl Into<String> for SpotInstanceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SpotInstanceType {
+    fn into(self) -> &'static str {
+        match self {
+            SpotInstanceType::OneTime => "one-time",
+            SpotInstanceType::Persistent => "persistent",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SpotInstanceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "one-time" => Ok(SpotInstanceType::OneTime),
+            "persistent" => Ok(SpotInstanceType::Persistent),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SpotInstanceTypeDeserializer;
 impl SpotInstanceTypeDeserializer {
     #[allow(unused_variables)]
@@ -38630,6 +41934,47 @@ impl StartInstancesResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum State {
+    Available,
+    Deleted,
+    Deleting,
+    Pending,
+}
+
+impl Into<String> for State {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for State {
+    fn into(self) -> &'static str {
+        match self {
+            State::Available => "Available",
+            State::Deleted => "Deleted",
+            State::Deleting => "Deleting",
+            State::Pending => "Pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for State {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Available" => Ok(State::Available),
+            "Deleted" => Ok(State::Deleted),
+            "Deleting" => Ok(State::Deleting),
+            "Pending" => Ok(State::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StateDeserializer;
 impl StateDeserializer {
     #[allow(unused_variables)]
@@ -38698,6 +42043,44 @@ impl StateReasonDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Status {
+    InClassic,
+    InVpc,
+    MoveInProgress,
+}
+
+impl Into<String> for Status {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Status {
+    fn into(self) -> &'static str {
+        match self {
+            Status::InClassic => "InClassic",
+            Status::InVpc => "InVpc",
+            Status::MoveInProgress => "MoveInProgress",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Status {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "InClassic" => Ok(Status::InClassic),
+            "InVpc" => Ok(Status::InVpc),
+            "MoveInProgress" => Ok(Status::MoveInProgress),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StatusDeserializer;
 impl StatusDeserializer {
     #[allow(unused_variables)]
@@ -38712,6 +42095,38 @@ impl StatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusName {
+    Reachability,
+}
+
+impl Into<String> for StatusName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusName {
+    fn into(self) -> &'static str {
+        match self {
+            StatusName::Reachability => "reachability",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "reachability" => Ok(StatusName::Reachability),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StatusNameDeserializer;
 impl StatusNameDeserializer {
     #[allow(unused_variables)]
@@ -38726,6 +42141,47 @@ impl StatusNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusType {
+    Failed,
+    Initializing,
+    InsufficientData,
+    Passed,
+}
+
+impl Into<String> for StatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusType {
+    fn into(self) -> &'static str {
+        match self {
+            StatusType::Failed => "failed",
+            StatusType::Initializing => "initializing",
+            StatusType::InsufficientData => "insufficient-data",
+            StatusType::Passed => "passed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "failed" => Ok(StatusType::Failed),
+            "initializing" => Ok(StatusType::Initializing),
+            "insufficient-data" => Ok(StatusType::InsufficientData),
+            "passed" => Ok(StatusType::Passed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StatusTypeDeserializer;
 impl StatusTypeDeserializer {
     #[allow(unused_variables)]
@@ -39102,6 +42558,53 @@ impl SubnetCidrBlockStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SubnetCidrBlockStateCode {
+    Associated,
+    Associating,
+    Disassociated,
+    Disassociating,
+    Failed,
+    Failing,
+}
+
+impl Into<String> for SubnetCidrBlockStateCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SubnetCidrBlockStateCode {
+    fn into(self) -> &'static str {
+        match self {
+            SubnetCidrBlockStateCode::Associated => "associated",
+            SubnetCidrBlockStateCode::Associating => "associating",
+            SubnetCidrBlockStateCode::Disassociated => "disassociated",
+            SubnetCidrBlockStateCode::Disassociating => "disassociating",
+            SubnetCidrBlockStateCode::Failed => "failed",
+            SubnetCidrBlockStateCode::Failing => "failing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SubnetCidrBlockStateCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "associated" => Ok(SubnetCidrBlockStateCode::Associated),
+            "associating" => Ok(SubnetCidrBlockStateCode::Associating),
+            "disassociated" => Ok(SubnetCidrBlockStateCode::Disassociated),
+            "disassociating" => Ok(SubnetCidrBlockStateCode::Disassociating),
+            "failed" => Ok(SubnetCidrBlockStateCode::Failed),
+            "failing" => Ok(SubnetCidrBlockStateCode::Failing),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SubnetCidrBlockStateCodeDeserializer;
 impl SubnetCidrBlockStateCodeDeserializer {
     #[allow(unused_variables)]
@@ -39273,6 +42776,41 @@ impl SubnetListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SubnetState {
+    Available,
+    Pending,
+}
+
+impl Into<String> for SubnetState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SubnetState {
+    fn into(self) -> &'static str {
+        match self {
+            SubnetState::Available => "available",
+            SubnetState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SubnetState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(SubnetState::Available),
+            "pending" => Ok(SubnetState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SubnetStateDeserializer;
 impl SubnetStateDeserializer {
     #[allow(unused_variables)]
@@ -39287,6 +42825,50 @@ impl SubnetStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SummaryStatus {
+    Impaired,
+    Initializing,
+    InsufficientData,
+    NotApplicable,
+    Ok,
+}
+
+impl Into<String> for SummaryStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SummaryStatus {
+    fn into(self) -> &'static str {
+        match self {
+            SummaryStatus::Impaired => "impaired",
+            SummaryStatus::Initializing => "initializing",
+            SummaryStatus::InsufficientData => "insufficient-data",
+            SummaryStatus::NotApplicable => "not-applicable",
+            SummaryStatus::Ok => "ok",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SummaryStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "impaired" => Ok(SummaryStatus::Impaired),
+            "initializing" => Ok(SummaryStatus::Initializing),
+            "insufficient-data" => Ok(SummaryStatus::InsufficientData),
+            "not-applicable" => Ok(SummaryStatus::NotApplicable),
+            "ok" => Ok(SummaryStatus::Ok),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SummaryStatusDeserializer;
 impl SummaryStatusDeserializer {
     #[allow(unused_variables)]
@@ -39774,6 +43356,41 @@ impl TargetReservationValueSetDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TelemetryStatus {
+    Down,
+    Up,
+}
+
+impl Into<String> for TelemetryStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TelemetryStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TelemetryStatus::Down => "DOWN",
+            TelemetryStatus::Up => "UP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TelemetryStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DOWN" => Ok(TelemetryStatus::Down),
+            "UP" => Ok(TelemetryStatus::Up),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TelemetryStatusDeserializer;
 impl TelemetryStatusDeserializer {
     #[allow(unused_variables)]
@@ -39788,6 +43405,44 @@ impl TelemetryStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Tenancy {
+    Dedicated,
+    Default,
+    Host,
+}
+
+impl Into<String> for Tenancy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Tenancy {
+    fn into(self) -> &'static str {
+        match self {
+            Tenancy::Dedicated => "dedicated",
+            Tenancy::Default => "default",
+            Tenancy::Host => "host",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Tenancy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dedicated" => Ok(Tenancy::Dedicated),
+            "default" => Ok(Tenancy::Default),
+            "host" => Ok(Tenancy::Host),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TenancyDeserializer;
 impl TenancyDeserializer {
     #[allow(unused_variables)]
@@ -39882,6 +43537,44 @@ impl TerminateInstancesResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TrafficType {
+    Accept,
+    All,
+    Reject,
+}
+
+impl Into<String> for TrafficType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TrafficType {
+    fn into(self) -> &'static str {
+        match self {
+            TrafficType::Accept => "ACCEPT",
+            TrafficType::All => "ALL",
+            TrafficType::Reject => "REJECT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TrafficType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCEPT" => Ok(TrafficType::Accept),
+            "ALL" => Ok(TrafficType::All),
+            "REJECT" => Ok(TrafficType::Reject),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TrafficTypeDeserializer;
 impl TrafficTypeDeserializer {
     #[allow(unused_variables)]
@@ -40797,6 +44490,41 @@ impl VgwTelemetryListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VirtualizationType {
+    Hvm,
+    Paravirtual,
+}
+
+impl Into<String> for VirtualizationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VirtualizationType {
+    fn into(self) -> &'static str {
+        match self {
+            VirtualizationType::Hvm => "hvm",
+            VirtualizationType::Paravirtual => "paravirtual",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VirtualizationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "hvm" => Ok(VirtualizationType::Hvm),
+            "paravirtual" => Ok(VirtualizationType::Paravirtual),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VirtualizationTypeDeserializer;
 impl VirtualizationTypeDeserializer {
     #[allow(unused_variables)]
@@ -41049,6 +44777,47 @@ impl VolumeAttachmentListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeAttachmentState {
+    Attached,
+    Attaching,
+    Detached,
+    Detaching,
+}
+
+impl Into<String> for VolumeAttachmentState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeAttachmentState {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeAttachmentState::Attached => "attached",
+            VolumeAttachmentState::Attaching => "attaching",
+            VolumeAttachmentState::Detached => "detached",
+            VolumeAttachmentState::Detaching => "detaching",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeAttachmentState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "attached" => Ok(VolumeAttachmentState::Attached),
+            "attaching" => Ok(VolumeAttachmentState::Attaching),
+            "detached" => Ok(VolumeAttachmentState::Detached),
+            "detaching" => Ok(VolumeAttachmentState::Detaching),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeAttachmentStateDeserializer;
 impl VolumeAttachmentStateDeserializer {
     #[allow(unused_variables)]
@@ -41063,6 +44832,41 @@ impl VolumeAttachmentStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeAttributeName {
+    AutoEnableIO,
+    ProductCodes,
+}
+
+impl Into<String> for VolumeAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeAttributeName::AutoEnableIO => "autoEnableIO",
+            VolumeAttributeName::ProductCodes => "productCodes",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "autoEnableIO" => Ok(VolumeAttributeName::AutoEnableIO),
+            "productCodes" => Ok(VolumeAttributeName::ProductCodes),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes an EBS volume.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct VolumeDetail {
@@ -41298,6 +45102,47 @@ impl VolumeModificationListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeModificationState {
+    Completed,
+    Failed,
+    Modifying,
+    Optimizing,
+}
+
+impl Into<String> for VolumeModificationState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeModificationState {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeModificationState::Completed => "completed",
+            VolumeModificationState::Failed => "failed",
+            VolumeModificationState::Modifying => "modifying",
+            VolumeModificationState::Optimizing => "optimizing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeModificationState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "completed" => Ok(VolumeModificationState::Completed),
+            "failed" => Ok(VolumeModificationState::Failed),
+            "modifying" => Ok(VolumeModificationState::Modifying),
+            "optimizing" => Ok(VolumeModificationState::Optimizing),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeModificationStateDeserializer;
 impl VolumeModificationStateDeserializer {
     #[allow(unused_variables)]
@@ -41312,6 +45157,53 @@ impl VolumeModificationStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeState {
+    Available,
+    Creating,
+    Deleted,
+    Deleting,
+    Error,
+    InUse,
+}
+
+impl Into<String> for VolumeState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeState {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeState::Available => "available",
+            VolumeState::Creating => "creating",
+            VolumeState::Deleted => "deleted",
+            VolumeState::Deleting => "deleting",
+            VolumeState::Error => "error",
+            VolumeState::InUse => "in-use",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(VolumeState::Available),
+            "creating" => Ok(VolumeState::Creating),
+            "deleted" => Ok(VolumeState::Deleted),
+            "deleting" => Ok(VolumeState::Deleting),
+            "error" => Ok(VolumeState::Error),
+            "in-use" => Ok(VolumeState::InUse),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeStateDeserializer;
 impl VolumeStateDeserializer {
     #[allow(unused_variables)]
@@ -41700,6 +45592,44 @@ impl VolumeStatusInfoDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeStatusInfoStatus {
+    Impaired,
+    InsufficientData,
+    Ok,
+}
+
+impl Into<String> for VolumeStatusInfoStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeStatusInfoStatus {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeStatusInfoStatus::Impaired => "impaired",
+            VolumeStatusInfoStatus::InsufficientData => "insufficient-data",
+            VolumeStatusInfoStatus::Ok => "ok",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeStatusInfoStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "impaired" => Ok(VolumeStatusInfoStatus::Impaired),
+            "insufficient-data" => Ok(VolumeStatusInfoStatus::InsufficientData),
+            "ok" => Ok(VolumeStatusInfoStatus::Ok),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeStatusInfoStatusDeserializer;
 impl VolumeStatusInfoStatusDeserializer {
     #[allow(unused_variables)]
@@ -41832,6 +45762,41 @@ impl VolumeStatusListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeStatusName {
+    IoEnabled,
+    IoPerformance,
+}
+
+impl Into<String> for VolumeStatusName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeStatusName {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeStatusName::IoEnabled => "io-enabled",
+            VolumeStatusName::IoPerformance => "io-performance",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeStatusName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "io-enabled" => Ok(VolumeStatusName::IoEnabled),
+            "io-performance" => Ok(VolumeStatusName::IoPerformance),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeStatusNameDeserializer;
 impl VolumeStatusNameDeserializer {
     #[allow(unused_variables)]
@@ -41846,6 +45811,50 @@ impl VolumeStatusNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeType {
+    Gp2,
+    Io1,
+    Sc1,
+    St1,
+    Standard,
+}
+
+impl Into<String> for VolumeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeType {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeType::Gp2 => "gp2",
+            VolumeType::Io1 => "io1",
+            VolumeType::Sc1 => "sc1",
+            VolumeType::St1 => "st1",
+            VolumeType::Standard => "standard",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "gp2" => Ok(VolumeType::Gp2),
+            "io1" => Ok(VolumeType::Io1),
+            "sc1" => Ok(VolumeType::Sc1),
+            "st1" => Ok(VolumeType::St1),
+            "standard" => Ok(VolumeType::Standard),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VolumeTypeDeserializer;
 impl VolumeTypeDeserializer {
     #[allow(unused_variables)]
@@ -42048,6 +46057,41 @@ impl VpcAttachmentListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpcAttributeName {
+    EnableDnsHostnames,
+    EnableDnsSupport,
+}
+
+impl Into<String> for VpcAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpcAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            VpcAttributeName::EnableDnsHostnames => "enableDnsHostnames",
+            VpcAttributeName::EnableDnsSupport => "enableDnsSupport",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpcAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "enableDnsHostnames" => Ok(VpcAttributeName::EnableDnsHostnames),
+            "enableDnsSupport" => Ok(VpcAttributeName::EnableDnsSupport),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the state of a CIDR block.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct VpcCidrBlockState {
@@ -42104,6 +46148,53 @@ impl VpcCidrBlockStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpcCidrBlockStateCode {
+    Associated,
+    Associating,
+    Disassociated,
+    Disassociating,
+    Failed,
+    Failing,
+}
+
+impl Into<String> for VpcCidrBlockStateCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpcCidrBlockStateCode {
+    fn into(self) -> &'static str {
+        match self {
+            VpcCidrBlockStateCode::Associated => "associated",
+            VpcCidrBlockStateCode::Associating => "associating",
+            VpcCidrBlockStateCode::Disassociated => "disassociated",
+            VpcCidrBlockStateCode::Disassociating => "disassociating",
+            VpcCidrBlockStateCode::Failed => "failed",
+            VpcCidrBlockStateCode::Failing => "failing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpcCidrBlockStateCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "associated" => Ok(VpcCidrBlockStateCode::Associated),
+            "associating" => Ok(VpcCidrBlockStateCode::Associating),
+            "disassociated" => Ok(VpcCidrBlockStateCode::Disassociated),
+            "disassociating" => Ok(VpcCidrBlockStateCode::Disassociating),
+            "failed" => Ok(VpcCidrBlockStateCode::Failed),
+            "failing" => Ok(VpcCidrBlockStateCode::Failing),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VpcCidrBlockStateCodeDeserializer;
 impl VpcCidrBlockStateCodeDeserializer {
     #[allow(unused_variables)]
@@ -42759,6 +46850,62 @@ impl VpcPeeringConnectionStateReasonDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpcPeeringConnectionStateReasonCode {
+    Active,
+    Deleted,
+    Deleting,
+    Expired,
+    Failed,
+    InitiatingRequest,
+    PendingAcceptance,
+    Provisioning,
+    Rejected,
+}
+
+impl Into<String> for VpcPeeringConnectionStateReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpcPeeringConnectionStateReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            VpcPeeringConnectionStateReasonCode::Active => "active",
+            VpcPeeringConnectionStateReasonCode::Deleted => "deleted",
+            VpcPeeringConnectionStateReasonCode::Deleting => "deleting",
+            VpcPeeringConnectionStateReasonCode::Expired => "expired",
+            VpcPeeringConnectionStateReasonCode::Failed => "failed",
+            VpcPeeringConnectionStateReasonCode::InitiatingRequest => "initiating-request",
+            VpcPeeringConnectionStateReasonCode::PendingAcceptance => "pending-acceptance",
+            VpcPeeringConnectionStateReasonCode::Provisioning => "provisioning",
+            VpcPeeringConnectionStateReasonCode::Rejected => "rejected",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpcPeeringConnectionStateReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(VpcPeeringConnectionStateReasonCode::Active),
+            "deleted" => Ok(VpcPeeringConnectionStateReasonCode::Deleted),
+            "deleting" => Ok(VpcPeeringConnectionStateReasonCode::Deleting),
+            "expired" => Ok(VpcPeeringConnectionStateReasonCode::Expired),
+            "failed" => Ok(VpcPeeringConnectionStateReasonCode::Failed),
+            "initiating-request" => Ok(VpcPeeringConnectionStateReasonCode::InitiatingRequest),
+            "pending-acceptance" => Ok(VpcPeeringConnectionStateReasonCode::PendingAcceptance),
+            "provisioning" => Ok(VpcPeeringConnectionStateReasonCode::Provisioning),
+            "rejected" => Ok(VpcPeeringConnectionStateReasonCode::Rejected),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VpcPeeringConnectionStateReasonCodeDeserializer;
 impl VpcPeeringConnectionStateReasonCodeDeserializer {
     #[allow(unused_variables)]
@@ -42846,6 +46993,41 @@ impl VpcPeeringConnectionVpcInfoDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpcState {
+    Available,
+    Pending,
+}
+
+impl Into<String> for VpcState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpcState {
+    fn into(self) -> &'static str {
+        match self {
+            VpcState::Available => "available",
+            VpcState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpcState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(VpcState::Available),
+            "pending" => Ok(VpcState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VpcStateDeserializer;
 impl VpcStateDeserializer {
     #[allow(unused_variables)]
@@ -43231,6 +47413,47 @@ impl VpnGatewayListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpnState {
+    Available,
+    Deleted,
+    Deleting,
+    Pending,
+}
+
+impl Into<String> for VpnState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpnState {
+    fn into(self) -> &'static str {
+        match self {
+            VpnState::Available => "available",
+            VpnState::Deleted => "deleted",
+            VpnState::Deleting => "deleting",
+            VpnState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpnState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(VpnState::Available),
+            "deleted" => Ok(VpnState::Deleted),
+            "deleting" => Ok(VpnState::Deleting),
+            "pending" => Ok(VpnState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VpnStateDeserializer;
 impl VpnStateDeserializer {
     #[allow(unused_variables)]
@@ -43349,6 +47572,38 @@ impl VpnStaticRouteListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VpnStaticRouteSource {
+    Static,
+}
+
+impl Into<String> for VpnStaticRouteSource {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VpnStaticRouteSource {
+    fn into(self) -> &'static str {
+        match self {
+            VpnStaticRouteSource::Static => "Static",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VpnStaticRouteSource {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Static" => Ok(VpnStaticRouteSource::Static),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VpnStaticRouteSourceDeserializer;
 impl VpnStaticRouteSourceDeserializer {
     #[allow(unused_variables)]
@@ -60868,7 +65123,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -60912,7 +65167,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -60956,7 +65211,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61000,7 +65255,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61044,7 +65299,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61089,7 +65344,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -61118,7 +65373,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61163,7 +65418,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -61192,7 +65447,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61236,7 +65491,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61282,7 +65537,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61327,7 +65582,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61370,7 +65625,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61415,7 +65670,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -61444,7 +65699,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61487,7 +65742,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61531,7 +65786,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61576,7 +65831,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -61605,7 +65860,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -61634,7 +65889,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61678,7 +65933,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61723,7 +65978,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -61751,7 +66006,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -61779,7 +66034,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61825,7 +66080,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61870,7 +66125,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61915,7 +66170,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -61960,7 +66215,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62001,7 +66256,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62045,7 +66300,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62090,7 +66345,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62133,7 +66388,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62178,7 +66433,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62224,7 +66479,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62268,7 +66523,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62312,7 +66567,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62356,7 +66611,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62401,7 +66656,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62446,7 +66701,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62487,7 +66742,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62530,7 +66785,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62575,7 +66830,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62620,7 +66875,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -62649,7 +66904,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62693,7 +66948,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62736,7 +66991,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -62765,7 +67020,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62809,7 +67064,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62853,7 +67108,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62898,7 +67153,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62943,7 +67198,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -62987,7 +67242,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63031,7 +67286,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63073,7 +67328,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63099,7 +67354,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63140,7 +67395,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63184,7 +67439,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63230,7 +67485,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63274,7 +67529,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63319,7 +67574,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63348,7 +67603,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63393,7 +67648,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63421,7 +67676,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63450,7 +67705,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63494,7 +67749,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63538,7 +67793,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63564,7 +67819,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63592,7 +67847,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63637,7 +67892,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63665,7 +67920,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63693,7 +67948,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63722,7 +67977,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -63765,7 +68020,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63791,7 +68046,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63819,7 +68074,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63847,7 +68102,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63873,7 +68128,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63901,7 +68156,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63928,7 +68183,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63954,7 +68209,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -63980,7 +68235,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64006,7 +68261,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64034,7 +68289,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64080,7 +68335,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64124,7 +68379,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64152,7 +68407,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64181,7 +68436,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64207,7 +68462,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -64236,7 +68491,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64280,7 +68535,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64326,7 +68581,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64370,7 +68625,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64416,7 +68671,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64461,7 +68716,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64506,7 +68761,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64550,7 +68805,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64597,7 +68852,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64640,7 +68895,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64685,7 +68940,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64730,7 +68985,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64775,7 +69030,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64821,7 +69076,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64865,7 +69120,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64909,7 +69164,7 @@ impl<P, D> Ec2 for Ec2Client<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64951,7 +69206,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -64994,7 +69249,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65040,7 +69295,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65084,7 +69339,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65128,7 +69383,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65173,7 +69428,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65218,7 +69473,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65262,7 +69517,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65308,7 +69563,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65351,7 +69606,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65397,7 +69652,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65441,7 +69696,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65487,7 +69742,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65531,7 +69786,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65576,7 +69831,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65622,7 +69877,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65667,7 +69922,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65711,7 +69966,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65756,7 +70011,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65800,7 +70055,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65845,7 +70100,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65890,7 +70145,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65935,7 +70190,7 @@ fn describe_iam_instance_profile_associations(&self, input: &DescribeIamInstance
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -65976,7 +70231,7 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66021,7 +70276,7 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66064,7 +70319,7 @@ fn describe_reserved_instances_modifications(&self, input: &DescribeReservedInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66107,7 +70362,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66151,7 +70406,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66196,7 +70451,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66241,7 +70496,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66285,7 +70540,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66329,7 +70584,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66375,7 +70630,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66419,7 +70674,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66464,7 +70719,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66509,7 +70764,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66554,7 +70809,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66599,7 +70854,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66644,7 +70899,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66688,7 +70943,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66732,7 +70987,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66777,7 +71032,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66821,7 +71076,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66866,7 +71121,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66911,7 +71166,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -66955,7 +71210,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67001,7 +71256,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67045,7 +71300,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67089,7 +71344,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67133,7 +71388,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67179,7 +71434,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67223,7 +71478,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67268,7 +71523,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67311,7 +71566,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67356,7 +71611,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67401,7 +71656,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -67429,7 +71684,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -67457,7 +71712,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67501,7 +71756,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -67529,7 +71784,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -67559,7 +71814,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67603,7 +71858,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67647,7 +71902,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -67676,7 +71931,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67720,7 +71975,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -67749,7 +72004,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67794,7 +72049,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67838,7 +72093,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -67865,7 +72120,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -67893,7 +72148,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67939,7 +72194,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -67983,7 +72238,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68028,7 +72283,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68074,7 +72329,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68117,7 +72372,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68162,7 +72417,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68205,7 +72460,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68249,7 +72504,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68293,7 +72548,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68337,7 +72592,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68381,7 +72636,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68425,7 +72680,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68467,7 +72722,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -68495,7 +72750,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -68523,7 +72778,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -68551,7 +72806,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -68581,7 +72836,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68625,7 +72880,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -68655,7 +72910,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68699,7 +72954,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -68729,7 +72984,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68772,7 +73027,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -68800,7 +73055,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68844,7 +73099,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -68872,7 +73127,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -68900,7 +73155,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68946,7 +73201,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -68989,7 +73244,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69034,7 +73289,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69080,7 +73335,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69125,7 +73380,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69169,7 +73424,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69211,7 +73466,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -69239,7 +73494,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69284,7 +73539,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69326,7 +73581,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -69354,7 +73609,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69400,7 +73655,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69444,7 +73699,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69488,7 +73743,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -69514,7 +73769,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -69543,7 +73798,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69587,7 +73842,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -69615,7 +73870,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69660,7 +73915,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69705,7 +73960,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -69733,7 +73988,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -69761,7 +74016,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -69790,7 +74045,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -69819,7 +74074,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69863,7 +74118,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -69892,7 +74147,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -69919,7 +74174,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -69964,7 +74219,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -70007,7 +74262,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -70051,7 +74306,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -70095,7 +74350,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -70141,7 +74396,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -70184,7 +74439,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -70213,7 +74468,7 @@ fn describe_scheduled_instance_availability(&self, input: &DescribeScheduledInst
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -446,6 +442,50 @@ pub struct ImageFailure {
     pub image_id: Option<ImageIdentifier>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ImageFailureCode {
+    ImageNotFound,
+    ImageTagDoesNotMatchDigest,
+    InvalidImageDigest,
+    InvalidImageTag,
+    MissingDigestAndTag,
+}
+
+impl Into<String> for ImageFailureCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ImageFailureCode {
+    fn into(self) -> &'static str {
+        match self {
+            ImageFailureCode::ImageNotFound => "ImageNotFound",
+            ImageFailureCode::ImageTagDoesNotMatchDigest => "ImageTagDoesNotMatchDigest",
+            ImageFailureCode::InvalidImageDigest => "InvalidImageDigest",
+            ImageFailureCode::InvalidImageTag => "InvalidImageTag",
+            ImageFailureCode::MissingDigestAndTag => "MissingDigestAndTag",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ImageFailureCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ImageNotFound" => Ok(ImageFailureCode::ImageNotFound),
+            "ImageTagDoesNotMatchDigest" => Ok(ImageFailureCode::ImageTagDoesNotMatchDigest),
+            "InvalidImageDigest" => Ok(ImageFailureCode::InvalidImageDigest),
+            "InvalidImageTag" => Ok(ImageFailureCode::InvalidImageTag),
+            "MissingDigestAndTag" => Ok(ImageFailureCode::MissingDigestAndTag),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An object with identifying information for an Amazon ECR image.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImageIdentifier {
@@ -503,6 +543,41 @@ pub struct Layer {
     pub media_type: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LayerAvailability {
+    Available,
+    Unavailable,
+}
+
+impl Into<String> for LayerAvailability {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LayerAvailability {
+    fn into(self) -> &'static str {
+        match self {
+            LayerAvailability::Available => "AVAILABLE",
+            LayerAvailability::Unavailable => "UNAVAILABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LayerAvailability {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(LayerAvailability::Available),
+            "UNAVAILABLE" => Ok(LayerAvailability::Unavailable),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An object representing an Amazon ECR image layer failure.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct LayerFailure {
@@ -518,6 +593,41 @@ pub struct LayerFailure {
     #[serde(rename="layerDigest")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub layer_digest: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LayerFailureCode {
+    InvalidLayerDigest,
+    MissingLayerDigest,
+}
+
+impl Into<String> for LayerFailureCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LayerFailureCode {
+    fn into(self) -> &'static str {
+        match self {
+            LayerFailureCode::InvalidLayerDigest => "InvalidLayerDigest",
+            LayerFailureCode::MissingLayerDigest => "MissingLayerDigest",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LayerFailureCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "InvalidLayerDigest" => Ok(LayerFailureCode::InvalidLayerDigest),
+            "MissingLayerDigest" => Ok(LayerFailureCode::MissingLayerDigest),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>An object representing a filter on a <a>ListImages</a> operation.</p>"]
@@ -647,6 +757,41 @@ pub struct SetRepositoryPolicyResponse {
     #[serde(rename="repositoryName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub repository_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TagStatus {
+    Tagged,
+    Untagged,
+}
+
+impl Into<String> for TagStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TagStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TagStatus::Tagged => "TAGGED",
+            TagStatus::Untagged => "UNTAGGED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TagStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "TAGGED" => Ok(TagStatus::Tagged),
+            "UNTAGGED" => Ok(TagStatus::Untagged),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -2486,7 +2631,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchCheckLayerAvailabilityResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2518,7 +2663,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchDeleteImageResponse>(String::from_utf8_lossy(&body)
@@ -2551,7 +2696,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchGetImageResponse>(String::from_utf8_lossy(&body)
@@ -2584,7 +2729,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CompleteLayerUploadResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2615,7 +2760,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateRepositoryResponse>(String::from_utf8_lossy(&body)
@@ -2648,7 +2793,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteRepositoryResponse>(String::from_utf8_lossy(&body)
@@ -2682,7 +2827,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteRepositoryPolicyResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2713,7 +2858,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeImagesResponse>(String::from_utf8_lossy(&body)
@@ -2746,7 +2891,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeRepositoriesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2778,7 +2923,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetAuthorizationTokenResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2810,7 +2955,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDownloadUrlForLayerResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2841,7 +2986,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRepositoryPolicyResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2872,7 +3017,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<InitiateLayerUploadResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2903,7 +3048,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListImagesResponse>(String::from_utf8_lossy(&body)
@@ -2934,7 +3079,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutImageResponse>(String::from_utf8_lossy(&body)
@@ -2967,7 +3112,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SetRepositoryPolicyResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2998,7 +3143,7 @@ impl<P, D> Ecr for EcrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UploadLayerPartResponse>(String::from_utf8_lossy(&body)

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -11,23 +11,66 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AgentUpdateStatus {
+    Failed,
+    Pending,
+    Staged,
+    Staging,
+    Updated,
+    Updating,
+}
+
+impl Into<String> for AgentUpdateStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AgentUpdateStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AgentUpdateStatus::Failed => "FAILED",
+            AgentUpdateStatus::Pending => "PENDING",
+            AgentUpdateStatus::Staged => "STAGED",
+            AgentUpdateStatus::Staging => "STAGING",
+            AgentUpdateStatus::Updated => "UPDATED",
+            AgentUpdateStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AgentUpdateStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(AgentUpdateStatus::Failed),
+            "PENDING" => Ok(AgentUpdateStatus::Pending),
+            "STAGED" => Ok(AgentUpdateStatus::Staged),
+            "STAGING" => Ok(AgentUpdateStatus::Staging),
+            "UPDATED" => Ok(AgentUpdateStatus::Updated),
+            "UPDATING" => Ok(AgentUpdateStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An attribute is a name-value pair associated with an Amazon ECS object. Attributes enable you to extend the Amazon ECS data model by adding custom metadata to your resources. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html#attributes\">Attributes</a> in the <i>Amazon EC2 Container Service Developer Guide</i>.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Attribute {
@@ -278,6 +321,41 @@ pub struct ContainerInstance {
     #[serde(rename="versionInfo")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub version_info: Option<VersionInfo>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContainerInstanceStatus {
+    Active,
+    Draining,
+}
+
+impl Into<String> for ContainerInstanceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContainerInstanceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ContainerInstanceStatus::Active => "ACTIVE",
+            ContainerInstanceStatus::Draining => "DRAINING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContainerInstanceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(ContainerInstanceStatus::Active),
+            "DRAINING" => Ok(ContainerInstanceStatus::Draining),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The overrides that should be sent to a container.</p>"]
@@ -617,6 +695,44 @@ pub struct DescribeTasksResponse {
     #[serde(rename="tasks")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tasks: Option<Vec<Task>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DesiredStatus {
+    Pending,
+    Running,
+    Stopped,
+}
+
+impl Into<String> for DesiredStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DesiredStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DesiredStatus::Pending => "PENDING",
+            DesiredStatus::Running => "RUNNING",
+            DesiredStatus::Stopped => "STOPPED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DesiredStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PENDING" => Ok(DesiredStatus::Pending),
+            "RUNNING" => Ok(DesiredStatus::Running),
+            "STOPPED" => Ok(DesiredStatus::Stopped),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -965,6 +1081,56 @@ pub struct LogConfiguration {
     pub options: Option<::std::collections::HashMap<String, String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LogDriver {
+    Awslogs,
+    Fluentd,
+    Gelf,
+    Journald,
+    JsonFile,
+    Splunk,
+    Syslog,
+}
+
+impl Into<String> for LogDriver {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LogDriver {
+    fn into(self) -> &'static str {
+        match self {
+            LogDriver::Awslogs => "awslogs",
+            LogDriver::Fluentd => "fluentd",
+            LogDriver::Gelf => "gelf",
+            LogDriver::Journald => "journald",
+            LogDriver::JsonFile => "json-file",
+            LogDriver::Splunk => "splunk",
+            LogDriver::Syslog => "syslog",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LogDriver {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "awslogs" => Ok(LogDriver::Awslogs),
+            "fluentd" => Ok(LogDriver::Fluentd),
+            "gelf" => Ok(LogDriver::Gelf),
+            "journald" => Ok(LogDriver::Journald),
+            "json-file" => Ok(LogDriver::JsonFile),
+            "splunk" => Ok(LogDriver::Splunk),
+            "syslog" => Ok(LogDriver::Syslog),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Details on a volume mount point that is used in a container definition.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MountPoint {
@@ -1003,6 +1169,44 @@ pub struct NetworkBinding {
     pub protocol: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkMode {
+    Bridge,
+    Host,
+    None,
+}
+
+impl Into<String> for NetworkMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkMode {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkMode::Bridge => "bridge",
+            NetworkMode::Host => "host",
+            NetworkMode::None => "none",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bridge" => Ok(NetworkMode::Bridge),
+            "host" => Ok(NetworkMode::Host),
+            "none" => Ok(NetworkMode::None),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An object representing a constraint on task placement. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html\">Task Placement Constraints</a> in the <i>Amazon EC2 Container Service Developer Guide</i>.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlacementConstraint {
@@ -1016,6 +1220,41 @@ pub struct PlacementConstraint {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlacementConstraintType {
+    DistinctInstance,
+    MemberOf,
+}
+
+impl Into<String> for PlacementConstraintType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlacementConstraintType {
+    fn into(self) -> &'static str {
+        match self {
+            PlacementConstraintType::DistinctInstance => "distinctInstance",
+            PlacementConstraintType::MemberOf => "memberOf",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlacementConstraintType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "distinctInstance" => Ok(PlacementConstraintType::DistinctInstance),
+            "memberOf" => Ok(PlacementConstraintType::MemberOf),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The task placement strategy for a task or service. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html\">Task Placement Strategies</a> in the <i>Amazon EC2 Container Service Developer Guide</i>.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlacementStrategy {
@@ -1027,6 +1266,44 @@ pub struct PlacementStrategy {
     #[serde(rename="type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlacementStrategyType {
+    Binpack,
+    Random,
+    Spread,
+}
+
+impl Into<String> for PlacementStrategyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlacementStrategyType {
+    fn into(self) -> &'static str {
+        match self {
+            PlacementStrategyType::Binpack => "binpack",
+            PlacementStrategyType::Random => "random",
+            PlacementStrategyType::Spread => "spread",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlacementStrategyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "binpack" => Ok(PlacementStrategyType::Binpack),
+            "random" => Ok(PlacementStrategyType::Random),
+            "spread" => Ok(PlacementStrategyType::Spread),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Port mappings allow containers to access ports on the host container instance to send or receive traffic. Port mappings are specified as part of the container definition. After a task reaches the <code>RUNNING</code> status, manual and automatic host and container port assignments are visible in the <code>networkBindings</code> section of <a>DescribeTasks</a> API responses.</p>"]
@@ -1301,6 +1578,41 @@ pub struct ServiceEvent {
     pub message: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SortOrder {
+    Asc,
+    Desc,
+}
+
+impl Into<String> for SortOrder {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SortOrder {
+    fn into(self) -> &'static str {
+        match self {
+            SortOrder::Asc => "ASC",
+            SortOrder::Desc => "DESC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SortOrder {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASC" => Ok(SortOrder::Asc),
+            "DESC" => Ok(SortOrder::Desc),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StartTaskRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster on which to start your task. If you do not specify a cluster, the default cluster is assumed.</p>"]
@@ -1430,6 +1742,38 @@ pub struct SubmitTaskStateChangeResponse {
     pub acknowledgment: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TargetType {
+    ContainerInstance,
+}
+
+impl Into<String> for TargetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TargetType {
+    fn into(self) -> &'static str {
+        match self {
+            TargetType::ContainerInstance => "container-instance",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TargetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "container-instance" => Ok(TargetType::ContainerInstance),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Details on a task in a cluster.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Task {
@@ -1540,6 +1884,44 @@ pub struct TaskDefinition {
     pub volumes: Option<Vec<Volume>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaskDefinitionFamilyStatus {
+    Active,
+    All,
+    Inactive,
+}
+
+impl Into<String> for TaskDefinitionFamilyStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaskDefinitionFamilyStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TaskDefinitionFamilyStatus::Active => "ACTIVE",
+            TaskDefinitionFamilyStatus::All => "ALL",
+            TaskDefinitionFamilyStatus::Inactive => "INACTIVE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaskDefinitionFamilyStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(TaskDefinitionFamilyStatus::Active),
+            "ALL" => Ok(TaskDefinitionFamilyStatus::All),
+            "INACTIVE" => Ok(TaskDefinitionFamilyStatus::Inactive),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An object representing a constraint on task placement in the task definition. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html\">Task Placement Constraints</a> in the <i>Amazon EC2 Container Service Developer Guide</i>.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TaskDefinitionPlacementConstraint {
@@ -1551,6 +1933,73 @@ pub struct TaskDefinitionPlacementConstraint {
     #[serde(rename="type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaskDefinitionPlacementConstraintType {
+    MemberOf,
+}
+
+impl Into<String> for TaskDefinitionPlacementConstraintType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaskDefinitionPlacementConstraintType {
+    fn into(self) -> &'static str {
+        match self {
+            TaskDefinitionPlacementConstraintType::MemberOf => "memberOf",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaskDefinitionPlacementConstraintType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "memberOf" => Ok(TaskDefinitionPlacementConstraintType::MemberOf),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaskDefinitionStatus {
+    Active,
+    Inactive,
+}
+
+impl Into<String> for TaskDefinitionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaskDefinitionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            TaskDefinitionStatus::Active => "ACTIVE",
+            TaskDefinitionStatus::Inactive => "INACTIVE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaskDefinitionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(TaskDefinitionStatus::Active),
+            "INACTIVE" => Ok(TaskDefinitionStatus::Inactive),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The overrides associated with a task.</p>"]
@@ -1566,6 +2015,41 @@ pub struct TaskOverride {
     pub task_role_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TransportProtocol {
+    Tcp,
+    Udp,
+}
+
+impl Into<String> for TransportProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TransportProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            TransportProtocol::Tcp => "tcp",
+            TransportProtocol::Udp => "udp",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TransportProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "tcp" => Ok(TransportProtocol::Tcp),
+            "udp" => Ok(TransportProtocol::Udp),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The <code>ulimit</code> settings to pass to the container.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Ulimit {
@@ -1578,6 +2062,80 @@ pub struct Ulimit {
     #[doc="<p>The soft limit for the ulimit type.</p>"]
     #[serde(rename="softLimit")]
     pub soft_limit: i64,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UlimitName {
+    Core,
+    Cpu,
+    Data,
+    Fsize,
+    Locks,
+    Memlock,
+    Msgqueue,
+    Nice,
+    Nofile,
+    Nproc,
+    Rss,
+    Rtprio,
+    Rttime,
+    Sigpending,
+    Stack,
+}
+
+impl Into<String> for UlimitName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UlimitName {
+    fn into(self) -> &'static str {
+        match self {
+            UlimitName::Core => "core",
+            UlimitName::Cpu => "cpu",
+            UlimitName::Data => "data",
+            UlimitName::Fsize => "fsize",
+            UlimitName::Locks => "locks",
+            UlimitName::Memlock => "memlock",
+            UlimitName::Msgqueue => "msgqueue",
+            UlimitName::Nice => "nice",
+            UlimitName::Nofile => "nofile",
+            UlimitName::Nproc => "nproc",
+            UlimitName::Rss => "rss",
+            UlimitName::Rtprio => "rtprio",
+            UlimitName::Rttime => "rttime",
+            UlimitName::Sigpending => "sigpending",
+            UlimitName::Stack => "stack",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UlimitName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "core" => Ok(UlimitName::Core),
+            "cpu" => Ok(UlimitName::Cpu),
+            "data" => Ok(UlimitName::Data),
+            "fsize" => Ok(UlimitName::Fsize),
+            "locks" => Ok(UlimitName::Locks),
+            "memlock" => Ok(UlimitName::Memlock),
+            "msgqueue" => Ok(UlimitName::Msgqueue),
+            "nice" => Ok(UlimitName::Nice),
+            "nofile" => Ok(UlimitName::Nofile),
+            "nproc" => Ok(UlimitName::Nproc),
+            "rss" => Ok(UlimitName::Rss),
+            "rtprio" => Ok(UlimitName::Rtprio),
+            "rttime" => Ok(UlimitName::Rttime),
+            "sigpending" => Ok(UlimitName::Sigpending),
+            "stack" => Ok(UlimitName::Stack),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -4830,7 +5388,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateClusterResponse>(String::from_utf8_lossy(&body)
@@ -4863,7 +5421,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateServiceResponse>(String::from_utf8_lossy(&body)
@@ -4896,7 +5454,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteAttributesResponse>(String::from_utf8_lossy(&body)
@@ -4929,7 +5487,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteClusterResponse>(String::from_utf8_lossy(&body)
@@ -4962,7 +5520,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteServiceResponse>(String::from_utf8_lossy(&body)
@@ -4996,7 +5554,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeregisterContainerInstanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5029,7 +5587,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeregisterTaskDefinitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5061,7 +5619,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeClustersResponse>(String::from_utf8_lossy(&body)
@@ -5095,7 +5653,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeContainerInstancesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5127,7 +5685,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeServicesResponse>(String::from_utf8_lossy(&body)
@@ -5161,7 +5719,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTaskDefinitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5192,7 +5750,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTasksResponse>(String::from_utf8_lossy(&body)
@@ -5226,7 +5784,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DiscoverPollEndpointResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5257,7 +5815,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAttributesResponse>(String::from_utf8_lossy(&body)
@@ -5290,7 +5848,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListClustersResponse>(String::from_utf8_lossy(&body)
@@ -5324,7 +5882,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListContainerInstancesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5355,7 +5913,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListServicesResponse>(String::from_utf8_lossy(&body)
@@ -5389,7 +5947,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTaskDefinitionFamiliesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5421,7 +5979,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTaskDefinitionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5450,7 +6008,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTasksResponse>(String::from_utf8_lossy(&body)
@@ -5483,7 +6041,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutAttributesResponse>(String::from_utf8_lossy(&body)
@@ -5517,7 +6075,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterContainerInstanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5550,7 +6108,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterTaskDefinitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5578,7 +6136,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RunTaskResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -5608,7 +6166,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartTaskResponse>(String::from_utf8_lossy(&body)
@@ -5639,7 +6197,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopTaskResponse>(String::from_utf8_lossy(&body)
@@ -5673,7 +6231,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SubmitContainerStateChangeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5706,7 +6264,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SubmitTaskStateChangeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5738,7 +6296,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateContainerAgentResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5770,7 +6328,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateContainerInstancesStateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5802,7 +6360,7 @@ impl<P, D> Ecs for EcsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateServiceResponse>(String::from_utf8_lossy(&body)

--- a/rusoto/services/efs/src/generated.rs
+++ b/rusoto/services/efs/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -280,6 +276,47 @@ pub struct FileSystemSize {
     pub value: i64,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LifeCycleState {
+    Available,
+    Creating,
+    Deleted,
+    Deleting,
+}
+
+impl Into<String> for LifeCycleState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LifeCycleState {
+    fn into(self) -> &'static str {
+        match self {
+            LifeCycleState::Available => "available",
+            LifeCycleState::Creating => "creating",
+            LifeCycleState::Deleted => "deleted",
+            LifeCycleState::Deleting => "deleting",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LifeCycleState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(LifeCycleState::Available),
+            "creating" => Ok(LifeCycleState::Creating),
+            "deleted" => Ok(LifeCycleState::Deleted),
+            "deleting" => Ok(LifeCycleState::Deleting),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ModifyMountTargetSecurityGroupsRequest {
@@ -319,6 +356,41 @@ pub struct MountTargetDescription {
     #[doc="<p>ID of the mount target's subnet.</p>"]
     #[serde(rename="SubnetId")]
     pub subnet_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PerformanceMode {
+    GeneralPurpose,
+    MaxIO,
+}
+
+impl Into<String> for PerformanceMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PerformanceMode {
+    fn into(self) -> &'static str {
+        match self {
+            PerformanceMode::GeneralPurpose => "generalPurpose",
+            PerformanceMode::MaxIO => "maxIO",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PerformanceMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "generalPurpose" => Ok(PerformanceMode::GeneralPurpose),
+            "maxIO" => Ok(PerformanceMode::MaxIO),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A tag is a key-value pair. Allowed characters: letters, whitespace, and numbers, representable in UTF-8, and the following characters:<code> + - = . _ : /</code> </p>"]
@@ -1515,7 +1587,7 @@ impl<P, D> Efs for EfsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1561,7 +1633,7 @@ impl<P, D> Efs for EfsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1606,7 +1678,7 @@ impl<P, D> Efs for EfsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -1641,7 +1713,7 @@ impl<P, D> Efs for EfsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -1676,7 +1748,7 @@ impl<P, D> Efs for EfsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -1710,7 +1782,7 @@ impl<P, D> Efs for EfsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -1757,7 +1829,7 @@ impl<P, D> Efs for EfsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1805,7 +1877,7 @@ impl<P, D> Efs for EfsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1866,7 +1938,7 @@ impl<P, D> Efs for EfsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1919,7 +1991,7 @@ impl<P, D> Efs for EfsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1966,7 +2038,7 @@ impl<P, D> Efs for EfsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -39,6 +35,41 @@ enum DeserializerNext {
     Skip,
     Element(String),
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AZMode {
+    CrossAz,
+    SingleAz,
+}
+
+impl Into<String> for AZMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AZMode {
+    fn into(self) -> &'static str {
+        match self {
+            AZMode::CrossAz => "cross-az",
+            AZMode::SingleAz => "single-az",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AZMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cross-az" => Ok(AZMode::CrossAz),
+            "single-az" => Ok(AZMode::SingleAz),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input of an AddTagsToResource operation.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct AddTagsToResourceMessage {
@@ -198,6 +229,47 @@ impl AuthorizeCacheSecurityGroupIngressResultDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutomaticFailoverStatus {
+    Disabled,
+    Disabling,
+    Enabled,
+    Enabling,
+}
+
+impl Into<String> for AutomaticFailoverStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutomaticFailoverStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AutomaticFailoverStatus::Disabled => "disabled",
+            AutomaticFailoverStatus::Disabling => "disabling",
+            AutomaticFailoverStatus::Enabled => "enabled",
+            AutomaticFailoverStatus::Enabling => "enabling",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutomaticFailoverStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "disabled" => Ok(AutomaticFailoverStatus::Disabled),
+            "disabling" => Ok(AutomaticFailoverStatus::Disabling),
+            "enabled" => Ok(AutomaticFailoverStatus::Enabled),
+            "enabling" => Ok(AutomaticFailoverStatus::Enabling),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AutomaticFailoverStatusDeserializer;
 impl AutomaticFailoverStatusDeserializer {
     #[allow(unused_variables)]
@@ -320,7 +392,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -334,7 +406,7 @@ impl BooleanOptionalDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1993,6 +2065,41 @@ impl CacheSubnetGroupsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeType {
+    Immediate,
+    RequiresReboot,
+}
+
+impl Into<String> for ChangeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeType {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeType::Immediate => "immediate",
+            ChangeType::RequiresReboot => "requires-reboot",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "immediate" => Ok(ChangeType::Immediate),
+            "requires-reboot" => Ok(ChangeType::RequiresReboot),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeTypeDeserializer;
 impl ChangeTypeDeserializer {
     #[allow(unused_variables)]
@@ -5590,6 +5697,41 @@ impl ParametersListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PendingAutomaticFailoverStatus {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for PendingAutomaticFailoverStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PendingAutomaticFailoverStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PendingAutomaticFailoverStatus::Disabled => "disabled",
+            PendingAutomaticFailoverStatus::Enabled => "enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PendingAutomaticFailoverStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "disabled" => Ok(PendingAutomaticFailoverStatus::Disabled),
+            "enabled" => Ok(PendingAutomaticFailoverStatus::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PendingAutomaticFailoverStatusDeserializer;
 impl PendingAutomaticFailoverStatusDeserializer {
     #[allow(unused_variables)]
@@ -7147,6 +7289,50 @@ impl SnapshotListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    CacheCluster,
+    CacheParameterGroup,
+    CacheSecurityGroup,
+    CacheSubnetGroup,
+    ReplicationGroup,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::CacheCluster => "cache-cluster",
+            SourceType::CacheParameterGroup => "cache-parameter-group",
+            SourceType::CacheSecurityGroup => "cache-security-group",
+            SourceType::CacheSubnetGroup => "cache-subnet-group",
+            SourceType::ReplicationGroup => "replication-group",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cache-cluster" => Ok(SourceType::CacheCluster),
+            "cache-parameter-group" => Ok(SourceType::CacheParameterGroup),
+            "cache-security-group" => Ok(SourceType::CacheSecurityGroup),
+            "cache-subnet-group" => Ok(SourceType::CacheSubnetGroup),
+            "replication-group" => Ok(SourceType::ReplicationGroup),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
     #[allow(unused_variables)]
@@ -11330,7 +11516,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11379,7 +11565,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11425,7 +11611,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11472,7 +11658,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11520,7 +11706,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11570,7 +11756,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11620,7 +11806,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11669,7 +11855,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11717,7 +11903,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11764,7 +11950,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11811,7 +11997,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11840,7 +12026,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11869,7 +12055,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11898,7 +12084,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11946,7 +12132,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11993,7 +12179,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12041,7 +12227,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12090,7 +12276,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12139,7 +12325,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12188,7 +12374,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12237,7 +12423,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12286,7 +12472,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12333,7 +12519,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12381,7 +12567,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12430,7 +12616,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12479,7 +12665,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12525,7 +12711,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12574,7 +12760,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12620,7 +12806,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12667,7 +12853,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12715,7 +12901,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12765,7 +12951,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12814,7 +13000,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12864,7 +13050,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12910,7 +13096,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12957,7 +13143,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13005,7 +13191,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13055,7 +13241,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13102,7 +13288,7 @@ impl<P, D> ElastiCache for ElastiCacheClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -91,13 +87,51 @@ impl AbortableOperationInProgressDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionHistoryStatus {
+    Completed,
+    Failed,
+    Unknown,
+}
+
+impl Into<String> for ActionHistoryStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionHistoryStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ActionHistoryStatus::Completed => "Completed",
+            ActionHistoryStatus::Failed => "Failed",
+            ActionHistoryStatus::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionHistoryStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Completed" => Ok(ActionHistoryStatus::Completed),
+            "Failed" => Ok(ActionHistoryStatus::Failed),
+            "Unknown" => Ok(ActionHistoryStatus::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ActionHistoryStatusDeserializer;
 impl ActionHistoryStatusDeserializer {
     #[allow(unused_variables)]
@@ -112,6 +146,47 @@ impl ActionHistoryStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionStatus {
+    Pending,
+    Running,
+    Scheduled,
+    Unknown,
+}
+
+impl Into<String> for ActionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ActionStatus::Pending => "Pending",
+            ActionStatus::Running => "Running",
+            ActionStatus::Scheduled => "Scheduled",
+            ActionStatus::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Pending" => Ok(ActionStatus::Pending),
+            "Running" => Ok(ActionStatus::Running),
+            "Scheduled" => Ok(ActionStatus::Scheduled),
+            "Unknown" => Ok(ActionStatus::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ActionStatusDeserializer;
 impl ActionStatusDeserializer {
     #[allow(unused_variables)]
@@ -126,6 +201,44 @@ impl ActionStatusDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionType {
+    InstanceRefresh,
+    PlatformUpdate,
+    Unknown,
+}
+
+impl Into<String> for ActionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionType {
+    fn into(self) -> &'static str {
+        match self {
+            ActionType::InstanceRefresh => "InstanceRefresh",
+            ActionType::PlatformUpdate => "PlatformUpdate",
+            ActionType::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "InstanceRefresh" => Ok(ActionType::InstanceRefresh),
+            "PlatformUpdate" => Ok(ActionType::PlatformUpdate),
+            "Unknown" => Ok(ActionType::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ActionTypeDeserializer;
 impl ActionTypeDeserializer {
     #[allow(unused_variables)]
@@ -930,6 +1043,50 @@ impl ApplicationVersionLifecycleConfigSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ApplicationVersionStatus {
+    Building,
+    Failed,
+    Processed,
+    Processing,
+    Unprocessed,
+}
+
+impl Into<String> for ApplicationVersionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ApplicationVersionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ApplicationVersionStatus::Building => "Building",
+            ApplicationVersionStatus::Failed => "Failed",
+            ApplicationVersionStatus::Processed => "Processed",
+            ApplicationVersionStatus::Processing => "Processing",
+            ApplicationVersionStatus::Unprocessed => "Unprocessed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ApplicationVersionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Building" => Ok(ApplicationVersionStatus::Building),
+            "Failed" => Ok(ApplicationVersionStatus::Failed),
+            "Processed" => Ok(ApplicationVersionStatus::Processed),
+            "Processing" => Ok(ApplicationVersionStatus::Processing),
+            "Unprocessed" => Ok(ApplicationVersionStatus::Unprocessed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ApplicationVersionStatusDeserializer;
 impl ApplicationVersionStatusDeserializer {
     #[allow(unused_variables)]
@@ -1229,7 +1386,7 @@ impl BoxedBooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1573,7 +1730,7 @@ impl CnameAvailabilityDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1615,6 +1772,82 @@ impl ComposeEnvironmentsMessageSerializer {
                                                field_value);
         }
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComputeType {
+    BuildGeneral1Large,
+    BuildGeneral1Medium,
+    BuildGeneral1Small,
+}
+
+impl Into<String> for ComputeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComputeType {
+    fn into(self) -> &'static str {
+        match self {
+            ComputeType::BuildGeneral1Large => "BUILD_GENERAL1_LARGE",
+            ComputeType::BuildGeneral1Medium => "BUILD_GENERAL1_MEDIUM",
+            ComputeType::BuildGeneral1Small => "BUILD_GENERAL1_SMALL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComputeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BUILD_GENERAL1_LARGE" => Ok(ComputeType::BuildGeneral1Large),
+            "BUILD_GENERAL1_MEDIUM" => Ok(ComputeType::BuildGeneral1Medium),
+            "BUILD_GENERAL1_SMALL" => Ok(ComputeType::BuildGeneral1Small),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConfigurationDeploymentStatus {
+    Deployed,
+    Failed,
+    Pending,
+}
+
+impl Into<String> for ConfigurationDeploymentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConfigurationDeploymentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ConfigurationDeploymentStatus::Deployed => "deployed",
+            ConfigurationDeploymentStatus::Failed => "failed",
+            ConfigurationDeploymentStatus::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConfigurationDeploymentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "deployed" => Ok(ConfigurationDeploymentStatus::Deployed),
+            "failed" => Ok(ConfigurationDeploymentStatus::Failed),
+            "pending" => Ok(ConfigurationDeploymentStatus::Pending),
+            _ => Err(()),
+        }
     }
 }
 
@@ -2045,6 +2278,41 @@ impl ConfigurationOptionValueDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConfigurationOptionValueType {
+    List,
+    Scalar,
+}
+
+impl Into<String> for ConfigurationOptionValueType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConfigurationOptionValueType {
+    fn into(self) -> &'static str {
+        match self {
+            ConfigurationOptionValueType::List => "List",
+            ConfigurationOptionValueType::Scalar => "Scalar",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConfigurationOptionValueType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "List" => Ok(ConfigurationOptionValueType::List),
+            "Scalar" => Ok(ConfigurationOptionValueType::Scalar),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ConfigurationOptionValueTypeDeserializer;
 impl ConfigurationOptionValueTypeDeserializer {
     #[allow(unused_variables)]
@@ -4436,6 +4704,47 @@ impl EnvironmentDescriptionsMessageDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EnvironmentHealth {
+    Green,
+    Grey,
+    Red,
+    Yellow,
+}
+
+impl Into<String> for EnvironmentHealth {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EnvironmentHealth {
+    fn into(self) -> &'static str {
+        match self {
+            EnvironmentHealth::Green => "Green",
+            EnvironmentHealth::Grey => "Grey",
+            EnvironmentHealth::Red => "Red",
+            EnvironmentHealth::Yellow => "Yellow",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EnvironmentHealth {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Green" => Ok(EnvironmentHealth::Green),
+            "Grey" => Ok(EnvironmentHealth::Grey),
+            "Red" => Ok(EnvironmentHealth::Red),
+            "Yellow" => Ok(EnvironmentHealth::Yellow),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EnvironmentHealthDeserializer;
 impl EnvironmentHealthDeserializer {
     #[allow(unused_variables)]
@@ -4451,6 +4760,59 @@ impl EnvironmentHealthDeserializer {
     }
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EnvironmentHealthAttribute {
+    All,
+    ApplicationMetrics,
+    Causes,
+    Color,
+    HealthStatus,
+    InstancesHealth,
+    RefreshedAt,
+    Status,
+}
+
+impl Into<String> for EnvironmentHealthAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EnvironmentHealthAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            EnvironmentHealthAttribute::All => "All",
+            EnvironmentHealthAttribute::ApplicationMetrics => "ApplicationMetrics",
+            EnvironmentHealthAttribute::Causes => "Causes",
+            EnvironmentHealthAttribute::Color => "Color",
+            EnvironmentHealthAttribute::HealthStatus => "HealthStatus",
+            EnvironmentHealthAttribute::InstancesHealth => "InstancesHealth",
+            EnvironmentHealthAttribute::RefreshedAt => "RefreshedAt",
+            EnvironmentHealthAttribute::Status => "Status",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EnvironmentHealthAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(EnvironmentHealthAttribute::All),
+            "ApplicationMetrics" => Ok(EnvironmentHealthAttribute::ApplicationMetrics),
+            "Causes" => Ok(EnvironmentHealthAttribute::Causes),
+            "Color" => Ok(EnvironmentHealthAttribute::Color),
+            "HealthStatus" => Ok(EnvironmentHealthAttribute::HealthStatus),
+            "InstancesHealth" => Ok(EnvironmentHealthAttribute::InstancesHealth),
+            "RefreshedAt" => Ok(EnvironmentHealthAttribute::RefreshedAt),
+            "Status" => Ok(EnvironmentHealthAttribute::Status),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `EnvironmentHealthAttributes` contents to a `SignedRequest`.
 struct EnvironmentHealthAttributesSerializer;
 impl EnvironmentHealthAttributesSerializer {
@@ -4458,6 +4820,59 @@ impl EnvironmentHealthAttributesSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EnvironmentHealthStatus {
+    Degraded,
+    Info,
+    NoData,
+    Ok,
+    Pending,
+    Severe,
+    Unknown,
+    Warning,
+}
+
+impl Into<String> for EnvironmentHealthStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EnvironmentHealthStatus {
+    fn into(self) -> &'static str {
+        match self {
+            EnvironmentHealthStatus::Degraded => "Degraded",
+            EnvironmentHealthStatus::Info => "Info",
+            EnvironmentHealthStatus::NoData => "NoData",
+            EnvironmentHealthStatus::Ok => "Ok",
+            EnvironmentHealthStatus::Pending => "Pending",
+            EnvironmentHealthStatus::Severe => "Severe",
+            EnvironmentHealthStatus::Unknown => "Unknown",
+            EnvironmentHealthStatus::Warning => "Warning",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EnvironmentHealthStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Degraded" => Ok(EnvironmentHealthStatus::Degraded),
+            "Info" => Ok(EnvironmentHealthStatus::Info),
+            "NoData" => Ok(EnvironmentHealthStatus::NoData),
+            "Ok" => Ok(EnvironmentHealthStatus::Ok),
+            "Pending" => Ok(EnvironmentHealthStatus::Pending),
+            "Severe" => Ok(EnvironmentHealthStatus::Severe),
+            "Unknown" => Ok(EnvironmentHealthStatus::Unknown),
+            "Warning" => Ok(EnvironmentHealthStatus::Warning),
+            _ => Err(()),
         }
     }
 }
@@ -4615,6 +5030,41 @@ impl EnvironmentInfoDescriptionListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EnvironmentInfoType {
+    Bundle,
+    Tail,
+}
+
+impl Into<String> for EnvironmentInfoType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EnvironmentInfoType {
+    fn into(self) -> &'static str {
+        match self {
+            EnvironmentInfoType::Bundle => "bundle",
+            EnvironmentInfoType::Tail => "tail",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EnvironmentInfoType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bundle" => Ok(EnvironmentInfoType::Bundle),
+            "tail" => Ok(EnvironmentInfoType::Tail),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EnvironmentInfoTypeDeserializer;
 impl EnvironmentInfoTypeDeserializer {
     #[allow(unused_variables)]
@@ -4942,6 +5392,50 @@ impl EnvironmentResourcesDescriptionDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EnvironmentStatus {
+    Launching,
+    Ready,
+    Terminated,
+    Terminating,
+    Updating,
+}
+
+impl Into<String> for EnvironmentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EnvironmentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            EnvironmentStatus::Launching => "Launching",
+            EnvironmentStatus::Ready => "Ready",
+            EnvironmentStatus::Terminated => "Terminated",
+            EnvironmentStatus::Terminating => "Terminating",
+            EnvironmentStatus::Updating => "Updating",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EnvironmentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Launching" => Ok(EnvironmentStatus::Launching),
+            "Ready" => Ok(EnvironmentStatus::Ready),
+            "Terminated" => Ok(EnvironmentStatus::Terminated),
+            "Terminating" => Ok(EnvironmentStatus::Terminating),
+            "Updating" => Ok(EnvironmentStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EnvironmentStatusDeserializer;
 impl EnvironmentStatusDeserializer {
     #[allow(unused_variables)]
@@ -5267,6 +5761,53 @@ impl EventMessageDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventSeverity {
+    Debug,
+    Error,
+    Fatal,
+    Info,
+    Trace,
+    Warn,
+}
+
+impl Into<String> for EventSeverity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventSeverity {
+    fn into(self) -> &'static str {
+        match self {
+            EventSeverity::Debug => "DEBUG",
+            EventSeverity::Error => "ERROR",
+            EventSeverity::Fatal => "FATAL",
+            EventSeverity::Info => "INFO",
+            EventSeverity::Trace => "TRACE",
+            EventSeverity::Warn => "WARN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventSeverity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEBUG" => Ok(EventSeverity::Debug),
+            "ERROR" => Ok(EventSeverity::Error),
+            "FATAL" => Ok(EventSeverity::Fatal),
+            "INFO" => Ok(EventSeverity::Info),
+            "TRACE" => Ok(EventSeverity::Trace),
+            "WARN" => Ok(EventSeverity::Warn),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventSeverityDeserializer;
 impl EventSeverityDeserializer {
     #[allow(unused_variables)]
@@ -5281,6 +5822,56 @@ impl EventSeverityDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FailureType {
+    CancellationFailed,
+    InternalFailure,
+    InvalidEnvironmentState,
+    PermissionsError,
+    RollbackFailed,
+    RollbackSuccessful,
+    UpdateCancelled,
+}
+
+impl Into<String> for FailureType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FailureType {
+    fn into(self) -> &'static str {
+        match self {
+            FailureType::CancellationFailed => "CancellationFailed",
+            FailureType::InternalFailure => "InternalFailure",
+            FailureType::InvalidEnvironmentState => "InvalidEnvironmentState",
+            FailureType::PermissionsError => "PermissionsError",
+            FailureType::RollbackFailed => "RollbackFailed",
+            FailureType::RollbackSuccessful => "RollbackSuccessful",
+            FailureType::UpdateCancelled => "UpdateCancelled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FailureType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CancellationFailed" => Ok(FailureType::CancellationFailed),
+            "InternalFailure" => Ok(FailureType::InternalFailure),
+            "InvalidEnvironmentState" => Ok(FailureType::InvalidEnvironmentState),
+            "PermissionsError" => Ok(FailureType::PermissionsError),
+            "RollbackFailed" => Ok(FailureType::RollbackFailed),
+            "RollbackSuccessful" => Ok(FailureType::RollbackSuccessful),
+            "UpdateCancelled" => Ok(FailureType::UpdateCancelled),
+            _ => Err(()),
+        }
+    }
+}
+
 struct FailureTypeDeserializer;
 impl FailureTypeDeserializer {
     #[allow(unused_variables)]
@@ -5565,6 +6156,68 @@ impl InstanceListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstancesHealthAttribute {
+    All,
+    ApplicationMetrics,
+    AvailabilityZone,
+    Causes,
+    Color,
+    Deployment,
+    HealthStatus,
+    InstanceType,
+    LaunchedAt,
+    RefreshedAt,
+    System,
+}
+
+impl Into<String> for InstancesHealthAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstancesHealthAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            InstancesHealthAttribute::All => "All",
+            InstancesHealthAttribute::ApplicationMetrics => "ApplicationMetrics",
+            InstancesHealthAttribute::AvailabilityZone => "AvailabilityZone",
+            InstancesHealthAttribute::Causes => "Causes",
+            InstancesHealthAttribute::Color => "Color",
+            InstancesHealthAttribute::Deployment => "Deployment",
+            InstancesHealthAttribute::HealthStatus => "HealthStatus",
+            InstancesHealthAttribute::InstanceType => "InstanceType",
+            InstancesHealthAttribute::LaunchedAt => "LaunchedAt",
+            InstancesHealthAttribute::RefreshedAt => "RefreshedAt",
+            InstancesHealthAttribute::System => "System",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstancesHealthAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(InstancesHealthAttribute::All),
+            "ApplicationMetrics" => Ok(InstancesHealthAttribute::ApplicationMetrics),
+            "AvailabilityZone" => Ok(InstancesHealthAttribute::AvailabilityZone),
+            "Causes" => Ok(InstancesHealthAttribute::Causes),
+            "Color" => Ok(InstancesHealthAttribute::Color),
+            "Deployment" => Ok(InstancesHealthAttribute::Deployment),
+            "HealthStatus" => Ok(InstancesHealthAttribute::HealthStatus),
+            "InstanceType" => Ok(InstancesHealthAttribute::InstanceType),
+            "LaunchedAt" => Ok(InstancesHealthAttribute::LaunchedAt),
+            "RefreshedAt" => Ok(InstancesHealthAttribute::RefreshedAt),
+            "System" => Ok(InstancesHealthAttribute::System),
+            _ => Err(()),
+        }
+    }
+}
+
 
 /// Serialize `InstancesHealthAttributes` contents to a `SignedRequest`.
 struct InstancesHealthAttributesSerializer;
@@ -7411,6 +8064,50 @@ impl PlatformProgrammingLanguagesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlatformStatus {
+    Creating,
+    Deleted,
+    Deleting,
+    Failed,
+    Ready,
+}
+
+impl Into<String> for PlatformStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlatformStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PlatformStatus::Creating => "Creating",
+            PlatformStatus::Deleted => "Deleted",
+            PlatformStatus::Deleting => "Deleting",
+            PlatformStatus::Failed => "Failed",
+            PlatformStatus::Ready => "Ready",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlatformStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Creating" => Ok(PlatformStatus::Creating),
+            "Deleted" => Ok(PlatformStatus::Deleted),
+            "Deleting" => Ok(PlatformStatus::Deleting),
+            "Failed" => Ok(PlatformStatus::Failed),
+            "Ready" => Ok(PlatformStatus::Ready),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PlatformStatusDeserializer;
 impl PlatformStatusDeserializer {
     #[allow(unused_variables)]
@@ -8414,6 +9111,41 @@ impl SourceLocationDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceRepository {
+    CodeCommit,
+    S3,
+}
+
+impl Into<String> for SourceRepository {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceRepository {
+    fn into(self) -> &'static str {
+        match self {
+            SourceRepository::CodeCommit => "CodeCommit",
+            SourceRepository::S3 => "S3",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceRepository {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CodeCommit" => Ok(SourceRepository::CodeCommit),
+            "S3" => Ok(SourceRepository::S3),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SourceRepositoryDeserializer;
 impl SourceRepositoryDeserializer {
     #[allow(unused_variables)]
@@ -8428,6 +9160,41 @@ impl SourceRepositoryDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    Git,
+    Zip,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::Git => "Git",
+            SourceType::Zip => "Zip",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Git" => Ok(SourceType::Git),
+            "Zip" => Ok(SourceType::Zip),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
     #[allow(unused_variables)]
@@ -9200,7 +9967,7 @@ impl UserDefinedOptionDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -9375,6 +10142,41 @@ impl ValidationMessagesListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ValidationSeverity {
+    Error,
+    Warning,
+}
+
+impl Into<String> for ValidationSeverity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ValidationSeverity {
+    fn into(self) -> &'static str {
+        match self {
+            ValidationSeverity::Error => "error",
+            ValidationSeverity::Warning => "warning",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ValidationSeverity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "error" => Ok(ValidationSeverity::Error),
+            "warning" => Ok(ValidationSeverity::Warning),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ValidationSeverityDeserializer;
 impl ValidationSeverityDeserializer {
     #[allow(unused_variables)]
@@ -12832,7 +13634,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12861,7 +13663,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12909,7 +13711,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12955,7 +13757,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13003,7 +13805,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13052,7 +13854,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13100,7 +13902,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13149,7 +13951,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13197,7 +13999,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13244,7 +14046,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13290,7 +14092,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13318,7 +14120,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13347,7 +14149,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13376,7 +14178,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -13406,7 +14208,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13454,7 +14256,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13502,7 +14304,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13551,7 +14353,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13601,7 +14403,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13649,7 +14451,7 @@ impl<P, D> ElasticBeanstalk for ElasticBeanstalkClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13698,7 +14500,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13745,7 +14547,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13792,7 +14594,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13840,7 +14642,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13888,7 +14690,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13936,7 +14738,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13986,7 +14788,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14035,7 +14837,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14082,7 +14884,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14129,7 +14931,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -14157,7 +14959,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -14185,7 +14987,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -14214,7 +15016,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14261,7 +15063,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -14289,7 +15091,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14336,7 +15138,7 @@ fn describe_environment_managed_action_history(&self, input: &DescribeEnvironmen
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14382,7 +15184,7 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14429,7 +15231,7 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14477,7 +15279,7 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14526,7 +15328,7 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14574,7 +15376,7 @@ fn update_application_resource_lifecycle(&self, input: &UpdateApplicationResourc
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -3200,7 +3196,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3244,7 +3240,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3290,7 +3286,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3336,7 +3332,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3381,7 +3377,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3426,7 +3422,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3479,7 +3475,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3531,7 +3527,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3583,7 +3579,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3635,7 +3631,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3678,7 +3674,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3723,7 +3719,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3768,7 +3764,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3812,7 +3808,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3858,7 +3854,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3905,7 +3901,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3954,7 +3950,7 @@ impl<P, D> Ets for EtsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -144,7 +140,7 @@ impl AccessLogEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1127,7 +1123,7 @@ impl ConnectionDrainingEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1648,7 +1644,7 @@ impl CrossZoneLoadBalancingEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -8025,7 +8021,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8073,7 +8069,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8120,7 +8116,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8167,7 +8163,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8215,7 +8211,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8263,7 +8259,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8310,7 +8306,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8358,7 +8354,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8408,7 +8404,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8457,7 +8453,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8505,7 +8501,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8555,7 +8551,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8605,7 +8601,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8653,7 +8649,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8701,7 +8697,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8749,7 +8745,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8797,7 +8793,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8845,7 +8841,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8893,7 +8889,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8940,7 +8936,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8988,7 +8984,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9036,7 +9032,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9085,7 +9081,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9133,7 +9129,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9181,7 +9177,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9226,7 +9222,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9271,7 +9267,7 @@ fn set_load_balancer_listener_ssl_certificate(&self, input: &SetLoadBalancerList
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9315,7 +9311,7 @@ fn set_load_balancer_policies_for_backend_server(&self, input: &SetLoadBalancerP
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9362,7 +9358,7 @@ fn set_load_balancer_policies_for_backend_server(&self, input: &SetLoadBalancerP
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -110,6 +106,38 @@ impl ActionSerializer {
         params.put(&format!("{}{}", prefix, "Type"),
                    &obj.type_.replace("+", "%2B"));
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionTypeEnum {
+    Forward,
+}
+
+impl Into<String> for ActionTypeEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionTypeEnum {
+    fn into(self) -> &'static str {
+        match self {
+            ActionTypeEnum::Forward => "forward",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionTypeEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "forward" => Ok(ActionTypeEnum::Forward),
+            _ => Err(()),
+        }
     }
 }
 
@@ -2201,6 +2229,41 @@ impl HttpCodeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IpAddressType {
+    Dualstack,
+    Ipv4,
+}
+
+impl Into<String> for IpAddressType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IpAddressType {
+    fn into(self) -> &'static str {
+        match self {
+            IpAddressType::Dualstack => "dualstack",
+            IpAddressType::Ipv4 => "ipv4",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IpAddressType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dualstack" => Ok(IpAddressType::Dualstack),
+            "ipv4" => Ok(IpAddressType::Ipv4),
+            _ => Err(()),
+        }
+    }
+}
+
 struct IpAddressTypeDeserializer;
 impl IpAddressTypeDeserializer {
     #[allow(unused_variables)]
@@ -2222,7 +2285,7 @@ impl IsDefaultDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2906,6 +2969,41 @@ impl LoadBalancerNamesSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LoadBalancerSchemeEnum {
+    Internal,
+    InternetFacing,
+}
+
+impl Into<String> for LoadBalancerSchemeEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LoadBalancerSchemeEnum {
+    fn into(self) -> &'static str {
+        match self {
+            LoadBalancerSchemeEnum::Internal => "internal",
+            LoadBalancerSchemeEnum::InternetFacing => "internet-facing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LoadBalancerSchemeEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "internal" => Ok(LoadBalancerSchemeEnum::Internal),
+            "internet-facing" => Ok(LoadBalancerSchemeEnum::InternetFacing),
+            _ => Err(()),
+        }
+    }
+}
+
 struct LoadBalancerSchemeEnumDeserializer;
 impl LoadBalancerSchemeEnumDeserializer {
     #[allow(unused_variables)]
@@ -2976,6 +3074,44 @@ impl LoadBalancerStateDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LoadBalancerStateEnum {
+    Active,
+    Failed,
+    Provisioning,
+}
+
+impl Into<String> for LoadBalancerStateEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LoadBalancerStateEnum {
+    fn into(self) -> &'static str {
+        match self {
+            LoadBalancerStateEnum::Active => "active",
+            LoadBalancerStateEnum::Failed => "failed",
+            LoadBalancerStateEnum::Provisioning => "provisioning",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LoadBalancerStateEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(LoadBalancerStateEnum::Active),
+            "failed" => Ok(LoadBalancerStateEnum::Failed),
+            "provisioning" => Ok(LoadBalancerStateEnum::Provisioning),
+            _ => Err(()),
+        }
+    }
+}
+
 struct LoadBalancerStateEnumDeserializer;
 impl LoadBalancerStateEnumDeserializer {
     #[allow(unused_variables)]
@@ -2990,6 +3126,38 @@ impl LoadBalancerStateEnumDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LoadBalancerTypeEnum {
+    Application,
+}
+
+impl Into<String> for LoadBalancerTypeEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LoadBalancerTypeEnum {
+    fn into(self) -> &'static str {
+        match self {
+            LoadBalancerTypeEnum::Application => "application",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LoadBalancerTypeEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "application" => Ok(LoadBalancerTypeEnum::Application),
+            _ => Err(()),
+        }
+    }
+}
+
 struct LoadBalancerTypeEnumDeserializer;
 impl LoadBalancerTypeEnumDeserializer {
     #[allow(unused_variables)]
@@ -3635,6 +3803,41 @@ impl PortDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProtocolEnum {
+    Http,
+    Https,
+}
+
+impl Into<String> for ProtocolEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProtocolEnum {
+    fn into(self) -> &'static str {
+        match self {
+            ProtocolEnum::Http => "HTTP",
+            ProtocolEnum::Https => "HTTPS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProtocolEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HTTP" => Ok(ProtocolEnum::Http),
+            "HTTPS" => Ok(ProtocolEnum::Https),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ProtocolEnumDeserializer;
 impl ProtocolEnumDeserializer {
     #[allow(unused_variables)]
@@ -5591,6 +5794,69 @@ impl TargetHealthDescriptionsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TargetHealthReasonEnum {
+    ElbInitialHealthChecking,
+    ElbInternalError,
+    ElbRegistrationInProgress,
+    TargetDeregistrationInProgress,
+    TargetFailedHealthChecks,
+    TargetInvalidState,
+    TargetNotInUse,
+    TargetNotRegistered,
+    TargetResponseCodeMismatch,
+    TargetTimeout,
+}
+
+impl Into<String> for TargetHealthReasonEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TargetHealthReasonEnum {
+    fn into(self) -> &'static str {
+        match self {
+            TargetHealthReasonEnum::ElbInitialHealthChecking => "Elb.InitialHealthChecking",
+            TargetHealthReasonEnum::ElbInternalError => "Elb.InternalError",
+            TargetHealthReasonEnum::ElbRegistrationInProgress => "Elb.RegistrationInProgress",
+            TargetHealthReasonEnum::TargetDeregistrationInProgress => {
+                "Target.DeregistrationInProgress"
+            }
+            TargetHealthReasonEnum::TargetFailedHealthChecks => "Target.FailedHealthChecks",
+            TargetHealthReasonEnum::TargetInvalidState => "Target.InvalidState",
+            TargetHealthReasonEnum::TargetNotInUse => "Target.NotInUse",
+            TargetHealthReasonEnum::TargetNotRegistered => "Target.NotRegistered",
+            TargetHealthReasonEnum::TargetResponseCodeMismatch => "Target.ResponseCodeMismatch",
+            TargetHealthReasonEnum::TargetTimeout => "Target.Timeout",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TargetHealthReasonEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Elb.InitialHealthChecking" => Ok(TargetHealthReasonEnum::ElbInitialHealthChecking),
+            "Elb.InternalError" => Ok(TargetHealthReasonEnum::ElbInternalError),
+            "Elb.RegistrationInProgress" => Ok(TargetHealthReasonEnum::ElbRegistrationInProgress),
+            "Target.DeregistrationInProgress" => {
+                Ok(TargetHealthReasonEnum::TargetDeregistrationInProgress)
+            }
+            "Target.FailedHealthChecks" => Ok(TargetHealthReasonEnum::TargetFailedHealthChecks),
+            "Target.InvalidState" => Ok(TargetHealthReasonEnum::TargetInvalidState),
+            "Target.NotInUse" => Ok(TargetHealthReasonEnum::TargetNotInUse),
+            "Target.NotRegistered" => Ok(TargetHealthReasonEnum::TargetNotRegistered),
+            "Target.ResponseCodeMismatch" => Ok(TargetHealthReasonEnum::TargetResponseCodeMismatch),
+            "Target.Timeout" => Ok(TargetHealthReasonEnum::TargetTimeout),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TargetHealthReasonEnumDeserializer;
 impl TargetHealthReasonEnumDeserializer {
     #[allow(unused_variables)]
@@ -5605,6 +5871,50 @@ impl TargetHealthReasonEnumDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TargetHealthStateEnum {
+    Draining,
+    Healthy,
+    Initial,
+    Unhealthy,
+    Unused,
+}
+
+impl Into<String> for TargetHealthStateEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TargetHealthStateEnum {
+    fn into(self) -> &'static str {
+        match self {
+            TargetHealthStateEnum::Draining => "draining",
+            TargetHealthStateEnum::Healthy => "healthy",
+            TargetHealthStateEnum::Initial => "initial",
+            TargetHealthStateEnum::Unhealthy => "unhealthy",
+            TargetHealthStateEnum::Unused => "unused",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TargetHealthStateEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "draining" => Ok(TargetHealthStateEnum::Draining),
+            "healthy" => Ok(TargetHealthStateEnum::Healthy),
+            "initial" => Ok(TargetHealthStateEnum::Initial),
+            "unhealthy" => Ok(TargetHealthStateEnum::Unhealthy),
+            "unused" => Ok(TargetHealthStateEnum::Unused),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TargetHealthStateEnumDeserializer;
 impl TargetHealthStateEnumDeserializer {
     #[allow(unused_variables)]
@@ -8527,7 +8837,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8574,7 +8884,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8621,7 +8931,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8666,7 +8976,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8713,7 +9023,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8760,7 +9070,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8807,7 +9117,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8852,7 +9162,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8899,7 +9209,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8946,7 +9256,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -8994,7 +9304,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9041,7 +9351,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9089,7 +9399,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9137,7 +9447,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9184,7 +9494,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9231,7 +9541,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9278,7 +9588,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9326,7 +9636,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9373,7 +9683,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9420,7 +9730,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9467,7 +9777,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9515,7 +9825,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9560,7 +9870,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9607,7 +9917,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9655,7 +9965,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9702,7 +10012,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9747,7 +10057,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9794,7 +10104,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9841,7 +10151,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9888,7 +10198,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -9933,7 +10243,7 @@ impl<P, D> Elb for ElbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -11,23 +11,60 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionOnFailure {
+    CancelAndWait,
+    Continue,
+    TerminateCluster,
+    TerminateJobFlow,
+}
+
+impl Into<String> for ActionOnFailure {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionOnFailure {
+    fn into(self) -> &'static str {
+        match self {
+            ActionOnFailure::CancelAndWait => "CANCEL_AND_WAIT",
+            ActionOnFailure::Continue => "CONTINUE",
+            ActionOnFailure::TerminateCluster => "TERMINATE_CLUSTER",
+            ActionOnFailure::TerminateJobFlow => "TERMINATE_JOB_FLOW",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionOnFailure {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCEL_AND_WAIT" => Ok(ActionOnFailure::CancelAndWait),
+            "CONTINUE" => Ok(ActionOnFailure::Continue),
+            "TERMINATE_CLUSTER" => Ok(ActionOnFailure::TerminateCluster),
+            "TERMINATE_JOB_FLOW" => Ok(ActionOnFailure::TerminateJobFlow),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AddInstanceFleetInput {
     #[doc="<p>The unique identifier of the cluster.</p>"]
@@ -109,6 +146,44 @@ pub struct AddTagsInput {
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AddTagsOutput;
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AdjustmentType {
+    ChangeInCapacity,
+    ExactCapacity,
+    PercentChangeInCapacity,
+}
+
+impl Into<String> for AdjustmentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AdjustmentType {
+    fn into(self) -> &'static str {
+        match self {
+            AdjustmentType::ChangeInCapacity => "CHANGE_IN_CAPACITY",
+            AdjustmentType::ExactCapacity => "EXACT_CAPACITY",
+            AdjustmentType::PercentChangeInCapacity => "PERCENT_CHANGE_IN_CAPACITY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AdjustmentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHANGE_IN_CAPACITY" => Ok(AdjustmentType::ChangeInCapacity),
+            "EXACT_CAPACITY" => Ok(AdjustmentType::ExactCapacity),
+            "PERCENT_CHANGE_IN_CAPACITY" => Ok(AdjustmentType::PercentChangeInCapacity),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An application is any Amazon or third-party software that you can add to the cluster. This structure contains a list of strings that indicates the software to use with the cluster and accepts a user argument list. Amazon EMR accepts and forwards the argument list to the corresponding installation script as bootstrap action argument. For more information, see <a href=\"http://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-mapr.html\">Using the MapR Distribution for Hadoop</a>. Currently supported values are:</p> <ul> <li> <p>\"mapr-m3\" - launch the cluster using MapR M3 Edition.</p> </li> <li> <p>\"mapr-m5\" - launch the cluster using MapR M5 Edition.</p> </li> <li> <p>\"mapr\" with the user arguments specifying \"--edition,m3\" or \"--edition,m5\" - launch the cluster using MapR M3 or M5 Edition, respectively.</p> </li> </ul> <note> <p>In Amazon EMR releases 4.x and later, the only accepted parameter is the application name. To pass arguments to applications, you supply a configuration for each application.</p> </note>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Application {
@@ -158,6 +233,53 @@ pub struct AutoScalingPolicyDescription {
     pub status: Option<AutoScalingPolicyStatus>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoScalingPolicyState {
+    Attached,
+    Attaching,
+    Detached,
+    Detaching,
+    Failed,
+    Pending,
+}
+
+impl Into<String> for AutoScalingPolicyState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoScalingPolicyState {
+    fn into(self) -> &'static str {
+        match self {
+            AutoScalingPolicyState::Attached => "ATTACHED",
+            AutoScalingPolicyState::Attaching => "ATTACHING",
+            AutoScalingPolicyState::Detached => "DETACHED",
+            AutoScalingPolicyState::Detaching => "DETACHING",
+            AutoScalingPolicyState::Failed => "FAILED",
+            AutoScalingPolicyState::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoScalingPolicyState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ATTACHED" => Ok(AutoScalingPolicyState::Attached),
+            "ATTACHING" => Ok(AutoScalingPolicyState::Attaching),
+            "DETACHED" => Ok(AutoScalingPolicyState::Detached),
+            "DETACHING" => Ok(AutoScalingPolicyState::Detaching),
+            "FAILED" => Ok(AutoScalingPolicyState::Failed),
+            "PENDING" => Ok(AutoScalingPolicyState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The reason for an <a>AutoScalingPolicyStatus</a> change.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AutoScalingPolicyStateChangeReason {
@@ -169,6 +291,44 @@ pub struct AutoScalingPolicyStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoScalingPolicyStateChangeReasonCode {
+    CleanupFailure,
+    ProvisionFailure,
+    UserRequest,
+}
+
+impl Into<String> for AutoScalingPolicyStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoScalingPolicyStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            AutoScalingPolicyStateChangeReasonCode::CleanupFailure => "CLEANUP_FAILURE",
+            AutoScalingPolicyStateChangeReasonCode::ProvisionFailure => "PROVISION_FAILURE",
+            AutoScalingPolicyStateChangeReasonCode::UserRequest => "USER_REQUEST",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoScalingPolicyStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLEANUP_FAILURE" => Ok(AutoScalingPolicyStateChangeReasonCode::CleanupFailure),
+            "PROVISION_FAILURE" => Ok(AutoScalingPolicyStateChangeReasonCode::ProvisionFailure),
+            "USER_REQUEST" => Ok(AutoScalingPolicyStateChangeReasonCode::UserRequest),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The status of an automatic scaling policy. </p>"]
@@ -241,6 +401,41 @@ pub struct CancelStepsOutput {
     #[serde(rename="CancelStepsInfoList")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub cancel_steps_info_list: Option<Vec<CancelStepsInfo>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CancelStepsRequestStatus {
+    Failed,
+    Submitted,
+}
+
+impl Into<String> for CancelStepsRequestStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CancelStepsRequestStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CancelStepsRequestStatus::Failed => "FAILED",
+            CancelStepsRequestStatus::Submitted => "SUBMITTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CancelStepsRequestStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(CancelStepsRequestStatus::Failed),
+            "SUBMITTED" => Ok(CancelStepsRequestStatus::Submitted),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The definition of a CloudWatch metric alarm, which determines when an automatic scaling activity is triggered. When the defined alarm conditions are satisfied, scaling activity begins.</p>"]
@@ -381,6 +576,56 @@ pub struct Cluster {
     pub visible_to_all_users: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ClusterState {
+    Bootstrapping,
+    Running,
+    Starting,
+    Terminated,
+    TerminatedWithErrors,
+    Terminating,
+    Waiting,
+}
+
+impl Into<String> for ClusterState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ClusterState {
+    fn into(self) -> &'static str {
+        match self {
+            ClusterState::Bootstrapping => "BOOTSTRAPPING",
+            ClusterState::Running => "RUNNING",
+            ClusterState::Starting => "STARTING",
+            ClusterState::Terminated => "TERMINATED",
+            ClusterState::TerminatedWithErrors => "TERMINATED_WITH_ERRORS",
+            ClusterState::Terminating => "TERMINATING",
+            ClusterState::Waiting => "WAITING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ClusterState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BOOTSTRAPPING" => Ok(ClusterState::Bootstrapping),
+            "RUNNING" => Ok(ClusterState::Running),
+            "STARTING" => Ok(ClusterState::Starting),
+            "TERMINATED" => Ok(ClusterState::Terminated),
+            "TERMINATED_WITH_ERRORS" => Ok(ClusterState::TerminatedWithErrors),
+            "TERMINATING" => Ok(ClusterState::Terminating),
+            "WAITING" => Ok(ClusterState::Waiting),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The reason that the cluster changed to its current state.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ClusterStateChangeReason {
@@ -392,6 +637,59 @@ pub struct ClusterStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ClusterStateChangeReasonCode {
+    AllStepsCompleted,
+    BootstrapFailure,
+    InstanceFailure,
+    InstanceFleetTimeout,
+    InternalError,
+    StepFailure,
+    UserRequest,
+    ValidationError,
+}
+
+impl Into<String> for ClusterStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ClusterStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            ClusterStateChangeReasonCode::AllStepsCompleted => "ALL_STEPS_COMPLETED",
+            ClusterStateChangeReasonCode::BootstrapFailure => "BOOTSTRAP_FAILURE",
+            ClusterStateChangeReasonCode::InstanceFailure => "INSTANCE_FAILURE",
+            ClusterStateChangeReasonCode::InstanceFleetTimeout => "INSTANCE_FLEET_TIMEOUT",
+            ClusterStateChangeReasonCode::InternalError => "INTERNAL_ERROR",
+            ClusterStateChangeReasonCode::StepFailure => "STEP_FAILURE",
+            ClusterStateChangeReasonCode::UserRequest => "USER_REQUEST",
+            ClusterStateChangeReasonCode::ValidationError => "VALIDATION_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ClusterStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL_STEPS_COMPLETED" => Ok(ClusterStateChangeReasonCode::AllStepsCompleted),
+            "BOOTSTRAP_FAILURE" => Ok(ClusterStateChangeReasonCode::BootstrapFailure),
+            "INSTANCE_FAILURE" => Ok(ClusterStateChangeReasonCode::InstanceFailure),
+            "INSTANCE_FLEET_TIMEOUT" => Ok(ClusterStateChangeReasonCode::InstanceFleetTimeout),
+            "INTERNAL_ERROR" => Ok(ClusterStateChangeReasonCode::InternalError),
+            "STEP_FAILURE" => Ok(ClusterStateChangeReasonCode::StepFailure),
+            "USER_REQUEST" => Ok(ClusterStateChangeReasonCode::UserRequest),
+            "VALIDATION_ERROR" => Ok(ClusterStateChangeReasonCode::ValidationError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The detailed status of the cluster.</p>"]
@@ -464,6 +762,47 @@ pub struct Command {
     #[serde(rename="ScriptPath")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub script_path: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperator {
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+}
+
+impl Into<String> for ComparisonOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperator::GreaterThan => "GREATER_THAN",
+            ComparisonOperator::GreaterThanOrEqual => "GREATER_THAN_OR_EQUAL",
+            ComparisonOperator::LessThan => "LESS_THAN",
+            ComparisonOperator::LessThanOrEqual => "LESS_THAN_OR_EQUAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GREATER_THAN" => Ok(ComparisonOperator::GreaterThan),
+            "GREATER_THAN_OR_EQUAL" => Ok(ComparisonOperator::GreaterThanOrEqual),
+            "LESS_THAN" => Ok(ComparisonOperator::LessThan),
+            "LESS_THAN_OR_EQUAL" => Ok(ComparisonOperator::LessThanOrEqual),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<note> <p>Amazon EMR releases 4.x or later.</p> </note> <p>An optional configuration specification to be used when provisioning cluster instances, which can include configurations for applications and software bundled with Amazon EMR. A configuration consists of a classification, properties, and optional nested configurations. A classification refers to an application-specific configuration file. Properties are the settings you want to change in that file. For more information, see <a href=\"http://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html\">Configuring Applications</a>.</p>"]
@@ -814,6 +1153,41 @@ pub struct Instance {
     pub status: Option<InstanceStatus>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceCollectionType {
+    InstanceFleet,
+    InstanceGroup,
+}
+
+impl Into<String> for InstanceCollectionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceCollectionType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceCollectionType::InstanceFleet => "INSTANCE_FLEET",
+            InstanceCollectionType::InstanceGroup => "INSTANCE_GROUP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceCollectionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSTANCE_FLEET" => Ok(InstanceCollectionType::InstanceFleet),
+            "INSTANCE_GROUP" => Ok(InstanceCollectionType::InstanceGroup),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes an instance fleet, which is a group of EC2 instances that host a particular node type (master, core, or task) in an Amazon EMR cluster. Instance fleets can consist of a mix of instance types and On-Demand and Spot instances, which are provisioned to meet a defined target capacity. </p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceFleet {
@@ -911,6 +1285,56 @@ pub struct InstanceFleetProvisioningSpecifications {
     pub spot_specification: SpotProvisioningSpecification,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceFleetState {
+    Bootstrapping,
+    Provisioning,
+    Resizing,
+    Running,
+    Suspended,
+    Terminated,
+    Terminating,
+}
+
+impl Into<String> for InstanceFleetState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceFleetState {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceFleetState::Bootstrapping => "BOOTSTRAPPING",
+            InstanceFleetState::Provisioning => "PROVISIONING",
+            InstanceFleetState::Resizing => "RESIZING",
+            InstanceFleetState::Running => "RUNNING",
+            InstanceFleetState::Suspended => "SUSPENDED",
+            InstanceFleetState::Terminated => "TERMINATED",
+            InstanceFleetState::Terminating => "TERMINATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceFleetState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BOOTSTRAPPING" => Ok(InstanceFleetState::Bootstrapping),
+            "PROVISIONING" => Ok(InstanceFleetState::Provisioning),
+            "RESIZING" => Ok(InstanceFleetState::Resizing),
+            "RUNNING" => Ok(InstanceFleetState::Running),
+            "SUSPENDED" => Ok(InstanceFleetState::Suspended),
+            "TERMINATED" => Ok(InstanceFleetState::Terminated),
+            "TERMINATING" => Ok(InstanceFleetState::Terminating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides status change reason details for the instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceFleetStateChangeReason {
@@ -922,6 +1346,47 @@ pub struct InstanceFleetStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceFleetStateChangeReasonCode {
+    ClusterTerminated,
+    InstanceFailure,
+    InternalError,
+    ValidationError,
+}
+
+impl Into<String> for InstanceFleetStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceFleetStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceFleetStateChangeReasonCode::ClusterTerminated => "CLUSTER_TERMINATED",
+            InstanceFleetStateChangeReasonCode::InstanceFailure => "INSTANCE_FAILURE",
+            InstanceFleetStateChangeReasonCode::InternalError => "INTERNAL_ERROR",
+            InstanceFleetStateChangeReasonCode::ValidationError => "VALIDATION_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceFleetStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLUSTER_TERMINATED" => Ok(InstanceFleetStateChangeReasonCode::ClusterTerminated),
+            "INSTANCE_FAILURE" => Ok(InstanceFleetStateChangeReasonCode::InstanceFailure),
+            "INTERNAL_ERROR" => Ok(InstanceFleetStateChangeReasonCode::InternalError),
+            "VALIDATION_ERROR" => Ok(InstanceFleetStateChangeReasonCode::ValidationError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The status of the instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
@@ -956,6 +1421,44 @@ pub struct InstanceFleetTimeline {
     #[serde(rename="ReadyDateTime")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub ready_date_time: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceFleetType {
+    Core,
+    Master,
+    Task,
+}
+
+impl Into<String> for InstanceFleetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceFleetType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceFleetType::Core => "CORE",
+            InstanceFleetType::Master => "MASTER",
+            InstanceFleetType::Task => "TASK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceFleetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CORE" => Ok(InstanceFleetType::Core),
+            "MASTER" => Ok(InstanceFleetType::Master),
+            "TASK" => Ok(InstanceFleetType::Task),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>This entity represents an instance group, which is a group of instances that have common purpose. For example, CORE instance group is used for HDFS.</p>"]
@@ -1131,6 +1634,65 @@ pub struct InstanceGroupModifyConfig {
     pub shrink_policy: Option<ShrinkPolicy>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceGroupState {
+    Arrested,
+    Bootstrapping,
+    Ended,
+    Provisioning,
+    Resizing,
+    Running,
+    ShuttingDown,
+    Suspended,
+    Terminated,
+    Terminating,
+}
+
+impl Into<String> for InstanceGroupState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceGroupState {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceGroupState::Arrested => "ARRESTED",
+            InstanceGroupState::Bootstrapping => "BOOTSTRAPPING",
+            InstanceGroupState::Ended => "ENDED",
+            InstanceGroupState::Provisioning => "PROVISIONING",
+            InstanceGroupState::Resizing => "RESIZING",
+            InstanceGroupState::Running => "RUNNING",
+            InstanceGroupState::ShuttingDown => "SHUTTING_DOWN",
+            InstanceGroupState::Suspended => "SUSPENDED",
+            InstanceGroupState::Terminated => "TERMINATED",
+            InstanceGroupState::Terminating => "TERMINATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceGroupState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ARRESTED" => Ok(InstanceGroupState::Arrested),
+            "BOOTSTRAPPING" => Ok(InstanceGroupState::Bootstrapping),
+            "ENDED" => Ok(InstanceGroupState::Ended),
+            "PROVISIONING" => Ok(InstanceGroupState::Provisioning),
+            "RESIZING" => Ok(InstanceGroupState::Resizing),
+            "RUNNING" => Ok(InstanceGroupState::Running),
+            "SHUTTING_DOWN" => Ok(InstanceGroupState::ShuttingDown),
+            "SUSPENDED" => Ok(InstanceGroupState::Suspended),
+            "TERMINATED" => Ok(InstanceGroupState::Terminated),
+            "TERMINATING" => Ok(InstanceGroupState::Terminating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The status change reason details for the instance group.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceGroupStateChangeReason {
@@ -1142,6 +1704,47 @@ pub struct InstanceGroupStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceGroupStateChangeReasonCode {
+    ClusterTerminated,
+    InstanceFailure,
+    InternalError,
+    ValidationError,
+}
+
+impl Into<String> for InstanceGroupStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceGroupStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceGroupStateChangeReasonCode::ClusterTerminated => "CLUSTER_TERMINATED",
+            InstanceGroupStateChangeReasonCode::InstanceFailure => "INSTANCE_FAILURE",
+            InstanceGroupStateChangeReasonCode::InternalError => "INTERNAL_ERROR",
+            InstanceGroupStateChangeReasonCode::ValidationError => "VALIDATION_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceGroupStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLUSTER_TERMINATED" => Ok(InstanceGroupStateChangeReasonCode::ClusterTerminated),
+            "INSTANCE_FAILURE" => Ok(InstanceGroupStateChangeReasonCode::InstanceFailure),
+            "INTERNAL_ERROR" => Ok(InstanceGroupStateChangeReasonCode::InternalError),
+            "VALIDATION_ERROR" => Ok(InstanceGroupStateChangeReasonCode::ValidationError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The details of the instance group status.</p>"]
@@ -1178,6 +1781,44 @@ pub struct InstanceGroupTimeline {
     pub ready_date_time: Option<f64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceGroupType {
+    Core,
+    Master,
+    Task,
+}
+
+impl Into<String> for InstanceGroupType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceGroupType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceGroupType::Core => "CORE",
+            InstanceGroupType::Master => "MASTER",
+            InstanceGroupType::Task => "TASK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceGroupType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CORE" => Ok(InstanceGroupType::Core),
+            "MASTER" => Ok(InstanceGroupType::Master),
+            "TASK" => Ok(InstanceGroupType::Task),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Custom policy for requesting termination protection or termination of specific instances when shrinking an instance group.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceResizePolicy {
@@ -1195,6 +1836,88 @@ pub struct InstanceResizePolicy {
     pub instances_to_terminate: Option<Vec<String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceRoleType {
+    Core,
+    Master,
+    Task,
+}
+
+impl Into<String> for InstanceRoleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceRoleType {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceRoleType::Core => "CORE",
+            InstanceRoleType::Master => "MASTER",
+            InstanceRoleType::Task => "TASK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceRoleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CORE" => Ok(InstanceRoleType::Core),
+            "MASTER" => Ok(InstanceRoleType::Master),
+            "TASK" => Ok(InstanceRoleType::Task),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceState {
+    AwaitingFulfillment,
+    Bootstrapping,
+    Provisioning,
+    Running,
+    Terminated,
+}
+
+impl Into<String> for InstanceState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceState {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceState::AwaitingFulfillment => "AWAITING_FULFILLMENT",
+            InstanceState::Bootstrapping => "BOOTSTRAPPING",
+            InstanceState::Provisioning => "PROVISIONING",
+            InstanceState::Running => "RUNNING",
+            InstanceState::Terminated => "TERMINATED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWAITING_FULFILLMENT" => Ok(InstanceState::AwaitingFulfillment),
+            "BOOTSTRAPPING" => Ok(InstanceState::Bootstrapping),
+            "PROVISIONING" => Ok(InstanceState::Provisioning),
+            "RUNNING" => Ok(InstanceState::Running),
+            "TERMINATED" => Ok(InstanceState::Terminated),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The details of the status change reason for the instance.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceStateChangeReason {
@@ -1206,6 +1929,50 @@ pub struct InstanceStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceStateChangeReasonCode {
+    BootstrapFailure,
+    ClusterTerminated,
+    InstanceFailure,
+    InternalError,
+    ValidationError,
+}
+
+impl Into<String> for InstanceStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceStateChangeReasonCode::BootstrapFailure => "BOOTSTRAP_FAILURE",
+            InstanceStateChangeReasonCode::ClusterTerminated => "CLUSTER_TERMINATED",
+            InstanceStateChangeReasonCode::InstanceFailure => "INSTANCE_FAILURE",
+            InstanceStateChangeReasonCode::InternalError => "INTERNAL_ERROR",
+            InstanceStateChangeReasonCode::ValidationError => "VALIDATION_ERROR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BOOTSTRAP_FAILURE" => Ok(InstanceStateChangeReasonCode::BootstrapFailure),
+            "CLUSTER_TERMINATED" => Ok(InstanceStateChangeReasonCode::ClusterTerminated),
+            "INSTANCE_FAILURE" => Ok(InstanceStateChangeReasonCode::InstanceFailure),
+            "INTERNAL_ERROR" => Ok(InstanceStateChangeReasonCode::InternalError),
+            "VALIDATION_ERROR" => Ok(InstanceStateChangeReasonCode::ValidationError),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The instance status details.</p>"]
@@ -1358,6 +2125,59 @@ pub struct JobFlowDetail {
     #[serde(rename="VisibleToAllUsers")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub visible_to_all_users: Option<bool>,
+}
+
+#[doc="<p>The type of instance.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobFlowExecutionState {
+    Bootstrapping,
+    Completed,
+    Failed,
+    Running,
+    ShuttingDown,
+    Starting,
+    Terminated,
+    Waiting,
+}
+
+impl Into<String> for JobFlowExecutionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobFlowExecutionState {
+    fn into(self) -> &'static str {
+        match self {
+            JobFlowExecutionState::Bootstrapping => "BOOTSTRAPPING",
+            JobFlowExecutionState::Completed => "COMPLETED",
+            JobFlowExecutionState::Failed => "FAILED",
+            JobFlowExecutionState::Running => "RUNNING",
+            JobFlowExecutionState::ShuttingDown => "SHUTTING_DOWN",
+            JobFlowExecutionState::Starting => "STARTING",
+            JobFlowExecutionState::Terminated => "TERMINATED",
+            JobFlowExecutionState::Waiting => "WAITING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobFlowExecutionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BOOTSTRAPPING" => Ok(JobFlowExecutionState::Bootstrapping),
+            "COMPLETED" => Ok(JobFlowExecutionState::Completed),
+            "FAILED" => Ok(JobFlowExecutionState::Failed),
+            "RUNNING" => Ok(JobFlowExecutionState::Running),
+            "SHUTTING_DOWN" => Ok(JobFlowExecutionState::ShuttingDown),
+            "STARTING" => Ok(JobFlowExecutionState::Starting),
+            "TERMINATED" => Ok(JobFlowExecutionState::Terminated),
+            "WAITING" => Ok(JobFlowExecutionState::Waiting),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes the status of the cluster (job flow).</p>"]
@@ -1732,6 +2552,41 @@ pub struct ListStepsOutput {
     pub steps: Option<Vec<StepSummary>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MarketType {
+    OnDemand,
+    Spot,
+}
+
+impl Into<String> for MarketType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MarketType {
+    fn into(self) -> &'static str {
+        match self {
+            MarketType::OnDemand => "ON_DEMAND",
+            MarketType::Spot => "SPOT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MarketType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ON_DEMAND" => Ok(MarketType::OnDemand),
+            "SPOT" => Ok(MarketType::Spot),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A CloudWatch dimension, which is specified using a <code>Key</code> (known as a <code>Name</code> in CloudWatch), <code>Value</code> pair. By default, Amazon EMR uses one dimension whose <code>Key</code> is <code>JobFlowID</code> and <code>Value</code> is a variable representing the cluster ID, which is <code>${emr.clusterId}</code>. This enables the rule to bootstrap when the cluster ID becomes available.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MetricDimension {
@@ -1838,6 +2693,41 @@ pub struct RemoveTagsInput {
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RemoveTagsOutput;
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RepoUpgradeOnBoot {
+    None,
+    Security,
+}
+
+impl Into<String> for RepoUpgradeOnBoot {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RepoUpgradeOnBoot {
+    fn into(self) -> &'static str {
+        match self {
+            RepoUpgradeOnBoot::None => "NONE",
+            RepoUpgradeOnBoot::Security => "SECURITY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RepoUpgradeOnBoot {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NONE" => Ok(RepoUpgradeOnBoot::None),
+            "SECURITY" => Ok(RepoUpgradeOnBoot::Security),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p> Input to the <a>RunJobFlow</a> operation. </p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct RunJobFlowInput {
@@ -1936,6 +2826,41 @@ pub struct RunJobFlowOutput {
     #[serde(rename="JobFlowId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub job_flow_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScaleDownBehavior {
+    TerminateAtInstanceHour,
+    TerminateAtTaskCompletion,
+}
+
+impl Into<String> for ScaleDownBehavior {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScaleDownBehavior {
+    fn into(self) -> &'static str {
+        match self {
+            ScaleDownBehavior::TerminateAtInstanceHour => "TERMINATE_AT_INSTANCE_HOUR",
+            ScaleDownBehavior::TerminateAtTaskCompletion => "TERMINATE_AT_TASK_COMPLETION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScaleDownBehavior {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "TERMINATE_AT_INSTANCE_HOUR" => Ok(ScaleDownBehavior::TerminateAtInstanceHour),
+            "TERMINATE_AT_TASK_COMPLETION" => Ok(ScaleDownBehavior::TerminateAtTaskCompletion),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The type of adjustment the automatic scaling activity makes when triggered, and the periodicity of the adjustment.</p>"]
@@ -2078,6 +3003,85 @@ pub struct SpotProvisioningSpecification {
     pub timeout_duration_minutes: i64,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SpotProvisioningTimeoutAction {
+    SwitchToOnDemand,
+    TerminateCluster,
+}
+
+impl Into<String> for SpotProvisioningTimeoutAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SpotProvisioningTimeoutAction {
+    fn into(self) -> &'static str {
+        match self {
+            SpotProvisioningTimeoutAction::SwitchToOnDemand => "SWITCH_TO_ON_DEMAND",
+            SpotProvisioningTimeoutAction::TerminateCluster => "TERMINATE_CLUSTER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SpotProvisioningTimeoutAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SWITCH_TO_ON_DEMAND" => Ok(SpotProvisioningTimeoutAction::SwitchToOnDemand),
+            "TERMINATE_CLUSTER" => Ok(SpotProvisioningTimeoutAction::TerminateCluster),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Statistic {
+    Average,
+    Maximum,
+    Minimum,
+    SampleCount,
+    Sum,
+}
+
+impl Into<String> for Statistic {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Statistic {
+    fn into(self) -> &'static str {
+        match self {
+            Statistic::Average => "AVERAGE",
+            Statistic::Maximum => "MAXIMUM",
+            Statistic::Minimum => "MINIMUM",
+            Statistic::SampleCount => "SAMPLE_COUNT",
+            Statistic::Sum => "SUM",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Statistic {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVERAGE" => Ok(Statistic::Average),
+            "MAXIMUM" => Ok(Statistic::Maximum),
+            "MINIMUM" => Ok(Statistic::Minimum),
+            "SAMPLE_COUNT" => Ok(Statistic::SampleCount),
+            "SUM" => Ok(Statistic::Sum),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>This represents a step in a cluster.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Step {
@@ -2129,6 +3133,56 @@ pub struct StepDetail {
     pub step_config: StepConfig,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StepExecutionState {
+    Cancelled,
+    Completed,
+    Continue,
+    Failed,
+    Interrupted,
+    Pending,
+    Running,
+}
+
+impl Into<String> for StepExecutionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StepExecutionState {
+    fn into(self) -> &'static str {
+        match self {
+            StepExecutionState::Cancelled => "CANCELLED",
+            StepExecutionState::Completed => "COMPLETED",
+            StepExecutionState::Continue => "CONTINUE",
+            StepExecutionState::Failed => "FAILED",
+            StepExecutionState::Interrupted => "INTERRUPTED",
+            StepExecutionState::Pending => "PENDING",
+            StepExecutionState::Running => "RUNNING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StepExecutionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(StepExecutionState::Cancelled),
+            "COMPLETED" => Ok(StepExecutionState::Completed),
+            "CONTINUE" => Ok(StepExecutionState::Continue),
+            "FAILED" => Ok(StepExecutionState::Failed),
+            "INTERRUPTED" => Ok(StepExecutionState::Interrupted),
+            "PENDING" => Ok(StepExecutionState::Pending),
+            "RUNNING" => Ok(StepExecutionState::Running),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The execution state of a step.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct StepExecutionStatusDetail {
@@ -2152,6 +3206,56 @@ pub struct StepExecutionStatusDetail {
     pub state: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StepState {
+    Cancelled,
+    CancelPending,
+    Completed,
+    Failed,
+    Interrupted,
+    Pending,
+    Running,
+}
+
+impl Into<String> for StepState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StepState {
+    fn into(self) -> &'static str {
+        match self {
+            StepState::Cancelled => "CANCELLED",
+            StepState::CancelPending => "CANCEL_PENDING",
+            StepState::Completed => "COMPLETED",
+            StepState::Failed => "FAILED",
+            StepState::Interrupted => "INTERRUPTED",
+            StepState::Pending => "PENDING",
+            StepState::Running => "RUNNING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StepState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(StepState::Cancelled),
+            "CANCEL_PENDING" => Ok(StepState::CancelPending),
+            "COMPLETED" => Ok(StepState::Completed),
+            "FAILED" => Ok(StepState::Failed),
+            "INTERRUPTED" => Ok(StepState::Interrupted),
+            "PENDING" => Ok(StepState::Pending),
+            "RUNNING" => Ok(StepState::Running),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The details of the step state change reason.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct StepStateChangeReason {
@@ -2163,6 +3267,38 @@ pub struct StepStateChangeReason {
     #[serde(rename="Message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StepStateChangeReasonCode {
+    None,
+}
+
+impl Into<String> for StepStateChangeReasonCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StepStateChangeReasonCode {
+    fn into(self) -> &'static str {
+        match self {
+            StepStateChangeReasonCode::None => "NONE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StepStateChangeReasonCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NONE" => Ok(StepStateChangeReasonCode::None),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The execution status details of the cluster step.</p>"]
@@ -2260,6 +3396,116 @@ pub struct TerminateJobFlowsInput {
     #[doc="<p>A list of job flows to be shutdown.</p>"]
     #[serde(rename="JobFlowIds")]
     pub job_flow_ids: Vec<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Unit {
+    Bits,
+    BitsPerSecond,
+    Bytes,
+    BytesPerSecond,
+    Count,
+    CountPerSecond,
+    GigaBits,
+    GigaBitsPerSecond,
+    GigaBytes,
+    GigaBytesPerSecond,
+    KiloBits,
+    KiloBitsPerSecond,
+    KiloBytes,
+    KiloBytesPerSecond,
+    MegaBits,
+    MegaBitsPerSecond,
+    MegaBytes,
+    MegaBytesPerSecond,
+    MicroSeconds,
+    MilliSeconds,
+    None,
+    Percent,
+    Seconds,
+    TeraBits,
+    TeraBitsPerSecond,
+    TeraBytes,
+    TeraBytesPerSecond,
+}
+
+impl Into<String> for Unit {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Unit {
+    fn into(self) -> &'static str {
+        match self {
+            Unit::Bits => "BITS",
+            Unit::BitsPerSecond => "BITS_PER_SECOND",
+            Unit::Bytes => "BYTES",
+            Unit::BytesPerSecond => "BYTES_PER_SECOND",
+            Unit::Count => "COUNT",
+            Unit::CountPerSecond => "COUNT_PER_SECOND",
+            Unit::GigaBits => "GIGA_BITS",
+            Unit::GigaBitsPerSecond => "GIGA_BITS_PER_SECOND",
+            Unit::GigaBytes => "GIGA_BYTES",
+            Unit::GigaBytesPerSecond => "GIGA_BYTES_PER_SECOND",
+            Unit::KiloBits => "KILO_BITS",
+            Unit::KiloBitsPerSecond => "KILO_BITS_PER_SECOND",
+            Unit::KiloBytes => "KILO_BYTES",
+            Unit::KiloBytesPerSecond => "KILO_BYTES_PER_SECOND",
+            Unit::MegaBits => "MEGA_BITS",
+            Unit::MegaBitsPerSecond => "MEGA_BITS_PER_SECOND",
+            Unit::MegaBytes => "MEGA_BYTES",
+            Unit::MegaBytesPerSecond => "MEGA_BYTES_PER_SECOND",
+            Unit::MicroSeconds => "MICRO_SECONDS",
+            Unit::MilliSeconds => "MILLI_SECONDS",
+            Unit::None => "NONE",
+            Unit::Percent => "PERCENT",
+            Unit::Seconds => "SECONDS",
+            Unit::TeraBits => "TERA_BITS",
+            Unit::TeraBitsPerSecond => "TERA_BITS_PER_SECOND",
+            Unit::TeraBytes => "TERA_BYTES",
+            Unit::TeraBytesPerSecond => "TERA_BYTES_PER_SECOND",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Unit {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BITS" => Ok(Unit::Bits),
+            "BITS_PER_SECOND" => Ok(Unit::BitsPerSecond),
+            "BYTES" => Ok(Unit::Bytes),
+            "BYTES_PER_SECOND" => Ok(Unit::BytesPerSecond),
+            "COUNT" => Ok(Unit::Count),
+            "COUNT_PER_SECOND" => Ok(Unit::CountPerSecond),
+            "GIGA_BITS" => Ok(Unit::GigaBits),
+            "GIGA_BITS_PER_SECOND" => Ok(Unit::GigaBitsPerSecond),
+            "GIGA_BYTES" => Ok(Unit::GigaBytes),
+            "GIGA_BYTES_PER_SECOND" => Ok(Unit::GigaBytesPerSecond),
+            "KILO_BITS" => Ok(Unit::KiloBits),
+            "KILO_BITS_PER_SECOND" => Ok(Unit::KiloBitsPerSecond),
+            "KILO_BYTES" => Ok(Unit::KiloBytes),
+            "KILO_BYTES_PER_SECOND" => Ok(Unit::KiloBytesPerSecond),
+            "MEGA_BITS" => Ok(Unit::MegaBits),
+            "MEGA_BITS_PER_SECOND" => Ok(Unit::MegaBitsPerSecond),
+            "MEGA_BYTES" => Ok(Unit::MegaBytes),
+            "MEGA_BYTES_PER_SECOND" => Ok(Unit::MegaBytesPerSecond),
+            "MICRO_SECONDS" => Ok(Unit::MicroSeconds),
+            "MILLI_SECONDS" => Ok(Unit::MilliSeconds),
+            "NONE" => Ok(Unit::None),
+            "PERCENT" => Ok(Unit::Percent),
+            "SECONDS" => Ok(Unit::Seconds),
+            "TERA_BITS" => Ok(Unit::TeraBits),
+            "TERA_BITS_PER_SECOND" => Ok(Unit::TeraBitsPerSecond),
+            "TERA_BYTES" => Ok(Unit::TeraBytes),
+            "TERA_BYTES_PER_SECOND" => Ok(Unit::TeraBytesPerSecond),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>EBS volume specifications such as volume type, IOPS, and size (GiB) that will be requested for the EBS volume attached to an EC2 instance in the cluster.</p>"]
@@ -4711,7 +5957,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddInstanceFleetOutput>(String::from_utf8_lossy(&body)
@@ -4743,7 +5989,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddInstanceGroupsOutput>(String::from_utf8_lossy(&body)
@@ -4775,7 +6021,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddJobFlowStepsOutput>(String::from_utf8_lossy(&body)
@@ -4805,7 +6051,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -4836,7 +6082,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CancelStepsOutput>(String::from_utf8_lossy(&body)
@@ -4870,7 +6116,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateSecurityConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4903,7 +6149,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteSecurityConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4934,7 +6180,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeClusterOutput>(String::from_utf8_lossy(&body)
@@ -4966,7 +6212,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeJobFlowsOutput>(String::from_utf8_lossy(&body)
@@ -5000,7 +6246,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeSecurityConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5031,7 +6277,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeStepOutput>(String::from_utf8_lossy(&body)
@@ -5063,7 +6309,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListBootstrapActionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5093,7 +6339,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListClustersOutput>(String::from_utf8_lossy(&body)
@@ -5125,7 +6371,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListInstanceFleetsOutput>(String::from_utf8_lossy(&body)
@@ -5157,7 +6403,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListInstanceGroupsOutput>(String::from_utf8_lossy(&body)
@@ -5189,7 +6435,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListInstancesOutput>(String::from_utf8_lossy(&body)
@@ -5223,7 +6469,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListSecurityConfigurationsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5252,7 +6498,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListStepsOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -5283,7 +6529,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5309,7 +6555,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5335,7 +6581,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutAutoScalingPolicyOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5366,7 +6612,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveAutoScalingPolicyOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5395,7 +6641,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveTagsOutput>(String::from_utf8_lossy(&body)
@@ -5425,7 +6671,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RunJobFlowOutput>(String::from_utf8_lossy(&body)
@@ -5457,7 +6703,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5484,7 +6730,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5510,7 +6756,7 @@ impl<P, D> Emr for EmrClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -446,6 +442,41 @@ pub struct Rule {
     #[serde(rename="State")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RuleState {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for RuleState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RuleState {
+    fn into(self) -> &'static str {
+        match self {
+            RuleState::Disabled => "DISABLED",
+            RuleState::Enabled => "ENABLED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RuleState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLED" => Ok(RuleState::Disabled),
+            "ENABLED" => Ok(RuleState::Enabled),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>This parameter contains the criteria (either InstanceIds or a tag) used to specify which EC2 instances are to be sent the command. </p>"]
@@ -1922,7 +1953,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1945,7 +1976,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEventBusResponse>(String::from_utf8_lossy(&body)
@@ -1977,7 +2008,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeRuleResponse>(String::from_utf8_lossy(&body)
@@ -2007,7 +2038,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2031,7 +2062,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2058,7 +2089,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRuleNamesByTargetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2086,7 +2117,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&body)
@@ -2118,7 +2149,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTargetsByRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2146,7 +2177,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutEventsResponse>(String::from_utf8_lossy(&body)
@@ -2176,7 +2207,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2200,7 +2231,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutRuleResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -2231,7 +2262,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutTargetsResponse>(String::from_utf8_lossy(&body)
@@ -2263,7 +2294,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2289,7 +2320,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveTargetsResponse>(String::from_utf8_lossy(&body)
@@ -2321,7 +2352,7 @@ impl<P, D> CloudWatchEvents for CloudWatchEventsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<TestEventPatternResponse>(String::from_utf8_lossy(&body)

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -56,6 +52,47 @@ pub struct CloudWatchLoggingOptions {
     #[serde(rename="LogStreamName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub log_stream_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CompressionFormat {
+    Gzip,
+    Snappy,
+    Uncompressed,
+    Zip,
+}
+
+impl Into<String> for CompressionFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CompressionFormat {
+    fn into(self) -> &'static str {
+        match self {
+            CompressionFormat::Gzip => "GZIP",
+            CompressionFormat::Snappy => "Snappy",
+            CompressionFormat::Uncompressed => "UNCOMPRESSED",
+            CompressionFormat::Zip => "ZIP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CompressionFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GZIP" => Ok(CompressionFormat::Gzip),
+            "Snappy" => Ok(CompressionFormat::Snappy),
+            "UNCOMPRESSED" => Ok(CompressionFormat::Uncompressed),
+            "ZIP" => Ok(CompressionFormat::Zip),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a <code>COPY</code> command for Amazon Redshift.</p>"]
@@ -155,6 +192,79 @@ pub struct DeliveryStreamDescription {
     #[doc="<p>Each time the destination is updated for a delivery stream, the version ID is changed, and the current version ID is required when updating the destination. This is so that the service knows it is applying the changes to the correct version of the delivery stream.</p>"]
     #[serde(rename="VersionId")]
     pub version_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeliveryStreamStatus {
+    Active,
+    Creating,
+    Deleting,
+}
+
+impl Into<String> for DeliveryStreamStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeliveryStreamStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DeliveryStreamStatus::Active => "ACTIVE",
+            DeliveryStreamStatus::Creating => "CREATING",
+            DeliveryStreamStatus::Deleting => "DELETING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeliveryStreamStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(DeliveryStreamStatus::Active),
+            "CREATING" => Ok(DeliveryStreamStatus::Creating),
+            "DELETING" => Ok(DeliveryStreamStatus::Deleting),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeliveryStreamType {
+    DirectPut,
+    KinesisStreamAsSource,
+}
+
+impl Into<String> for DeliveryStreamType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeliveryStreamType {
+    fn into(self) -> &'static str {
+        match self {
+            DeliveryStreamType::DirectPut => "DirectPut",
+            DeliveryStreamType::KinesisStreamAsSource => "KinesisStreamAsSource",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeliveryStreamType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DirectPut" => Ok(DeliveryStreamType::DirectPut),
+            "KinesisStreamAsSource" => Ok(DeliveryStreamType::KinesisStreamAsSource),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -354,6 +464,50 @@ pub struct ElasticsearchDestinationUpdate {
     pub type_name: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ElasticsearchIndexRotationPeriod {
+    NoRotation,
+    OneDay,
+    OneHour,
+    OneMonth,
+    OneWeek,
+}
+
+impl Into<String> for ElasticsearchIndexRotationPeriod {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ElasticsearchIndexRotationPeriod {
+    fn into(self) -> &'static str {
+        match self {
+            ElasticsearchIndexRotationPeriod::NoRotation => "NoRotation",
+            ElasticsearchIndexRotationPeriod::OneDay => "OneDay",
+            ElasticsearchIndexRotationPeriod::OneHour => "OneHour",
+            ElasticsearchIndexRotationPeriod::OneMonth => "OneMonth",
+            ElasticsearchIndexRotationPeriod::OneWeek => "OneWeek",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ElasticsearchIndexRotationPeriod {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NoRotation" => Ok(ElasticsearchIndexRotationPeriod::NoRotation),
+            "OneDay" => Ok(ElasticsearchIndexRotationPeriod::OneDay),
+            "OneHour" => Ok(ElasticsearchIndexRotationPeriod::OneHour),
+            "OneMonth" => Ok(ElasticsearchIndexRotationPeriod::OneMonth),
+            "OneWeek" => Ok(ElasticsearchIndexRotationPeriod::OneWeek),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Configures retry behavior in case Kinesis Firehose is unable to deliver documents to Amazon ES.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticsearchRetryOptions {
@@ -361,6 +515,41 @@ pub struct ElasticsearchRetryOptions {
     #[serde(rename="DurationInSeconds")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub duration_in_seconds: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ElasticsearchS3BackupMode {
+    AllDocuments,
+    FailedDocumentsOnly,
+}
+
+impl Into<String> for ElasticsearchS3BackupMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ElasticsearchS3BackupMode {
+    fn into(self) -> &'static str {
+        match self {
+            ElasticsearchS3BackupMode::AllDocuments => "AllDocuments",
+            ElasticsearchS3BackupMode::FailedDocumentsOnly => "FailedDocumentsOnly",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ElasticsearchS3BackupMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AllDocuments" => Ok(ElasticsearchS3BackupMode::AllDocuments),
+            "FailedDocumentsOnly" => Ok(ElasticsearchS3BackupMode::FailedDocumentsOnly),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes the encryption for a destination in Amazon S3.</p>"]
@@ -582,6 +771,38 @@ pub struct ListDeliveryStreamsOutput {
     pub has_more_delivery_streams: bool,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NoEncryptionConfig {
+    NoEncryption,
+}
+
+impl Into<String> for NoEncryptionConfig {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NoEncryptionConfig {
+    fn into(self) -> &'static str {
+        match self {
+            NoEncryptionConfig::NoEncryption => "NoEncryption",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NoEncryptionConfig {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NoEncryption" => Ok(NoEncryptionConfig::NoEncryption),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes a data processing configuration.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProcessingConfiguration {
@@ -616,6 +837,73 @@ pub struct ProcessorParameter {
     #[doc="<p>The parameter value.</p>"]
     #[serde(rename="ParameterValue")]
     pub parameter_value: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProcessorParameterName {
+    LambdaArn,
+    NumberOfRetries,
+}
+
+impl Into<String> for ProcessorParameterName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProcessorParameterName {
+    fn into(self) -> &'static str {
+        match self {
+            ProcessorParameterName::LambdaArn => "LambdaArn",
+            ProcessorParameterName::NumberOfRetries => "NumberOfRetries",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProcessorParameterName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LambdaArn" => Ok(ProcessorParameterName::LambdaArn),
+            "NumberOfRetries" => Ok(ProcessorParameterName::NumberOfRetries),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProcessorType {
+    Lambda,
+}
+
+impl Into<String> for ProcessorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProcessorType {
+    fn into(self) -> &'static str {
+        match self {
+            ProcessorType::Lambda => "Lambda",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProcessorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Lambda" => Ok(ProcessorType::Lambda),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -824,6 +1112,76 @@ pub struct RedshiftRetryOptions {
     #[serde(rename="DurationInSeconds")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub duration_in_seconds: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RedshiftS3BackupMode {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for RedshiftS3BackupMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RedshiftS3BackupMode {
+    fn into(self) -> &'static str {
+        match self {
+            RedshiftS3BackupMode::Disabled => "Disabled",
+            RedshiftS3BackupMode::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RedshiftS3BackupMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(RedshiftS3BackupMode::Disabled),
+            "Enabled" => Ok(RedshiftS3BackupMode::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum S3BackupMode {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for S3BackupMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for S3BackupMode {
+    fn into(self) -> &'static str {
+        match self {
+            S3BackupMode::Disabled => "Disabled",
+            S3BackupMode::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for S3BackupMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(S3BackupMode::Disabled),
+            "Enabled" => Ok(S3BackupMode::Enabled),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes the configuration of a destination in Amazon S3.</p>"]
@@ -1764,7 +2122,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDeliveryStreamOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1794,7 +2152,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteDeliveryStreamOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1825,7 +2183,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeDeliveryStreamOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1855,7 +2213,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetKinesisStreamOutput>(String::from_utf8_lossy(&body)
@@ -1887,7 +2245,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListDeliveryStreamsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1915,7 +2273,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutRecordOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -1946,7 +2304,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutRecordBatchOutput>(String::from_utf8_lossy(&body)
@@ -1978,7 +2336,7 @@ impl<P, D> KinesisFirehose for KinesisFirehoseClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDestinationOutput>(String::from_utf8_lossy(&body)

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -44,6 +40,41 @@ pub struct AcceptMatchInput {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AcceptMatchOutput;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AcceptanceType {
+    Accept,
+    Reject,
+}
+
+impl Into<String> for AcceptanceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AcceptanceType {
+    fn into(self) -> &'static str {
+        match self {
+            AcceptanceType::Accept => "ACCEPT",
+            AcceptanceType::Reject => "REJECT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AcceptanceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCEPT" => Ok(AcceptanceType::Accept),
+            "REJECT" => Ok(AcceptanceType::Reject),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="<p>Properties describing a fleet alias.</p> <p>Alias-related operations include:</p> <ul> <li> <p> <a>CreateAlias</a> </p> </li> <li> <p> <a>ListAliases</a> </p> </li> <li> <p> <a>DescribeAlias</a> </p> </li> <li> <p> <a>UpdateAlias</a> </p> </li> <li> <p> <a>DeleteAlias</a> </p> </li> <li> <p> <a>ResolveAlias</a> </p> </li> </ul>"]
 #[derive(Default,Debug,Clone,Deserialize)]
@@ -147,6 +178,89 @@ pub struct Build {
     #[serde(rename="Version")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub version: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BuildStatus {
+    Failed,
+    Initialized,
+    Ready,
+}
+
+impl Into<String> for BuildStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BuildStatus {
+    fn into(self) -> &'static str {
+        match self {
+            BuildStatus::Failed => "FAILED",
+            BuildStatus::Initialized => "INITIALIZED",
+            BuildStatus::Ready => "READY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BuildStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(BuildStatus::Failed),
+            "INITIALIZED" => Ok(BuildStatus::Initialized),
+            "READY" => Ok(BuildStatus::Ready),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperatorType {
+    GreaterThanOrEqualToThreshold,
+    GreaterThanThreshold,
+    LessThanOrEqualToThreshold,
+    LessThanThreshold,
+}
+
+impl Into<String> for ComparisonOperatorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperatorType {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperatorType::GreaterThanOrEqualToThreshold => {
+                "GreaterThanOrEqualToThreshold"
+            }
+            ComparisonOperatorType::GreaterThanThreshold => "GreaterThanThreshold",
+            ComparisonOperatorType::LessThanOrEqualToThreshold => "LessThanOrEqualToThreshold",
+            ComparisonOperatorType::LessThanThreshold => "LessThanThreshold",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperatorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GreaterThanOrEqualToThreshold" => {
+                Ok(ComparisonOperatorType::GreaterThanOrEqualToThreshold)
+            }
+            "GreaterThanThreshold" => Ok(ComparisonOperatorType::GreaterThanThreshold),
+            "LessThanOrEqualToThreshold" => Ok(ComparisonOperatorType::LessThanOrEqualToThreshold),
+            "LessThanThreshold" => Ok(ComparisonOperatorType::LessThanThreshold),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
@@ -1124,6 +1238,119 @@ pub struct EC2InstanceLimit {
     pub instance_limit: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EC2InstanceType {
+    C32Xlarge,
+    C34Xlarge,
+    C38Xlarge,
+    C3Large,
+    C3Xlarge,
+    C42Xlarge,
+    C44Xlarge,
+    C48Xlarge,
+    C4Large,
+    C4Xlarge,
+    M32Xlarge,
+    M3Large,
+    M3Medium,
+    M3Xlarge,
+    M410Xlarge,
+    M42Xlarge,
+    M44Xlarge,
+    M4Large,
+    M4Xlarge,
+    R32Xlarge,
+    R34Xlarge,
+    R38Xlarge,
+    R3Large,
+    R3Xlarge,
+    T2Large,
+    T2Medium,
+    T2Micro,
+    T2Small,
+}
+
+impl Into<String> for EC2InstanceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EC2InstanceType {
+    fn into(self) -> &'static str {
+        match self {
+            EC2InstanceType::C32Xlarge => "c3.2xlarge",
+            EC2InstanceType::C34Xlarge => "c3.4xlarge",
+            EC2InstanceType::C38Xlarge => "c3.8xlarge",
+            EC2InstanceType::C3Large => "c3.large",
+            EC2InstanceType::C3Xlarge => "c3.xlarge",
+            EC2InstanceType::C42Xlarge => "c4.2xlarge",
+            EC2InstanceType::C44Xlarge => "c4.4xlarge",
+            EC2InstanceType::C48Xlarge => "c4.8xlarge",
+            EC2InstanceType::C4Large => "c4.large",
+            EC2InstanceType::C4Xlarge => "c4.xlarge",
+            EC2InstanceType::M32Xlarge => "m3.2xlarge",
+            EC2InstanceType::M3Large => "m3.large",
+            EC2InstanceType::M3Medium => "m3.medium",
+            EC2InstanceType::M3Xlarge => "m3.xlarge",
+            EC2InstanceType::M410Xlarge => "m4.10xlarge",
+            EC2InstanceType::M42Xlarge => "m4.2xlarge",
+            EC2InstanceType::M44Xlarge => "m4.4xlarge",
+            EC2InstanceType::M4Large => "m4.large",
+            EC2InstanceType::M4Xlarge => "m4.xlarge",
+            EC2InstanceType::R32Xlarge => "r3.2xlarge",
+            EC2InstanceType::R34Xlarge => "r3.4xlarge",
+            EC2InstanceType::R38Xlarge => "r3.8xlarge",
+            EC2InstanceType::R3Large => "r3.large",
+            EC2InstanceType::R3Xlarge => "r3.xlarge",
+            EC2InstanceType::T2Large => "t2.large",
+            EC2InstanceType::T2Medium => "t2.medium",
+            EC2InstanceType::T2Micro => "t2.micro",
+            EC2InstanceType::T2Small => "t2.small",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EC2InstanceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "c3.2xlarge" => Ok(EC2InstanceType::C32Xlarge),
+            "c3.4xlarge" => Ok(EC2InstanceType::C34Xlarge),
+            "c3.8xlarge" => Ok(EC2InstanceType::C38Xlarge),
+            "c3.large" => Ok(EC2InstanceType::C3Large),
+            "c3.xlarge" => Ok(EC2InstanceType::C3Xlarge),
+            "c4.2xlarge" => Ok(EC2InstanceType::C42Xlarge),
+            "c4.4xlarge" => Ok(EC2InstanceType::C44Xlarge),
+            "c4.8xlarge" => Ok(EC2InstanceType::C48Xlarge),
+            "c4.large" => Ok(EC2InstanceType::C4Large),
+            "c4.xlarge" => Ok(EC2InstanceType::C4Xlarge),
+            "m3.2xlarge" => Ok(EC2InstanceType::M32Xlarge),
+            "m3.large" => Ok(EC2InstanceType::M3Large),
+            "m3.medium" => Ok(EC2InstanceType::M3Medium),
+            "m3.xlarge" => Ok(EC2InstanceType::M3Xlarge),
+            "m4.10xlarge" => Ok(EC2InstanceType::M410Xlarge),
+            "m4.2xlarge" => Ok(EC2InstanceType::M42Xlarge),
+            "m4.4xlarge" => Ok(EC2InstanceType::M44Xlarge),
+            "m4.large" => Ok(EC2InstanceType::M4Large),
+            "m4.xlarge" => Ok(EC2InstanceType::M4Xlarge),
+            "r3.2xlarge" => Ok(EC2InstanceType::R32Xlarge),
+            "r3.4xlarge" => Ok(EC2InstanceType::R34Xlarge),
+            "r3.8xlarge" => Ok(EC2InstanceType::R38Xlarge),
+            "r3.large" => Ok(EC2InstanceType::R3Large),
+            "r3.xlarge" => Ok(EC2InstanceType::R3Xlarge),
+            "t2.large" => Ok(EC2InstanceType::T2Large),
+            "t2.medium" => Ok(EC2InstanceType::T2Medium),
+            "t2.micro" => Ok(EC2InstanceType::T2Micro),
+            "t2.small" => Ok(EC2InstanceType::T2Small),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Log entry describing an event that involves Amazon GameLift resources (such as a fleet). In addition to tracking activity, event codes and messages can provide additional information for troubleshooting and debugging problems.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Event {
@@ -1151,6 +1378,148 @@ pub struct Event {
     #[serde(rename="ResourceId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub resource_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventCode {
+    FleetActivationFailed,
+    FleetActivationFailedNoInstances,
+    FleetBinaryDownloadFailed,
+    FleetCreated,
+    FleetCreationExtractingBuild,
+    FleetCreationRunningInstaller,
+    FleetCreationValidatingRuntimeConfig,
+    FleetDeleted,
+    FleetInitializationFailed,
+    FleetNewGameSessionProtectionPolicyUpdated,
+    FleetScalingEvent,
+    FleetStateActivating,
+    FleetStateActive,
+    FleetStateBuilding,
+    FleetStateDownloading,
+    FleetStateError,
+    FleetStateValidating,
+    FleetValidationExecutableRuntimeFailure,
+    FleetValidationLaunchPathNotFound,
+    FleetValidationTimedOut,
+    GameSessionActivationTimeout,
+    GenericEvent,
+    ServerProcessCrashed,
+    ServerProcessForceTerminated,
+    ServerProcessInvalidPath,
+    ServerProcessProcessExitTimeout,
+    ServerProcessProcessReadyTimeout,
+    ServerProcessSdkInitializationTimeout,
+    ServerProcessTerminatedUnhealthy,
+}
+
+impl Into<String> for EventCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventCode {
+    fn into(self) -> &'static str {
+        match self {
+            EventCode::FleetActivationFailed => "FLEET_ACTIVATION_FAILED",
+            EventCode::FleetActivationFailedNoInstances => "FLEET_ACTIVATION_FAILED_NO_INSTANCES",
+            EventCode::FleetBinaryDownloadFailed => "FLEET_BINARY_DOWNLOAD_FAILED",
+            EventCode::FleetCreated => "FLEET_CREATED",
+            EventCode::FleetCreationExtractingBuild => "FLEET_CREATION_EXTRACTING_BUILD",
+            EventCode::FleetCreationRunningInstaller => "FLEET_CREATION_RUNNING_INSTALLER",
+            EventCode::FleetCreationValidatingRuntimeConfig => {
+                "FLEET_CREATION_VALIDATING_RUNTIME_CONFIG"
+            }
+            EventCode::FleetDeleted => "FLEET_DELETED",
+            EventCode::FleetInitializationFailed => "FLEET_INITIALIZATION_FAILED",
+            EventCode::FleetNewGameSessionProtectionPolicyUpdated => {
+                "FLEET_NEW_GAME_SESSION_PROTECTION_POLICY_UPDATED"
+            }
+            EventCode::FleetScalingEvent => "FLEET_SCALING_EVENT",
+            EventCode::FleetStateActivating => "FLEET_STATE_ACTIVATING",
+            EventCode::FleetStateActive => "FLEET_STATE_ACTIVE",
+            EventCode::FleetStateBuilding => "FLEET_STATE_BUILDING",
+            EventCode::FleetStateDownloading => "FLEET_STATE_DOWNLOADING",
+            EventCode::FleetStateError => "FLEET_STATE_ERROR",
+            EventCode::FleetStateValidating => "FLEET_STATE_VALIDATING",
+            EventCode::FleetValidationExecutableRuntimeFailure => {
+                "FLEET_VALIDATION_EXECUTABLE_RUNTIME_FAILURE"
+            }
+            EventCode::FleetValidationLaunchPathNotFound => {
+                "FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND"
+            }
+            EventCode::FleetValidationTimedOut => "FLEET_VALIDATION_TIMED_OUT",
+            EventCode::GameSessionActivationTimeout => "GAME_SESSION_ACTIVATION_TIMEOUT",
+            EventCode::GenericEvent => "GENERIC_EVENT",
+            EventCode::ServerProcessCrashed => "SERVER_PROCESS_CRASHED",
+            EventCode::ServerProcessForceTerminated => "SERVER_PROCESS_FORCE_TERMINATED",
+            EventCode::ServerProcessInvalidPath => "SERVER_PROCESS_INVALID_PATH",
+            EventCode::ServerProcessProcessExitTimeout => "SERVER_PROCESS_PROCESS_EXIT_TIMEOUT",
+            EventCode::ServerProcessProcessReadyTimeout => "SERVER_PROCESS_PROCESS_READY_TIMEOUT",
+            EventCode::ServerProcessSdkInitializationTimeout => {
+                "SERVER_PROCESS_SDK_INITIALIZATION_TIMEOUT"
+            }
+            EventCode::ServerProcessTerminatedUnhealthy => "SERVER_PROCESS_TERMINATED_UNHEALTHY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FLEET_ACTIVATION_FAILED" => Ok(EventCode::FleetActivationFailed),
+            "FLEET_ACTIVATION_FAILED_NO_INSTANCES" => {
+                Ok(EventCode::FleetActivationFailedNoInstances)
+            }
+            "FLEET_BINARY_DOWNLOAD_FAILED" => Ok(EventCode::FleetBinaryDownloadFailed),
+            "FLEET_CREATED" => Ok(EventCode::FleetCreated),
+            "FLEET_CREATION_EXTRACTING_BUILD" => Ok(EventCode::FleetCreationExtractingBuild),
+            "FLEET_CREATION_RUNNING_INSTALLER" => Ok(EventCode::FleetCreationRunningInstaller),
+            "FLEET_CREATION_VALIDATING_RUNTIME_CONFIG" => {
+                Ok(EventCode::FleetCreationValidatingRuntimeConfig)
+            }
+            "FLEET_DELETED" => Ok(EventCode::FleetDeleted),
+            "FLEET_INITIALIZATION_FAILED" => Ok(EventCode::FleetInitializationFailed),
+            "FLEET_NEW_GAME_SESSION_PROTECTION_POLICY_UPDATED" => {
+                Ok(EventCode::FleetNewGameSessionProtectionPolicyUpdated)
+            }
+            "FLEET_SCALING_EVENT" => Ok(EventCode::FleetScalingEvent),
+            "FLEET_STATE_ACTIVATING" => Ok(EventCode::FleetStateActivating),
+            "FLEET_STATE_ACTIVE" => Ok(EventCode::FleetStateActive),
+            "FLEET_STATE_BUILDING" => Ok(EventCode::FleetStateBuilding),
+            "FLEET_STATE_DOWNLOADING" => Ok(EventCode::FleetStateDownloading),
+            "FLEET_STATE_ERROR" => Ok(EventCode::FleetStateError),
+            "FLEET_STATE_VALIDATING" => Ok(EventCode::FleetStateValidating),
+            "FLEET_VALIDATION_EXECUTABLE_RUNTIME_FAILURE" => {
+                Ok(EventCode::FleetValidationExecutableRuntimeFailure)
+            }
+            "FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND" => {
+                Ok(EventCode::FleetValidationLaunchPathNotFound)
+            }
+            "FLEET_VALIDATION_TIMED_OUT" => Ok(EventCode::FleetValidationTimedOut),
+            "GAME_SESSION_ACTIVATION_TIMEOUT" => Ok(EventCode::GameSessionActivationTimeout),
+            "GENERIC_EVENT" => Ok(EventCode::GenericEvent),
+            "SERVER_PROCESS_CRASHED" => Ok(EventCode::ServerProcessCrashed),
+            "SERVER_PROCESS_FORCE_TERMINATED" => Ok(EventCode::ServerProcessForceTerminated),
+            "SERVER_PROCESS_INVALID_PATH" => Ok(EventCode::ServerProcessInvalidPath),
+            "SERVER_PROCESS_PROCESS_EXIT_TIMEOUT" => Ok(EventCode::ServerProcessProcessExitTimeout),
+            "SERVER_PROCESS_PROCESS_READY_TIMEOUT" => {
+                Ok(EventCode::ServerProcessProcessReadyTimeout)
+            }
+            "SERVER_PROCESS_SDK_INITIALIZATION_TIMEOUT" => {
+                Ok(EventCode::ServerProcessSdkInitializationTimeout)
+            }
+            "SERVER_PROCESS_TERMINATED_UNHEALTHY" => {
+                Ok(EventCode::ServerProcessTerminatedUnhealthy)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>General properties describing a fleet.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul>"]
@@ -1233,6 +1602,62 @@ pub struct FleetCapacity {
     #[serde(rename="InstanceType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FleetStatus {
+    Activating,
+    Active,
+    Building,
+    Deleting,
+    Downloading,
+    Error,
+    New,
+    Terminated,
+    Validating,
+}
+
+impl Into<String> for FleetStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FleetStatus {
+    fn into(self) -> &'static str {
+        match self {
+            FleetStatus::Activating => "ACTIVATING",
+            FleetStatus::Active => "ACTIVE",
+            FleetStatus::Building => "BUILDING",
+            FleetStatus::Deleting => "DELETING",
+            FleetStatus::Downloading => "DOWNLOADING",
+            FleetStatus::Error => "ERROR",
+            FleetStatus::New => "NEW",
+            FleetStatus::Terminated => "TERMINATED",
+            FleetStatus::Validating => "VALIDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FleetStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVATING" => Ok(FleetStatus::Activating),
+            "ACTIVE" => Ok(FleetStatus::Active),
+            "BUILDING" => Ok(FleetStatus::Building),
+            "DELETING" => Ok(FleetStatus::Deleting),
+            "DOWNLOADING" => Ok(FleetStatus::Downloading),
+            "ERROR" => Ok(FleetStatus::Error),
+            "NEW" => Ok(FleetStatus::New),
+            "TERMINATED" => Ok(FleetStatus::Terminated),
+            "VALIDATING" => Ok(FleetStatus::Validating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Current status of fleet utilization, including the number of game and player sessions being hosted.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul>"]
@@ -1435,6 +1860,47 @@ pub struct GameSessionPlacement {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GameSessionPlacementState {
+    Cancelled,
+    Fulfilled,
+    Pending,
+    TimedOut,
+}
+
+impl Into<String> for GameSessionPlacementState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GameSessionPlacementState {
+    fn into(self) -> &'static str {
+        match self {
+            GameSessionPlacementState::Cancelled => "CANCELLED",
+            GameSessionPlacementState::Fulfilled => "FULFILLED",
+            GameSessionPlacementState::Pending => "PENDING",
+            GameSessionPlacementState::TimedOut => "TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GameSessionPlacementState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(GameSessionPlacementState::Cancelled),
+            "FULFILLED" => Ok(GameSessionPlacementState::Fulfilled),
+            "PENDING" => Ok(GameSessionPlacementState::Pending),
+            "TIMED_OUT" => Ok(GameSessionPlacementState::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Configuration of a queue that is used to process game session placement requests. The queue configuration identifies several game features:</p> <ul> <li> <p>The destinations where a new game session can potentially be hosted. Amazon GameLift tries these destinations in an order based on either the queue's default order or player latency information, if provided in a placement request. With latency information, Amazon GameLift can place game sessions where the majority of players are reporting the lowest possible latency. </p> </li> <li> <p>The length of time that placement requests can wait in the queue before timing out. </p> </li> <li> <p>A set of optional latency policies that protect individual players from high latencies, preventing game sessions from being placed where any individual player is reporting latency higher than a policy's maximum.</p> </li> </ul> <p>Queue-related operations include:</p> <ul> <li> <p> <a>CreateGameSessionQueue</a> </p> </li> <li> <p> <a>DescribeGameSessionQueues</a> </p> </li> <li> <p> <a>UpdateGameSessionQueue</a> </p> </li> <li> <p> <a>DeleteGameSessionQueue</a> </p> </li> </ul>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct GameSessionQueue {
@@ -1467,6 +1933,50 @@ pub struct GameSessionQueueDestination {
     #[serde(rename="DestinationArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub destination_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GameSessionStatus {
+    Activating,
+    Active,
+    Error,
+    Terminated,
+    Terminating,
+}
+
+impl Into<String> for GameSessionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GameSessionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            GameSessionStatus::Activating => "ACTIVATING",
+            GameSessionStatus::Active => "ACTIVE",
+            GameSessionStatus::Error => "ERROR",
+            GameSessionStatus::Terminated => "TERMINATED",
+            GameSessionStatus::Terminating => "TERMINATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GameSessionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVATING" => Ok(GameSessionStatus::Activating),
+            "ACTIVE" => Ok(GameSessionStatus::Active),
+            "ERROR" => Ok(GameSessionStatus::Error),
+            "TERMINATED" => Ok(GameSessionStatus::Terminated),
+            "TERMINATING" => Ok(GameSessionStatus::Terminating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
@@ -1577,6 +2087,44 @@ pub struct InstanceCredentials {
     pub user_name: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceStatus {
+    Active,
+    Pending,
+    Terminating,
+}
+
+impl Into<String> for InstanceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceStatus::Active => "ACTIVE",
+            InstanceStatus::Pending => "PENDING",
+            InstanceStatus::Terminating => "TERMINATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(InstanceStatus::Active),
+            "PENDING" => Ok(InstanceStatus::Pending),
+            "TERMINATING" => Ok(InstanceStatus::Terminating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A range of IP addresses and port settings that allow inbound traffic to connect to server processes on Amazon GameLift. Each game session hosted on a fleet is assigned a unique combination of IP address and port number, which must fall into the fleet's allowed ranges. This combination is included in the <a>GameSession</a> object. </p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IpPermission {
@@ -1592,6 +2140,41 @@ pub struct IpPermission {
     #[doc="<p>Ending value for a range of allowed port numbers. Port numbers are end-inclusive. This value must be higher than <code>FromPort</code>.</p>"]
     #[serde(rename="ToPort")]
     pub to_port: i64,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IpProtocol {
+    Tcp,
+    Udp,
+}
+
+impl Into<String> for IpProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IpProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            IpProtocol::Tcp => "TCP",
+            IpProtocol::Udp => "UDP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IpProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "TCP" => Ok(IpProtocol::Tcp),
+            "UDP" => Ok(IpProtocol::Udp),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
@@ -1758,6 +2341,59 @@ pub struct MatchmakingConfiguration {
     pub rule_set_name: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MatchmakingConfigurationStatus {
+    Cancelled,
+    Completed,
+    Failed,
+    Placing,
+    Queued,
+    RequiresAcceptance,
+    Searching,
+    TimedOut,
+}
+
+impl Into<String> for MatchmakingConfigurationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MatchmakingConfigurationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            MatchmakingConfigurationStatus::Cancelled => "CANCELLED",
+            MatchmakingConfigurationStatus::Completed => "COMPLETED",
+            MatchmakingConfigurationStatus::Failed => "FAILED",
+            MatchmakingConfigurationStatus::Placing => "PLACING",
+            MatchmakingConfigurationStatus::Queued => "QUEUED",
+            MatchmakingConfigurationStatus::RequiresAcceptance => "REQUIRES_ACCEPTANCE",
+            MatchmakingConfigurationStatus::Searching => "SEARCHING",
+            MatchmakingConfigurationStatus::TimedOut => "TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MatchmakingConfigurationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(MatchmakingConfigurationStatus::Cancelled),
+            "COMPLETED" => Ok(MatchmakingConfigurationStatus::Completed),
+            "FAILED" => Ok(MatchmakingConfigurationStatus::Failed),
+            "PLACING" => Ok(MatchmakingConfigurationStatus::Placing),
+            "QUEUED" => Ok(MatchmakingConfigurationStatus::Queued),
+            "REQUIRES_ACCEPTANCE" => Ok(MatchmakingConfigurationStatus::RequiresAcceptance),
+            "SEARCHING" => Ok(MatchmakingConfigurationStatus::Searching),
+            "TIMED_OUT" => Ok(MatchmakingConfigurationStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Set of rule statements, used with FlexMatch, that determine how to build a certain kind of player match. Each rule set describes a type of group to be created and defines the parameters for acceptable player matches. Rule sets are used in <a>MatchmakingConfiguration</a> objects.</p> <p>A rule set may define the following elements for a match. For detailed information and examples showing how to construct a rule set, see <a href=\"http://docs.aws.amazon.com/gamelift/latest/developerguide/match-rules.html\">Create Matchmaking Rules for Your Game</a>. </p> <ul> <li> <p>Teams -- Required. A rule set must define one or multiple teams for the match and set minimum and maximum team sizes. For example, a rule set might describe a 4x4 match that requires all eight slots to be filled. </p> </li> <li> <p>Player attributes -- Optional. These attributes specify a set of player characteristics to evaluate when looking for a match. Matchmaking requests that use a rule set with player attributes must provide the corresponding attribute values. For example, an attribute might specify a player's skill or level.</p> </li> <li> <p>Rules -- Optional. Rules define how to evaluate potential players for a match based on player attributes. A rule might specify minimum requirements for individual players--such as each player must meet a certain skill level, or may describe an entire group--such as all teams must be evenly matched or have at least one player in a certain role. </p> </li> <li> <p>Expansions -- Optional. Expansions allow you to relax the rules after a period of time if no acceptable matches are found. This feature lets you balance getting players into games in a reasonable amount of time instead of making them wait indefinitely for the best possible match. For example, you might use an expansion to increase the maximum skill variance between players after 30 seconds.</p> </li> </ul>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct MatchmakingRuleSet {
@@ -1809,6 +2445,103 @@ pub struct MatchmakingTicket {
     #[serde(rename="TicketId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub ticket_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricName {
+    ActivatingGameSessions,
+    ActiveGameSessions,
+    ActiveInstances,
+    AvailableGameSessions,
+    AvailablePlayerSessions,
+    CurrentPlayerSessions,
+    IdleInstances,
+    PercentAvailableGameSessions,
+    PercentIdleInstances,
+    QueueDepth,
+    WaitTime,
+}
+
+impl Into<String> for MetricName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricName {
+    fn into(self) -> &'static str {
+        match self {
+            MetricName::ActivatingGameSessions => "ActivatingGameSessions",
+            MetricName::ActiveGameSessions => "ActiveGameSessions",
+            MetricName::ActiveInstances => "ActiveInstances",
+            MetricName::AvailableGameSessions => "AvailableGameSessions",
+            MetricName::AvailablePlayerSessions => "AvailablePlayerSessions",
+            MetricName::CurrentPlayerSessions => "CurrentPlayerSessions",
+            MetricName::IdleInstances => "IdleInstances",
+            MetricName::PercentAvailableGameSessions => "PercentAvailableGameSessions",
+            MetricName::PercentIdleInstances => "PercentIdleInstances",
+            MetricName::QueueDepth => "QueueDepth",
+            MetricName::WaitTime => "WaitTime",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivatingGameSessions" => Ok(MetricName::ActivatingGameSessions),
+            "ActiveGameSessions" => Ok(MetricName::ActiveGameSessions),
+            "ActiveInstances" => Ok(MetricName::ActiveInstances),
+            "AvailableGameSessions" => Ok(MetricName::AvailableGameSessions),
+            "AvailablePlayerSessions" => Ok(MetricName::AvailablePlayerSessions),
+            "CurrentPlayerSessions" => Ok(MetricName::CurrentPlayerSessions),
+            "IdleInstances" => Ok(MetricName::IdleInstances),
+            "PercentAvailableGameSessions" => Ok(MetricName::PercentAvailableGameSessions),
+            "PercentIdleInstances" => Ok(MetricName::PercentIdleInstances),
+            "QueueDepth" => Ok(MetricName::QueueDepth),
+            "WaitTime" => Ok(MetricName::WaitTime),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperatingSystem {
+    AmazonLinux,
+    Windows2012,
+}
+
+impl Into<String> for OperatingSystem {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperatingSystem {
+    fn into(self) -> &'static str {
+        match self {
+            OperatingSystem::AmazonLinux => "AMAZON_LINUX",
+            OperatingSystem::Windows2012 => "WINDOWS_2012",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperatingSystem {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AMAZON_LINUX" => Ok(OperatingSystem::AmazonLinux),
+            "WINDOWS_2012" => Ok(OperatingSystem::Windows2012),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about a player session that was created as part of a <a>StartGameSessionPlacement</a> request. This object contains only the player ID and player session ID. To retrieve full details on a player session, call <a>DescribePlayerSessions</a> with the player session ID.</p> <p>Player-session-related operations include:</p> <ul> <li> <p> <a>CreatePlayerSession</a> </p> </li> <li> <p> <a>CreatePlayerSessions</a> </p> </li> <li> <p> <a>DescribePlayerSessions</a> </p> </li> <li> <p>Game session placements</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul> </li> </ul>"]
@@ -1920,6 +2653,117 @@ pub struct PlayerSession {
     pub termination_time: Option<f64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlayerSessionCreationPolicy {
+    AcceptAll,
+    DenyAll,
+}
+
+impl Into<String> for PlayerSessionCreationPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlayerSessionCreationPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            PlayerSessionCreationPolicy::AcceptAll => "ACCEPT_ALL",
+            PlayerSessionCreationPolicy::DenyAll => "DENY_ALL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlayerSessionCreationPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCEPT_ALL" => Ok(PlayerSessionCreationPolicy::AcceptAll),
+            "DENY_ALL" => Ok(PlayerSessionCreationPolicy::DenyAll),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlayerSessionStatus {
+    Active,
+    Completed,
+    Reserved,
+    Timedout,
+}
+
+impl Into<String> for PlayerSessionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlayerSessionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PlayerSessionStatus::Active => "ACTIVE",
+            PlayerSessionStatus::Completed => "COMPLETED",
+            PlayerSessionStatus::Reserved => "RESERVED",
+            PlayerSessionStatus::Timedout => "TIMEDOUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlayerSessionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(PlayerSessionStatus::Active),
+            "COMPLETED" => Ok(PlayerSessionStatus::Completed),
+            "RESERVED" => Ok(PlayerSessionStatus::Reserved),
+            "TIMEDOUT" => Ok(PlayerSessionStatus::Timedout),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProtectionPolicy {
+    FullProtection,
+    NoProtection,
+}
+
+impl Into<String> for ProtectionPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProtectionPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            ProtectionPolicy::FullProtection => "FullProtection",
+            ProtectionPolicy::NoProtection => "NoProtection",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProtectionPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FullProtection" => Ok(ProtectionPolicy::FullProtection),
+            "NoProtection" => Ok(ProtectionPolicy::NoProtection),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input for a request action.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutScalingPolicyInput {
@@ -2026,6 +2870,41 @@ pub struct RoutingStrategy {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RoutingStrategyType {
+    Simple,
+    Terminal,
+}
+
+impl Into<String> for RoutingStrategyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RoutingStrategyType {
+    fn into(self) -> &'static str {
+        match self {
+            RoutingStrategyType::Simple => "SIMPLE",
+            RoutingStrategyType::Terminal => "TERMINAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RoutingStrategyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SIMPLE" => Ok(RoutingStrategyType::Simple),
+            "TERMINAL" => Ok(RoutingStrategyType::Terminal),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A collection of server process configurations that describe what processes to run on each instance in a fleet. All fleets must have a run-time configuration. Each instance in the fleet launches the server processes specified in the run-time configuration and launches new ones as existing processes end. Each instance regularly checks for an updated run-time configuration and follows the new instructions. </p> <p>The run-time configuration enables the instances in a fleet to run multiple processes simultaneously. Potential scenarios are as follows: (1) Run multiple processes of a single game server executable to maximize usage of your hosting resources. (2) Run one or more processes of different build executables, such as your game server executable and a related program, or two or more different versions of a game server. (3) Run multiple processes of a single game server but with different launch parameters, for example to run one process on each instance in debug mode.</p> <p>A Amazon GameLift instance is limited to 50 processes running simultaneously. A run-time configuration must specify fewer than this limit. To calculate the total number of processes specified in a run-time configuration, add the values of the <code>ConcurrentExecutions</code> parameter for each <code> <a>ServerProcess</a> </code> object in the run-time configuration.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RuntimeConfiguration {
@@ -2058,6 +2937,44 @@ pub struct S3Location {
     #[serde(rename="RoleArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScalingAdjustmentType {
+    ChangeInCapacity,
+    ExactCapacity,
+    PercentChangeInCapacity,
+}
+
+impl Into<String> for ScalingAdjustmentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScalingAdjustmentType {
+    fn into(self) -> &'static str {
+        match self {
+            ScalingAdjustmentType::ChangeInCapacity => "ChangeInCapacity",
+            ScalingAdjustmentType::ExactCapacity => "ExactCapacity",
+            ScalingAdjustmentType::PercentChangeInCapacity => "PercentChangeInCapacity",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScalingAdjustmentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ChangeInCapacity" => Ok(ScalingAdjustmentType::ChangeInCapacity),
+            "ExactCapacity" => Ok(ScalingAdjustmentType::ExactCapacity),
+            "PercentChangeInCapacity" => Ok(ScalingAdjustmentType::PercentChangeInCapacity),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Rule that controls how a fleet is scaled. Scaling policies are uniquely identified by the combination of name and fleet ID.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul>"]
@@ -2099,6 +3016,56 @@ pub struct ScalingPolicy {
     #[serde(rename="Threshold")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub threshold: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScalingStatusType {
+    Active,
+    Deleted,
+    DeleteRequested,
+    Deleting,
+    Error,
+    UpdateRequested,
+    Updating,
+}
+
+impl Into<String> for ScalingStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScalingStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            ScalingStatusType::Active => "ACTIVE",
+            ScalingStatusType::Deleted => "DELETED",
+            ScalingStatusType::DeleteRequested => "DELETE_REQUESTED",
+            ScalingStatusType::Deleting => "DELETING",
+            ScalingStatusType::Error => "ERROR",
+            ScalingStatusType::UpdateRequested => "UPDATE_REQUESTED",
+            ScalingStatusType::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScalingStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(ScalingStatusType::Active),
+            "DELETED" => Ok(ScalingStatusType::Deleted),
+            "DELETE_REQUESTED" => Ok(ScalingStatusType::DeleteRequested),
+            "DELETING" => Ok(ScalingStatusType::Deleting),
+            "ERROR" => Ok(ScalingStatusType::Error),
+            "UPDATE_REQUESTED" => Ok(ScalingStatusType::UpdateRequested),
+            "UPDATING" => Ok(ScalingStatusType::Updating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
@@ -8731,7 +9698,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AcceptMatchOutput>(String::from_utf8_lossy(&body)
@@ -8763,7 +9730,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateAliasOutput>(String::from_utf8_lossy(&body)
@@ -8795,7 +9762,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateBuildOutput>(String::from_utf8_lossy(&body)
@@ -8827,7 +9794,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateFleetOutput>(String::from_utf8_lossy(&body)
@@ -8859,7 +9826,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateGameSessionOutput>(String::from_utf8_lossy(&body)
@@ -8892,7 +9859,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateGameSessionQueueOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8923,7 +9890,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateMatchmakingConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8955,7 +9922,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateMatchmakingRuleSetOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8986,7 +9953,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreatePlayerSessionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9016,7 +9983,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreatePlayerSessionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9044,7 +10011,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9068,7 +10035,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9092,7 +10059,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9119,7 +10086,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteGameSessionQueueOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9150,7 +10117,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteMatchmakingConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9181,7 +10148,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9207,7 +10174,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAliasOutput>(String::from_utf8_lossy(&body)
@@ -9239,7 +10206,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeBuildOutput>(String::from_utf8_lossy(&body)
@@ -9272,7 +10239,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEC2InstanceLimitsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9304,7 +10271,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeFleetAttributesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9336,7 +10303,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeFleetCapacityOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9366,7 +10333,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeFleetEventsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9397,7 +10364,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeFleetPortSettingsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9429,7 +10396,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeFleetUtilizationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9461,7 +10428,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeGameSessionDetailsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9493,7 +10460,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeGameSessionPlacementOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9525,7 +10492,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeGameSessionQueuesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9556,7 +10523,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeGameSessionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9586,7 +10553,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeInstancesOutput>(String::from_utf8_lossy(&body)
@@ -9618,7 +10585,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMatchmakingOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9649,7 +10616,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMatchmakingConfigurationsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9680,7 +10647,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMatchmakingRuleSetsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9712,7 +10679,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribePlayerSessionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9743,7 +10710,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeRuntimeConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9775,7 +10742,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeScalingPoliciesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9807,7 +10774,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetGameSessionLogUrlOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9837,7 +10804,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetInstanceAccessOutput>(String::from_utf8_lossy(&body)
@@ -9869,7 +10836,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAliasesOutput>(String::from_utf8_lossy(&body)
@@ -9899,7 +10866,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListBuildsOutput>(String::from_utf8_lossy(&body)
@@ -9929,7 +10896,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListFleetsOutput>(String::from_utf8_lossy(&body)
@@ -9961,7 +10928,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutScalingPolicyOutput>(String::from_utf8_lossy(&body)
@@ -9994,7 +10961,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RequestUploadCredentialsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10025,7 +10992,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ResolveAliasOutput>(String::from_utf8_lossy(&body)
@@ -10057,7 +11024,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SearchGameSessionsOutput>(String::from_utf8_lossy(&body)
@@ -10090,7 +11057,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartGameSessionPlacementOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10121,7 +11088,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartMatchmakingOutput>(String::from_utf8_lossy(&body)
@@ -10154,7 +11121,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopGameSessionPlacementOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10185,7 +11152,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopMatchmakingOutput>(String::from_utf8_lossy(&body)
@@ -10217,7 +11184,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateAliasOutput>(String::from_utf8_lossy(&body)
@@ -10249,7 +11216,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateBuildOutput>(String::from_utf8_lossy(&body)
@@ -10282,7 +11249,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateFleetAttributesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10312,7 +11279,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateFleetCapacityOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10343,7 +11310,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateFleetPortSettingsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10374,7 +11341,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateGameSessionOutput>(String::from_utf8_lossy(&body)
@@ -10407,7 +11374,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateGameSessionQueueOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10438,7 +11405,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateMatchmakingConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10470,7 +11437,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateRuntimeConfigurationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10502,7 +11469,7 @@ impl<P, D> GameLift for GameLiftClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ValidateMatchmakingRuleSetOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -52,6 +48,41 @@ pub struct AbortVaultLockInput {
     #[doc="<p>The name of the vault.</p>"]
     #[serde(rename="vaultName")]
     pub vault_name: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionCode {
+    ArchiveRetrieval,
+    InventoryRetrieval,
+}
+
+impl Into<String> for ActionCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionCode {
+    fn into(self) -> &'static str {
+        match self {
+            ActionCode::ArchiveRetrieval => "ArchiveRetrieval",
+            ActionCode::InventoryRetrieval => "InventoryRetrieval",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ArchiveRetrieval" => Ok(ActionCode::ArchiveRetrieval),
+            "InventoryRetrieval" => Ok(ActionCode::InventoryRetrieval),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The input values for <code>AddTagsToVault</code>.</p>"]
@@ -926,6 +957,44 @@ pub struct SetVaultNotificationsInput {
     #[serde(rename="vaultNotificationConfig")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vault_notification_config: Option<VaultNotificationConfig>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusCode {
+    Failed,
+    InProgress,
+    Succeeded,
+}
+
+impl Into<String> for StatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            StatusCode::Failed => "Failed",
+            StatusCode::InProgress => "InProgress",
+            StatusCode::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(StatusCode::Failed),
+            "InProgress" => Ok(StatusCode::InProgress),
+            "Succeeded" => Ok(StatusCode::Succeeded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides options to add an archive to a vault.</p>"]
@@ -4463,7 +4532,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4496,7 +4565,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4532,7 +4601,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4575,7 +4644,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4634,7 +4703,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4669,7 +4738,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4717,7 +4786,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4750,7 +4819,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4785,7 +4854,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4821,7 +4890,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4858,7 +4927,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4904,7 +4973,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4950,7 +5019,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5000,7 +5069,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut result = GetJobOutputOutput::default();
 
@@ -5030,7 +5099,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
                     let value = content_type.to_owned();
                     result.content_type = Some(value)
                 };
-                result.status = Some(StatusCode::to_u16(&response.status) as i64);
+                result.status = Some(::hyper::status::StatusCode::to_u16(&response.status) as i64);
                 Ok(result)
             }
             _ => {
@@ -5062,7 +5131,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5108,7 +5177,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5155,7 +5224,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5202,7 +5271,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5264,7 +5333,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5320,7 +5389,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5380,7 +5449,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5433,7 +5502,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5485,7 +5554,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5531,7 +5600,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5579,7 +5648,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5628,7 +5697,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5674,7 +5743,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5728,7 +5797,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5763,7 +5832,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5799,7 +5868,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5835,7 +5904,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5883,7 +5952,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5953,7 +6022,7 @@ impl<P, D> Glacier for GlacierClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/glue/src/generated.rs
+++ b/rusoto/services/glue/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -346,6 +342,103 @@ pub struct ConnectionInput {
     pub physical_connection_requirements: Option<PhysicalConnectionRequirements>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConnectionPropertyKey {
+    ConfigFiles,
+    Host,
+    InstanceId,
+    JdbcConnectionUrl,
+    JdbcDriverClassName,
+    JdbcDriverJarUri,
+    JdbcEngine,
+    JdbcEngineVersion,
+    Password,
+    Port,
+    Username,
+}
+
+impl Into<String> for ConnectionPropertyKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConnectionPropertyKey {
+    fn into(self) -> &'static str {
+        match self {
+            ConnectionPropertyKey::ConfigFiles => "CONFIG_FILES",
+            ConnectionPropertyKey::Host => "HOST",
+            ConnectionPropertyKey::InstanceId => "INSTANCE_ID",
+            ConnectionPropertyKey::JdbcConnectionUrl => "JDBC_CONNECTION_URL",
+            ConnectionPropertyKey::JdbcDriverClassName => "JDBC_DRIVER_CLASS_NAME",
+            ConnectionPropertyKey::JdbcDriverJarUri => "JDBC_DRIVER_JAR_URI",
+            ConnectionPropertyKey::JdbcEngine => "JDBC_ENGINE",
+            ConnectionPropertyKey::JdbcEngineVersion => "JDBC_ENGINE_VERSION",
+            ConnectionPropertyKey::Password => "PASSWORD",
+            ConnectionPropertyKey::Port => "PORT",
+            ConnectionPropertyKey::Username => "USERNAME",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConnectionPropertyKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONFIG_FILES" => Ok(ConnectionPropertyKey::ConfigFiles),
+            "HOST" => Ok(ConnectionPropertyKey::Host),
+            "INSTANCE_ID" => Ok(ConnectionPropertyKey::InstanceId),
+            "JDBC_CONNECTION_URL" => Ok(ConnectionPropertyKey::JdbcConnectionUrl),
+            "JDBC_DRIVER_CLASS_NAME" => Ok(ConnectionPropertyKey::JdbcDriverClassName),
+            "JDBC_DRIVER_JAR_URI" => Ok(ConnectionPropertyKey::JdbcDriverJarUri),
+            "JDBC_ENGINE" => Ok(ConnectionPropertyKey::JdbcEngine),
+            "JDBC_ENGINE_VERSION" => Ok(ConnectionPropertyKey::JdbcEngineVersion),
+            "PASSWORD" => Ok(ConnectionPropertyKey::Password),
+            "PORT" => Ok(ConnectionPropertyKey::Port),
+            "USERNAME" => Ok(ConnectionPropertyKey::Username),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConnectionType {
+    Jdbc,
+    Sftp,
+}
+
+impl Into<String> for ConnectionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConnectionType {
+    fn into(self) -> &'static str {
+        match self {
+            ConnectionType::Jdbc => "JDBC",
+            ConnectionType::Sftp => "SFTP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConnectionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "JDBC" => Ok(ConnectionType::Jdbc),
+            "SFTP" => Ok(ConnectionType::Sftp),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies the connections used by a job.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConnectionsList {
@@ -455,6 +548,44 @@ pub struct CrawlerMetrics {
     #[serde(rename="TimeLeftSeconds")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub time_left_seconds: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CrawlerState {
+    Ready,
+    Running,
+    Stopping,
+}
+
+impl Into<String> for CrawlerState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CrawlerState {
+    fn into(self) -> &'static str {
+        match self {
+            CrawlerState::Ready => "READY",
+            CrawlerState::Running => "RUNNING",
+            CrawlerState::Stopping => "STOPPING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CrawlerState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "READY" => Ok(CrawlerState::Ready),
+            "RUNNING" => Ok(CrawlerState::Running),
+            "STOPPING" => Ok(CrawlerState::Stopping),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Specifies crawler targets.</p>"]
@@ -852,6 +983,44 @@ pub struct DatabaseInput {
     #[serde(rename="Parameters")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<::std::collections::HashMap<String, String>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeleteBehavior {
+    DeleteFromDatabase,
+    DeprecateInDatabase,
+    Log,
+}
+
+impl Into<String> for DeleteBehavior {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeleteBehavior {
+    fn into(self) -> &'static str {
+        match self {
+            DeleteBehavior::DeleteFromDatabase => "DELETE_FROM_DATABASE",
+            DeleteBehavior::DeprecateInDatabase => "DEPRECATE_IN_DATABASE",
+            DeleteBehavior::Log => "LOG",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeleteBehavior {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETE_FROM_DATABASE" => Ok(DeleteBehavior::DeleteFromDatabase),
+            "DEPRECATE_IN_DATABASE" => Ok(DeleteBehavior::DeprecateInDatabase),
+            "LOG" => Ok(DeleteBehavior::Log),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1994,6 +2163,53 @@ pub struct JobRun {
     pub trigger_name: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobRunState {
+    Failed,
+    Running,
+    Starting,
+    Stopped,
+    Stopping,
+    Succeeded,
+}
+
+impl Into<String> for JobRunState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobRunState {
+    fn into(self) -> &'static str {
+        match self {
+            JobRunState::Failed => "FAILED",
+            JobRunState::Running => "RUNNING",
+            JobRunState::Starting => "STARTING",
+            JobRunState::Stopped => "STOPPED",
+            JobRunState::Stopping => "STOPPING",
+            JobRunState::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobRunState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(JobRunState::Failed),
+            "RUNNING" => Ok(JobRunState::Running),
+            "STARTING" => Ok(JobRunState::Starting),
+            "STOPPED" => Ok(JobRunState::Stopped),
+            "STOPPING" => Ok(JobRunState::Stopping),
+            "SUCCEEDED" => Ok(JobRunState::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies information used to update an existing job.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct JobUpdate {
@@ -2064,6 +2280,44 @@ pub struct LastCrawlInfo {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LastCrawlStatus {
+    Cancelled,
+    Failed,
+    Succeeded,
+}
+
+impl Into<String> for LastCrawlStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LastCrawlStatus {
+    fn into(self) -> &'static str {
+        match self {
+            LastCrawlStatus::Cancelled => "CANCELLED",
+            LastCrawlStatus::Failed => "FAILED",
+            LastCrawlStatus::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LastCrawlStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(LastCrawlStatus::Cancelled),
+            "FAILED" => Ok(LastCrawlStatus::Failed),
+            "SUCCEEDED" => Ok(LastCrawlStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The location of resources.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct Location {
@@ -2075,6 +2329,70 @@ pub struct Location {
     #[serde(rename="S3")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub s3: Option<Vec<CodeGenNodeArg>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Logical {
+    And,
+}
+
+impl Into<String> for Logical {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Logical {
+    fn into(self) -> &'static str {
+        match self {
+            Logical::And => "AND",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Logical {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AND" => Ok(Logical::And),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LogicalOperator {
+    Equals,
+}
+
+impl Into<String> for LogicalOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LogicalOperator {
+    fn into(self) -> &'static str {
+        match self {
+            LogicalOperator::Equals => "EQUALS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LogicalOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EQUALS" => Ok(LogicalOperator::Equals),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Defines a mapping.</p>"]
@@ -2241,6 +2559,44 @@ pub struct Predicate {
     pub logical: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PrincipalType {
+    Group,
+    Role,
+    User,
+}
+
+impl Into<String> for PrincipalType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PrincipalType {
+    fn into(self) -> &'static str {
+        match self {
+            PrincipalType::Group => "GROUP",
+            PrincipalType::Role => "ROLE",
+            PrincipalType::User => "USER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PrincipalType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GROUP" => Ok(PrincipalType::Group),
+            "ROLE" => Ok(PrincipalType::Role),
+            "USER" => Ok(PrincipalType::User),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ResetJobBookmarkRequest {
     #[doc="<p>The name of the job in question.</p>"]
@@ -2254,6 +2610,44 @@ pub struct ResetJobBookmarkResponse {
     #[serde(rename="JobBookmarkEntry")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub job_bookmark_entry: Option<JobBookmarkEntry>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceType {
+    Archive,
+    File,
+    Jar,
+}
+
+impl Into<String> for ResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceType::Archive => "ARCHIVE",
+            ResourceType::File => "FILE",
+            ResourceType::Jar => "JAR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ARCHIVE" => Ok(ResourceType::Archive),
+            "FILE" => Ok(ResourceType::File),
+            "JAR" => Ok(ResourceType::Jar),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>URIs for function resources.</p>"]
@@ -2293,6 +2687,44 @@ pub struct Schedule {
     #[serde(rename="State")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScheduleState {
+    NotScheduled,
+    Scheduled,
+    Transitioning,
+}
+
+impl Into<String> for ScheduleState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScheduleState {
+    fn into(self) -> &'static str {
+        match self {
+            ScheduleState::NotScheduled => "NOT_SCHEDULED",
+            ScheduleState::Scheduled => "SCHEDULED",
+            ScheduleState::Transitioning => "TRANSITIONING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScheduleState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NOT_SCHEDULED" => Ok(ScheduleState::NotScheduled),
+            "SCHEDULED" => Ok(ScheduleState::Scheduled),
+            "TRANSITIONING" => Ok(ScheduleState::Transitioning),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Crawler policy for update and deletion behavior.</p>"]
@@ -2683,6 +3115,97 @@ pub struct Trigger {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TriggerState {
+    Activated,
+    Activating,
+    Created,
+    Creating,
+    Deactivated,
+    Deactivating,
+    Deleting,
+    Updating,
+}
+
+impl Into<String> for TriggerState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TriggerState {
+    fn into(self) -> &'static str {
+        match self {
+            TriggerState::Activated => "ACTIVATED",
+            TriggerState::Activating => "ACTIVATING",
+            TriggerState::Created => "CREATED",
+            TriggerState::Creating => "CREATING",
+            TriggerState::Deactivated => "DEACTIVATED",
+            TriggerState::Deactivating => "DEACTIVATING",
+            TriggerState::Deleting => "DELETING",
+            TriggerState::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TriggerState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVATED" => Ok(TriggerState::Activated),
+            "ACTIVATING" => Ok(TriggerState::Activating),
+            "CREATED" => Ok(TriggerState::Created),
+            "CREATING" => Ok(TriggerState::Creating),
+            "DEACTIVATED" => Ok(TriggerState::Deactivated),
+            "DEACTIVATING" => Ok(TriggerState::Deactivating),
+            "DELETING" => Ok(TriggerState::Deleting),
+            "UPDATING" => Ok(TriggerState::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TriggerType {
+    Conditional,
+    OnDemand,
+    Scheduled,
+}
+
+impl Into<String> for TriggerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TriggerType {
+    fn into(self) -> &'static str {
+        match self {
+            TriggerType::Conditional => "CONDITIONAL",
+            TriggerType::OnDemand => "ON_DEMAND",
+            TriggerType::Scheduled => "SCHEDULED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TriggerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONDITIONAL" => Ok(TriggerType::Conditional),
+            "ON_DEMAND" => Ok(TriggerType::OnDemand),
+            "SCHEDULED" => Ok(TriggerType::Scheduled),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A structure used to provide information used to updata a trigger.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct TriggerUpdate {
@@ -2706,6 +3229,41 @@ pub struct TriggerUpdate {
     #[serde(rename="Schedule")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub schedule: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UpdateBehavior {
+    Log,
+    UpdateInDatabase,
+}
+
+impl Into<String> for UpdateBehavior {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UpdateBehavior {
+    fn into(self) -> &'static str {
+        match self {
+            UpdateBehavior::Log => "LOG",
+            UpdateBehavior::UpdateInDatabase => "UPDATE_IN_DATABASE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UpdateBehavior {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LOG" => Ok(UpdateBehavior::Log),
+            "UPDATE_IN_DATABASE" => Ok(UpdateBehavior::UpdateInDatabase),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -10549,7 +11107,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchCreatePartitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10580,7 +11138,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchDeleteConnectionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10611,7 +11169,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchDeletePartitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10641,7 +11199,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchDeleteTableResponse>(String::from_utf8_lossy(&body)
@@ -10673,7 +11231,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchGetPartitionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10703,7 +11261,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateClassifierResponse>(String::from_utf8_lossy(&body)
@@ -10735,7 +11293,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateConnectionResponse>(String::from_utf8_lossy(&body)
@@ -10767,7 +11325,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateCrawlerResponse>(String::from_utf8_lossy(&body)
@@ -10799,7 +11357,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDatabaseResponse>(String::from_utf8_lossy(&body)
@@ -10831,7 +11389,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDevEndpointResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10859,7 +11417,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateJobResponse>(String::from_utf8_lossy(&body)
@@ -10891,7 +11449,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreatePartitionResponse>(String::from_utf8_lossy(&body)
@@ -10923,7 +11481,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateScriptResponse>(String::from_utf8_lossy(&body)
@@ -10955,7 +11513,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateTableResponse>(String::from_utf8_lossy(&body)
@@ -10987,7 +11545,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateTriggerResponse>(String::from_utf8_lossy(&body)
@@ -11020,7 +11578,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateUserDefinedFunctionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -11051,7 +11609,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteClassifierResponse>(String::from_utf8_lossy(&body)
@@ -11083,7 +11641,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteConnectionResponse>(String::from_utf8_lossy(&body)
@@ -11115,7 +11673,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteCrawlerResponse>(String::from_utf8_lossy(&body)
@@ -11147,7 +11705,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteDatabaseResponse>(String::from_utf8_lossy(&body)
@@ -11179,7 +11737,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteDevEndpointResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -11207,7 +11765,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteJobResponse>(String::from_utf8_lossy(&body)
@@ -11239,7 +11797,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeletePartitionResponse>(String::from_utf8_lossy(&body)
@@ -11271,7 +11829,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteTableResponse>(String::from_utf8_lossy(&body)
@@ -11303,7 +11861,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteTriggerResponse>(String::from_utf8_lossy(&body)
@@ -11336,7 +11894,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteUserDefinedFunctionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -11368,7 +11926,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetCatalogImportStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -11398,7 +11956,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetClassifierResponse>(String::from_utf8_lossy(&body)
@@ -11430,7 +11988,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetClassifiersResponse>(String::from_utf8_lossy(&body)
@@ -11462,7 +12020,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetConnectionResponse>(String::from_utf8_lossy(&body)
@@ -11494,7 +12052,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetConnectionsResponse>(String::from_utf8_lossy(&body)
@@ -11526,7 +12084,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetCrawlerResponse>(String::from_utf8_lossy(&body)
@@ -11558,7 +12116,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetCrawlerMetricsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -11588,7 +12146,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetCrawlersResponse>(String::from_utf8_lossy(&body)
@@ -11620,7 +12178,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDatabaseResponse>(String::from_utf8_lossy(&body)
@@ -11652,7 +12210,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDatabasesResponse>(String::from_utf8_lossy(&body)
@@ -11684,7 +12242,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDataflowGraphResponse>(String::from_utf8_lossy(&body)
@@ -11716,7 +12274,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDevEndpointResponse>(String::from_utf8_lossy(&body)
@@ -11748,7 +12306,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDevEndpointsResponse>(String::from_utf8_lossy(&body)
@@ -11778,7 +12336,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetJobResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -11807,7 +12365,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetJobRunResponse>(String::from_utf8_lossy(&body)
@@ -11839,7 +12397,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetJobRunsResponse>(String::from_utf8_lossy(&body)
@@ -11869,7 +12427,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetJobsResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -11900,7 +12458,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetMappingResponse>(String::from_utf8_lossy(&body)
@@ -11932,7 +12490,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetPartitionResponse>(String::from_utf8_lossy(&body)
@@ -11964,7 +12522,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetPartitionsResponse>(String::from_utf8_lossy(&body)
@@ -11994,7 +12552,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetPlanResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -12023,7 +12581,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetTableResponse>(String::from_utf8_lossy(&body)
@@ -12055,7 +12613,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetTableVersionsResponse>(String::from_utf8_lossy(&body)
@@ -12085,7 +12643,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetTablesResponse>(String::from_utf8_lossy(&body)
@@ -12117,7 +12675,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetTriggerResponse>(String::from_utf8_lossy(&body)
@@ -12149,7 +12707,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetTriggersResponse>(String::from_utf8_lossy(&body)
@@ -12182,7 +12740,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetUserDefinedFunctionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -12213,7 +12771,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetUserDefinedFunctionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -12244,7 +12802,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ImportCatalogToGlueResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -12274,7 +12832,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ResetJobBookmarkResponse>(String::from_utf8_lossy(&body)
@@ -12306,7 +12864,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartCrawlerResponse>(String::from_utf8_lossy(&body)
@@ -12339,7 +12897,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartCrawlerScheduleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -12369,7 +12927,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartJobRunResponse>(String::from_utf8_lossy(&body)
@@ -12401,7 +12959,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartTriggerResponse>(String::from_utf8_lossy(&body)
@@ -12433,7 +12991,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopCrawlerResponse>(String::from_utf8_lossy(&body)
@@ -12465,7 +13023,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopCrawlerScheduleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -12495,7 +13053,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopTriggerResponse>(String::from_utf8_lossy(&body)
@@ -12527,7 +13085,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateClassifierResponse>(String::from_utf8_lossy(&body)
@@ -12559,7 +13117,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateConnectionResponse>(String::from_utf8_lossy(&body)
@@ -12591,7 +13149,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateCrawlerResponse>(String::from_utf8_lossy(&body)
@@ -12624,7 +13182,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateCrawlerScheduleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -12654,7 +13212,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDatabaseResponse>(String::from_utf8_lossy(&body)
@@ -12686,7 +13244,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDevEndpointResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -12714,7 +13272,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateJobResponse>(String::from_utf8_lossy(&body)
@@ -12746,7 +13304,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdatePartitionResponse>(String::from_utf8_lossy(&body)
@@ -12778,7 +13336,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateTableResponse>(String::from_utf8_lossy(&body)
@@ -12810,7 +13368,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateTriggerResponse>(String::from_utf8_lossy(&body)
@@ -12843,7 +13401,7 @@ impl<P, D> Glue for GlueClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateUserDefinedFunctionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/greengrass/src/generated.rs
+++ b/rusoto/services/greengrass/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -797,6 +793,41 @@ pub struct Deployment {
     #[serde(rename="GroupArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub group_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentType {
+    NewDeployment,
+    Redeployment,
+}
+
+impl Into<String> for DeploymentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentType {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentType::NewDeployment => "NewDeployment",
+            DeploymentType::Redeployment => "Redeployment",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NewDeployment" => Ok(DeploymentType::NewDeployment),
+            "Redeployment" => Ok(DeploymentType::Redeployment),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="Information on a Device"]
@@ -1979,6 +2010,41 @@ pub struct Logger {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LoggerComponent {
+    GreengrassSystem,
+    Lambda,
+}
+
+impl Into<String> for LoggerComponent {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LoggerComponent {
+    fn into(self) -> &'static str {
+        match self {
+            LoggerComponent::GreengrassSystem => "GreengrassSystem",
+            LoggerComponent::Lambda => "Lambda",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LoggerComponent {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GreengrassSystem" => Ok(LoggerComponent::GreengrassSystem),
+            "Lambda" => Ok(LoggerComponent::Lambda),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="Information on logger definition version"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoggerDefinitionVersion {
@@ -1986,6 +2052,85 @@ pub struct LoggerDefinitionVersion {
     #[serde(rename="Loggers")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub loggers: Option<Vec<Logger>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LoggerLevel {
+    Debug,
+    Error,
+    Fatal,
+    Info,
+    Warn,
+}
+
+impl Into<String> for LoggerLevel {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LoggerLevel {
+    fn into(self) -> &'static str {
+        match self {
+            LoggerLevel::Debug => "DEBUG",
+            LoggerLevel::Error => "ERROR",
+            LoggerLevel::Fatal => "FATAL",
+            LoggerLevel::Info => "INFO",
+            LoggerLevel::Warn => "WARN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LoggerLevel {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEBUG" => Ok(LoggerLevel::Debug),
+            "ERROR" => Ok(LoggerLevel::Error),
+            "FATAL" => Ok(LoggerLevel::Fatal),
+            "INFO" => Ok(LoggerLevel::Info),
+            "WARN" => Ok(LoggerLevel::Warn),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LoggerType {
+    AwscloudWatch,
+    FileSystem,
+}
+
+impl Into<String> for LoggerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LoggerType {
+    fn into(self) -> &'static str {
+        match self {
+            LoggerType::AwscloudWatch => "AWSCloudWatch",
+            LoggerType::FileSystem => "FileSystem",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LoggerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWSCloudWatch" => Ok(LoggerType::AwscloudWatch),
+            "FileSystem" => Ok(LoggerType::FileSystem),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="Information on subscription"]
@@ -7814,7 +7959,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7860,7 +8005,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7911,7 +8056,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7961,7 +8106,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8012,7 +8157,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8061,7 +8206,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8112,7 +8257,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8163,7 +8308,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8215,7 +8360,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8266,7 +8411,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8315,7 +8460,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8367,7 +8512,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8416,7 +8561,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8467,7 +8612,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8518,7 +8663,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8571,7 +8716,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8619,7 +8764,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8665,7 +8810,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8712,7 +8857,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8758,7 +8903,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8804,7 +8949,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8851,7 +8996,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8899,7 +9044,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8946,7 +9091,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8993,7 +9138,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9038,7 +9183,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9083,7 +9228,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9130,7 +9275,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9178,7 +9323,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9223,7 +9368,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9271,7 +9416,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9319,7 +9464,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9368,7 +9513,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9412,7 +9557,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9459,7 +9604,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9507,7 +9652,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9555,7 +9700,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9600,7 +9745,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9648,7 +9793,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9694,7 +9839,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9742,7 +9887,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9792,7 +9937,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9847,7 +9992,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9900,7 +10045,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9952,7 +10097,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10005,7 +10150,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10059,7 +10204,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10113,7 +10258,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10168,7 +10313,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10216,7 +10361,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10271,7 +10416,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10322,7 +10467,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10375,7 +10520,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10429,7 +10574,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10484,7 +10629,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10538,7 +10683,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10587,7 +10732,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10635,7 +10780,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10682,7 +10827,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10730,7 +10875,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10777,7 +10922,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10825,7 +10970,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10874,7 +11019,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10922,7 +11067,7 @@ impl<P, D> GreenGrass for GreenGrassClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -280,6 +276,44 @@ pub struct EntityFilter {
     pub tags: Option<Vec<::std::collections::HashMap<String, String>>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EntityStatusCode {
+    Impaired,
+    Unimpaired,
+    Unknown,
+}
+
+impl Into<String> for EntityStatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EntityStatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            EntityStatusCode::Impaired => "IMPAIRED",
+            EntityStatusCode::Unimpaired => "UNIMPAIRED",
+            EntityStatusCode::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EntityStatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IMPAIRED" => Ok(EntityStatusCode::Impaired),
+            "UNIMPAIRED" => Ok(EntityStatusCode::Unimpaired),
+            "UNKNOWN" => Ok(EntityStatusCode::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Summary information about an event, returned by the <a>DescribeEvents</a> operation. The <a>DescribeEventDetails</a> operation also returns this information, as well as the <a>EventDescription</a> and additional event metadata.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Event {
@@ -336,6 +370,38 @@ pub struct EventAggregate {
     #[serde(rename="count")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub count: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventAggregateField {
+    EventTypeCategory,
+}
+
+impl Into<String> for EventAggregateField {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventAggregateField {
+    fn into(self) -> &'static str {
+        match self {
+            EventAggregateField::EventTypeCategory => "eventTypeCategory",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventAggregateField {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "eventTypeCategory" => Ok(EventAggregateField::EventTypeCategory),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Detailed information about an event. A combination of an <a>Event</a> object, an <a>EventDescription</a> object, and additional metadata about the event. Returned by the <a>DescribeEventDetails</a> operation.</p>"]
@@ -427,6 +493,82 @@ pub struct EventFilter {
     #[serde(rename="tags")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<::std::collections::HashMap<String, String>>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventStatusCode {
+    Closed,
+    Open,
+    Upcoming,
+}
+
+impl Into<String> for EventStatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventStatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            EventStatusCode::Closed => "closed",
+            EventStatusCode::Open => "open",
+            EventStatusCode::Upcoming => "upcoming",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventStatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "closed" => Ok(EventStatusCode::Closed),
+            "open" => Ok(EventStatusCode::Open),
+            "upcoming" => Ok(EventStatusCode::Upcoming),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventTypeCategory {
+    AccountNotification,
+    Issue,
+    ScheduledChange,
+}
+
+impl Into<String> for EventTypeCategory {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventTypeCategory {
+    fn into(self) -> &'static str {
+        match self {
+            EventTypeCategory::AccountNotification => "accountNotification",
+            EventTypeCategory::Issue => "issue",
+            EventTypeCategory::ScheduledChange => "scheduledChange",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventTypeCategory {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "accountNotification" => Ok(EventTypeCategory::AccountNotification),
+            "issue" => Ok(EventTypeCategory::Issue),
+            "scheduledChange" => Ok(EventTypeCategory::ScheduledChange),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The values to use to filter results from the <a>DescribeEventTypes</a> operation.</p>"]
@@ -1022,7 +1164,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAffectedEntitiesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1055,7 +1197,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEntityAggregatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1087,7 +1229,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEventAggregatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1119,7 +1261,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEventDetailsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1149,7 +1291,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEventTypesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1179,7 +1321,7 @@ impl<P, D> AWSHealth for AWSHealthClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&body)

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -486,6 +482,44 @@ impl ArnTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssignmentStatusType {
+    Any,
+    Assigned,
+    Unassigned,
+}
+
+impl Into<String> for AssignmentStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssignmentStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            AssignmentStatusType::Any => "Any",
+            AssignmentStatusType::Assigned => "Assigned",
+            AssignmentStatusType::Unassigned => "Unassigned",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssignmentStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Any" => Ok(AssignmentStatusType::Any),
+            "Assigned" => Ok(AssignmentStatusType::Assigned),
+            "Unassigned" => Ok(AssignmentStatusType::Unassigned),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone)]
 pub struct AttachGroupPolicyRequest {
     #[doc="<p>The name (friendly name, not ARN) of the group to attach the policy to.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
@@ -681,7 +715,7 @@ impl BooleanObjectTypeDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -695,7 +729,7 @@ impl BooleanTypeDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1015,6 +1049,71 @@ impl ContextKeyNamesResultListTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContextKeyTypeEnum {
+    Binary,
+    BinaryList,
+    Boolean,
+    BooleanList,
+    Date,
+    DateList,
+    Ip,
+    IpList,
+    Numeric,
+    NumericList,
+    String,
+    StringList,
+}
+
+impl Into<String> for ContextKeyTypeEnum {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContextKeyTypeEnum {
+    fn into(self) -> &'static str {
+        match self {
+            ContextKeyTypeEnum::Binary => "binary",
+            ContextKeyTypeEnum::BinaryList => "binaryList",
+            ContextKeyTypeEnum::Boolean => "boolean",
+            ContextKeyTypeEnum::BooleanList => "booleanList",
+            ContextKeyTypeEnum::Date => "date",
+            ContextKeyTypeEnum::DateList => "dateList",
+            ContextKeyTypeEnum::Ip => "ip",
+            ContextKeyTypeEnum::IpList => "ipList",
+            ContextKeyTypeEnum::Numeric => "numeric",
+            ContextKeyTypeEnum::NumericList => "numericList",
+            ContextKeyTypeEnum::String => "string",
+            ContextKeyTypeEnum::StringList => "stringList",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContextKeyTypeEnum {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "binary" => Ok(ContextKeyTypeEnum::Binary),
+            "binaryList" => Ok(ContextKeyTypeEnum::BinaryList),
+            "boolean" => Ok(ContextKeyTypeEnum::Boolean),
+            "booleanList" => Ok(ContextKeyTypeEnum::BooleanList),
+            "date" => Ok(ContextKeyTypeEnum::Date),
+            "dateList" => Ok(ContextKeyTypeEnum::DateList),
+            "ip" => Ok(ContextKeyTypeEnum::Ip),
+            "ipList" => Ok(ContextKeyTypeEnum::IpList),
+            "numeric" => Ok(ContextKeyTypeEnum::Numeric),
+            "numericList" => Ok(ContextKeyTypeEnum::NumericList),
+            "string" => Ok(ContextKeyTypeEnum::String),
+            "stringList" => Ok(ContextKeyTypeEnum::StringList),
+            _ => Err(()),
+        }
+    }
+}
+
 
 /// Serialize `ContextKeyValueListType` contents to a `SignedRequest`.
 struct ContextKeyValueListTypeSerializer;
@@ -2692,6 +2791,41 @@ impl EnableMFADeviceRequestSerializer {
 }
 
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EncodingType {
+    Pem,
+    Ssh,
+}
+
+impl Into<String> for EncodingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EncodingType {
+    fn into(self) -> &'static str {
+        match self {
+            EncodingType::Pem => "PEM",
+            EncodingType::Ssh => "SSH",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EncodingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PEM" => Ok(EncodingType::Pem),
+            "SSH" => Ok(EncodingType::Ssh),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `EntityListType` contents to a `SignedRequest`.
 struct EntityListTypeSerializer;
 impl EntityListTypeSerializer {
@@ -2699,6 +2833,50 @@ impl EntityListTypeSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EntityType {
+    AwsmanagedPolicy,
+    Group,
+    LocalManagedPolicy,
+    Role,
+    User,
+}
+
+impl Into<String> for EntityType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EntityType {
+    fn into(self) -> &'static str {
+        match self {
+            EntityType::AwsmanagedPolicy => "AWSManagedPolicy",
+            EntityType::Group => "Group",
+            EntityType::LocalManagedPolicy => "LocalManagedPolicy",
+            EntityType::Role => "Role",
+            EntityType::User => "User",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EntityType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWSManagedPolicy" => Ok(EntityType::AwsmanagedPolicy),
+            "Group" => Ok(EntityType::Group),
+            "LocalManagedPolicy" => Ok(EntityType::LocalManagedPolicy),
+            "Role" => Ok(EntityType::Role),
+            "User" => Ok(EntityType::User),
+            _ => Err(()),
         }
     }
 }
@@ -8316,6 +8494,44 @@ impl PolicyDocumentVersionListTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PolicyEvaluationDecisionType {
+    Allowed,
+    ExplicitDeny,
+    ImplicitDeny,
+}
+
+impl Into<String> for PolicyEvaluationDecisionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PolicyEvaluationDecisionType {
+    fn into(self) -> &'static str {
+        match self {
+            PolicyEvaluationDecisionType::Allowed => "allowed",
+            PolicyEvaluationDecisionType::ExplicitDeny => "explicitDeny",
+            PolicyEvaluationDecisionType::ImplicitDeny => "implicitDeny",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PolicyEvaluationDecisionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "allowed" => Ok(PolicyEvaluationDecisionType::Allowed),
+            "explicitDeny" => Ok(PolicyEvaluationDecisionType::ExplicitDeny),
+            "implicitDeny" => Ok(PolicyEvaluationDecisionType::ImplicitDeny),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PolicyEvaluationDecisionTypeDeserializer;
 impl PolicyEvaluationDecisionTypeDeserializer {
     #[allow(unused_variables)]
@@ -8648,6 +8864,94 @@ impl PolicyRoleListTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PolicyScopeType {
+    Aws,
+    All,
+    Local,
+}
+
+impl Into<String> for PolicyScopeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PolicyScopeType {
+    fn into(self) -> &'static str {
+        match self {
+            PolicyScopeType::Aws => "AWS",
+            PolicyScopeType::All => "All",
+            PolicyScopeType::Local => "Local",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PolicyScopeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS" => Ok(PolicyScopeType::Aws),
+            "All" => Ok(PolicyScopeType::All),
+            "Local" => Ok(PolicyScopeType::Local),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PolicySourceType {
+    AwsManaged,
+    Group,
+    None,
+    Resource,
+    Role,
+    User,
+    UserManaged,
+}
+
+impl Into<String> for PolicySourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PolicySourceType {
+    fn into(self) -> &'static str {
+        match self {
+            PolicySourceType::AwsManaged => "aws-managed",
+            PolicySourceType::Group => "group",
+            PolicySourceType::None => "none",
+            PolicySourceType::Resource => "resource",
+            PolicySourceType::Role => "role",
+            PolicySourceType::User => "user",
+            PolicySourceType::UserManaged => "user-managed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PolicySourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "aws-managed" => Ok(PolicySourceType::AwsManaged),
+            "group" => Ok(PolicySourceType::Group),
+            "none" => Ok(PolicySourceType::None),
+            "resource" => Ok(PolicySourceType::Resource),
+            "role" => Ok(PolicySourceType::Role),
+            "user" => Ok(PolicySourceType::User),
+            "user-managed" => Ok(PolicySourceType::UserManaged),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PolicySourceTypeDeserializer;
 impl PolicySourceTypeDeserializer {
     #[allow(unused_variables)]
@@ -9124,6 +9428,38 @@ impl ReportContentTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportFormatType {
+    TextCsv,
+}
+
+impl Into<String> for ReportFormatType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportFormatType {
+    fn into(self) -> &'static str {
+        match self {
+            ReportFormatType::TextCsv => "text/csv",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportFormatType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "text/csv" => Ok(ReportFormatType::TextCsv),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReportFormatTypeDeserializer;
 impl ReportFormatTypeDeserializer {
     #[allow(unused_variables)]
@@ -9152,6 +9488,44 @@ impl ReportStateDescriptionTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportStateType {
+    Complete,
+    Inprogress,
+    Started,
+}
+
+impl Into<String> for ReportStateType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportStateType {
+    fn into(self) -> &'static str {
+        match self {
+            ReportStateType::Complete => "COMPLETE",
+            ReportStateType::Inprogress => "INPROGRESS",
+            ReportStateType::Started => "STARTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportStateType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLETE" => Ok(ReportStateType::Complete),
+            "INPROGRESS" => Ok(ReportStateType::Inprogress),
+            "STARTED" => Ok(ReportStateType::Started),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReportStateTypeDeserializer;
 impl ReportStateTypeDeserializer {
     #[allow(unused_variables)]
@@ -10943,6 +11317,41 @@ impl StatementListTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusType {
+    Active,
+    Inactive,
+}
+
+impl Into<String> for StatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusType {
+    fn into(self) -> &'static str {
+        match self {
+            StatusType::Active => "Active",
+            StatusType::Inactive => "Inactive",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(StatusType::Active),
+            "Inactive" => Ok(StatusType::Inactive),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StatusTypeDeserializer;
 impl StatusTypeDeserializer {
     #[allow(unused_variables)]
@@ -10971,6 +11380,116 @@ impl StringTypeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SummaryKeyType {
+    AccessKeysPerUserQuota,
+    AccountAccessKeysPresent,
+    AccountMFAEnabled,
+    AccountSigningCertificatesPresent,
+    AttachedPoliciesPerGroupQuota,
+    AttachedPoliciesPerRoleQuota,
+    AttachedPoliciesPerUserQuota,
+    GroupPolicySizeQuota,
+    Groups,
+    GroupsPerUserQuota,
+    GroupsQuota,
+    Mfadevices,
+    MfadevicesInUse,
+    Policies,
+    PoliciesQuota,
+    PolicySizeQuota,
+    PolicyVersionsInUse,
+    PolicyVersionsInUseQuota,
+    ServerCertificates,
+    ServerCertificatesQuota,
+    SigningCertificatesPerUserQuota,
+    UserPolicySizeQuota,
+    Users,
+    UsersQuota,
+    VersionsPerPolicyQuota,
+}
+
+impl Into<String> for SummaryKeyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SummaryKeyType {
+    fn into(self) -> &'static str {
+        match self {
+            SummaryKeyType::AccessKeysPerUserQuota => "AccessKeysPerUserQuota",
+            SummaryKeyType::AccountAccessKeysPresent => "AccountAccessKeysPresent",
+            SummaryKeyType::AccountMFAEnabled => "AccountMFAEnabled",
+            SummaryKeyType::AccountSigningCertificatesPresent => {
+                "AccountSigningCertificatesPresent"
+            }
+            SummaryKeyType::AttachedPoliciesPerGroupQuota => "AttachedPoliciesPerGroupQuota",
+            SummaryKeyType::AttachedPoliciesPerRoleQuota => "AttachedPoliciesPerRoleQuota",
+            SummaryKeyType::AttachedPoliciesPerUserQuota => "AttachedPoliciesPerUserQuota",
+            SummaryKeyType::GroupPolicySizeQuota => "GroupPolicySizeQuota",
+            SummaryKeyType::Groups => "Groups",
+            SummaryKeyType::GroupsPerUserQuota => "GroupsPerUserQuota",
+            SummaryKeyType::GroupsQuota => "GroupsQuota",
+            SummaryKeyType::Mfadevices => "MFADevices",
+            SummaryKeyType::MfadevicesInUse => "MFADevicesInUse",
+            SummaryKeyType::Policies => "Policies",
+            SummaryKeyType::PoliciesQuota => "PoliciesQuota",
+            SummaryKeyType::PolicySizeQuota => "PolicySizeQuota",
+            SummaryKeyType::PolicyVersionsInUse => "PolicyVersionsInUse",
+            SummaryKeyType::PolicyVersionsInUseQuota => "PolicyVersionsInUseQuota",
+            SummaryKeyType::ServerCertificates => "ServerCertificates",
+            SummaryKeyType::ServerCertificatesQuota => "ServerCertificatesQuota",
+            SummaryKeyType::SigningCertificatesPerUserQuota => "SigningCertificatesPerUserQuota",
+            SummaryKeyType::UserPolicySizeQuota => "UserPolicySizeQuota",
+            SummaryKeyType::Users => "Users",
+            SummaryKeyType::UsersQuota => "UsersQuota",
+            SummaryKeyType::VersionsPerPolicyQuota => "VersionsPerPolicyQuota",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SummaryKeyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AccessKeysPerUserQuota" => Ok(SummaryKeyType::AccessKeysPerUserQuota),
+            "AccountAccessKeysPresent" => Ok(SummaryKeyType::AccountAccessKeysPresent),
+            "AccountMFAEnabled" => Ok(SummaryKeyType::AccountMFAEnabled),
+            "AccountSigningCertificatesPresent" => {
+                Ok(SummaryKeyType::AccountSigningCertificatesPresent)
+            }
+            "AttachedPoliciesPerGroupQuota" => Ok(SummaryKeyType::AttachedPoliciesPerGroupQuota),
+            "AttachedPoliciesPerRoleQuota" => Ok(SummaryKeyType::AttachedPoliciesPerRoleQuota),
+            "AttachedPoliciesPerUserQuota" => Ok(SummaryKeyType::AttachedPoliciesPerUserQuota),
+            "GroupPolicySizeQuota" => Ok(SummaryKeyType::GroupPolicySizeQuota),
+            "Groups" => Ok(SummaryKeyType::Groups),
+            "GroupsPerUserQuota" => Ok(SummaryKeyType::GroupsPerUserQuota),
+            "GroupsQuota" => Ok(SummaryKeyType::GroupsQuota),
+            "MFADevices" => Ok(SummaryKeyType::Mfadevices),
+            "MFADevicesInUse" => Ok(SummaryKeyType::MfadevicesInUse),
+            "Policies" => Ok(SummaryKeyType::Policies),
+            "PoliciesQuota" => Ok(SummaryKeyType::PoliciesQuota),
+            "PolicySizeQuota" => Ok(SummaryKeyType::PolicySizeQuota),
+            "PolicyVersionsInUse" => Ok(SummaryKeyType::PolicyVersionsInUse),
+            "PolicyVersionsInUseQuota" => Ok(SummaryKeyType::PolicyVersionsInUseQuota),
+            "ServerCertificates" => Ok(SummaryKeyType::ServerCertificates),
+            "ServerCertificatesQuota" => Ok(SummaryKeyType::ServerCertificatesQuota),
+            "SigningCertificatesPerUserQuota" => {
+                Ok(SummaryKeyType::SigningCertificatesPerUserQuota)
+            }
+            "UserPolicySizeQuota" => Ok(SummaryKeyType::UserPolicySizeQuota),
+            "Users" => Ok(SummaryKeyType::Users),
+            "UsersQuota" => Ok(SummaryKeyType::UsersQuota),
+            "VersionsPerPolicyQuota" => Ok(SummaryKeyType::VersionsPerPolicyQuota),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SummaryKeyTypeDeserializer;
 impl SummaryKeyTypeDeserializer {
     #[allow(unused_variables)]
@@ -23084,7 +23603,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23112,7 +23631,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23139,7 +23658,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23167,7 +23686,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23195,7 +23714,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23223,7 +23742,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23249,7 +23768,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23277,7 +23796,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23324,7 +23843,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23352,7 +23871,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23400,7 +23919,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23448,7 +23967,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23496,7 +24015,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23543,7 +24062,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23590,7 +24109,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23637,7 +24156,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23684,7 +24203,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23732,7 +24251,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23782,7 +24301,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23829,7 +24348,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23877,7 +24396,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23925,7 +24444,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23953,7 +24472,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -23981,7 +24500,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24007,7 +24526,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24034,7 +24553,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24062,7 +24581,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24090,7 +24609,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24118,7 +24637,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24146,7 +24665,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24173,7 +24692,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24201,7 +24720,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24227,7 +24746,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24255,7 +24774,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24283,7 +24802,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24311,7 +24830,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24339,7 +24858,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24368,7 +24887,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24397,7 +24916,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24424,7 +24943,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24452,7 +24971,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24480,7 +24999,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24508,7 +25027,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24536,7 +25055,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24564,7 +25083,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24592,7 +25111,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24620,7 +25139,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24670,7 +25189,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24719,7 +25238,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24766,7 +25285,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24813,7 +25332,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24861,7 +25380,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24911,7 +25430,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24958,7 +25477,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25003,7 +25522,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25050,7 +25569,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25097,7 +25616,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25144,7 +25663,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25192,7 +25711,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25239,7 +25758,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25286,7 +25805,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25331,7 +25850,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25378,7 +25897,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25425,7 +25944,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25472,7 +25991,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25520,7 +26039,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25566,7 +26085,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25613,7 +26132,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25660,7 +26179,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25707,7 +26226,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25755,7 +26274,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25803,7 +26322,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25853,7 +26372,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25903,7 +26422,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25951,7 +26470,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25998,7 +26517,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26045,7 +26564,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26093,7 +26612,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26142,7 +26661,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26189,7 +26708,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26237,7 +26756,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26284,7 +26803,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26331,7 +26850,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26378,7 +26897,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26423,7 +26942,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26470,7 +26989,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26517,7 +27036,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26565,7 +27084,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26614,7 +27133,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26662,7 +27181,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26711,7 +27230,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26756,7 +27275,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26804,7 +27323,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26850,7 +27369,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26876,7 +27395,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26902,7 +27421,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26933,7 +27452,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26961,7 +27480,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -26990,7 +27509,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27019,7 +27538,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27066,7 +27585,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27094,7 +27613,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27123,7 +27642,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27171,7 +27690,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27219,7 +27738,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27247,7 +27766,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27276,7 +27795,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27302,7 +27821,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27330,7 +27849,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27359,7 +27878,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27388,7 +27907,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27436,7 +27955,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27483,7 +28002,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27511,7 +28030,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27540,7 +28059,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27569,7 +28088,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27596,7 +28115,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27624,7 +28143,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27672,7 +28191,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27722,7 +28241,7 @@ impl<P, D> Iam for IamClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -699,7 +695,7 @@ impl IsCanceledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -713,7 +709,7 @@ impl IsTruncatedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -806,6 +802,41 @@ impl JobIdListSerializer {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
             params.put(&key, &obj);
+        }
+    }
+}
+
+#[doc="Specifies whether the job to initiate is an import or export job."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobType {
+    Export,
+    Import,
+}
+
+impl Into<String> for JobType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobType {
+    fn into(self) -> &'static str {
+        match self {
+            JobType::Export => "Export",
+            JobType::Import => "Import",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Export" => Ok(JobType::Export),
+            "Import" => Ok(JobType::Import),
+            _ => Err(()),
         }
     }
 }
@@ -1071,7 +1102,7 @@ impl SuccessDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2016,7 +2047,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -2064,7 +2095,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -2114,7 +2145,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -2162,7 +2193,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -2208,7 +2239,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -2256,7 +2287,7 @@ impl<P, D> ImportExport for ImportExportClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -11,23 +11,86 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccessDeniedErrorCode {
+    AccessDeniedToAssessmentRun,
+    AccessDeniedToAssessmentTarget,
+    AccessDeniedToAssessmentTemplate,
+    AccessDeniedToFinding,
+    AccessDeniedToIamRole,
+    AccessDeniedToResourceGroup,
+    AccessDeniedToRulesPackage,
+    AccessDeniedToSnsTopic,
+}
+
+impl Into<String> for AccessDeniedErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccessDeniedErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            AccessDeniedErrorCode::AccessDeniedToAssessmentRun => "ACCESS_DENIED_TO_ASSESSMENT_RUN",
+            AccessDeniedErrorCode::AccessDeniedToAssessmentTarget => {
+                "ACCESS_DENIED_TO_ASSESSMENT_TARGET"
+            }
+            AccessDeniedErrorCode::AccessDeniedToAssessmentTemplate => {
+                "ACCESS_DENIED_TO_ASSESSMENT_TEMPLATE"
+            }
+            AccessDeniedErrorCode::AccessDeniedToFinding => "ACCESS_DENIED_TO_FINDING",
+            AccessDeniedErrorCode::AccessDeniedToIamRole => "ACCESS_DENIED_TO_IAM_ROLE",
+            AccessDeniedErrorCode::AccessDeniedToResourceGroup => "ACCESS_DENIED_TO_RESOURCE_GROUP",
+            AccessDeniedErrorCode::AccessDeniedToRulesPackage => "ACCESS_DENIED_TO_RULES_PACKAGE",
+            AccessDeniedErrorCode::AccessDeniedToSnsTopic => "ACCESS_DENIED_TO_SNS_TOPIC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccessDeniedErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCESS_DENIED_TO_ASSESSMENT_RUN" => {
+                Ok(AccessDeniedErrorCode::AccessDeniedToAssessmentRun)
+            }
+            "ACCESS_DENIED_TO_ASSESSMENT_TARGET" => {
+                Ok(AccessDeniedErrorCode::AccessDeniedToAssessmentTarget)
+            }
+            "ACCESS_DENIED_TO_ASSESSMENT_TEMPLATE" => {
+                Ok(AccessDeniedErrorCode::AccessDeniedToAssessmentTemplate)
+            }
+            "ACCESS_DENIED_TO_FINDING" => Ok(AccessDeniedErrorCode::AccessDeniedToFinding),
+            "ACCESS_DENIED_TO_IAM_ROLE" => Ok(AccessDeniedErrorCode::AccessDeniedToIamRole),
+            "ACCESS_DENIED_TO_RESOURCE_GROUP" => {
+                Ok(AccessDeniedErrorCode::AccessDeniedToResourceGroup)
+            }
+            "ACCESS_DENIED_TO_RULES_PACKAGE" => {
+                Ok(AccessDeniedErrorCode::AccessDeniedToRulesPackage)
+            }
+            "ACCESS_DENIED_TO_SNS_TOPIC" => Ok(AccessDeniedErrorCode::AccessDeniedToSnsTopic),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AddAttributesToFindingsRequest {
     #[doc="<p>The array of attributes that you want to assign to specified findings.</p>"]
@@ -63,6 +126,88 @@ pub struct AgentFilter {
     #[doc="<p>The current health state of the agent. Values can be set to <b>HEALTHY</b> or <b>UNHEALTHY</b>.</p>"]
     #[serde(rename="agentHealths")]
     pub agent_healths: Vec<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AgentHealth {
+    Healthy,
+    Unhealthy,
+}
+
+impl Into<String> for AgentHealth {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AgentHealth {
+    fn into(self) -> &'static str {
+        match self {
+            AgentHealth::Healthy => "HEALTHY",
+            AgentHealth::Unhealthy => "UNHEALTHY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AgentHealth {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HEALTHY" => Ok(AgentHealth::Healthy),
+            "UNHEALTHY" => Ok(AgentHealth::Unhealthy),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AgentHealthCode {
+    Idle,
+    Running,
+    Shutdown,
+    Throttled,
+    Unhealthy,
+    Unknown,
+}
+
+impl Into<String> for AgentHealthCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AgentHealthCode {
+    fn into(self) -> &'static str {
+        match self {
+            AgentHealthCode::Idle => "IDLE",
+            AgentHealthCode::Running => "RUNNING",
+            AgentHealthCode::Shutdown => "SHUTDOWN",
+            AgentHealthCode::Throttled => "THROTTLED",
+            AgentHealthCode::Unhealthy => "UNHEALTHY",
+            AgentHealthCode::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AgentHealthCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IDLE" => Ok(AgentHealthCode::Idle),
+            "RUNNING" => Ok(AgentHealthCode::Running),
+            "SHUTDOWN" => Ok(AgentHealthCode::Shutdown),
+            "THROTTLED" => Ok(AgentHealthCode::Throttled),
+            "UNHEALTHY" => Ok(AgentHealthCode::Unhealthy),
+            "UNKNOWN" => Ok(AgentHealthCode::Unknown),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Used as a response element in the <a>PreviewAgents</a> action.</p>"]
@@ -216,6 +361,119 @@ pub struct AssessmentRunNotification {
     pub sns_topic_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssessmentRunNotificationSnsStatusCode {
+    AccessDenied,
+    InternalError,
+    Success,
+    TopicDoesNotExist,
+}
+
+impl Into<String> for AssessmentRunNotificationSnsStatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssessmentRunNotificationSnsStatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            AssessmentRunNotificationSnsStatusCode::AccessDenied => "ACCESS_DENIED",
+            AssessmentRunNotificationSnsStatusCode::InternalError => "INTERNAL_ERROR",
+            AssessmentRunNotificationSnsStatusCode::Success => "SUCCESS",
+            AssessmentRunNotificationSnsStatusCode::TopicDoesNotExist => "TOPIC_DOES_NOT_EXIST",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssessmentRunNotificationSnsStatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCESS_DENIED" => Ok(AssessmentRunNotificationSnsStatusCode::AccessDenied),
+            "INTERNAL_ERROR" => Ok(AssessmentRunNotificationSnsStatusCode::InternalError),
+            "SUCCESS" => Ok(AssessmentRunNotificationSnsStatusCode::Success),
+            "TOPIC_DOES_NOT_EXIST" => Ok(AssessmentRunNotificationSnsStatusCode::TopicDoesNotExist),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssessmentRunState {
+    Canceled,
+    CollectingData,
+    Completed,
+    CompletedWithErrors,
+    Created,
+    DataCollected,
+    Error,
+    EvaluatingRules,
+    Failed,
+    StartDataCollectionInProgress,
+    StartDataCollectionPending,
+    StartEvaluatingRulesPending,
+    StopDataCollectionPending,
+}
+
+impl Into<String> for AssessmentRunState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssessmentRunState {
+    fn into(self) -> &'static str {
+        match self {
+            AssessmentRunState::Canceled => "CANCELED",
+            AssessmentRunState::CollectingData => "COLLECTING_DATA",
+            AssessmentRunState::Completed => "COMPLETED",
+            AssessmentRunState::CompletedWithErrors => "COMPLETED_WITH_ERRORS",
+            AssessmentRunState::Created => "CREATED",
+            AssessmentRunState::DataCollected => "DATA_COLLECTED",
+            AssessmentRunState::Error => "ERROR",
+            AssessmentRunState::EvaluatingRules => "EVALUATING_RULES",
+            AssessmentRunState::Failed => "FAILED",
+            AssessmentRunState::StartDataCollectionInProgress => {
+                "START_DATA_COLLECTION_IN_PROGRESS"
+            }
+            AssessmentRunState::StartDataCollectionPending => "START_DATA_COLLECTION_PENDING",
+            AssessmentRunState::StartEvaluatingRulesPending => "START_EVALUATING_RULES_PENDING",
+            AssessmentRunState::StopDataCollectionPending => "STOP_DATA_COLLECTION_PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssessmentRunState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELED" => Ok(AssessmentRunState::Canceled),
+            "COLLECTING_DATA" => Ok(AssessmentRunState::CollectingData),
+            "COMPLETED" => Ok(AssessmentRunState::Completed),
+            "COMPLETED_WITH_ERRORS" => Ok(AssessmentRunState::CompletedWithErrors),
+            "CREATED" => Ok(AssessmentRunState::Created),
+            "DATA_COLLECTED" => Ok(AssessmentRunState::DataCollected),
+            "ERROR" => Ok(AssessmentRunState::Error),
+            "EVALUATING_RULES" => Ok(AssessmentRunState::EvaluatingRules),
+            "FAILED" => Ok(AssessmentRunState::Failed),
+            "START_DATA_COLLECTION_IN_PROGRESS" => {
+                Ok(AssessmentRunState::StartDataCollectionInProgress)
+            }
+            "START_DATA_COLLECTION_PENDING" => Ok(AssessmentRunState::StartDataCollectionPending),
+            "START_EVALUATING_RULES_PENDING" => Ok(AssessmentRunState::StartEvaluatingRulesPending),
+            "STOP_DATA_COLLECTION_PENDING" => Ok(AssessmentRunState::StopDataCollectionPending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Used as one of the elements of the <a>AssessmentRun</a> data type.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AssessmentRunStateChange {
@@ -325,6 +583,38 @@ pub struct AssetAttributes {
     #[doc="<p>The schema version of this data type.</p>"]
     #[serde(rename="schemaVersion")]
     pub schema_version: i64,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssetType {
+    Ec2Instance,
+}
+
+impl Into<String> for AssetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssetType {
+    fn into(self) -> &'static str {
+        match self {
+            AssetType::Ec2Instance => "ec2-instance",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ec2-instance" => Ok(AssetType::Ec2Instance),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>This data type is used as a request parameter in the <a>AddAttributesToFindings</a> and <a>CreateAssessmentTemplate</a> actions.</p>"]
@@ -575,6 +865,53 @@ pub struct FailedItemDetails {
     pub retryable: bool,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FailedItemErrorCode {
+    AccessDenied,
+    DuplicateArn,
+    InternalError,
+    InvalidArn,
+    ItemDoesNotExist,
+    LimitExceeded,
+}
+
+impl Into<String> for FailedItemErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FailedItemErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            FailedItemErrorCode::AccessDenied => "ACCESS_DENIED",
+            FailedItemErrorCode::DuplicateArn => "DUPLICATE_ARN",
+            FailedItemErrorCode::InternalError => "INTERNAL_ERROR",
+            FailedItemErrorCode::InvalidArn => "INVALID_ARN",
+            FailedItemErrorCode::ItemDoesNotExist => "ITEM_DOES_NOT_EXIST",
+            FailedItemErrorCode::LimitExceeded => "LIMIT_EXCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FailedItemErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCESS_DENIED" => Ok(FailedItemErrorCode::AccessDenied),
+            "DUPLICATE_ARN" => Ok(FailedItemErrorCode::DuplicateArn),
+            "INTERNAL_ERROR" => Ok(FailedItemErrorCode::InternalError),
+            "INVALID_ARN" => Ok(FailedItemErrorCode::InvalidArn),
+            "ITEM_DOES_NOT_EXIST" => Ok(FailedItemErrorCode::ItemDoesNotExist),
+            "LIMIT_EXCEEDED" => Ok(FailedItemErrorCode::LimitExceeded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about an Amazon Inspector finding. This data type is used as the response element in the <a>DescribeFindings</a> action.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Finding {
@@ -722,6 +1059,50 @@ pub struct GetTelemetryMetadataResponse {
     pub telemetry_metadata: Vec<TelemetryMetadata>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InspectorEvent {
+    AssessmentRunCompleted,
+    AssessmentRunStarted,
+    AssessmentRunStateChanged,
+    FindingReported,
+    Other,
+}
+
+impl Into<String> for InspectorEvent {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InspectorEvent {
+    fn into(self) -> &'static str {
+        match self {
+            InspectorEvent::AssessmentRunCompleted => "ASSESSMENT_RUN_COMPLETED",
+            InspectorEvent::AssessmentRunStarted => "ASSESSMENT_RUN_STARTED",
+            InspectorEvent::AssessmentRunStateChanged => "ASSESSMENT_RUN_STATE_CHANGED",
+            InspectorEvent::FindingReported => "FINDING_REPORTED",
+            InspectorEvent::Other => "OTHER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InspectorEvent {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSESSMENT_RUN_COMPLETED" => Ok(InspectorEvent::AssessmentRunCompleted),
+            "ASSESSMENT_RUN_STARTED" => Ok(InspectorEvent::AssessmentRunStarted),
+            "ASSESSMENT_RUN_STATE_CHANGED" => Ok(InspectorEvent::AssessmentRunStateChanged),
+            "FINDING_REPORTED" => Ok(InspectorEvent::FindingReported),
+            "OTHER" => Ok(InspectorEvent::Other),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>This data type is used in the <a>Finding</a> data type.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InspectorServiceAttributes {
@@ -736,6 +1117,396 @@ pub struct InspectorServiceAttributes {
     #[doc="<p>The schema version of this data type.</p>"]
     #[serde(rename="schemaVersion")]
     pub schema_version: i64,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InvalidCrossAccountRoleErrorCode {
+    RoleDoesNotExistOrInvalidTrustRelationship,
+    RoleDoesNotHaveCorrectPolicy,
+}
+
+impl Into<String> for InvalidCrossAccountRoleErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InvalidCrossAccountRoleErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            InvalidCrossAccountRoleErrorCode::RoleDoesNotExistOrInvalidTrustRelationship => {
+                "ROLE_DOES_NOT_EXIST_OR_INVALID_TRUST_RELATIONSHIP"
+            }
+            InvalidCrossAccountRoleErrorCode::RoleDoesNotHaveCorrectPolicy => {
+                "ROLE_DOES_NOT_HAVE_CORRECT_POLICY"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for InvalidCrossAccountRoleErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ROLE_DOES_NOT_EXIST_OR_INVALID_TRUST_RELATIONSHIP" => {
+                Ok(InvalidCrossAccountRoleErrorCode::RoleDoesNotExistOrInvalidTrustRelationship)
+            }
+            "ROLE_DOES_NOT_HAVE_CORRECT_POLICY" => {
+                Ok(InvalidCrossAccountRoleErrorCode::RoleDoesNotHaveCorrectPolicy)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InvalidInputErrorCode {
+    AssessmentTargetNameAlreadyTaken,
+    AssessmentTemplateNameAlreadyTaken,
+    InvalidAgentId,
+    InvalidAssessmentRunArn,
+    InvalidAssessmentRunCompletionTimeRange,
+    InvalidAssessmentRunDurationRange,
+    InvalidAssessmentRunStartTimeRange,
+    InvalidAssessmentRunState,
+    InvalidAssessmentRunStateChangeTimeRange,
+    InvalidAssessmentTargetArn,
+    InvalidAssessmentTargetName,
+    InvalidAssessmentTargetNamePattern,
+    InvalidAssessmentTemplateArn,
+    InvalidAssessmentTemplateDuration,
+    InvalidAssessmentTemplateDurationRange,
+    InvalidAssessmentTemplateName,
+    InvalidAssessmentTemplateNamePattern,
+    InvalidAttribute,
+    InvalidAutoScalingGroup,
+    InvalidEvent,
+    InvalidFindingArn,
+    InvalidIamRoleArn,
+    InvalidLocale,
+    InvalidMaxResults,
+    InvalidNumberOfAgentIds,
+    InvalidNumberOfAssessmentRunArns,
+    InvalidNumberOfAssessmentRunStates,
+    InvalidNumberOfAssessmentTargetArns,
+    InvalidNumberOfAssessmentTemplateArns,
+    InvalidNumberOfAttributes,
+    InvalidNumberOfAutoScalingGroups,
+    InvalidNumberOfFindingArns,
+    InvalidNumberOfResourceGroupArns,
+    InvalidNumberOfResourceGroupTags,
+    InvalidNumberOfRulesPackageArns,
+    InvalidNumberOfRuleNames,
+    InvalidNumberOfSeverities,
+    InvalidNumberOfTags,
+    InvalidNumberOfUserAttributes,
+    InvalidPaginationToken,
+    InvalidResourceArn,
+    InvalidResourceGroupArn,
+    InvalidResourceGroupTagKey,
+    InvalidResourceGroupTagValue,
+    InvalidRulesPackageArn,
+    InvalidRuleName,
+    InvalidSeverity,
+    InvalidSnsTopicArn,
+    InvalidTag,
+    InvalidTagKey,
+    InvalidTagValue,
+    InvalidUserAttribute,
+    InvalidUserAttributeKey,
+    InvalidUserAttributeValue,
+}
+
+impl Into<String> for InvalidInputErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InvalidInputErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            InvalidInputErrorCode::AssessmentTargetNameAlreadyTaken => {
+                "ASSESSMENT_TARGET_NAME_ALREADY_TAKEN"
+            }
+            InvalidInputErrorCode::AssessmentTemplateNameAlreadyTaken => {
+                "ASSESSMENT_TEMPLATE_NAME_ALREADY_TAKEN"
+            }
+            InvalidInputErrorCode::InvalidAgentId => "INVALID_AGENT_ID",
+            InvalidInputErrorCode::InvalidAssessmentRunArn => "INVALID_ASSESSMENT_RUN_ARN",
+            InvalidInputErrorCode::InvalidAssessmentRunCompletionTimeRange => {
+                "INVALID_ASSESSMENT_RUN_COMPLETION_TIME_RANGE"
+            }
+            InvalidInputErrorCode::InvalidAssessmentRunDurationRange => {
+                "INVALID_ASSESSMENT_RUN_DURATION_RANGE"
+            }
+            InvalidInputErrorCode::InvalidAssessmentRunStartTimeRange => {
+                "INVALID_ASSESSMENT_RUN_START_TIME_RANGE"
+            }
+            InvalidInputErrorCode::InvalidAssessmentRunState => "INVALID_ASSESSMENT_RUN_STATE",
+            InvalidInputErrorCode::InvalidAssessmentRunStateChangeTimeRange => {
+                "INVALID_ASSESSMENT_RUN_STATE_CHANGE_TIME_RANGE"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTargetArn => "INVALID_ASSESSMENT_TARGET_ARN",
+            InvalidInputErrorCode::InvalidAssessmentTargetName => "INVALID_ASSESSMENT_TARGET_NAME",
+            InvalidInputErrorCode::InvalidAssessmentTargetNamePattern => {
+                "INVALID_ASSESSMENT_TARGET_NAME_PATTERN"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTemplateArn => {
+                "INVALID_ASSESSMENT_TEMPLATE_ARN"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTemplateDuration => {
+                "INVALID_ASSESSMENT_TEMPLATE_DURATION"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTemplateDurationRange => {
+                "INVALID_ASSESSMENT_TEMPLATE_DURATION_RANGE"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTemplateName => {
+                "INVALID_ASSESSMENT_TEMPLATE_NAME"
+            }
+            InvalidInputErrorCode::InvalidAssessmentTemplateNamePattern => {
+                "INVALID_ASSESSMENT_TEMPLATE_NAME_PATTERN"
+            }
+            InvalidInputErrorCode::InvalidAttribute => "INVALID_ATTRIBUTE",
+            InvalidInputErrorCode::InvalidAutoScalingGroup => "INVALID_AUTO_SCALING_GROUP",
+            InvalidInputErrorCode::InvalidEvent => "INVALID_EVENT",
+            InvalidInputErrorCode::InvalidFindingArn => "INVALID_FINDING_ARN",
+            InvalidInputErrorCode::InvalidIamRoleArn => "INVALID_IAM_ROLE_ARN",
+            InvalidInputErrorCode::InvalidLocale => "INVALID_LOCALE",
+            InvalidInputErrorCode::InvalidMaxResults => "INVALID_MAX_RESULTS",
+            InvalidInputErrorCode::InvalidNumberOfAgentIds => "INVALID_NUMBER_OF_AGENT_IDS",
+            InvalidInputErrorCode::InvalidNumberOfAssessmentRunArns => {
+                "INVALID_NUMBER_OF_ASSESSMENT_RUN_ARNS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfAssessmentRunStates => {
+                "INVALID_NUMBER_OF_ASSESSMENT_RUN_STATES"
+            }
+            InvalidInputErrorCode::InvalidNumberOfAssessmentTargetArns => {
+                "INVALID_NUMBER_OF_ASSESSMENT_TARGET_ARNS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfAssessmentTemplateArns => {
+                "INVALID_NUMBER_OF_ASSESSMENT_TEMPLATE_ARNS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfAttributes => "INVALID_NUMBER_OF_ATTRIBUTES",
+            InvalidInputErrorCode::InvalidNumberOfAutoScalingGroups => {
+                "INVALID_NUMBER_OF_AUTO_SCALING_GROUPS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfFindingArns => "INVALID_NUMBER_OF_FINDING_ARNS",
+            InvalidInputErrorCode::InvalidNumberOfResourceGroupArns => {
+                "INVALID_NUMBER_OF_RESOURCE_GROUP_ARNS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfResourceGroupTags => {
+                "INVALID_NUMBER_OF_RESOURCE_GROUP_TAGS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfRulesPackageArns => {
+                "INVALID_NUMBER_OF_RULES_PACKAGE_ARNS"
+            }
+            InvalidInputErrorCode::InvalidNumberOfRuleNames => "INVALID_NUMBER_OF_RULE_NAMES",
+            InvalidInputErrorCode::InvalidNumberOfSeverities => "INVALID_NUMBER_OF_SEVERITIES",
+            InvalidInputErrorCode::InvalidNumberOfTags => "INVALID_NUMBER_OF_TAGS",
+            InvalidInputErrorCode::InvalidNumberOfUserAttributes => {
+                "INVALID_NUMBER_OF_USER_ATTRIBUTES"
+            }
+            InvalidInputErrorCode::InvalidPaginationToken => "INVALID_PAGINATION_TOKEN",
+            InvalidInputErrorCode::InvalidResourceArn => "INVALID_RESOURCE_ARN",
+            InvalidInputErrorCode::InvalidResourceGroupArn => "INVALID_RESOURCE_GROUP_ARN",
+            InvalidInputErrorCode::InvalidResourceGroupTagKey => "INVALID_RESOURCE_GROUP_TAG_KEY",
+            InvalidInputErrorCode::InvalidResourceGroupTagValue => {
+                "INVALID_RESOURCE_GROUP_TAG_VALUE"
+            }
+            InvalidInputErrorCode::InvalidRulesPackageArn => "INVALID_RULES_PACKAGE_ARN",
+            InvalidInputErrorCode::InvalidRuleName => "INVALID_RULE_NAME",
+            InvalidInputErrorCode::InvalidSeverity => "INVALID_SEVERITY",
+            InvalidInputErrorCode::InvalidSnsTopicArn => "INVALID_SNS_TOPIC_ARN",
+            InvalidInputErrorCode::InvalidTag => "INVALID_TAG",
+            InvalidInputErrorCode::InvalidTagKey => "INVALID_TAG_KEY",
+            InvalidInputErrorCode::InvalidTagValue => "INVALID_TAG_VALUE",
+            InvalidInputErrorCode::InvalidUserAttribute => "INVALID_USER_ATTRIBUTE",
+            InvalidInputErrorCode::InvalidUserAttributeKey => "INVALID_USER_ATTRIBUTE_KEY",
+            InvalidInputErrorCode::InvalidUserAttributeValue => "INVALID_USER_ATTRIBUTE_VALUE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InvalidInputErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSESSMENT_TARGET_NAME_ALREADY_TAKEN" => {
+                Ok(InvalidInputErrorCode::AssessmentTargetNameAlreadyTaken)
+            }
+            "ASSESSMENT_TEMPLATE_NAME_ALREADY_TAKEN" => {
+                Ok(InvalidInputErrorCode::AssessmentTemplateNameAlreadyTaken)
+            }
+            "INVALID_AGENT_ID" => Ok(InvalidInputErrorCode::InvalidAgentId),
+            "INVALID_ASSESSMENT_RUN_ARN" => Ok(InvalidInputErrorCode::InvalidAssessmentRunArn),
+            "INVALID_ASSESSMENT_RUN_COMPLETION_TIME_RANGE" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentRunCompletionTimeRange)
+            }
+            "INVALID_ASSESSMENT_RUN_DURATION_RANGE" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentRunDurationRange)
+            }
+            "INVALID_ASSESSMENT_RUN_START_TIME_RANGE" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentRunStartTimeRange)
+            }
+            "INVALID_ASSESSMENT_RUN_STATE" => Ok(InvalidInputErrorCode::InvalidAssessmentRunState),
+            "INVALID_ASSESSMENT_RUN_STATE_CHANGE_TIME_RANGE" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentRunStateChangeTimeRange)
+            }
+            "INVALID_ASSESSMENT_TARGET_ARN" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTargetArn)
+            }
+            "INVALID_ASSESSMENT_TARGET_NAME" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTargetName)
+            }
+            "INVALID_ASSESSMENT_TARGET_NAME_PATTERN" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTargetNamePattern)
+            }
+            "INVALID_ASSESSMENT_TEMPLATE_ARN" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTemplateArn)
+            }
+            "INVALID_ASSESSMENT_TEMPLATE_DURATION" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTemplateDuration)
+            }
+            "INVALID_ASSESSMENT_TEMPLATE_DURATION_RANGE" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTemplateDurationRange)
+            }
+            "INVALID_ASSESSMENT_TEMPLATE_NAME" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTemplateName)
+            }
+            "INVALID_ASSESSMENT_TEMPLATE_NAME_PATTERN" => {
+                Ok(InvalidInputErrorCode::InvalidAssessmentTemplateNamePattern)
+            }
+            "INVALID_ATTRIBUTE" => Ok(InvalidInputErrorCode::InvalidAttribute),
+            "INVALID_AUTO_SCALING_GROUP" => Ok(InvalidInputErrorCode::InvalidAutoScalingGroup),
+            "INVALID_EVENT" => Ok(InvalidInputErrorCode::InvalidEvent),
+            "INVALID_FINDING_ARN" => Ok(InvalidInputErrorCode::InvalidFindingArn),
+            "INVALID_IAM_ROLE_ARN" => Ok(InvalidInputErrorCode::InvalidIamRoleArn),
+            "INVALID_LOCALE" => Ok(InvalidInputErrorCode::InvalidLocale),
+            "INVALID_MAX_RESULTS" => Ok(InvalidInputErrorCode::InvalidMaxResults),
+            "INVALID_NUMBER_OF_AGENT_IDS" => Ok(InvalidInputErrorCode::InvalidNumberOfAgentIds),
+            "INVALID_NUMBER_OF_ASSESSMENT_RUN_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfAssessmentRunArns)
+            }
+            "INVALID_NUMBER_OF_ASSESSMENT_RUN_STATES" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfAssessmentRunStates)
+            }
+            "INVALID_NUMBER_OF_ASSESSMENT_TARGET_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfAssessmentTargetArns)
+            }
+            "INVALID_NUMBER_OF_ASSESSMENT_TEMPLATE_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfAssessmentTemplateArns)
+            }
+            "INVALID_NUMBER_OF_ATTRIBUTES" => Ok(InvalidInputErrorCode::InvalidNumberOfAttributes),
+            "INVALID_NUMBER_OF_AUTO_SCALING_GROUPS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfAutoScalingGroups)
+            }
+            "INVALID_NUMBER_OF_FINDING_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfFindingArns)
+            }
+            "INVALID_NUMBER_OF_RESOURCE_GROUP_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfResourceGroupArns)
+            }
+            "INVALID_NUMBER_OF_RESOURCE_GROUP_TAGS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfResourceGroupTags)
+            }
+            "INVALID_NUMBER_OF_RULES_PACKAGE_ARNS" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfRulesPackageArns)
+            }
+            "INVALID_NUMBER_OF_RULE_NAMES" => Ok(InvalidInputErrorCode::InvalidNumberOfRuleNames),
+            "INVALID_NUMBER_OF_SEVERITIES" => Ok(InvalidInputErrorCode::InvalidNumberOfSeverities),
+            "INVALID_NUMBER_OF_TAGS" => Ok(InvalidInputErrorCode::InvalidNumberOfTags),
+            "INVALID_NUMBER_OF_USER_ATTRIBUTES" => {
+                Ok(InvalidInputErrorCode::InvalidNumberOfUserAttributes)
+            }
+            "INVALID_PAGINATION_TOKEN" => Ok(InvalidInputErrorCode::InvalidPaginationToken),
+            "INVALID_RESOURCE_ARN" => Ok(InvalidInputErrorCode::InvalidResourceArn),
+            "INVALID_RESOURCE_GROUP_ARN" => Ok(InvalidInputErrorCode::InvalidResourceGroupArn),
+            "INVALID_RESOURCE_GROUP_TAG_KEY" => {
+                Ok(InvalidInputErrorCode::InvalidResourceGroupTagKey)
+            }
+            "INVALID_RESOURCE_GROUP_TAG_VALUE" => {
+                Ok(InvalidInputErrorCode::InvalidResourceGroupTagValue)
+            }
+            "INVALID_RULES_PACKAGE_ARN" => Ok(InvalidInputErrorCode::InvalidRulesPackageArn),
+            "INVALID_RULE_NAME" => Ok(InvalidInputErrorCode::InvalidRuleName),
+            "INVALID_SEVERITY" => Ok(InvalidInputErrorCode::InvalidSeverity),
+            "INVALID_SNS_TOPIC_ARN" => Ok(InvalidInputErrorCode::InvalidSnsTopicArn),
+            "INVALID_TAG" => Ok(InvalidInputErrorCode::InvalidTag),
+            "INVALID_TAG_KEY" => Ok(InvalidInputErrorCode::InvalidTagKey),
+            "INVALID_TAG_VALUE" => Ok(InvalidInputErrorCode::InvalidTagValue),
+            "INVALID_USER_ATTRIBUTE" => Ok(InvalidInputErrorCode::InvalidUserAttribute),
+            "INVALID_USER_ATTRIBUTE_KEY" => Ok(InvalidInputErrorCode::InvalidUserAttributeKey),
+            "INVALID_USER_ATTRIBUTE_VALUE" => Ok(InvalidInputErrorCode::InvalidUserAttributeValue),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LimitExceededErrorCode {
+    AssessmentRunLimitExceeded,
+    AssessmentTargetLimitExceeded,
+    AssessmentTemplateLimitExceeded,
+    EventSubscriptionLimitExceeded,
+    ResourceGroupLimitExceeded,
+}
+
+impl Into<String> for LimitExceededErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LimitExceededErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            LimitExceededErrorCode::AssessmentRunLimitExceeded => "ASSESSMENT_RUN_LIMIT_EXCEEDED",
+            LimitExceededErrorCode::AssessmentTargetLimitExceeded => {
+                "ASSESSMENT_TARGET_LIMIT_EXCEEDED"
+            }
+            LimitExceededErrorCode::AssessmentTemplateLimitExceeded => {
+                "ASSESSMENT_TEMPLATE_LIMIT_EXCEEDED"
+            }
+            LimitExceededErrorCode::EventSubscriptionLimitExceeded => {
+                "EVENT_SUBSCRIPTION_LIMIT_EXCEEDED"
+            }
+            LimitExceededErrorCode::ResourceGroupLimitExceeded => "RESOURCE_GROUP_LIMIT_EXCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LimitExceededErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSESSMENT_RUN_LIMIT_EXCEEDED" => {
+                Ok(LimitExceededErrorCode::AssessmentRunLimitExceeded)
+            }
+            "ASSESSMENT_TARGET_LIMIT_EXCEEDED" => {
+                Ok(LimitExceededErrorCode::AssessmentTargetLimitExceeded)
+            }
+            "ASSESSMENT_TEMPLATE_LIMIT_EXCEEDED" => {
+                Ok(LimitExceededErrorCode::AssessmentTemplateLimitExceeded)
+            }
+            "EVENT_SUBSCRIPTION_LIMIT_EXCEEDED" => {
+                Ok(LimitExceededErrorCode::EventSubscriptionLimitExceeded)
+            }
+            "RESOURCE_GROUP_LIMIT_EXCEEDED" => {
+                Ok(LimitExceededErrorCode::ResourceGroupLimitExceeded)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -952,6 +1723,99 @@ pub struct ListTagsForResourceResponse {
     pub tags: Vec<Tag>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Locale {
+    EnUs,
+}
+
+impl Into<String> for Locale {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Locale {
+    fn into(self) -> &'static str {
+        match self {
+            Locale::EnUs => "EN_US",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Locale {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EN_US" => Ok(Locale::EnUs),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NoSuchEntityErrorCode {
+    AssessmentRunDoesNotExist,
+    AssessmentTargetDoesNotExist,
+    AssessmentTemplateDoesNotExist,
+    FindingDoesNotExist,
+    IamRoleDoesNotExist,
+    ResourceGroupDoesNotExist,
+    RulesPackageDoesNotExist,
+    SnsTopicDoesNotExist,
+}
+
+impl Into<String> for NoSuchEntityErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NoSuchEntityErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            NoSuchEntityErrorCode::AssessmentRunDoesNotExist => "ASSESSMENT_RUN_DOES_NOT_EXIST",
+            NoSuchEntityErrorCode::AssessmentTargetDoesNotExist => {
+                "ASSESSMENT_TARGET_DOES_NOT_EXIST"
+            }
+            NoSuchEntityErrorCode::AssessmentTemplateDoesNotExist => {
+                "ASSESSMENT_TEMPLATE_DOES_NOT_EXIST"
+            }
+            NoSuchEntityErrorCode::FindingDoesNotExist => "FINDING_DOES_NOT_EXIST",
+            NoSuchEntityErrorCode::IamRoleDoesNotExist => "IAM_ROLE_DOES_NOT_EXIST",
+            NoSuchEntityErrorCode::ResourceGroupDoesNotExist => "RESOURCE_GROUP_DOES_NOT_EXIST",
+            NoSuchEntityErrorCode::RulesPackageDoesNotExist => "RULES_PACKAGE_DOES_NOT_EXIST",
+            NoSuchEntityErrorCode::SnsTopicDoesNotExist => "SNS_TOPIC_DOES_NOT_EXIST",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NoSuchEntityErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSESSMENT_RUN_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::AssessmentRunDoesNotExist),
+            "ASSESSMENT_TARGET_DOES_NOT_EXIST" => {
+                Ok(NoSuchEntityErrorCode::AssessmentTargetDoesNotExist)
+            }
+            "ASSESSMENT_TEMPLATE_DOES_NOT_EXIST" => {
+                Ok(NoSuchEntityErrorCode::AssessmentTemplateDoesNotExist)
+            }
+            "FINDING_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::FindingDoesNotExist),
+            "IAM_ROLE_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::IamRoleDoesNotExist),
+            "RESOURCE_GROUP_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::ResourceGroupDoesNotExist),
+            "RULES_PACKAGE_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::RulesPackageDoesNotExist),
+            "SNS_TOPIC_DOES_NOT_EXIST" => Ok(NoSuchEntityErrorCode::SnsTopicDoesNotExist),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PreviewAgentsRequest {
     #[doc="<p>You can use this parameter to indicate the maximum number of items you want in the response. The default value is 10. The maximum value is 500.</p>"]
@@ -1000,6 +1864,114 @@ pub struct RemoveAttributesFromFindingsResponse {
     #[doc="<p>Attributes details that cannot be described. An error code is provided for each failed item.</p>"]
     #[serde(rename="failedItems")]
     pub failed_items: ::std::collections::HashMap<String, FailedItemDetails>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportFileFormat {
+    Html,
+    Pdf,
+}
+
+impl Into<String> for ReportFileFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportFileFormat {
+    fn into(self) -> &'static str {
+        match self {
+            ReportFileFormat::Html => "HTML",
+            ReportFileFormat::Pdf => "PDF",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportFileFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HTML" => Ok(ReportFileFormat::Html),
+            "PDF" => Ok(ReportFileFormat::Pdf),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportStatus {
+    Completed,
+    Failed,
+    WorkInProgress,
+}
+
+impl Into<String> for ReportStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReportStatus::Completed => "COMPLETED",
+            ReportStatus::Failed => "FAILED",
+            ReportStatus::WorkInProgress => "WORK_IN_PROGRESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLETED" => Ok(ReportStatus::Completed),
+            "FAILED" => Ok(ReportStatus::Failed),
+            "WORK_IN_PROGRESS" => Ok(ReportStatus::WorkInProgress),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReportType {
+    Finding,
+    Full,
+}
+
+impl Into<String> for ReportType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReportType {
+    fn into(self) -> &'static str {
+        match self {
+            ReportType::Finding => "FINDING",
+            ReportType::Full => "FULL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReportType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FINDING" => Ok(ReportType::Finding),
+            "FULL" => Ok(ReportType::Full),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains information about a resource group. The resource group defines a set of tags that, when queried, identify the AWS resources that make up the assessment target. This data type is used as the response element in the <a>DescribeResourceGroups</a> action.</p>"]
@@ -1060,6 +2032,50 @@ pub struct SetTagsForResourceRequest {
     pub tags: Option<Vec<Tag>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Severity {
+    High,
+    Informational,
+    Low,
+    Medium,
+    Undefined,
+}
+
+impl Into<String> for Severity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Severity {
+    fn into(self) -> &'static str {
+        match self {
+            Severity::High => "High",
+            Severity::Informational => "Informational",
+            Severity::Low => "Low",
+            Severity::Medium => "Medium",
+            Severity::Undefined => "Undefined",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Severity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "High" => Ok(Severity::High),
+            "Informational" => Ok(Severity::Informational),
+            "Low" => Ok(Severity::Low),
+            "Medium" => Ok(Severity::Medium),
+            "Undefined" => Ok(Severity::Undefined),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StartAssessmentRunRequest {
     #[doc="<p>You can specify the name for the assessment run. The name must be unique for the assessment template whose ARN is used to start the assessment run.</p>"]
@@ -1076,6 +2092,41 @@ pub struct StartAssessmentRunResponse {
     #[doc="<p>The ARN of the assessment run that has been started.</p>"]
     #[serde(rename="assessmentRunArn")]
     pub assessment_run_arn: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StopAction {
+    SkipEvaluation,
+    StartEvaluation,
+}
+
+impl Into<String> for StopAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StopAction {
+    fn into(self) -> &'static str {
+        match self {
+            StopAction::SkipEvaluation => "SKIP_EVALUATION",
+            StopAction::StartEvaluation => "START_EVALUATION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StopAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SKIP_EVALUATION" => Ok(StopAction::SkipEvaluation),
+            "START_EVALUATION" => Ok(StopAction::StartEvaluation),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -4648,7 +5699,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddAttributesToFindingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4680,7 +5731,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateAssessmentTargetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4711,7 +5762,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateAssessmentTemplateResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4742,7 +5793,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateResourceGroupResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4772,7 +5823,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4798,7 +5849,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4824,7 +5875,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4852,7 +5903,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAssessmentRunsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4883,7 +5934,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAssessmentTargetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4916,7 +5967,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAssessmentTemplatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4947,7 +5998,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeCrossAccountAccessRoleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4978,7 +6029,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeFindingsResponse>(String::from_utf8_lossy(&body)
@@ -5011,7 +6062,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeResourceGroupsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5042,7 +6093,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeRulesPackagesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5072,7 +6123,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetAssessmentReportResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5103,7 +6154,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetTelemetryMetadataResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5134,7 +6185,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAssessmentRunAgentsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5165,7 +6216,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAssessmentRunsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5196,7 +6247,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAssessmentTargetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5227,7 +6278,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAssessmentTemplatesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5259,7 +6310,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListEventSubscriptionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5289,7 +6340,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListFindingsResponse>(String::from_utf8_lossy(&body)
@@ -5321,7 +6372,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRulesPackagesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5351,7 +6402,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsForResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5381,7 +6432,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PreviewAgentsResponse>(String::from_utf8_lossy(&body)
@@ -5414,7 +6465,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5443,7 +6494,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveAttributesFromFindingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5474,7 +6525,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5500,7 +6551,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartAssessmentRunResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5530,7 +6581,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5556,7 +6607,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5582,7 +6633,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5608,7 +6659,7 @@ impl<P, D> Inspector for InspectorClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -137,6 +133,41 @@ pub struct AttributePayload {
     pub merge: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoRegistrationStatus {
+    Disable,
+    Enable,
+}
+
+impl Into<String> for AutoRegistrationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoRegistrationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AutoRegistrationStatus::Disable => "DISABLE",
+            AutoRegistrationStatus::Enable => "ENABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoRegistrationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DISABLE" => Ok(AutoRegistrationStatus::Disable),
+            "ENABLE" => Ok(AutoRegistrationStatus::Enable),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A CA certificate.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CACertificate {
@@ -191,12 +222,100 @@ pub struct CACertificateDescription {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CACertificateStatus {
+    Active,
+    Inactive,
+}
+
+impl Into<String> for CACertificateStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CACertificateStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CACertificateStatus::Active => "ACTIVE",
+            CACertificateStatus::Inactive => "INACTIVE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CACertificateStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(CACertificateStatus::Active),
+            "INACTIVE" => Ok(CACertificateStatus::Inactive),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The input for the CancelCertificateTransfer operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct CancelCertificateTransferRequest {
     #[doc="<p>The ID of the certificate.</p>"]
     #[serde(rename="certificateId")]
     pub certificate_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CannedAccessControlList {
+    AuthenticatedRead,
+    AwsExecRead,
+    BucketOwnerFullControl,
+    BucketOwnerRead,
+    LogDeliveryWrite,
+    Private,
+    PublicRead,
+    PublicReadWrite,
+}
+
+impl Into<String> for CannedAccessControlList {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CannedAccessControlList {
+    fn into(self) -> &'static str {
+        match self {
+            CannedAccessControlList::AuthenticatedRead => "authenticated-read",
+            CannedAccessControlList::AwsExecRead => "aws-exec-read",
+            CannedAccessControlList::BucketOwnerFullControl => "bucket-owner-full-control",
+            CannedAccessControlList::BucketOwnerRead => "bucket-owner-read",
+            CannedAccessControlList::LogDeliveryWrite => "log-delivery-write",
+            CannedAccessControlList::Private => "private",
+            CannedAccessControlList::PublicRead => "public-read",
+            CannedAccessControlList::PublicReadWrite => "public-read-write",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CannedAccessControlList {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "authenticated-read" => Ok(CannedAccessControlList::AuthenticatedRead),
+            "aws-exec-read" => Ok(CannedAccessControlList::AwsExecRead),
+            "bucket-owner-full-control" => Ok(CannedAccessControlList::BucketOwnerFullControl),
+            "bucket-owner-read" => Ok(CannedAccessControlList::BucketOwnerRead),
+            "log-delivery-write" => Ok(CannedAccessControlList::LogDeliveryWrite),
+            "private" => Ok(CannedAccessControlList::Private),
+            "public-read" => Ok(CannedAccessControlList::PublicRead),
+            "public-read-write" => Ok(CannedAccessControlList::PublicReadWrite),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about a certificate.</p>"]
@@ -263,6 +382,53 @@ pub struct CertificateDescription {
     #[serde(rename="transferData")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub transfer_data: Option<TransferData>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CertificateStatus {
+    Active,
+    Inactive,
+    PendingActivation,
+    PendingTransfer,
+    RegisterInactive,
+    Revoked,
+}
+
+impl Into<String> for CertificateStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CertificateStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CertificateStatus::Active => "ACTIVE",
+            CertificateStatus::Inactive => "INACTIVE",
+            CertificateStatus::PendingActivation => "PENDING_ACTIVATION",
+            CertificateStatus::PendingTransfer => "PENDING_TRANSFER",
+            CertificateStatus::RegisterInactive => "REGISTER_INACTIVE",
+            CertificateStatus::Revoked => "REVOKED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CertificateStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(CertificateStatus::Active),
+            "INACTIVE" => Ok(CertificateStatus::Inactive),
+            "PENDING_ACTIVATION" => Ok(CertificateStatus::PendingActivation),
+            "PENDING_TRANSFER" => Ok(CertificateStatus::PendingTransfer),
+            "REGISTER_INACTIVE" => Ok(CertificateStatus::RegisterInactive),
+            "REVOKED" => Ok(CertificateStatus::Revoked),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes an action that updates a CloudWatch alarm.</p>"]
@@ -788,6 +954,41 @@ pub struct DynamoDBv2Action {
     #[serde(rename="roleArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DynamoKeyType {
+    Number,
+    String,
+}
+
+impl Into<String> for DynamoKeyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DynamoKeyType {
+    fn into(self) -> &'static str {
+        match self {
+            DynamoKeyType::Number => "NUMBER",
+            DynamoKeyType::String => "STRING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DynamoKeyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NUMBER" => Ok(DynamoKeyType::Number),
+            "STRING" => Ok(DynamoKeyType::String),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes an action that writes data to an Amazon Elasticsearch Service domain.</p>"]
@@ -1369,6 +1570,50 @@ pub struct ListTopicRulesResponse {
     pub rules: Option<Vec<TopicRuleListItem>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LogLevel {
+    Debug,
+    Disabled,
+    Error,
+    Info,
+    Warn,
+}
+
+impl Into<String> for LogLevel {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LogLevel {
+    fn into(self) -> &'static str {
+        match self {
+            LogLevel::Debug => "DEBUG",
+            LogLevel::Disabled => "DISABLED",
+            LogLevel::Error => "ERROR",
+            LogLevel::Info => "INFO",
+            LogLevel::Warn => "WARN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LogLevel {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEBUG" => Ok(LogLevel::Debug),
+            "DISABLED" => Ok(LogLevel::Disabled),
+            "ERROR" => Ok(LogLevel::Error),
+            "INFO" => Ok(LogLevel::Info),
+            "WARN" => Ok(LogLevel::Warn),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the logging options payload.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct LoggingOptionsPayload {
@@ -1379,6 +1624,41 @@ pub struct LoggingOptionsPayload {
     #[doc="<p>The ARN of the IAM role that grants access.</p>"]
     #[serde(rename="roleArn")]
     pub role_arn: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MessageFormat {
+    Json,
+    Raw,
+}
+
+impl Into<String> for MessageFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MessageFormat {
+    fn into(self) -> &'static str {
+        match self {
+            MessageFormat::Json => "JSON",
+            MessageFormat::Raw => "RAW",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MessageFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "JSON" => Ok(MessageFormat::Json),
+            "RAW" => Ok(MessageFormat::Raw),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A certificate that has been transfered but not yet accepted.</p>"]
@@ -8459,7 +8739,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8494,7 +8774,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8529,7 +8809,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8574,7 +8854,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8614,7 +8894,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8665,7 +8945,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8712,7 +8992,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8762,7 +9042,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8807,7 +9087,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8853,7 +9133,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8898,7 +9178,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -8932,7 +9212,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -8977,7 +9257,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -9008,7 +9288,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -9043,7 +9323,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -9076,7 +9356,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9125,7 +9405,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9170,7 +9450,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9214,7 +9494,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -9249,7 +9529,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9295,7 +9575,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9341,7 +9621,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9383,7 +9663,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9427,7 +9707,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9472,7 +9752,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9517,7 +9797,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -9552,7 +9832,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9596,7 +9876,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -9629,7 +9909,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -9660,7 +9940,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9702,7 +9982,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9748,7 +10028,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9791,7 +10071,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9835,7 +10115,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9889,7 +10169,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9943,7 +10223,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9999,7 +10279,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10054,7 +10334,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10110,7 +10390,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10165,7 +10445,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10210,7 +10490,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10265,7 +10545,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10317,7 +10597,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10362,7 +10642,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10416,7 +10696,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10476,7 +10756,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10533,7 +10813,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10586,7 +10866,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10632,7 +10912,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10678,7 +10958,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10713,7 +10993,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10748,7 +11028,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10783,7 +11063,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10820,7 +11100,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10872,7 +11152,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10908,7 +11188,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -10942,7 +11222,7 @@ impl<P, D> Iot for IotClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -126,6 +122,41 @@ pub struct EnableEnhancedMonitoringInput {
     #[doc="<p>The name of the stream for which to enable enhanced monitoring.</p>"]
     #[serde(rename="StreamName")]
     pub stream_name: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EncryptionType {
+    Kms,
+    None,
+}
+
+impl Into<String> for EncryptionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EncryptionType {
+    fn into(self) -> &'static str {
+        match self {
+            EncryptionType::Kms => "KMS",
+            EncryptionType::None => "NONE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EncryptionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KMS" => Ok(EncryptionType::Kms),
+            "NONE" => Ok(EncryptionType::None),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents enhanced metrics types.</p>"]
@@ -300,6 +331,63 @@ pub struct MergeShardsInput {
     pub stream_name: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricsName {
+    All,
+    IncomingBytes,
+    IncomingRecords,
+    IteratorAgeMilliseconds,
+    OutgoingBytes,
+    OutgoingRecords,
+    ReadProvisionedThroughputExceeded,
+    WriteProvisionedThroughputExceeded,
+}
+
+impl Into<String> for MetricsName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricsName {
+    fn into(self) -> &'static str {
+        match self {
+            MetricsName::All => "ALL",
+            MetricsName::IncomingBytes => "IncomingBytes",
+            MetricsName::IncomingRecords => "IncomingRecords",
+            MetricsName::IteratorAgeMilliseconds => "IteratorAgeMilliseconds",
+            MetricsName::OutgoingBytes => "OutgoingBytes",
+            MetricsName::OutgoingRecords => "OutgoingRecords",
+            MetricsName::ReadProvisionedThroughputExceeded => "ReadProvisionedThroughputExceeded",
+            MetricsName::WriteProvisionedThroughputExceeded => "WriteProvisionedThroughputExceeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricsName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL" => Ok(MetricsName::All),
+            "IncomingBytes" => Ok(MetricsName::IncomingBytes),
+            "IncomingRecords" => Ok(MetricsName::IncomingRecords),
+            "IteratorAgeMilliseconds" => Ok(MetricsName::IteratorAgeMilliseconds),
+            "OutgoingBytes" => Ok(MetricsName::OutgoingBytes),
+            "OutgoingRecords" => Ok(MetricsName::OutgoingRecords),
+            "ReadProvisionedThroughputExceeded" => {
+                Ok(MetricsName::ReadProvisionedThroughputExceeded)
+            }
+            "WriteProvisionedThroughputExceeded" => {
+                Ok(MetricsName::WriteProvisionedThroughputExceeded)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the input for <code>PutRecord</code>.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutRecordInput {
@@ -448,6 +536,38 @@ pub struct RemoveTagsFromStreamInput {
     pub tag_keys: Vec<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScalingType {
+    UniformScaling,
+}
+
+impl Into<String> for ScalingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScalingType {
+    fn into(self) -> &'static str {
+        match self {
+            ScalingType::UniformScaling => "UNIFORM_SCALING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScalingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "UNIFORM_SCALING" => Ok(ScalingType::UniformScaling),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The range of possible sequence numbers for the shard.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct SequenceNumberRange {
@@ -480,6 +600,50 @@ pub struct Shard {
     #[doc="<p>The unique identifier of the shard within the stream.</p>"]
     #[serde(rename="ShardId")]
     pub shard_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ShardIteratorType {
+    AfterSequenceNumber,
+    AtSequenceNumber,
+    AtTimestamp,
+    Latest,
+    TrimHorizon,
+}
+
+impl Into<String> for ShardIteratorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ShardIteratorType {
+    fn into(self) -> &'static str {
+        match self {
+            ShardIteratorType::AfterSequenceNumber => "AFTER_SEQUENCE_NUMBER",
+            ShardIteratorType::AtSequenceNumber => "AT_SEQUENCE_NUMBER",
+            ShardIteratorType::AtTimestamp => "AT_TIMESTAMP",
+            ShardIteratorType::Latest => "LATEST",
+            ShardIteratorType::TrimHorizon => "TRIM_HORIZON",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ShardIteratorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AFTER_SEQUENCE_NUMBER" => Ok(ShardIteratorType::AfterSequenceNumber),
+            "AT_SEQUENCE_NUMBER" => Ok(ShardIteratorType::AtSequenceNumber),
+            "AT_TIMESTAMP" => Ok(ShardIteratorType::AtTimestamp),
+            "LATEST" => Ok(ShardIteratorType::Latest),
+            "TRIM_HORIZON" => Ok(ShardIteratorType::TrimHorizon),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents the input for <code>SplitShard</code>.</p>"]
@@ -557,6 +721,47 @@ pub struct StreamDescription {
     #[doc="<p>The current status of the stream being described. The stream status is one of the following states:</p> <ul> <li> <p> <code>CREATING</code> - The stream is being created. Amazon Kinesis immediately returns and sets <code>StreamStatus</code> to <code>CREATING</code>.</p> </li> <li> <p> <code>DELETING</code> - The stream is being deleted. The specified stream is in the <code>DELETING</code> state until Amazon Kinesis completes the deletion.</p> </li> <li> <p> <code>ACTIVE</code> - The stream exists and is ready for read and write operations or deletion. You should perform read and write operations only on an <code>ACTIVE</code> stream.</p> </li> <li> <p> <code>UPDATING</code> - Shards in the stream are being merged or split. Read and write operations continue to work while the stream is in the <code>UPDATING</code> state.</p> </li> </ul>"]
     #[serde(rename="StreamStatus")]
     pub stream_status: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StreamStatus {
+    Active,
+    Creating,
+    Deleting,
+    Updating,
+}
+
+impl Into<String> for StreamStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StreamStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StreamStatus::Active => "ACTIVE",
+            StreamStatus::Creating => "CREATING",
+            StreamStatus::Deleting => "DELETING",
+            StreamStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StreamStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(StreamStatus::Active),
+            "CREATING" => Ok(StreamStatus::Creating),
+            "DELETING" => Ok(StreamStatus::Deleting),
+            "UPDATING" => Ok(StreamStatus::Updating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Metadata assigned to the stream, consisting of a key-value pair.</p>"]
@@ -2823,7 +3028,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2847,7 +3052,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2874,7 +3079,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2899,7 +3104,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -2922,7 +3127,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeLimitsOutput>(String::from_utf8_lossy(&body)
@@ -2954,7 +3159,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeStreamOutput>(String::from_utf8_lossy(&body)
@@ -2987,7 +3192,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<EnhancedMonitoringOutput>(String::from_utf8_lossy(&body)
@@ -3021,7 +3226,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<EnhancedMonitoringOutput>(String::from_utf8_lossy(&body)
@@ -3052,7 +3257,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRecordsOutput>(String::from_utf8_lossy(&body)
@@ -3084,7 +3289,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetShardIteratorOutput>(String::from_utf8_lossy(&body)
@@ -3117,7 +3322,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3144,7 +3349,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListStreamsOutput>(String::from_utf8_lossy(&body)
@@ -3176,7 +3381,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsForStreamOutput>(String::from_utf8_lossy(&body)
@@ -3206,7 +3411,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3230,7 +3435,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutRecordOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -3259,7 +3464,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutRecordsOutput>(String::from_utf8_lossy(&body)
@@ -3291,7 +3496,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3315,7 +3520,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3341,7 +3546,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3367,7 +3572,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3393,7 +3598,7 @@ impl<P, D> Kinesis for KinesisClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateShardCountOutput>(String::from_utf8_lossy(&body)

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -146,6 +142,53 @@ pub struct ApplicationDetail {
     #[serde(rename="ReferenceDataSourceDescriptions")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub reference_data_source_descriptions: Option<Vec<ReferenceDataSourceDescription>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ApplicationStatus {
+    Deleting,
+    Ready,
+    Running,
+    Starting,
+    Stopping,
+    Updating,
+}
+
+impl Into<String> for ApplicationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ApplicationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ApplicationStatus::Deleting => "DELETING",
+            ApplicationStatus::Ready => "READY",
+            ApplicationStatus::Running => "RUNNING",
+            ApplicationStatus::Starting => "STARTING",
+            ApplicationStatus::Stopping => "STOPPING",
+            ApplicationStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ApplicationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETING" => Ok(ApplicationStatus::Deleting),
+            "READY" => Ok(ApplicationStatus::Ready),
+            "RUNNING" => Ok(ApplicationStatus::Running),
+            "STARTING" => Ok(ApplicationStatus::Starting),
+            "STOPPING" => Ok(ApplicationStatus::Stopping),
+            "UPDATING" => Ok(ApplicationStatus::Updating),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides application summary information, including the application Amazon Resource Name (ARN), name, and status.</p>"]
@@ -502,6 +545,44 @@ pub struct InputSchemaUpdate {
     pub record_format_update: Option<RecordFormat>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InputStartingPosition {
+    LastStoppedPoint,
+    Now,
+    TrimHorizon,
+}
+
+impl Into<String> for InputStartingPosition {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InputStartingPosition {
+    fn into(self) -> &'static str {
+        match self {
+            InputStartingPosition::LastStoppedPoint => "LAST_STOPPED_POINT",
+            InputStartingPosition::Now => "NOW",
+            InputStartingPosition::TrimHorizon => "TRIM_HORIZON",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InputStartingPosition {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LAST_STOPPED_POINT" => Ok(InputStartingPosition::LastStoppedPoint),
+            "NOW" => Ok(InputStartingPosition::Now),
+            "TRIM_HORIZON" => Ok(InputStartingPosition::TrimHorizon),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the point at which the application reads from the streaming source.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InputStartingPositionConfiguration {
@@ -822,6 +903,41 @@ pub struct RecordFormat {
     #[doc="<p>The type of record format.</p>"]
     #[serde(rename="RecordFormatType")]
     pub record_format_type: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RecordFormatType {
+    Csv,
+    Json,
+}
+
+impl Into<String> for RecordFormatType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RecordFormatType {
+    fn into(self) -> &'static str {
+        match self {
+            RecordFormatType::Csv => "CSV",
+            RecordFormatType::Json => "JSON",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RecordFormatType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CSV" => Ok(RecordFormatType::Csv),
+            "JSON" => Ok(RecordFormatType::Json),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes the reference data source by providing the source information (S3 bucket name and object key name), the resulting in-application table name that is created, and the necessary schema to map the data elements in the Amazon S3 object to the in-application table.</p>"]
@@ -2501,7 +2617,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddApplicationCloudWatchLoggingOptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2532,7 +2648,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddApplicationInputResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2564,7 +2680,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddApplicationOutputResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2597,7 +2713,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddApplicationReferenceDataSourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2628,7 +2744,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2659,7 +2775,7 @@ fn add_application_cloud_watch_logging_option(&self, input: &AddApplicationCloud
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2688,7 +2804,7 @@ fn delete_application_cloud_watch_logging_option(&self, input: &DeleteApplicatio
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteApplicationCloudWatchLoggingOptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2720,7 +2836,7 @@ fn delete_application_cloud_watch_logging_option(&self, input: &DeleteApplicatio
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteApplicationOutputResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2750,7 +2866,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteApplicationReferenceDataSourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2781,7 +2897,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2812,7 +2928,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DiscoverInputSchemaResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2842,7 +2958,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListApplicationsResponse>(String::from_utf8_lossy(&body)
@@ -2874,7 +2990,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartApplicationResponse>(String::from_utf8_lossy(&body)
@@ -2906,7 +3022,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopApplicationResponse>(String::from_utf8_lossy(&body)
@@ -2939,7 +3055,7 @@ fn delete_application_reference_data_source(&self, input: &DeleteApplicationRefe
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateApplicationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -11,23 +11,57 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AlgorithmSpec {
+    RsaesOaepSha1,
+    RsaesOaepSha256,
+    RsaesPkcs1V15,
+}
+
+impl Into<String> for AlgorithmSpec {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AlgorithmSpec {
+    fn into(self) -> &'static str {
+        match self {
+            AlgorithmSpec::RsaesOaepSha1 => "RSAES_OAEP_SHA_1",
+            AlgorithmSpec::RsaesOaepSha256 => "RSAES_OAEP_SHA_256",
+            AlgorithmSpec::RsaesPkcs1V15 => "RSAES_PKCS1_V1_5",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AlgorithmSpec {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RSAES_OAEP_SHA_1" => Ok(AlgorithmSpec::RsaesOaepSha1),
+            "RSAES_OAEP_SHA_256" => Ok(AlgorithmSpec::RsaesOaepSha256),
+            "RSAES_PKCS1_V1_5" => Ok(AlgorithmSpec::RsaesPkcs1V15),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about an alias.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AliasListEntry {
@@ -146,6 +180,41 @@ pub struct CreateKeyResponse {
     #[serde(rename="KeyMetadata")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub key_metadata: Option<KeyMetadata>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DataKeySpec {
+    Aes128,
+    Aes256,
+}
+
+impl Into<String> for DataKeySpec {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DataKeySpec {
+    fn into(self) -> &'static str {
+        match self {
+            DataKeySpec::Aes128 => "AES_128",
+            DataKeySpec::Aes256 => "AES_256",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DataKeySpec {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AES_128" => Ok(DataKeySpec::Aes128),
+            "AES_256" => Ok(DataKeySpec::Aes256),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -282,6 +351,41 @@ pub struct EncryptResponse {
     #[serde(rename="KeyId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub key_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExpirationModelType {
+    KeyMaterialDoesNotExpire,
+    KeyMaterialExpires,
+}
+
+impl Into<String> for ExpirationModelType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExpirationModelType {
+    fn into(self) -> &'static str {
+        match self {
+            ExpirationModelType::KeyMaterialDoesNotExpire => "KEY_MATERIAL_DOES_NOT_EXPIRE",
+            ExpirationModelType::KeyMaterialExpires => "KEY_MATERIAL_EXPIRES",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExpirationModelType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KEY_MATERIAL_DOES_NOT_EXPIRE" => Ok(ExpirationModelType::KeyMaterialDoesNotExpire),
+            "KEY_MATERIAL_EXPIRES" => Ok(ExpirationModelType::KeyMaterialExpires),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -518,6 +622,64 @@ pub struct GrantListEntry {
     pub retiring_principal: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GrantOperation {
+    CreateGrant,
+    Decrypt,
+    DescribeKey,
+    Encrypt,
+    GenerateDataKey,
+    GenerateDataKeyWithoutPlaintext,
+    ReEncryptFrom,
+    ReEncryptTo,
+    RetireGrant,
+}
+
+impl Into<String> for GrantOperation {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GrantOperation {
+    fn into(self) -> &'static str {
+        match self {
+            GrantOperation::CreateGrant => "CreateGrant",
+            GrantOperation::Decrypt => "Decrypt",
+            GrantOperation::DescribeKey => "DescribeKey",
+            GrantOperation::Encrypt => "Encrypt",
+            GrantOperation::GenerateDataKey => "GenerateDataKey",
+            GrantOperation::GenerateDataKeyWithoutPlaintext => "GenerateDataKeyWithoutPlaintext",
+            GrantOperation::ReEncryptFrom => "ReEncryptFrom",
+            GrantOperation::ReEncryptTo => "ReEncryptTo",
+            GrantOperation::RetireGrant => "RetireGrant",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GrantOperation {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreateGrant" => Ok(GrantOperation::CreateGrant),
+            "Decrypt" => Ok(GrantOperation::Decrypt),
+            "DescribeKey" => Ok(GrantOperation::DescribeKey),
+            "Encrypt" => Ok(GrantOperation::Encrypt),
+            "GenerateDataKey" => Ok(GrantOperation::GenerateDataKey),
+            "GenerateDataKeyWithoutPlaintext" => {
+                Ok(GrantOperation::GenerateDataKeyWithoutPlaintext)
+            }
+            "ReEncryptFrom" => Ok(GrantOperation::ReEncryptFrom),
+            "ReEncryptTo" => Ok(GrantOperation::ReEncryptTo),
+            "RetireGrant" => Ok(GrantOperation::RetireGrant),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ImportKeyMaterialRequest {
     #[doc="<p>The encrypted key material to import. It must be encrypted with the public key that you received in the response to a previous <a>GetParametersForImport</a> request, using the wrapping algorithm that you specified in that request.</p>"]
@@ -563,6 +725,41 @@ pub struct KeyListEntry {
     #[serde(rename="KeyId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub key_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum KeyManagerType {
+    Aws,
+    Customer,
+}
+
+impl Into<String> for KeyManagerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for KeyManagerType {
+    fn into(self) -> &'static str {
+        match self {
+            KeyManagerType::Aws => "AWS",
+            KeyManagerType::Customer => "CUSTOMER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for KeyManagerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS" => Ok(KeyManagerType::Aws),
+            "CUSTOMER" => Ok(KeyManagerType::Customer),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains metadata about a customer master key (CMK).</p> <p>This data type is used as a response element for the <a>CreateKey</a> and <a>DescribeKey</a> operations.</p>"]
@@ -619,6 +816,79 @@ pub struct KeyMetadata {
     #[serde(rename="ValidTo")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub valid_to: Option<f64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum KeyState {
+    Disabled,
+    Enabled,
+    PendingDeletion,
+    PendingImport,
+}
+
+impl Into<String> for KeyState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for KeyState {
+    fn into(self) -> &'static str {
+        match self {
+            KeyState::Disabled => "Disabled",
+            KeyState::Enabled => "Enabled",
+            KeyState::PendingDeletion => "PendingDeletion",
+            KeyState::PendingImport => "PendingImport",
+        }
+    }
+}
+
+impl ::std::str::FromStr for KeyState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(KeyState::Disabled),
+            "Enabled" => Ok(KeyState::Enabled),
+            "PendingDeletion" => Ok(KeyState::PendingDeletion),
+            "PendingImport" => Ok(KeyState::PendingImport),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum KeyUsageType {
+    EncryptDecrypt,
+}
+
+impl Into<String> for KeyUsageType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for KeyUsageType {
+    fn into(self) -> &'static str {
+        match self {
+            KeyUsageType::EncryptDecrypt => "ENCRYPT_DECRYPT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for KeyUsageType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ENCRYPT_DECRYPT" => Ok(KeyUsageType::EncryptDecrypt),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -785,6 +1055,41 @@ pub struct ListRetirableGrantsRequest {
     pub retiring_principal: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OriginType {
+    AwsKms,
+    External,
+}
+
+impl Into<String> for OriginType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OriginType {
+    fn into(self) -> &'static str {
+        match self {
+            OriginType::AwsKms => "AWS_KMS",
+            OriginType::External => "EXTERNAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OriginType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS_KMS" => Ok(OriginType::AwsKms),
+            "EXTERNAL" => Ok(OriginType::External),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutKeyPolicyRequest {
     #[doc="<p>A flag to indicate whether to bypass the key policy lockout safety check.</p> <important> <p>Setting this value to true increases the likelihood that the CMK becomes unmanageable. Do not set this value to true indiscriminately.</p> <p>For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </important> <p>Use this parameter only when you intend to prevent the principal that is making the request from making a subsequent <code>PutKeyPolicy</code> request on the CMK.</p> <p>The default value is false.</p>"]
@@ -947,6 +1252,38 @@ pub struct UpdateKeyDescriptionRequest {
     #[doc="<p>A unique identifier for the CMK. This value can be a globally unique identifier or the fully specified ARN to a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul>"]
     #[serde(rename="KeyId")]
     pub key_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WrappingKeySpec {
+    Rsa2048,
+}
+
+impl Into<String> for WrappingKeySpec {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WrappingKeySpec {
+    fn into(self) -> &'static str {
+        match self {
+            WrappingKeySpec::Rsa2048 => "RSA_2048",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WrappingKeySpec {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RSA_2048" => Ok(WrappingKeySpec::Rsa2048),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by CancelKeyDeletion
@@ -4915,7 +5252,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CancelKeyDeletionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4943,7 +5280,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4969,7 +5306,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateGrantResponse>(String::from_utf8_lossy(&body)
@@ -4999,7 +5336,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateKeyResponse>(String::from_utf8_lossy(&body)
@@ -5029,7 +5366,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DecryptResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -5058,7 +5395,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5084,7 +5421,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5111,7 +5448,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeKeyResponse>(String::from_utf8_lossy(&body)
@@ -5141,7 +5478,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5167,7 +5504,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5191,7 +5528,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5217,7 +5554,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5241,7 +5578,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<EncryptResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -5272,7 +5609,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GenerateDataKeyResponse>(String::from_utf8_lossy(&body)
@@ -5306,7 +5643,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GenerateDataKeyWithoutPlaintextResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5337,7 +5674,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GenerateRandomResponse>(String::from_utf8_lossy(&body)
@@ -5369,7 +5706,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetKeyPolicyResponse>(String::from_utf8_lossy(&body)
@@ -5402,7 +5739,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetKeyRotationStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5433,7 +5770,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetParametersForImportResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5463,7 +5800,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ImportKeyMaterialResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5493,7 +5830,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAliasesResponse>(String::from_utf8_lossy(&body)
@@ -5525,7 +5862,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListGrantsResponse>(String::from_utf8_lossy(&body)
@@ -5557,7 +5894,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListKeyPoliciesResponse>(String::from_utf8_lossy(&body)
@@ -5587,7 +5924,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListKeysResponse>(String::from_utf8_lossy(&body)
@@ -5619,7 +5956,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListResourceTagsResponse>(String::from_utf8_lossy(&body)
@@ -5651,7 +5988,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListGrantsResponse>(String::from_utf8_lossy(&body)
@@ -5681,7 +6018,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5705,7 +6042,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ReEncryptResponse>(String::from_utf8_lossy(&body)
@@ -5735,7 +6072,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5759,7 +6096,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5785,7 +6122,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ScheduleKeyDeletionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5813,7 +6150,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5837,7 +6174,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5861,7 +6198,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5887,7 +6224,7 @@ impl<P, D> Kms for KmsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -337,6 +333,44 @@ pub struct EventSourceMappingConfiguration {
     pub uuid: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventSourcePosition {
+    AtTimestamp,
+    Latest,
+    TrimHorizon,
+}
+
+impl Into<String> for EventSourcePosition {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventSourcePosition {
+    fn into(self) -> &'static str {
+        match self {
+            EventSourcePosition::AtTimestamp => "AT_TIMESTAMP",
+            EventSourcePosition::Latest => "LATEST",
+            EventSourcePosition::TrimHorizon => "TRIM_HORIZON",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventSourcePosition {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AT_TIMESTAMP" => Ok(EventSourcePosition::AtTimestamp),
+            "LATEST" => Ok(EventSourcePosition::Latest),
+            "TRIM_HORIZON" => Ok(EventSourcePosition::TrimHorizon),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The code for the Lambda function.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct FunctionCode {
@@ -450,6 +484,38 @@ pub struct FunctionConfiguration {
     #[serde(rename="VpcConfig")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_config: Option<VpcConfigResponse>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FunctionVersion {
+    All,
+}
+
+impl Into<String> for FunctionVersion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FunctionVersion {
+    fn into(self) -> &'static str {
+        match self {
+            FunctionVersion::All => "ALL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FunctionVersion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL" => Ok(FunctionVersion::All),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -586,6 +652,44 @@ pub struct InvocationResponse {
     pub payload: Option<Vec<u8>>,
     #[doc="<p>The HTTP status code will be in the 200 range for successful request. For the <code>RequestResponse</code> invocation type this status code will be 200. For the <code>Event</code> invocation type this status code will be 202. For the <code>DryRun</code> invocation type the status code will be 204. </p>"]
     pub status_code: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InvocationType {
+    DryRun,
+    Event,
+    RequestResponse,
+}
+
+impl Into<String> for InvocationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InvocationType {
+    fn into(self) -> &'static str {
+        match self {
+            InvocationType::DryRun => "DryRun",
+            InvocationType::Event => "Event",
+            InvocationType::RequestResponse => "RequestResponse",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InvocationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DryRun" => Ok(InvocationType::DryRun),
+            "Event" => Ok(InvocationType::Event),
+            "RequestResponse" => Ok(InvocationType::RequestResponse),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p/>"]
@@ -756,6 +860,41 @@ pub struct ListVersionsByFunctionResponse {
     pub versions: Option<Vec<FunctionConfiguration>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LogType {
+    None,
+    Tail,
+}
+
+impl Into<String> for LogType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LogType {
+    fn into(self) -> &'static str {
+        match self {
+            LogType::None => "None",
+            LogType::Tail => "Tail",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LogType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "None" => Ok(LogType::None),
+            "Tail" => Ok(LogType::Tail),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p/>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PublishVersionRequest {
@@ -787,6 +926,59 @@ pub struct RemovePermissionRequest {
     pub statement_id: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Runtime {
+    Dotnetcore10,
+    Java8,
+    Nodejs,
+    Nodejs43,
+    Nodejs43Edge,
+    Nodejs610,
+    Python27,
+    Python36,
+}
+
+impl Into<String> for Runtime {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Runtime {
+    fn into(self) -> &'static str {
+        match self {
+            Runtime::Dotnetcore10 => "dotnetcore1.0",
+            Runtime::Java8 => "java8",
+            Runtime::Nodejs => "nodejs",
+            Runtime::Nodejs43 => "nodejs4.3",
+            Runtime::Nodejs43Edge => "nodejs4.3-edge",
+            Runtime::Nodejs610 => "nodejs6.10",
+            Runtime::Python27 => "python2.7",
+            Runtime::Python36 => "python3.6",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Runtime {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dotnetcore1.0" => Ok(Runtime::Dotnetcore10),
+            "java8" => Ok(Runtime::Java8),
+            "nodejs" => Ok(Runtime::Nodejs),
+            "nodejs4.3" => Ok(Runtime::Nodejs43),
+            "nodejs4.3-edge" => Ok(Runtime::Nodejs43Edge),
+            "nodejs6.10" => Ok(Runtime::Nodejs610),
+            "python2.7" => Ok(Runtime::Python27),
+            "python3.6" => Ok(Runtime::Python36),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct TagResourceRequest {
     #[doc="<p>The ARN (Amazon Resource Name) of the Lambda function.</p>"]
@@ -795,6 +987,52 @@ pub struct TagResourceRequest {
     #[doc="<p>The list of tags (key-value pairs) you are assigning to the Lambda function.</p>"]
     #[serde(rename="Tags")]
     pub tags: ::std::collections::HashMap<String, String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ThrottleReason {
+    CallerRateLimitExceeded,
+    ConcurrentInvocationLimitExceeded,
+    FunctionInvocationRateLimitExceeded,
+}
+
+impl Into<String> for ThrottleReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ThrottleReason {
+    fn into(self) -> &'static str {
+        match self {
+            ThrottleReason::CallerRateLimitExceeded => "CallerRateLimitExceeded",
+            ThrottleReason::ConcurrentInvocationLimitExceeded => {
+                "ConcurrentInvocationLimitExceeded"
+            }
+            ThrottleReason::FunctionInvocationRateLimitExceeded => {
+                "FunctionInvocationRateLimitExceeded"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ThrottleReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CallerRateLimitExceeded" => Ok(ThrottleReason::CallerRateLimitExceeded),
+            "ConcurrentInvocationLimitExceeded" => {
+                Ok(ThrottleReason::ConcurrentInvocationLimitExceeded)
+            }
+            "FunctionInvocationRateLimitExceeded" => {
+                Ok(ThrottleReason::FunctionInvocationRateLimitExceeded)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The parent object that contains your function's tracing settings.</p>"]
@@ -813,6 +1051,41 @@ pub struct TracingConfigResponse {
     #[serde(rename="Mode")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub mode: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TracingMode {
+    Active,
+    PassThrough,
+}
+
+impl Into<String> for TracingMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TracingMode {
+    fn into(self) -> &'static str {
+        match self {
+            TracingMode::Active => "Active",
+            TracingMode::PassThrough => "PassThrough",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TracingMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(TracingMode::Active),
+            "PassThrough" => Ok(TracingMode::PassThrough),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -3996,7 +4269,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4042,7 +4315,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4088,7 +4361,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4135,7 +4408,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4179,7 +4452,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4214,7 +4487,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4263,7 +4536,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -4294,7 +4567,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4338,7 +4611,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4384,7 +4657,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4434,7 +4707,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4484,7 +4757,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4532,7 +4805,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4595,7 +4868,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut result = InvocationResponse::default();
 
@@ -4612,7 +4885,8 @@ impl<P, D> Lambda for LambdaClient<P, D>
                     let value = log_result.to_owned();
                     result.log_result = Some(value)
                 };
-                result.status_code = Some(StatusCode::to_u16(&response.status) as i64);
+                result.status_code = Some(::hyper::status::StatusCode::to_u16(&response.status) as
+                                          i64);
                 Ok(result)
             }
             _ => {
@@ -4644,7 +4918,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4658,7 +4932,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
                 let mut result = serde_json::from_slice::<InvokeAsyncResponse>(&body).unwrap();
 
 
-                result.status = Some(StatusCode::to_u16(&response.status) as i64);
+                result.status = Some(::hyper::status::StatusCode::to_u16(&response.status) as i64);
                 Ok(result)
             }
             _ => {
@@ -4699,7 +4973,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4757,7 +5031,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4816,7 +5090,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4858,7 +5132,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4911,7 +5185,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4958,7 +5232,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5008,7 +5282,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5040,7 +5314,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5075,7 +5349,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5111,7 +5385,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5158,7 +5432,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Accepted => {
+            ::hyper::status::StatusCode::Accepted => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5206,7 +5480,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5253,7 +5527,7 @@ impl<P, D> Lambda for LambdaClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/lex-models/src/generated.rs
+++ b/rusoto/services/lex-models/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -159,6 +155,44 @@ pub struct BuiltinSlotTypeMetadata {
     pub supported_locales: Option<Vec<String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChannelType {
+    Facebook,
+    Slack,
+    TwilioSms,
+}
+
+impl Into<String> for ChannelType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChannelType {
+    fn into(self) -> &'static str {
+        match self {
+            ChannelType::Facebook => "Facebook",
+            ChannelType::Slack => "Slack",
+            ChannelType::TwilioSms => "Twilio-Sms",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChannelType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Facebook" => Ok(ChannelType::Facebook),
+            "Slack" => Ok(ChannelType::Slack),
+            "Twilio-Sms" => Ok(ChannelType::TwilioSms),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies a Lambda function that verifies requests to a bot or fulfills the user's request to a bot..</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CodeHook {
@@ -168,6 +202,41 @@ pub struct CodeHook {
     #[doc="<p>The Amazon Resource Name (ARN) of the Lambda function.</p>"]
     #[serde(rename="uri")]
     pub uri: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContentType {
+    PlainText,
+    Ssml,
+}
+
+impl Into<String> for ContentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContentType {
+    fn into(self) -> &'static str {
+        match self {
+            ContentType::PlainText => "PlainText",
+            ContentType::Ssml => "SSML",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PlainText" => Ok(ContentType::PlainText),
+            "SSML" => Ok(ContentType::Ssml),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -476,6 +545,41 @@ pub struct FulfillmentActivity {
     #[doc="<p> How the intent should be fulfilled, either by running a Lambda function or by returning the slot data to the client application. </p>"]
     #[serde(rename="type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FulfillmentActivityType {
+    CodeHook,
+    ReturnIntent,
+}
+
+impl Into<String> for FulfillmentActivityType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FulfillmentActivityType {
+    fn into(self) -> &'static str {
+        match self {
+            FulfillmentActivityType::CodeHook => "CodeHook",
+            FulfillmentActivityType::ReturnIntent => "ReturnIntent",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FulfillmentActivityType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CodeHook" => Ok(FulfillmentActivityType::CodeHook),
+            "ReturnIntent" => Ok(FulfillmentActivityType::ReturnIntent),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1133,6 +1237,38 @@ pub struct IntentMetadata {
     pub version: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Locale {
+    EnUS,
+}
+
+impl Into<String> for Locale {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Locale {
+    fn into(self) -> &'static str {
+        match self {
+            Locale::EnUS => "en-US",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Locale {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en-US" => Ok(Locale::EnUS),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The message object that provides the message text and its type.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Message {
@@ -1142,6 +1278,41 @@ pub struct Message {
     #[doc="<p>The content type of the message string.</p>"]
     #[serde(rename="contentType")]
     pub content_type: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProcessBehavior {
+    Build,
+    Save,
+}
+
+impl Into<String> for ProcessBehavior {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProcessBehavior {
+    fn into(self) -> &'static str {
+        match self {
+            ProcessBehavior::Build => "BUILD",
+            ProcessBehavior::Save => "SAVE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProcessBehavior {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BUILD" => Ok(ProcessBehavior::Build),
+            "SAVE" => Ok(ProcessBehavior::Save),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Obtains information from the user. To define a prompt, provide one or more messages and specify the number of attempts to get information from the user. If you provide more than one message, Amazon Lex chooses one of the messages to use to prompt the user. For more information, see <a>how-it-works</a>.</p>"]
@@ -1487,6 +1658,47 @@ pub struct PutSlotTypeResponse {
     pub version: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReferenceType {
+    Bot,
+    BotAlias,
+    BotChannel,
+    Intent,
+}
+
+impl Into<String> for ReferenceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReferenceType {
+    fn into(self) -> &'static str {
+        match self {
+            ReferenceType::Bot => "Bot",
+            ReferenceType::BotAlias => "BotAlias",
+            ReferenceType::BotChannel => "BotChannel",
+            ReferenceType::Intent => "Intent",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReferenceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Bot" => Ok(ReferenceType::Bot),
+            "BotAlias" => Ok(ReferenceType::BotAlias),
+            "BotChannel" => Ok(ReferenceType::BotChannel),
+            "Intent" => Ok(ReferenceType::Intent),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the resource that refers to the resource that you are attempting to delete. This object is returned as part of the <code>ResourceInUseException</code> exception. </p>"]
 #[derive(Default,Debug,Clone)]
 pub struct ResourceReference {
@@ -1535,6 +1747,41 @@ pub struct Slot {
     pub value_elicitation_prompt: Option<Prompt>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SlotConstraint {
+    Optional,
+    Required,
+}
+
+impl Into<String> for SlotConstraint {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SlotConstraint {
+    fn into(self) -> &'static str {
+        match self {
+            SlotConstraint::Optional => "Optional",
+            SlotConstraint::Required => "Required",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SlotConstraint {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Optional" => Ok(SlotConstraint::Optional),
+            "Required" => Ok(SlotConstraint::Required),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides information about a slot type..</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct SlotTypeMetadata {
@@ -1570,6 +1817,82 @@ pub struct Statement {
     #[serde(rename="responseCard")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub response_card: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Status {
+    Building,
+    Failed,
+    NotBuilt,
+    Ready,
+}
+
+impl Into<String> for Status {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Status {
+    fn into(self) -> &'static str {
+        match self {
+            Status::Building => "BUILDING",
+            Status::Failed => "FAILED",
+            Status::NotBuilt => "NOT_BUILT",
+            Status::Ready => "READY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Status {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BUILDING" => Ok(Status::Building),
+            "FAILED" => Ok(Status::Failed),
+            "NOT_BUILT" => Ok(Status::NotBuilt),
+            "READY" => Ok(Status::Ready),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StatusType {
+    Detected,
+    Missed,
+}
+
+impl Into<String> for StatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StatusType {
+    fn into(self) -> &'static str {
+        match self {
+            StatusType::Detected => "Detected",
+            StatusType::Missed => "Missed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Detected" => Ok(StatusType::Detected),
+            "Missed" => Ok(StatusType::Missed),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides information about a single utterance that was made to your bot. </p>"]
@@ -5133,7 +5456,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5178,7 +5501,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5224,7 +5547,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5267,7 +5590,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5300,7 +5623,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5336,7 +5659,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5372,7 +5695,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5403,7 +5726,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5438,7 +5761,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5469,7 +5792,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5504,7 +5827,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5539,7 +5862,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -5572,7 +5895,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5618,7 +5941,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5672,7 +5995,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5720,7 +6043,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5779,7 +6102,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5832,7 +6155,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5884,7 +6207,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5928,7 +6251,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5985,7 +6308,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6042,7 +6365,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6086,7 +6409,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6137,7 +6460,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6191,7 +6514,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6237,7 +6560,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6288,7 +6611,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6342,7 +6665,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6392,7 +6715,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6435,7 +6758,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6482,7 +6805,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6525,7 +6848,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6570,7 +6893,7 @@ impl<P, D> LexModels for LexModelsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/lex-runtime/src/generated.rs
+++ b/rusoto/services/lex-runtime/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -37,6 +33,89 @@ pub struct Button {
     #[doc="<p>The value sent to Amazon Lex when a user chooses the button. For example, consider button text \"NYC.\" When the user chooses the button, the value sent can be \"New York City.\"</p>"]
     #[serde(rename="value")]
     pub value: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContentType {
+    ApplicationVndAmazonawsCardGeneric,
+}
+
+impl Into<String> for ContentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContentType {
+    fn into(self) -> &'static str {
+        match self {
+            ContentType::ApplicationVndAmazonawsCardGeneric => {
+                "application/vnd.amazonaws.card.generic"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "application/vnd.amazonaws.card.generic" => {
+                Ok(ContentType::ApplicationVndAmazonawsCardGeneric)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DialogState {
+    ConfirmIntent,
+    ElicitIntent,
+    ElicitSlot,
+    Failed,
+    Fulfilled,
+    ReadyForFulfillment,
+}
+
+impl Into<String> for DialogState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DialogState {
+    fn into(self) -> &'static str {
+        match self {
+            DialogState::ConfirmIntent => "ConfirmIntent",
+            DialogState::ElicitIntent => "ElicitIntent",
+            DialogState::ElicitSlot => "ElicitSlot",
+            DialogState::Failed => "Failed",
+            DialogState::Fulfilled => "Fulfilled",
+            DialogState::ReadyForFulfillment => "ReadyForFulfillment",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DialogState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ConfirmIntent" => Ok(DialogState::ConfirmIntent),
+            "ElicitIntent" => Ok(DialogState::ElicitIntent),
+            "ElicitSlot" => Ok(DialogState::ElicitSlot),
+            "Failed" => Ok(DialogState::Failed),
+            "Fulfilled" => Ok(DialogState::Fulfilled),
+            "ReadyForFulfillment" => Ok(DialogState::ReadyForFulfillment),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents an option rendered to the user when a prompt is shown. It could be an image, a button, a link, or text. </p>"]
@@ -502,7 +581,7 @@ impl<P, D> LexRuntime for LexRuntimeClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut result = PostContentResponse::default();
 
@@ -577,7 +656,7 @@ impl<P, D> LexRuntime for LexRuntimeClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -11,23 +11,54 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccessDirection {
+    Inbound,
+    Outbound,
+}
+
+impl Into<String> for AccessDirection {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccessDirection {
+    fn into(self) -> &'static str {
+        match self {
+            AccessDirection::Inbound => "inbound",
+            AccessDirection::Outbound => "outbound",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccessDirection {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "inbound" => Ok(AccessDirection::Inbound),
+            "outbound" => Ok(AccessDirection::Outbound),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AllocateStaticIpRequest {
     #[doc="<p>The name of the static IP address.</p>"]
@@ -121,6 +152,41 @@ pub struct Blueprint {
     #[serde(rename="versionCode")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub version_code: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BlueprintType {
+    App,
+    Os,
+}
+
+impl Into<String> for BlueprintType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BlueprintType {
+    fn into(self) -> &'static str {
+        match self {
+            BlueprintType::App => "app",
+            BlueprintType::Os => "os",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BlueprintType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "app" => Ok(BlueprintType::App),
+            "os" => Ok(BlueprintType::Os),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a bundle, which is a set of specs describing your virtual private server (or <i>instance</i>).</p>"]
@@ -1090,6 +1156,41 @@ pub struct InstanceAccessDetails {
     pub username: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceAccessProtocol {
+    Rdp,
+    Ssh,
+}
+
+impl Into<String> for InstanceAccessProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceAccessProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceAccessProtocol::Rdp => "rdp",
+            InstanceAccessProtocol::Ssh => "ssh",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceAccessProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "rdp" => Ok(InstanceAccessProtocol::Rdp),
+            "ssh" => Ok(InstanceAccessProtocol::Ssh),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the hardware for the instance.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceHardware {
@@ -1105,6 +1206,53 @@ pub struct InstanceHardware {
     #[serde(rename="ramSizeInGb")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub ram_size_in_gb: Option<f32>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceMetricName {
+    Cpuutilization,
+    NetworkIn,
+    NetworkOut,
+    StatusCheckFailed,
+    StatusCheckFailedInstance,
+    StatusCheckFailedSystem,
+}
+
+impl Into<String> for InstanceMetricName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceMetricName {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceMetricName::Cpuutilization => "CPUUtilization",
+            InstanceMetricName::NetworkIn => "NetworkIn",
+            InstanceMetricName::NetworkOut => "NetworkOut",
+            InstanceMetricName::StatusCheckFailed => "StatusCheckFailed",
+            InstanceMetricName::StatusCheckFailedInstance => "StatusCheckFailed_Instance",
+            InstanceMetricName::StatusCheckFailedSystem => "StatusCheckFailed_System",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceMetricName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CPUUtilization" => Ok(InstanceMetricName::Cpuutilization),
+            "NetworkIn" => Ok(InstanceMetricName::NetworkIn),
+            "NetworkOut" => Ok(InstanceMetricName::NetworkOut),
+            "StatusCheckFailed" => Ok(InstanceMetricName::StatusCheckFailed),
+            "StatusCheckFailed_Instance" => Ok(InstanceMetricName::StatusCheckFailedInstance),
+            "StatusCheckFailed_System" => Ok(InstanceMetricName::StatusCheckFailedSystem),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes monthly data transfer rates and port information for an instance.</p>"]
@@ -1231,6 +1379,44 @@ pub struct InstanceSnapshot {
     pub support_code: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceSnapshotState {
+    Available,
+    Error,
+    Pending,
+}
+
+impl Into<String> for InstanceSnapshotState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceSnapshotState {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceSnapshotState::Available => "available",
+            InstanceSnapshotState::Error => "error",
+            InstanceSnapshotState::Pending => "pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceSnapshotState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "available" => Ok(InstanceSnapshotState::Available),
+            "error" => Ok(InstanceSnapshotState::Error),
+            "pending" => Ok(InstanceSnapshotState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the virtual private server (or <i>instance</i>) status.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InstanceState {
@@ -1321,6 +1507,160 @@ pub struct MetricDatapoint {
     pub unit: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricStatistic {
+    Average,
+    Maximum,
+    Minimum,
+    SampleCount,
+    Sum,
+}
+
+impl Into<String> for MetricStatistic {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricStatistic {
+    fn into(self) -> &'static str {
+        match self {
+            MetricStatistic::Average => "Average",
+            MetricStatistic::Maximum => "Maximum",
+            MetricStatistic::Minimum => "Minimum",
+            MetricStatistic::SampleCount => "SampleCount",
+            MetricStatistic::Sum => "Sum",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricStatistic {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Average" => Ok(MetricStatistic::Average),
+            "Maximum" => Ok(MetricStatistic::Maximum),
+            "Minimum" => Ok(MetricStatistic::Minimum),
+            "SampleCount" => Ok(MetricStatistic::SampleCount),
+            "Sum" => Ok(MetricStatistic::Sum),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetricUnit {
+    Bits,
+    BitsSecond,
+    Bytes,
+    BytesSecond,
+    Count,
+    CountSecond,
+    Gigabits,
+    GigabitsSecond,
+    Gigabytes,
+    GigabytesSecond,
+    Kilobits,
+    KilobitsSecond,
+    Kilobytes,
+    KilobytesSecond,
+    Megabits,
+    MegabitsSecond,
+    Megabytes,
+    MegabytesSecond,
+    Microseconds,
+    Milliseconds,
+    None,
+    Percent,
+    Seconds,
+    Terabits,
+    TerabitsSecond,
+    Terabytes,
+    TerabytesSecond,
+}
+
+impl Into<String> for MetricUnit {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetricUnit {
+    fn into(self) -> &'static str {
+        match self {
+            MetricUnit::Bits => "Bits",
+            MetricUnit::BitsSecond => "Bits/Second",
+            MetricUnit::Bytes => "Bytes",
+            MetricUnit::BytesSecond => "Bytes/Second",
+            MetricUnit::Count => "Count",
+            MetricUnit::CountSecond => "Count/Second",
+            MetricUnit::Gigabits => "Gigabits",
+            MetricUnit::GigabitsSecond => "Gigabits/Second",
+            MetricUnit::Gigabytes => "Gigabytes",
+            MetricUnit::GigabytesSecond => "Gigabytes/Second",
+            MetricUnit::Kilobits => "Kilobits",
+            MetricUnit::KilobitsSecond => "Kilobits/Second",
+            MetricUnit::Kilobytes => "Kilobytes",
+            MetricUnit::KilobytesSecond => "Kilobytes/Second",
+            MetricUnit::Megabits => "Megabits",
+            MetricUnit::MegabitsSecond => "Megabits/Second",
+            MetricUnit::Megabytes => "Megabytes",
+            MetricUnit::MegabytesSecond => "Megabytes/Second",
+            MetricUnit::Microseconds => "Microseconds",
+            MetricUnit::Milliseconds => "Milliseconds",
+            MetricUnit::None => "None",
+            MetricUnit::Percent => "Percent",
+            MetricUnit::Seconds => "Seconds",
+            MetricUnit::Terabits => "Terabits",
+            MetricUnit::TerabitsSecond => "Terabits/Second",
+            MetricUnit::Terabytes => "Terabytes",
+            MetricUnit::TerabytesSecond => "Terabytes/Second",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetricUnit {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Bits" => Ok(MetricUnit::Bits),
+            "Bits/Second" => Ok(MetricUnit::BitsSecond),
+            "Bytes" => Ok(MetricUnit::Bytes),
+            "Bytes/Second" => Ok(MetricUnit::BytesSecond),
+            "Count" => Ok(MetricUnit::Count),
+            "Count/Second" => Ok(MetricUnit::CountSecond),
+            "Gigabits" => Ok(MetricUnit::Gigabits),
+            "Gigabits/Second" => Ok(MetricUnit::GigabitsSecond),
+            "Gigabytes" => Ok(MetricUnit::Gigabytes),
+            "Gigabytes/Second" => Ok(MetricUnit::GigabytesSecond),
+            "Kilobits" => Ok(MetricUnit::Kilobits),
+            "Kilobits/Second" => Ok(MetricUnit::KilobitsSecond),
+            "Kilobytes" => Ok(MetricUnit::Kilobytes),
+            "Kilobytes/Second" => Ok(MetricUnit::KilobytesSecond),
+            "Megabits" => Ok(MetricUnit::Megabits),
+            "Megabits/Second" => Ok(MetricUnit::MegabitsSecond),
+            "Megabytes" => Ok(MetricUnit::Megabytes),
+            "Megabytes/Second" => Ok(MetricUnit::MegabytesSecond),
+            "Microseconds" => Ok(MetricUnit::Microseconds),
+            "Milliseconds" => Ok(MetricUnit::Milliseconds),
+            "None" => Ok(MetricUnit::None),
+            "Percent" => Ok(MetricUnit::Percent),
+            "Seconds" => Ok(MetricUnit::Seconds),
+            "Terabits" => Ok(MetricUnit::Terabits),
+            "Terabits/Second" => Ok(MetricUnit::TerabitsSecond),
+            "Terabytes" => Ok(MetricUnit::Terabytes),
+            "Terabytes/Second" => Ok(MetricUnit::TerabytesSecond),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the monthly data transfer in and out of your virtual private server (or <i>instance</i>).</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct MonthlyTransfer {
@@ -1328,6 +1668,44 @@ pub struct MonthlyTransfer {
     #[serde(rename="gbPerMonthAllocated")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub gb_per_month_allocated: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NetworkProtocol {
+    All,
+    Tcp,
+    Udp,
+}
+
+impl Into<String> for NetworkProtocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NetworkProtocol {
+    fn into(self) -> &'static str {
+        match self {
+            NetworkProtocol::All => "all",
+            NetworkProtocol::Tcp => "tcp",
+            NetworkProtocol::Udp => "udp",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NetworkProtocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(NetworkProtocol::All),
+            "tcp" => Ok(NetworkProtocol::Tcp),
+            "udp" => Ok(NetworkProtocol::Udp),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1401,6 +1779,133 @@ pub struct Operation {
     pub status_changed_at: Option<f64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationStatus {
+    Completed,
+    Failed,
+    NotStarted,
+    Started,
+}
+
+impl Into<String> for OperationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            OperationStatus::Completed => "Completed",
+            OperationStatus::Failed => "Failed",
+            OperationStatus::NotStarted => "NotStarted",
+            OperationStatus::Started => "Started",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Completed" => Ok(OperationStatus::Completed),
+            "Failed" => Ok(OperationStatus::Failed),
+            "NotStarted" => Ok(OperationStatus::NotStarted),
+            "Started" => Ok(OperationStatus::Started),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationType {
+    AllocateStaticIp,
+    AttachStaticIp,
+    CloseInstancePublicPorts,
+    CreateDomain,
+    CreateInstance,
+    CreateInstanceSnapshot,
+    CreateInstancesFromSnapshot,
+    DeleteDomain,
+    DeleteDomainEntry,
+    DeleteInstance,
+    DeleteInstanceSnapshot,
+    DetachStaticIp,
+    OpenInstancePublicPorts,
+    PutInstancePublicPorts,
+    RebootInstance,
+    ReleaseStaticIp,
+    StartInstance,
+    StopInstance,
+    UpdateDomainEntry,
+}
+
+impl Into<String> for OperationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationType {
+    fn into(self) -> &'static str {
+        match self {
+            OperationType::AllocateStaticIp => "AllocateStaticIp",
+            OperationType::AttachStaticIp => "AttachStaticIp",
+            OperationType::CloseInstancePublicPorts => "CloseInstancePublicPorts",
+            OperationType::CreateDomain => "CreateDomain",
+            OperationType::CreateInstance => "CreateInstance",
+            OperationType::CreateInstanceSnapshot => "CreateInstanceSnapshot",
+            OperationType::CreateInstancesFromSnapshot => "CreateInstancesFromSnapshot",
+            OperationType::DeleteDomain => "DeleteDomain",
+            OperationType::DeleteDomainEntry => "DeleteDomainEntry",
+            OperationType::DeleteInstance => "DeleteInstance",
+            OperationType::DeleteInstanceSnapshot => "DeleteInstanceSnapshot",
+            OperationType::DetachStaticIp => "DetachStaticIp",
+            OperationType::OpenInstancePublicPorts => "OpenInstancePublicPorts",
+            OperationType::PutInstancePublicPorts => "PutInstancePublicPorts",
+            OperationType::RebootInstance => "RebootInstance",
+            OperationType::ReleaseStaticIp => "ReleaseStaticIp",
+            OperationType::StartInstance => "StartInstance",
+            OperationType::StopInstance => "StopInstance",
+            OperationType::UpdateDomainEntry => "UpdateDomainEntry",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AllocateStaticIp" => Ok(OperationType::AllocateStaticIp),
+            "AttachStaticIp" => Ok(OperationType::AttachStaticIp),
+            "CloseInstancePublicPorts" => Ok(OperationType::CloseInstancePublicPorts),
+            "CreateDomain" => Ok(OperationType::CreateDomain),
+            "CreateInstance" => Ok(OperationType::CreateInstance),
+            "CreateInstanceSnapshot" => Ok(OperationType::CreateInstanceSnapshot),
+            "CreateInstancesFromSnapshot" => Ok(OperationType::CreateInstancesFromSnapshot),
+            "DeleteDomain" => Ok(OperationType::DeleteDomain),
+            "DeleteDomainEntry" => Ok(OperationType::DeleteDomainEntry),
+            "DeleteInstance" => Ok(OperationType::DeleteInstance),
+            "DeleteInstanceSnapshot" => Ok(OperationType::DeleteInstanceSnapshot),
+            "DetachStaticIp" => Ok(OperationType::DetachStaticIp),
+            "OpenInstancePublicPorts" => Ok(OperationType::OpenInstancePublicPorts),
+            "PutInstancePublicPorts" => Ok(OperationType::PutInstancePublicPorts),
+            "RebootInstance" => Ok(OperationType::RebootInstance),
+            "ReleaseStaticIp" => Ok(OperationType::ReleaseStaticIp),
+            "StartInstance" => Ok(OperationType::StartInstance),
+            "StopInstance" => Ok(OperationType::StopInstance),
+            "UpdateDomainEntry" => Ok(OperationType::UpdateDomainEntry),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PeerVpcRequest;
 
@@ -1410,6 +1915,41 @@ pub struct PeerVpcResult {
     #[serde(rename="operation")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub operation: Option<Operation>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PortAccessType {
+    Private,
+    Public,
+}
+
+impl Into<String> for PortAccessType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PortAccessType {
+    fn into(self) -> &'static str {
+        match self {
+            PortAccessType::Private => "Private",
+            PortAccessType::Public => "Public",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PortAccessType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Private" => Ok(PortAccessType::Private),
+            "Public" => Ok(PortAccessType::Public),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes information about the ports on your virtual private server (or <i>instance</i>).</p>"]
@@ -1427,6 +1967,41 @@ pub struct PortInfo {
     #[serde(rename="toPort")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub to_port: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PortState {
+    Closed,
+    Open,
+}
+
+impl Into<String> for PortState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PortState {
+    fn into(self) -> &'static str {
+        match self {
+            PortState::Closed => "closed",
+            PortState::Open => "open",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PortState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "closed" => Ok(PortState::Closed),
+            "open" => Ok(PortState::Open),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1487,6 +2062,68 @@ pub struct Region {
     pub name: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RegionName {
+    ApNortheast1,
+    ApNortheast2,
+    ApSouth1,
+    ApSoutheast1,
+    ApSoutheast2,
+    EuCentral1,
+    EuWest1,
+    UsEast1,
+    UsEast2,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for RegionName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RegionName {
+    fn into(self) -> &'static str {
+        match self {
+            RegionName::ApNortheast1 => "ap-northeast-1",
+            RegionName::ApNortheast2 => "ap-northeast-2",
+            RegionName::ApSouth1 => "ap-south-1",
+            RegionName::ApSoutheast1 => "ap-southeast-1",
+            RegionName::ApSoutheast2 => "ap-southeast-2",
+            RegionName::EuCentral1 => "eu-central-1",
+            RegionName::EuWest1 => "eu-west-1",
+            RegionName::UsEast1 => "us-east-1",
+            RegionName::UsEast2 => "us-east-2",
+            RegionName::UsWest1 => "us-west-1",
+            RegionName::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RegionName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(RegionName::ApNortheast1),
+            "ap-northeast-2" => Ok(RegionName::ApNortheast2),
+            "ap-south-1" => Ok(RegionName::ApSouth1),
+            "ap-southeast-1" => Ok(RegionName::ApSoutheast1),
+            "ap-southeast-2" => Ok(RegionName::ApSoutheast2),
+            "eu-central-1" => Ok(RegionName::EuCentral1),
+            "eu-west-1" => Ok(RegionName::EuWest1),
+            "us-east-1" => Ok(RegionName::UsEast1),
+            "us-east-2" => Ok(RegionName::UsEast2),
+            "us-west-1" => Ok(RegionName::UsWest1),
+            "us-west-2" => Ok(RegionName::UsWest2),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ReleaseStaticIpRequest {
     #[doc="<p>The name of the static IP to delete.</p>"]
@@ -1513,6 +2150,53 @@ pub struct ResourceLocation {
     #[serde(rename="regionName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub region_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceType {
+    Domain,
+    Instance,
+    InstanceSnapshot,
+    KeyPair,
+    PeeredVpc,
+    StaticIp,
+}
+
+impl Into<String> for ResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceType::Domain => "Domain",
+            ResourceType::Instance => "Instance",
+            ResourceType::InstanceSnapshot => "InstanceSnapshot",
+            ResourceType::KeyPair => "KeyPair",
+            ResourceType::PeeredVpc => "PeeredVpc",
+            ResourceType::StaticIp => "StaticIp",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Domain" => Ok(ResourceType::Domain),
+            "Instance" => Ok(ResourceType::Instance),
+            "InstanceSnapshot" => Ok(ResourceType::InstanceSnapshot),
+            "KeyPair" => Ok(ResourceType::KeyPair),
+            "PeeredVpc" => Ok(ResourceType::PeeredVpc),
+            "StaticIp" => Ok(ResourceType::StaticIp),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -7359,7 +8043,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AllocateStaticIpResult>(String::from_utf8_lossy(&body)
@@ -7391,7 +8075,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AttachStaticIpResult>(String::from_utf8_lossy(&body)
@@ -7425,7 +8109,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CloseInstancePublicPortsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7456,7 +8140,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDomainResult>(String::from_utf8_lossy(&body)
@@ -7488,7 +8172,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDomainEntryResult>(String::from_utf8_lossy(&body)
@@ -7521,7 +8205,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateInstanceSnapshotResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7551,7 +8235,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateInstancesResult>(String::from_utf8_lossy(&body)
@@ -7585,7 +8269,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateInstancesFromSnapshotResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7616,7 +8300,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateKeyPairResult>(String::from_utf8_lossy(&body)
@@ -7648,7 +8332,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteDomainResult>(String::from_utf8_lossy(&body)
@@ -7680,7 +8364,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteDomainEntryResult>(String::from_utf8_lossy(&body)
@@ -7712,7 +8396,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteInstanceResult>(String::from_utf8_lossy(&body)
@@ -7745,7 +8429,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteInstanceSnapshotResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7775,7 +8459,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteKeyPairResult>(String::from_utf8_lossy(&body)
@@ -7807,7 +8491,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DetachStaticIpResult>(String::from_utf8_lossy(&body)
@@ -7838,7 +8522,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DownloadDefaultKeyPairResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7868,7 +8552,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetActiveNamesResult>(String::from_utf8_lossy(&body)
@@ -7900,7 +8584,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetBlueprintsResult>(String::from_utf8_lossy(&body)
@@ -7930,7 +8614,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetBundlesResult>(String::from_utf8_lossy(&body)
@@ -7960,7 +8644,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDomainResult>(String::from_utf8_lossy(&body).as_ref())
@@ -7989,7 +8673,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDomainsResult>(String::from_utf8_lossy(&body)
@@ -8021,7 +8705,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetInstanceResult>(String::from_utf8_lossy(&body)
@@ -8055,7 +8739,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetInstanceAccessDetailsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8087,7 +8771,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetInstanceMetricDataResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8118,7 +8802,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetInstancePortStatesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8148,7 +8832,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetInstanceSnapshotResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8178,7 +8862,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetInstanceSnapshotsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8208,7 +8892,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetInstanceStateResult>(String::from_utf8_lossy(&body)
@@ -8240,7 +8924,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetInstancesResult>(String::from_utf8_lossy(&body)
@@ -8270,7 +8954,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetKeyPairResult>(String::from_utf8_lossy(&body)
@@ -8302,7 +8986,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetKeyPairsResult>(String::from_utf8_lossy(&body)
@@ -8334,7 +9018,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetOperationResult>(String::from_utf8_lossy(&body)
@@ -8366,7 +9050,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetOperationsResult>(String::from_utf8_lossy(&body)
@@ -8400,7 +9084,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetOperationsForResourceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8429,7 +9113,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRegionsResult>(String::from_utf8_lossy(&body)
@@ -8461,7 +9145,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetStaticIpResult>(String::from_utf8_lossy(&body)
@@ -8493,7 +9177,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetStaticIpsResult>(String::from_utf8_lossy(&body)
@@ -8525,7 +9209,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ImportKeyPairResult>(String::from_utf8_lossy(&body)
@@ -8554,7 +9238,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<IsVpcPeeredResult>(String::from_utf8_lossy(&body)
@@ -8587,7 +9271,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<OpenInstancePublicPortsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8615,7 +9299,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PeerVpcResult>(String::from_utf8_lossy(&body).as_ref())
@@ -8647,7 +9331,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutInstancePublicPortsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8677,7 +9361,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RebootInstanceResult>(String::from_utf8_lossy(&body)
@@ -8709,7 +9393,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ReleaseStaticIpResult>(String::from_utf8_lossy(&body)
@@ -8741,7 +9425,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartInstanceResult>(String::from_utf8_lossy(&body)
@@ -8773,7 +9457,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopInstanceResult>(String::from_utf8_lossy(&body)
@@ -8802,7 +9486,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UnpeerVpcResult>(String::from_utf8_lossy(&body).as_ref())
@@ -8833,7 +9517,7 @@ impl<P, D> Lightsail for LightsailClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDomainEntryResult>(String::from_utf8_lossy(&body)

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -364,6 +360,41 @@ pub struct Destination {
     pub target_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Distribution {
+    ByLogStream,
+    Random,
+}
+
+impl Into<String> for Distribution {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Distribution {
+    fn into(self) -> &'static str {
+        match self {
+            Distribution::ByLogStream => "ByLogStream",
+            Distribution::Random => "Random",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Distribution {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ByLogStream" => Ok(Distribution::ByLogStream),
+            "Random" => Ok(Distribution::Random),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents an export task.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ExportTask {
@@ -429,6 +460,53 @@ pub struct ExportTaskStatus {
     #[serde(rename="message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExportTaskStatusCode {
+    Cancelled,
+    Completed,
+    Failed,
+    Pending,
+    PendingCancel,
+    Running,
+}
+
+impl Into<String> for ExportTaskStatusCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExportTaskStatusCode {
+    fn into(self) -> &'static str {
+        match self {
+            ExportTaskStatusCode::Cancelled => "CANCELLED",
+            ExportTaskStatusCode::Completed => "COMPLETED",
+            ExportTaskStatusCode::Failed => "FAILED",
+            ExportTaskStatusCode::Pending => "PENDING",
+            ExportTaskStatusCode::PendingCancel => "PENDING_CANCEL",
+            ExportTaskStatusCode::Running => "RUNNING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExportTaskStatusCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(ExportTaskStatusCode::Cancelled),
+            "COMPLETED" => Ok(ExportTaskStatusCode::Completed),
+            "FAILED" => Ok(ExportTaskStatusCode::Failed),
+            "PENDING" => Ok(ExportTaskStatusCode::Pending),
+            "PENDING_CANCEL" => Ok(ExportTaskStatusCode::PendingCancel),
+            "RUNNING" => Ok(ExportTaskStatusCode::Running),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -701,6 +779,41 @@ pub struct MetricTransformation {
     #[doc="<p>The value to publish to the CloudWatch metric when a filter pattern matches a log event.</p>"]
     #[serde(rename="metricValue")]
     pub metric_value: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OrderBy {
+    LastEventTime,
+    LogStreamName,
+}
+
+impl Into<String> for OrderBy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OrderBy {
+    fn into(self) -> &'static str {
+        match self {
+            OrderBy::LastEventTime => "LastEventTime",
+            OrderBy::LogStreamName => "LogStreamName",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OrderBy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LastEventTime" => Ok(OrderBy::LastEventTime),
+            "LogStreamName" => Ok(OrderBy::LogStreamName),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents a log event.</p>"]
@@ -3772,7 +3885,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3798,7 +3911,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateExportTaskResponse>(String::from_utf8_lossy(&body)
@@ -3828,7 +3941,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3854,7 +3967,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3880,7 +3993,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3904,7 +4017,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3930,7 +4043,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3956,7 +4069,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -3982,7 +4095,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4008,7 +4121,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4035,7 +4148,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeDestinationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4065,7 +4178,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeExportTasksResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4095,7 +4208,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeLogGroupsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4125,7 +4238,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeLogStreamsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4156,7 +4269,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMetricFiltersResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4187,7 +4300,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeSubscriptionFiltersResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4218,7 +4331,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<FilterLogEventsResponse>(String::from_utf8_lossy(&body)
@@ -4250,7 +4363,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetLogEventsResponse>(String::from_utf8_lossy(&body)
@@ -4282,7 +4395,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsLogGroupResponse>(String::from_utf8_lossy(&body)
@@ -4314,7 +4427,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutDestinationResponse>(String::from_utf8_lossy(&body)
@@ -4346,7 +4459,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4372,7 +4485,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutLogEventsResponse>(String::from_utf8_lossy(&body)
@@ -4404,7 +4517,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4430,7 +4543,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4456,7 +4569,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4480,7 +4593,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -4506,7 +4619,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<TestMetricFilterResponse>(String::from_utf8_lossy(&body)
@@ -4536,7 +4649,7 @@ impl<P, D> CloudWatchLogs for CloudWatchLogsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -52,6 +48,38 @@ pub struct AddTagsOutput {
     #[serde(rename="ResourceType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
+}
+
+#[doc="<p>The function used to train an <code>MLModel</code>. Training choices supported by Amazon ML include the following:</p> <ul> <li> <code>SGD</code> - Stochastic Gradient Descent.</li> <li> <code>RandomForest</code> - Random forest of decision trees.</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Algorithm {
+    Sgd,
+}
+
+impl Into<String> for Algorithm {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Algorithm {
+    fn into(self) -> &'static str {
+        match self {
+            Algorithm::Sgd => "sgd",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Algorithm {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "sgd" => Ok(Algorithm::Sgd),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p> Represents the output of a <code>GetBatchPrediction</code> operation.</p> <p> The content consists of the detailed metadata, the status, and the data file information of a <code>Batch Prediction</code>.</p>"]
@@ -116,6 +144,59 @@ pub struct BatchPrediction {
     #[serde(rename="TotalRecordCount")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub total_record_count: Option<i64>,
+}
+
+#[doc="<p>A list of the variables to use in searching or filtering <code>BatchPrediction</code>.</p> <ul> <li> <code>CreatedAt</code> - Sets the search criteria to <code>BatchPrediction</code> creation date.</li> <li> <code>Status</code> - Sets the search criteria to <code>BatchPrediction</code> status.</li> <li> <code>Name</code> - Sets the search criteria to the contents of <code>BatchPrediction</code><b> </b> <code>Name</code>.</li> <li> <code>IAMUser</code> - Sets the search criteria to the user account that invoked the <code>BatchPrediction</code> creation.</li> <li> <code>MLModelId</code> - Sets the search criteria to the <code>MLModel</code> used in the <code>BatchPrediction</code>.</li> <li> <code>DataSourceId</code> - Sets the search criteria to the <code>DataSource</code> used in the <code>BatchPrediction</code>.</li> <li> <code>DataURI</code> - Sets the search criteria to the data file(s) used in the <code>BatchPrediction</code>. The URL can identify either a file or an Amazon Simple Storage Service (Amazon S3) bucket or directory.</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BatchPredictionFilterVariable {
+    CreatedAt,
+    DataSourceId,
+    DataURI,
+    Iamuser,
+    LastUpdatedAt,
+    MlmodelId,
+    Name,
+    Status,
+}
+
+impl Into<String> for BatchPredictionFilterVariable {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BatchPredictionFilterVariable {
+    fn into(self) -> &'static str {
+        match self {
+            BatchPredictionFilterVariable::CreatedAt => "CreatedAt",
+            BatchPredictionFilterVariable::DataSourceId => "DataSourceId",
+            BatchPredictionFilterVariable::DataURI => "DataURI",
+            BatchPredictionFilterVariable::Iamuser => "IAMUser",
+            BatchPredictionFilterVariable::LastUpdatedAt => "LastUpdatedAt",
+            BatchPredictionFilterVariable::MlmodelId => "MLModelId",
+            BatchPredictionFilterVariable::Name => "Name",
+            BatchPredictionFilterVariable::Status => "Status",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BatchPredictionFilterVariable {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreatedAt" => Ok(BatchPredictionFilterVariable::CreatedAt),
+            "DataSourceId" => Ok(BatchPredictionFilterVariable::DataSourceId),
+            "DataURI" => Ok(BatchPredictionFilterVariable::DataURI),
+            "IAMUser" => Ok(BatchPredictionFilterVariable::Iamuser),
+            "LastUpdatedAt" => Ok(BatchPredictionFilterVariable::LastUpdatedAt),
+            "MLModelId" => Ok(BatchPredictionFilterVariable::MlmodelId),
+            "Name" => Ok(BatchPredictionFilterVariable::Name),
+            "Status" => Ok(BatchPredictionFilterVariable::Status),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -387,6 +468,53 @@ pub struct DataSource {
     #[serde(rename="Status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+#[doc="<p>A list of the variables to use in searching or filtering <code>DataSource</code>.</p> <ul> <li> <code>CreatedAt</code> - Sets the search criteria to <code>DataSource</code> creation date.</li> <li> <code>Status</code> - Sets the search criteria to <code>DataSource</code> status.</li> <li> <code>Name</code> - Sets the search criteria to the contents of <code>DataSource</code> <b> </b> <code>Name</code>.</li> <li> <code>DataUri</code> - Sets the search criteria to the URI of data files used to create the <code>DataSource</code>. The URI can identify either a file or an Amazon Simple Storage Service (Amazon S3) bucket or directory.</li> <li> <code>IAMUser</code> - Sets the search criteria to the user account that invoked the <code>DataSource</code> creation.</li> </ul> <note><title>Note</title> <p>The variable names should match the variable names in the <code>DataSource</code>.</p> </note>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DataSourceFilterVariable {
+    CreatedAt,
+    DataLocationS3,
+    Iamuser,
+    LastUpdatedAt,
+    Name,
+    Status,
+}
+
+impl Into<String> for DataSourceFilterVariable {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DataSourceFilterVariable {
+    fn into(self) -> &'static str {
+        match self {
+            DataSourceFilterVariable::CreatedAt => "CreatedAt",
+            DataSourceFilterVariable::DataLocationS3 => "DataLocationS3",
+            DataSourceFilterVariable::Iamuser => "IAMUser",
+            DataSourceFilterVariable::LastUpdatedAt => "LastUpdatedAt",
+            DataSourceFilterVariable::Name => "Name",
+            DataSourceFilterVariable::Status => "Status",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DataSourceFilterVariable {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreatedAt" => Ok(DataSourceFilterVariable::CreatedAt),
+            "DataLocationS3" => Ok(DataSourceFilterVariable::DataLocationS3),
+            "IAMUser" => Ok(DataSourceFilterVariable::Iamuser),
+            "LastUpdatedAt" => Ok(DataSourceFilterVariable::LastUpdatedAt),
+            "Name" => Ok(DataSourceFilterVariable::Name),
+            "Status" => Ok(DataSourceFilterVariable::Status),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -770,6 +898,85 @@ pub struct DescribeTagsOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[doc="Contains the key values of <code>DetailsMap</code>: <code>PredictiveModelType</code> - Indicates the type of the <code>MLModel</code>. <code>Algorithm</code> - Indicates the algorithm that was used for the <code>MLModel</code>."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DetailsAttributes {
+    Algorithm,
+    PredictiveModelType,
+}
+
+impl Into<String> for DetailsAttributes {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DetailsAttributes {
+    fn into(self) -> &'static str {
+        match self {
+            DetailsAttributes::Algorithm => "Algorithm",
+            DetailsAttributes::PredictiveModelType => "PredictiveModelType",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DetailsAttributes {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Algorithm" => Ok(DetailsAttributes::Algorithm),
+            "PredictiveModelType" => Ok(DetailsAttributes::PredictiveModelType),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="<p>Object status with the following possible values:</p> <ul> <li><code>PENDING</code></li> <li><code>INPROGRESS</code></li> <li><code>FAILED</code></li> <li><code>COMPLETED</code></li> <li><code>DELETED</code></li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EntityStatus {
+    Completed,
+    Deleted,
+    Failed,
+    Inprogress,
+    Pending,
+}
+
+impl Into<String> for EntityStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EntityStatus {
+    fn into(self) -> &'static str {
+        match self {
+            EntityStatus::Completed => "COMPLETED",
+            EntityStatus::Deleted => "DELETED",
+            EntityStatus::Failed => "FAILED",
+            EntityStatus::Inprogress => "INPROGRESS",
+            EntityStatus::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EntityStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLETED" => Ok(EntityStatus::Completed),
+            "DELETED" => Ok(EntityStatus::Deleted),
+            "FAILED" => Ok(EntityStatus::Failed),
+            "INPROGRESS" => Ok(EntityStatus::Inprogress),
+            "PENDING" => Ok(EntityStatus::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p> Represents the output of <code>GetEvaluation</code> operation. </p> <p>The content consists of the detailed metadata and data file information and the current status of the <code>Evaluation</code>.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Evaluation {
@@ -826,6 +1033,59 @@ pub struct Evaluation {
     #[serde(rename="Status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+#[doc="<p>A list of the variables to use in searching or filtering <code>Evaluation</code>.</p> <ul> <li> <code>CreatedAt</code> - Sets the search criteria to <code>Evaluation</code> creation date.</li> <li> <code>Status</code> - Sets the search criteria to <code>Evaluation</code> status.</li> <li> <code>Name</code> - Sets the search criteria to the contents of <code>Evaluation</code> <b> </b> <code>Name</code>.</li> <li> <code>IAMUser</code> - Sets the search criteria to the user account that invoked an evaluation.</li> <li> <code>MLModelId</code> - Sets the search criteria to the <code>Predictor</code> that was evaluated.</li> <li> <code>DataSourceId</code> - Sets the search criteria to the <code>DataSource</code> used in evaluation.</li> <li> <code>DataUri</code> - Sets the search criteria to the data file(s) used in evaluation. The URL can identify either a file or an Amazon Simple Storage Service (Amazon S3) bucket or directory.</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EvaluationFilterVariable {
+    CreatedAt,
+    DataSourceId,
+    DataURI,
+    Iamuser,
+    LastUpdatedAt,
+    MlmodelId,
+    Name,
+    Status,
+}
+
+impl Into<String> for EvaluationFilterVariable {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EvaluationFilterVariable {
+    fn into(self) -> &'static str {
+        match self {
+            EvaluationFilterVariable::CreatedAt => "CreatedAt",
+            EvaluationFilterVariable::DataSourceId => "DataSourceId",
+            EvaluationFilterVariable::DataURI => "DataURI",
+            EvaluationFilterVariable::Iamuser => "IAMUser",
+            EvaluationFilterVariable::LastUpdatedAt => "LastUpdatedAt",
+            EvaluationFilterVariable::MlmodelId => "MLModelId",
+            EvaluationFilterVariable::Name => "Name",
+            EvaluationFilterVariable::Status => "Status",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EvaluationFilterVariable {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreatedAt" => Ok(EvaluationFilterVariable::CreatedAt),
+            "DataSourceId" => Ok(EvaluationFilterVariable::DataSourceId),
+            "DataURI" => Ok(EvaluationFilterVariable::DataURI),
+            "IAMUser" => Ok(EvaluationFilterVariable::Iamuser),
+            "LastUpdatedAt" => Ok(EvaluationFilterVariable::LastUpdatedAt),
+            "MLModelId" => Ok(EvaluationFilterVariable::MlmodelId),
+            "Name" => Ok(EvaluationFilterVariable::Name),
+            "Status" => Ok(EvaluationFilterVariable::Status),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1248,6 +1508,103 @@ pub struct MLModel {
     pub training_parameters: Option<::std::collections::HashMap<String, String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MLModelFilterVariable {
+    Algorithm,
+    CreatedAt,
+    Iamuser,
+    LastUpdatedAt,
+    MlmodelType,
+    Name,
+    RealtimeEndpointStatus,
+    Status,
+    TrainingDataSourceId,
+    TrainingDataURI,
+}
+
+impl Into<String> for MLModelFilterVariable {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MLModelFilterVariable {
+    fn into(self) -> &'static str {
+        match self {
+            MLModelFilterVariable::Algorithm => "Algorithm",
+            MLModelFilterVariable::CreatedAt => "CreatedAt",
+            MLModelFilterVariable::Iamuser => "IAMUser",
+            MLModelFilterVariable::LastUpdatedAt => "LastUpdatedAt",
+            MLModelFilterVariable::MlmodelType => "MLModelType",
+            MLModelFilterVariable::Name => "Name",
+            MLModelFilterVariable::RealtimeEndpointStatus => "RealtimeEndpointStatus",
+            MLModelFilterVariable::Status => "Status",
+            MLModelFilterVariable::TrainingDataSourceId => "TrainingDataSourceId",
+            MLModelFilterVariable::TrainingDataURI => "TrainingDataURI",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MLModelFilterVariable {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Algorithm" => Ok(MLModelFilterVariable::Algorithm),
+            "CreatedAt" => Ok(MLModelFilterVariable::CreatedAt),
+            "IAMUser" => Ok(MLModelFilterVariable::Iamuser),
+            "LastUpdatedAt" => Ok(MLModelFilterVariable::LastUpdatedAt),
+            "MLModelType" => Ok(MLModelFilterVariable::MlmodelType),
+            "Name" => Ok(MLModelFilterVariable::Name),
+            "RealtimeEndpointStatus" => Ok(MLModelFilterVariable::RealtimeEndpointStatus),
+            "Status" => Ok(MLModelFilterVariable::Status),
+            "TrainingDataSourceId" => Ok(MLModelFilterVariable::TrainingDataSourceId),
+            "TrainingDataURI" => Ok(MLModelFilterVariable::TrainingDataURI),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MLModelType {
+    Binary,
+    Multiclass,
+    Regression,
+}
+
+impl Into<String> for MLModelType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MLModelType {
+    fn into(self) -> &'static str {
+        match self {
+            MLModelType::Binary => "BINARY",
+            MLModelType::Multiclass => "MULTICLASS",
+            MLModelType::Regression => "REGRESSION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MLModelType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BINARY" => Ok(MLModelType::Binary),
+            "MULTICLASS" => Ok(MLModelType::Multiclass),
+            "REGRESSION" => Ok(MLModelType::Regression),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Measurements of how well the <code>MLModel</code> performed on known observations. One of the following metrics is returned, based on the type of the <code>MLModel</code>: </p> <ul> <li> <p>BinaryAUC: The binary <code>MLModel</code> uses the Area Under the Curve (AUC) technique to measure performance. </p> </li> <li> <p>RegressionRMSE: The regression <code>MLModel</code> uses the Root Mean Square Error (RMSE) technique to measure performance. RMSE measures the difference between predicted and actual values for a single variable.</p> </li> <li> <p>MulticlassAvgFScore: The multiclass <code>MLModel</code> uses the F1 score technique to measure performance. </p> </li> </ul> <p> For more information about performance metrics, please see the <a href=\"http://docs.aws.amazon.com/machine-learning/latest/dg\">Amazon Machine Learning Developer Guide</a>. </p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct PerformanceMetrics {
@@ -1402,6 +1759,47 @@ pub struct RealtimeEndpointInfo {
     pub peak_requests_per_second: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RealtimeEndpointStatus {
+    Failed,
+    None,
+    Ready,
+    Updating,
+}
+
+impl Into<String> for RealtimeEndpointStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RealtimeEndpointStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RealtimeEndpointStatus::Failed => "FAILED",
+            RealtimeEndpointStatus::None => "NONE",
+            RealtimeEndpointStatus::Ready => "READY",
+            RealtimeEndpointStatus::Updating => "UPDATING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RealtimeEndpointStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(RealtimeEndpointStatus::Failed),
+            "NONE" => Ok(RealtimeEndpointStatus::None),
+            "READY" => Ok(RealtimeEndpointStatus::Ready),
+            "UPDATING" => Ok(RealtimeEndpointStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the data specification of an Amazon Redshift <code>DataSource</code>.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct RedshiftDataSpec {
@@ -1484,6 +1882,41 @@ pub struct S3DataSpec {
     pub data_schema_location_s3: Option<String>,
 }
 
+#[doc="<p>The sort order specified in a listing condition. Possible values include the following:</p> <ul> <li> <code>asc</code> - Present the information in ascending order (from A-Z).</li> <li> <code>dsc</code> - Present the information in descending order (from Z-A).</li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SortOrder {
+    Asc,
+    Dsc,
+}
+
+impl Into<String> for SortOrder {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SortOrder {
+    fn into(self) -> &'static str {
+        match self {
+            SortOrder::Asc => "asc",
+            SortOrder::Dsc => "dsc",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SortOrder {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "asc" => Ok(SortOrder::Asc),
+            "dsc" => Ok(SortOrder::Dsc),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A custom key-value pair associated with an ML object, such as an ML model.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
@@ -1495,6 +1928,47 @@ pub struct Tag {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaggableResourceType {
+    BatchPrediction,
+    DataSource,
+    Evaluation,
+    Mlmodel,
+}
+
+impl Into<String> for TaggableResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaggableResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            TaggableResourceType::BatchPrediction => "BatchPrediction",
+            TaggableResourceType::DataSource => "DataSource",
+            TaggableResourceType::Evaluation => "Evaluation",
+            TaggableResourceType::Mlmodel => "MLModel",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaggableResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BatchPrediction" => Ok(TaggableResourceType::BatchPrediction),
+            "DataSource" => Ok(TaggableResourceType::DataSource),
+            "Evaluation" => Ok(TaggableResourceType::Evaluation),
+            "MLModel" => Ok(TaggableResourceType::Mlmodel),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -4345,7 +4819,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddTagsOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -4377,7 +4851,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateBatchPredictionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4408,7 +4882,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDataSourceFromRDSOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4441,7 +4915,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDataSourceFromRedshiftOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4473,7 +4947,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDataSourceFromS3Output>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4503,7 +4977,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateEvaluationOutput>(String::from_utf8_lossy(&body)
@@ -4535,7 +5009,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateMLModelOutput>(String::from_utf8_lossy(&body)
@@ -4568,7 +5042,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateRealtimeEndpointOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4599,7 +5073,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteBatchPredictionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4629,7 +5103,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteDataSourceOutput>(String::from_utf8_lossy(&body)
@@ -4661,7 +5135,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteEvaluationOutput>(String::from_utf8_lossy(&body)
@@ -4693,7 +5167,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteMLModelOutput>(String::from_utf8_lossy(&body)
@@ -4726,7 +5200,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteRealtimeEndpointOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4754,7 +5228,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteTagsOutput>(String::from_utf8_lossy(&body)
@@ -4787,7 +5261,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeBatchPredictionsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4818,7 +5292,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeDataSourcesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4848,7 +5322,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEvaluationsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -4878,7 +5352,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMLModelsOutput>(String::from_utf8_lossy(&body)
@@ -4910,7 +5384,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTagsOutput>(String::from_utf8_lossy(&body)
@@ -4942,7 +5416,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetBatchPredictionOutput>(String::from_utf8_lossy(&body)
@@ -4974,7 +5448,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDataSourceOutput>(String::from_utf8_lossy(&body)
@@ -5006,7 +5480,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetEvaluationOutput>(String::from_utf8_lossy(&body)
@@ -5036,7 +5510,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetMLModelOutput>(String::from_utf8_lossy(&body)
@@ -5066,7 +5540,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PredictOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -5098,7 +5572,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateBatchPredictionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5128,7 +5602,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDataSourceOutput>(String::from_utf8_lossy(&body)
@@ -5160,7 +5634,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateEvaluationOutput>(String::from_utf8_lossy(&body)
@@ -5192,7 +5666,7 @@ impl<P, D> MachineLearning for MachineLearningClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateMLModelOutput>(String::from_utf8_lossy(&body)

--- a/rusoto/services/marketplace-entitlement/src/generated.rs
+++ b/rusoto/services/marketplace-entitlement/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -72,6 +68,41 @@ pub struct EntitlementValue {
     #[serde(rename="StringValue")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub string_value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GetEntitlementFilterName {
+    CustomerIdentifier,
+    Dimension,
+}
+
+impl Into<String> for GetEntitlementFilterName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GetEntitlementFilterName {
+    fn into(self) -> &'static str {
+        match self {
+            GetEntitlementFilterName::CustomerIdentifier => "CUSTOMER_IDENTIFIER",
+            GetEntitlementFilterName::Dimension => "DIMENSION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GetEntitlementFilterName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CUSTOMER_IDENTIFIER" => Ok(GetEntitlementFilterName::CustomerIdentifier),
+            "DIMENSION" => Ok(GetEntitlementFilterName::Dimension),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The GetEntitlementsRequest contains parameters for the GetEntitlements operation.</p>"]
@@ -248,7 +279,7 @@ impl<P, D> MarketplaceEntitlement for MarketplaceEntitlementClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetEntitlementsResult>(String::from_utf8_lossy(&body)

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -11,23 +11,155 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DataSetType {
+    CustomerProfileByGeography,
+    CustomerProfileByIndustry,
+    CustomerProfileByRevenue,
+    CustomerSubscriberAnnualSubscriptions,
+    CustomerSubscriberHourlyMonthlySubscriptions,
+    DailyBusinessCanceledProductSubscribers,
+    DailyBusinessFees,
+    DailyBusinessFreeTrialConversions,
+    DailyBusinessNewInstances,
+    DailyBusinessNewProductSubscribers,
+    DailyBusinessUsageByInstanceType,
+    DisbursedAmountByAgeOfDisbursedFunds,
+    DisbursedAmountByAgeOfUncollectedFunds,
+    DisbursedAmountByCustomerGeo,
+    DisbursedAmountByInstanceHours,
+    DisbursedAmountByProduct,
+    DisbursedAmountByProductWithUncollectedFunds,
+    MonthlyRevenueAnnualSubscriptions,
+    MonthlyRevenueBillingAndRevenueData,
+    SalesCompensationBilledRevenue,
+    UsSalesAndUseTaxRecords,
+}
+
+impl Into<String> for DataSetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DataSetType {
+    fn into(self) -> &'static str {
+        match self {
+            DataSetType::CustomerProfileByGeography => "customer_profile_by_geography",
+            DataSetType::CustomerProfileByIndustry => "customer_profile_by_industry",
+            DataSetType::CustomerProfileByRevenue => "customer_profile_by_revenue",
+            DataSetType::CustomerSubscriberAnnualSubscriptions => {
+                "customer_subscriber_annual_subscriptions"
+            }
+            DataSetType::CustomerSubscriberHourlyMonthlySubscriptions => {
+                "customer_subscriber_hourly_monthly_subscriptions"
+            }
+            DataSetType::DailyBusinessCanceledProductSubscribers => {
+                "daily_business_canceled_product_subscribers"
+            }
+            DataSetType::DailyBusinessFees => "daily_business_fees",
+            DataSetType::DailyBusinessFreeTrialConversions => {
+                "daily_business_free_trial_conversions"
+            }
+            DataSetType::DailyBusinessNewInstances => "daily_business_new_instances",
+            DataSetType::DailyBusinessNewProductSubscribers => {
+                "daily_business_new_product_subscribers"
+            }
+            DataSetType::DailyBusinessUsageByInstanceType => {
+                "daily_business_usage_by_instance_type"
+            }
+            DataSetType::DisbursedAmountByAgeOfDisbursedFunds => {
+                "disbursed_amount_by_age_of_disbursed_funds"
+            }
+            DataSetType::DisbursedAmountByAgeOfUncollectedFunds => {
+                "disbursed_amount_by_age_of_uncollected_funds"
+            }
+            DataSetType::DisbursedAmountByCustomerGeo => "disbursed_amount_by_customer_geo",
+            DataSetType::DisbursedAmountByInstanceHours => "disbursed_amount_by_instance_hours",
+            DataSetType::DisbursedAmountByProduct => "disbursed_amount_by_product",
+            DataSetType::DisbursedAmountByProductWithUncollectedFunds => {
+                "disbursed_amount_by_product_with_uncollected_funds"
+            }
+            DataSetType::MonthlyRevenueAnnualSubscriptions => {
+                "monthly_revenue_annual_subscriptions"
+            }
+            DataSetType::MonthlyRevenueBillingAndRevenueData => {
+                "monthly_revenue_billing_and_revenue_data"
+            }
+            DataSetType::SalesCompensationBilledRevenue => "sales_compensation_billed_revenue",
+            DataSetType::UsSalesAndUseTaxRecords => "us_sales_and_use_tax_records",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DataSetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "customer_profile_by_geography" => Ok(DataSetType::CustomerProfileByGeography),
+            "customer_profile_by_industry" => Ok(DataSetType::CustomerProfileByIndustry),
+            "customer_profile_by_revenue" => Ok(DataSetType::CustomerProfileByRevenue),
+            "customer_subscriber_annual_subscriptions" => {
+                Ok(DataSetType::CustomerSubscriberAnnualSubscriptions)
+            }
+            "customer_subscriber_hourly_monthly_subscriptions" => {
+                Ok(DataSetType::CustomerSubscriberHourlyMonthlySubscriptions)
+            }
+            "daily_business_canceled_product_subscribers" => {
+                Ok(DataSetType::DailyBusinessCanceledProductSubscribers)
+            }
+            "daily_business_fees" => Ok(DataSetType::DailyBusinessFees),
+            "daily_business_free_trial_conversions" => {
+                Ok(DataSetType::DailyBusinessFreeTrialConversions)
+            }
+            "daily_business_new_instances" => Ok(DataSetType::DailyBusinessNewInstances),
+            "daily_business_new_product_subscribers" => {
+                Ok(DataSetType::DailyBusinessNewProductSubscribers)
+            }
+            "daily_business_usage_by_instance_type" => {
+                Ok(DataSetType::DailyBusinessUsageByInstanceType)
+            }
+            "disbursed_amount_by_age_of_disbursed_funds" => {
+                Ok(DataSetType::DisbursedAmountByAgeOfDisbursedFunds)
+            }
+            "disbursed_amount_by_age_of_uncollected_funds" => {
+                Ok(DataSetType::DisbursedAmountByAgeOfUncollectedFunds)
+            }
+            "disbursed_amount_by_customer_geo" => Ok(DataSetType::DisbursedAmountByCustomerGeo),
+            "disbursed_amount_by_instance_hours" => Ok(DataSetType::DisbursedAmountByInstanceHours),
+            "disbursed_amount_by_product" => Ok(DataSetType::DisbursedAmountByProduct),
+            "disbursed_amount_by_product_with_uncollected_funds" => {
+                Ok(DataSetType::DisbursedAmountByProductWithUncollectedFunds)
+            }
+            "monthly_revenue_annual_subscriptions" => {
+                Ok(DataSetType::MonthlyRevenueAnnualSubscriptions)
+            }
+            "monthly_revenue_billing_and_revenue_data" => {
+                Ok(DataSetType::MonthlyRevenueBillingAndRevenueData)
+            }
+            "sales_compensation_billed_revenue" => Ok(DataSetType::SalesCompensationBilledRevenue),
+            "us_sales_and_use_tax_records" => Ok(DataSetType::UsSalesAndUseTaxRecords),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="Container for the parameters to the GenerateDataSet operation."]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct GenerateDataSetRequest {
@@ -100,6 +232,45 @@ pub struct StartSupportDataExportResult {
     #[serde(rename="dataSetRequestId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub data_set_request_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SupportDataSetType {
+    CustomerSupportContactsData,
+    TestCustomerSupportContactsData,
+}
+
+impl Into<String> for SupportDataSetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SupportDataSetType {
+    fn into(self) -> &'static str {
+        match self {
+            SupportDataSetType::CustomerSupportContactsData => "customer_support_contacts_data",
+            SupportDataSetType::TestCustomerSupportContactsData => {
+                "test_customer_support_contacts_data"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for SupportDataSetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "customer_support_contacts_data" => Ok(SupportDataSetType::CustomerSupportContactsData),
+            "test_customer_support_contacts_data" => {
+                Ok(SupportDataSetType::TestCustomerSupportContactsData)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by GenerateDataSet
@@ -317,7 +488,7 @@ impl<P, D> MarketplaceCommerceAnalytics for MarketplaceCommerceAnalyticsClient<P
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GenerateDataSetResult>(String::from_utf8_lossy(&body)
@@ -352,7 +523,7 @@ impl<P, D> MarketplaceCommerceAnalytics for MarketplaceCommerceAnalyticsClient<P
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartSupportDataExportResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -131,6 +127,44 @@ pub struct UsageRecordResult {
     #[serde(rename="UsageRecord")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub usage_record: Option<UsageRecord>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UsageRecordResultStatus {
+    CustomerNotSubscribed,
+    DuplicateRecord,
+    Success,
+}
+
+impl Into<String> for UsageRecordResultStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UsageRecordResultStatus {
+    fn into(self) -> &'static str {
+        match self {
+            UsageRecordResultStatus::CustomerNotSubscribed => "CustomerNotSubscribed",
+            UsageRecordResultStatus::DuplicateRecord => "DuplicateRecord",
+            UsageRecordResultStatus::Success => "Success",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UsageRecordResultStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CustomerNotSubscribed" => Ok(UsageRecordResultStatus::CustomerNotSubscribed),
+            "DuplicateRecord" => Ok(UsageRecordResultStatus::DuplicateRecord),
+            "Success" => Ok(UsageRecordResultStatus::Success),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by BatchMeterUsage
@@ -512,7 +546,7 @@ impl<P, D> MarketplaceMetering for MarketplaceMeteringClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<BatchMeterUsageResult>(String::from_utf8_lossy(&body)
@@ -542,7 +576,7 @@ impl<P, D> MarketplaceMetering for MarketplaceMeteringClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<MeterUsageResult>(String::from_utf8_lossy(&body)
@@ -574,7 +608,7 @@ impl<P, D> MarketplaceMetering for MarketplaceMeteringClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ResolveCustomerResult>(String::from_utf8_lossy(&body)

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -113,6 +109,44 @@ pub struct Assignment {
     pub worker_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssignmentStatus {
+    Approved,
+    Rejected,
+    Submitted,
+}
+
+impl Into<String> for AssignmentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssignmentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AssignmentStatus::Approved => "Approved",
+            AssignmentStatus::Rejected => "Rejected",
+            AssignmentStatus::Submitted => "Submitted",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssignmentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Approved" => Ok(AssignmentStatus::Approved),
+            "Rejected" => Ok(AssignmentStatus::Rejected),
+            "Submitted" => Ok(AssignmentStatus::Submitted),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AssociateQualificationWithWorkerRequest {
     #[doc="<p>The value of the Qualification to assign.</p>"]
@@ -156,6 +190,65 @@ pub struct BonusPayment {
     #[serde(rename="WorkerId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub worker_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Comparator {
+    DoesNotExist,
+    EqualTo,
+    Exists,
+    GreaterThan,
+    GreaterThanOrEqualTo,
+    In,
+    LessThan,
+    LessThanOrEqualTo,
+    NotEqualTo,
+    NotIn,
+}
+
+impl Into<String> for Comparator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Comparator {
+    fn into(self) -> &'static str {
+        match self {
+            Comparator::DoesNotExist => "DoesNotExist",
+            Comparator::EqualTo => "EqualTo",
+            Comparator::Exists => "Exists",
+            Comparator::GreaterThan => "GreaterThan",
+            Comparator::GreaterThanOrEqualTo => "GreaterThanOrEqualTo",
+            Comparator::In => "In",
+            Comparator::LessThan => "LessThan",
+            Comparator::LessThanOrEqualTo => "LessThanOrEqualTo",
+            Comparator::NotEqualTo => "NotEqualTo",
+            Comparator::NotIn => "NotIn",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Comparator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DoesNotExist" => Ok(Comparator::DoesNotExist),
+            "EqualTo" => Ok(Comparator::EqualTo),
+            "Exists" => Ok(Comparator::Exists),
+            "GreaterThan" => Ok(Comparator::GreaterThan),
+            "GreaterThanOrEqualTo" => Ok(Comparator::GreaterThanOrEqualTo),
+            "In" => Ok(Comparator::In),
+            "LessThan" => Ok(Comparator::LessThan),
+            "LessThanOrEqualTo" => Ok(Comparator::LessThanOrEqualTo),
+            "NotEqualTo" => Ok(Comparator::NotEqualTo),
+            "NotIn" => Ok(Comparator::NotIn),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -446,6 +539,71 @@ pub struct DisassociateQualificationFromWorkerRequest {
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DisassociateQualificationFromWorkerResponse;
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventType {
+    AssignmentAbandoned,
+    AssignmentAccepted,
+    AssignmentApproved,
+    AssignmentRejected,
+    AssignmentReturned,
+    AssignmentSubmitted,
+    Hitcreated,
+    Hitdisposed,
+    Hitexpired,
+    Hitextended,
+    Hitreviewable,
+    Ping,
+}
+
+impl Into<String> for EventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventType {
+    fn into(self) -> &'static str {
+        match self {
+            EventType::AssignmentAbandoned => "AssignmentAbandoned",
+            EventType::AssignmentAccepted => "AssignmentAccepted",
+            EventType::AssignmentApproved => "AssignmentApproved",
+            EventType::AssignmentRejected => "AssignmentRejected",
+            EventType::AssignmentReturned => "AssignmentReturned",
+            EventType::AssignmentSubmitted => "AssignmentSubmitted",
+            EventType::Hitcreated => "HITCreated",
+            EventType::Hitdisposed => "HITDisposed",
+            EventType::Hitexpired => "HITExpired",
+            EventType::Hitextended => "HITExtended",
+            EventType::Hitreviewable => "HITReviewable",
+            EventType::Ping => "Ping",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AssignmentAbandoned" => Ok(EventType::AssignmentAbandoned),
+            "AssignmentAccepted" => Ok(EventType::AssignmentAccepted),
+            "AssignmentApproved" => Ok(EventType::AssignmentApproved),
+            "AssignmentRejected" => Ok(EventType::AssignmentRejected),
+            "AssignmentReturned" => Ok(EventType::AssignmentReturned),
+            "AssignmentSubmitted" => Ok(EventType::AssignmentSubmitted),
+            "HITCreated" => Ok(EventType::Hitcreated),
+            "HITDisposed" => Ok(EventType::Hitdisposed),
+            "HITExpired" => Ok(EventType::Hitexpired),
+            "HITExtended" => Ok(EventType::Hitextended),
+            "HITReviewable" => Ok(EventType::Hitreviewable),
+            "Ping" => Ok(EventType::Ping),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct GetAccountBalanceRequest;
 
@@ -643,6 +801,91 @@ pub struct HITLayoutParameter {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HITReviewStatus {
+    MarkedForReview,
+    NotReviewed,
+    ReviewedAppropriate,
+    ReviewedInappropriate,
+}
+
+impl Into<String> for HITReviewStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HITReviewStatus {
+    fn into(self) -> &'static str {
+        match self {
+            HITReviewStatus::MarkedForReview => "MarkedForReview",
+            HITReviewStatus::NotReviewed => "NotReviewed",
+            HITReviewStatus::ReviewedAppropriate => "ReviewedAppropriate",
+            HITReviewStatus::ReviewedInappropriate => "ReviewedInappropriate",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HITReviewStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "MarkedForReview" => Ok(HITReviewStatus::MarkedForReview),
+            "NotReviewed" => Ok(HITReviewStatus::NotReviewed),
+            "ReviewedAppropriate" => Ok(HITReviewStatus::ReviewedAppropriate),
+            "ReviewedInappropriate" => Ok(HITReviewStatus::ReviewedInappropriate),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HITStatus {
+    Assignable,
+    Disposed,
+    Reviewable,
+    Reviewing,
+    Unassignable,
+}
+
+impl Into<String> for HITStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HITStatus {
+    fn into(self) -> &'static str {
+        match self {
+            HITStatus::Assignable => "Assignable",
+            HITStatus::Disposed => "Disposed",
+            HITStatus::Reviewable => "Reviewable",
+            HITStatus::Reviewing => "Reviewing",
+            HITStatus::Unassignable => "Unassignable",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HITStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Assignable" => Ok(HITStatus::Assignable),
+            "Disposed" => Ok(HITStatus::Disposed),
+            "Reviewable" => Ok(HITStatus::Reviewable),
+            "Reviewing" => Ok(HITStatus::Reviewing),
+            "Unassignable" => Ok(HITStatus::Unassignable),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1015,6 +1258,76 @@ pub struct NotificationSpecification {
     pub version: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NotificationTransport {
+    Email,
+    Sqs,
+}
+
+impl Into<String> for NotificationTransport {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NotificationTransport {
+    fn into(self) -> &'static str {
+        match self {
+            NotificationTransport::Email => "Email",
+            NotificationTransport::Sqs => "SQS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NotificationTransport {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Email" => Ok(NotificationTransport::Email),
+            "SQS" => Ok(NotificationTransport::Sqs),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NotifyWorkersFailureCode {
+    HardFailure,
+    SoftFailure,
+}
+
+impl Into<String> for NotifyWorkersFailureCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NotifyWorkersFailureCode {
+    fn into(self) -> &'static str {
+        match self {
+            NotifyWorkersFailureCode::HardFailure => "HardFailure",
+            NotifyWorkersFailureCode::SoftFailure => "SoftFailure",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NotifyWorkersFailureCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HardFailure" => Ok(NotifyWorkersFailureCode::HardFailure),
+            "SoftFailure" => Ok(NotifyWorkersFailureCode::SoftFailure),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p> When MTurk encounters an issue with notifying the Workers you specified, it returns back this object with failure details. </p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct NotifyWorkersFailureStatus {
@@ -1163,6 +1476,41 @@ pub struct QualificationRequirement {
     pub required_to_preview: Option<bool>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum QualificationStatus {
+    Granted,
+    Revoked,
+}
+
+impl Into<String> for QualificationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for QualificationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            QualificationStatus::Granted => "Granted",
+            QualificationStatus::Revoked => "Revoked",
+        }
+    }
+}
+
+impl ::std::str::FromStr for QualificationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Granted" => Ok(QualificationStatus::Granted),
+            "Revoked" => Ok(QualificationStatus::Revoked),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p> The QualificationType data structure represents a Qualification type, a description of a property of a Worker that must match the requirements of a HIT for the Worker to be able to accept the HIT. The type also describes how a Worker can obtain a Qualification of that type, such as through a Qualification test. </p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct QualificationType {
@@ -1218,6 +1566,41 @@ pub struct QualificationType {
     #[serde(rename="TestDurationInSeconds")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub test_duration_in_seconds: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum QualificationTypeStatus {
+    Active,
+    Inactive,
+}
+
+impl Into<String> for QualificationTypeStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for QualificationTypeStatus {
+    fn into(self) -> &'static str {
+        match self {
+            QualificationTypeStatus::Active => "Active",
+            QualificationTypeStatus::Inactive => "Inactive",
+        }
+    }
+}
+
+impl ::std::str::FromStr for QualificationTypeStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(QualificationTypeStatus::Active),
+            "Inactive" => Ok(QualificationTypeStatus::Inactive),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1285,6 +1668,47 @@ pub struct ReviewActionDetail {
     pub target_type: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReviewActionStatus {
+    Cancelled,
+    Failed,
+    Intended,
+    Succeeded,
+}
+
+impl Into<String> for ReviewActionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReviewActionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReviewActionStatus::Cancelled => "Cancelled",
+            ReviewActionStatus::Failed => "Failed",
+            ReviewActionStatus::Intended => "Intended",
+            ReviewActionStatus::Succeeded => "Succeeded",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReviewActionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(ReviewActionStatus::Cancelled),
+            "Failed" => Ok(ReviewActionStatus::Failed),
+            "Intended" => Ok(ReviewActionStatus::Intended),
+            "Succeeded" => Ok(ReviewActionStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p> HIT Review Policy data structures represent HIT review policies, which you specify when you create a HIT. </p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReviewPolicy {
@@ -1296,6 +1720,41 @@ pub struct ReviewPolicy {
     #[serde(rename="PolicyName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub policy_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReviewPolicyLevel {
+    Assignment,
+    Hit,
+}
+
+impl Into<String> for ReviewPolicyLevel {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReviewPolicyLevel {
+    fn into(self) -> &'static str {
+        match self {
+            ReviewPolicyLevel::Assignment => "Assignment",
+            ReviewPolicyLevel::Hit => "HIT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReviewPolicyLevel {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Assignment" => Ok(ReviewPolicyLevel::Assignment),
+            "HIT" => Ok(ReviewPolicyLevel::Hit),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p> Contains both ReviewResult and ReviewAction elements for a particular HIT. </p>"]
@@ -1338,6 +1797,41 @@ pub struct ReviewResultDetail {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReviewableHITStatus {
+    Reviewable,
+    Reviewing,
+}
+
+impl Into<String> for ReviewableHITStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReviewableHITStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReviewableHITStatus::Reviewable => "Reviewable",
+            ReviewableHITStatus::Reviewing => "Reviewing",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReviewableHITStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Reviewable" => Ok(ReviewableHITStatus::Reviewable),
+            "Reviewing" => Ok(ReviewableHITStatus::Reviewing),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -5098,7 +5592,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AcceptQualificationRequestResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5130,7 +5624,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ApproveAssignmentResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5162,7 +5656,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AssociateQualificationWithWorkerResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5195,7 +5689,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateAdditionalAssignmentsForHITResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5223,7 +5717,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateHITResponse>(String::from_utf8_lossy(&body)
@@ -5256,7 +5750,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateHITTypeResponse>(String::from_utf8_lossy(&body)
@@ -5290,7 +5784,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateHITWithHITTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5322,7 +5816,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5354,7 +5848,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateWorkerBlockResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5382,7 +5876,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteHITResponse>(String::from_utf8_lossy(&body)
@@ -5416,7 +5910,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5448,7 +5942,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteWorkerBlockResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5481,7 +5975,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisassociateQualificationFromWorkerResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5509,7 +6003,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetAccountBalanceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5540,7 +6034,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetAssignmentResponse>(String::from_utf8_lossy(&body)
@@ -5573,7 +6067,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetFileUploadURLResponse>(String::from_utf8_lossy(&body)
@@ -5603,7 +6097,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetHITResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -5636,7 +6130,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetQualificationScoreResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5668,7 +6162,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5700,7 +6194,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAssignmentsForHITResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5731,7 +6225,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListBonusPaymentsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5759,7 +6253,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListHITsResponse>(String::from_utf8_lossy(&body)
@@ -5793,7 +6287,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListHITsForQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5826,7 +6320,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListQualificationRequestsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5859,7 +6353,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListQualificationTypesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5891,7 +6385,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListReviewPolicyResultsForHITResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5923,7 +6417,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListReviewableHITsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5954,7 +6448,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListWorkerBlocksResponse>(String::from_utf8_lossy(&body)
@@ -5988,7 +6482,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListWorkersWithQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6019,7 +6513,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<NotifyWorkersResponse>(String::from_utf8_lossy(&body)
@@ -6052,7 +6546,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RejectAssignmentResponse>(String::from_utf8_lossy(&body)
@@ -6086,7 +6580,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RejectQualificationRequestResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6115,7 +6609,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SendBonusResponse>(String::from_utf8_lossy(&body)
@@ -6149,7 +6643,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SendTestEventNotificationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6182,7 +6676,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateExpirationForHITResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6214,7 +6708,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateHITReviewStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6245,7 +6739,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateHITTypeOfHITResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6277,7 +6771,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateNotificationSettingsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6310,7 +6804,7 @@ impl<P, D> MechanicalTurk for MechanicalTurkClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateQualificationTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -102,6 +98,132 @@ pub struct App {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AppAttributesKeys {
+    AutoBundleOnDeploy,
+    AwsFlowRubySettings,
+    DocumentRoot,
+    RailsEnv,
+}
+
+impl Into<String> for AppAttributesKeys {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AppAttributesKeys {
+    fn into(self) -> &'static str {
+        match self {
+            AppAttributesKeys::AutoBundleOnDeploy => "AutoBundleOnDeploy",
+            AppAttributesKeys::AwsFlowRubySettings => "AwsFlowRubySettings",
+            AppAttributesKeys::DocumentRoot => "DocumentRoot",
+            AppAttributesKeys::RailsEnv => "RailsEnv",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AppAttributesKeys {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AutoBundleOnDeploy" => Ok(AppAttributesKeys::AutoBundleOnDeploy),
+            "AwsFlowRubySettings" => Ok(AppAttributesKeys::AwsFlowRubySettings),
+            "DocumentRoot" => Ok(AppAttributesKeys::DocumentRoot),
+            "RailsEnv" => Ok(AppAttributesKeys::RailsEnv),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AppType {
+    AwsFlowRuby,
+    Java,
+    Nodejs,
+    Other,
+    Php,
+    Rails,
+    Static,
+}
+
+impl Into<String> for AppType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AppType {
+    fn into(self) -> &'static str {
+        match self {
+            AppType::AwsFlowRuby => "aws-flow-ruby",
+            AppType::Java => "java",
+            AppType::Nodejs => "nodejs",
+            AppType::Other => "other",
+            AppType::Php => "php",
+            AppType::Rails => "rails",
+            AppType::Static => "static",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AppType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "aws-flow-ruby" => Ok(AppType::AwsFlowRuby),
+            "java" => Ok(AppType::Java),
+            "nodejs" => Ok(AppType::Nodejs),
+            "other" => Ok(AppType::Other),
+            "php" => Ok(AppType::Php),
+            "rails" => Ok(AppType::Rails),
+            "static" => Ok(AppType::Static),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Architecture {
+    I386,
+    X8664,
+}
+
+impl Into<String> for Architecture {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Architecture {
+    fn into(self) -> &'static str {
+        match self {
+            Architecture::I386 => "i386",
+            Architecture::X8664 => "x86_64",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Architecture {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "i386" => Ok(Architecture::I386),
+            "x86_64" => Ok(Architecture::X8664),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AssignInstanceRequest {
     #[doc="<p>The instance ID.</p>"]
@@ -175,6 +297,41 @@ pub struct AutoScalingThresholds {
     #[serde(rename="ThresholdsWaitTime")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub thresholds_wait_time: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutoScalingType {
+    Load,
+    Timer,
+}
+
+impl Into<String> for AutoScalingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutoScalingType {
+    fn into(self) -> &'static str {
+        match self {
+            AutoScalingType::Load => "load",
+            AutoScalingType::Timer => "timer",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutoScalingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "load" => Ok(AutoScalingType::Load),
+            "timer" => Ok(AutoScalingType::Timer),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a block device mapping. This data type maps directly to the Amazon EC2 <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html\">BlockDeviceMapping</a> data type. </p>"]
@@ -322,6 +479,346 @@ pub struct CloudWatchLogsConfiguration {
     pub log_streams: Option<Vec<CloudWatchLogsLogStream>>,
 }
 
+#[doc="<p>Specifies the encoding of the log file so that the file can be read correctly. The default is <code>utf_8</code>. Encodings supported by Python <code>codecs.decode()</code> can be used here.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloudWatchLogsEncoding {
+    Ascii,
+    Big5,
+    Big5Hkscs,
+    Cp037,
+    Cp1006,
+    Cp1026,
+    Cp1140,
+    Cp1250,
+    Cp1251,
+    Cp1252,
+    Cp1253,
+    Cp1254,
+    Cp1255,
+    Cp1256,
+    Cp1257,
+    Cp1258,
+    Cp424,
+    Cp437,
+    Cp500,
+    Cp720,
+    Cp737,
+    Cp775,
+    Cp850,
+    Cp852,
+    Cp855,
+    Cp856,
+    Cp857,
+    Cp858,
+    Cp860,
+    Cp861,
+    Cp862,
+    Cp863,
+    Cp864,
+    Cp865,
+    Cp866,
+    Cp869,
+    Cp874,
+    Cp875,
+    Cp932,
+    Cp949,
+    Cp950,
+    EucJis2004,
+    EucJisx0213,
+    EucJp,
+    EucKr,
+    Gb18030,
+    Gb2312,
+    Gbk,
+    Hz,
+    Iso2022Jp,
+    Iso2022Jp1,
+    Iso2022Jp2,
+    Iso2022Jp2004,
+    Iso2022Jp3,
+    Iso2022JpExt,
+    Iso2022Kr,
+    Iso885910,
+    Iso885913,
+    Iso885914,
+    Iso885915,
+    Iso885916,
+    Iso88592,
+    Iso88593,
+    Iso88594,
+    Iso88595,
+    Iso88596,
+    Iso88597,
+    Iso88598,
+    Iso88599,
+    Johab,
+    Koi8R,
+    Koi8U,
+    Latin1,
+    MacCyrillic,
+    MacGreek,
+    MacIceland,
+    MacLatin2,
+    MacRoman,
+    MacTurkish,
+    Ptcp154,
+    ShiftJis,
+    ShiftJis2004,
+    ShiftJisx0213,
+    Utf16,
+    Utf16Be,
+    Utf16Le,
+    Utf32,
+    Utf32Be,
+    Utf32Le,
+    Utf7,
+    Utf8,
+    Utf8Sig,
+}
+
+impl Into<String> for CloudWatchLogsEncoding {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloudWatchLogsEncoding {
+    fn into(self) -> &'static str {
+        match self {
+            CloudWatchLogsEncoding::Ascii => "ascii",
+            CloudWatchLogsEncoding::Big5 => "big5",
+            CloudWatchLogsEncoding::Big5Hkscs => "big5hkscs",
+            CloudWatchLogsEncoding::Cp037 => "cp037",
+            CloudWatchLogsEncoding::Cp1006 => "cp1006",
+            CloudWatchLogsEncoding::Cp1026 => "cp1026",
+            CloudWatchLogsEncoding::Cp1140 => "cp1140",
+            CloudWatchLogsEncoding::Cp1250 => "cp1250",
+            CloudWatchLogsEncoding::Cp1251 => "cp1251",
+            CloudWatchLogsEncoding::Cp1252 => "cp1252",
+            CloudWatchLogsEncoding::Cp1253 => "cp1253",
+            CloudWatchLogsEncoding::Cp1254 => "cp1254",
+            CloudWatchLogsEncoding::Cp1255 => "cp1255",
+            CloudWatchLogsEncoding::Cp1256 => "cp1256",
+            CloudWatchLogsEncoding::Cp1257 => "cp1257",
+            CloudWatchLogsEncoding::Cp1258 => "cp1258",
+            CloudWatchLogsEncoding::Cp424 => "cp424",
+            CloudWatchLogsEncoding::Cp437 => "cp437",
+            CloudWatchLogsEncoding::Cp500 => "cp500",
+            CloudWatchLogsEncoding::Cp720 => "cp720",
+            CloudWatchLogsEncoding::Cp737 => "cp737",
+            CloudWatchLogsEncoding::Cp775 => "cp775",
+            CloudWatchLogsEncoding::Cp850 => "cp850",
+            CloudWatchLogsEncoding::Cp852 => "cp852",
+            CloudWatchLogsEncoding::Cp855 => "cp855",
+            CloudWatchLogsEncoding::Cp856 => "cp856",
+            CloudWatchLogsEncoding::Cp857 => "cp857",
+            CloudWatchLogsEncoding::Cp858 => "cp858",
+            CloudWatchLogsEncoding::Cp860 => "cp860",
+            CloudWatchLogsEncoding::Cp861 => "cp861",
+            CloudWatchLogsEncoding::Cp862 => "cp862",
+            CloudWatchLogsEncoding::Cp863 => "cp863",
+            CloudWatchLogsEncoding::Cp864 => "cp864",
+            CloudWatchLogsEncoding::Cp865 => "cp865",
+            CloudWatchLogsEncoding::Cp866 => "cp866",
+            CloudWatchLogsEncoding::Cp869 => "cp869",
+            CloudWatchLogsEncoding::Cp874 => "cp874",
+            CloudWatchLogsEncoding::Cp875 => "cp875",
+            CloudWatchLogsEncoding::Cp932 => "cp932",
+            CloudWatchLogsEncoding::Cp949 => "cp949",
+            CloudWatchLogsEncoding::Cp950 => "cp950",
+            CloudWatchLogsEncoding::EucJis2004 => "euc_jis_2004",
+            CloudWatchLogsEncoding::EucJisx0213 => "euc_jisx0213",
+            CloudWatchLogsEncoding::EucJp => "euc_jp",
+            CloudWatchLogsEncoding::EucKr => "euc_kr",
+            CloudWatchLogsEncoding::Gb18030 => "gb18030",
+            CloudWatchLogsEncoding::Gb2312 => "gb2312",
+            CloudWatchLogsEncoding::Gbk => "gbk",
+            CloudWatchLogsEncoding::Hz => "hz",
+            CloudWatchLogsEncoding::Iso2022Jp => "iso2022_jp",
+            CloudWatchLogsEncoding::Iso2022Jp1 => "iso2022_jp_1",
+            CloudWatchLogsEncoding::Iso2022Jp2 => "iso2022_jp_2",
+            CloudWatchLogsEncoding::Iso2022Jp2004 => "iso2022_jp_2004",
+            CloudWatchLogsEncoding::Iso2022Jp3 => "iso2022_jp_3",
+            CloudWatchLogsEncoding::Iso2022JpExt => "iso2022_jp_ext",
+            CloudWatchLogsEncoding::Iso2022Kr => "iso2022_kr",
+            CloudWatchLogsEncoding::Iso885910 => "iso8859_10",
+            CloudWatchLogsEncoding::Iso885913 => "iso8859_13",
+            CloudWatchLogsEncoding::Iso885914 => "iso8859_14",
+            CloudWatchLogsEncoding::Iso885915 => "iso8859_15",
+            CloudWatchLogsEncoding::Iso885916 => "iso8859_16",
+            CloudWatchLogsEncoding::Iso88592 => "iso8859_2",
+            CloudWatchLogsEncoding::Iso88593 => "iso8859_3",
+            CloudWatchLogsEncoding::Iso88594 => "iso8859_4",
+            CloudWatchLogsEncoding::Iso88595 => "iso8859_5",
+            CloudWatchLogsEncoding::Iso88596 => "iso8859_6",
+            CloudWatchLogsEncoding::Iso88597 => "iso8859_7",
+            CloudWatchLogsEncoding::Iso88598 => "iso8859_8",
+            CloudWatchLogsEncoding::Iso88599 => "iso8859_9",
+            CloudWatchLogsEncoding::Johab => "johab",
+            CloudWatchLogsEncoding::Koi8R => "koi8_r",
+            CloudWatchLogsEncoding::Koi8U => "koi8_u",
+            CloudWatchLogsEncoding::Latin1 => "latin_1",
+            CloudWatchLogsEncoding::MacCyrillic => "mac_cyrillic",
+            CloudWatchLogsEncoding::MacGreek => "mac_greek",
+            CloudWatchLogsEncoding::MacIceland => "mac_iceland",
+            CloudWatchLogsEncoding::MacLatin2 => "mac_latin2",
+            CloudWatchLogsEncoding::MacRoman => "mac_roman",
+            CloudWatchLogsEncoding::MacTurkish => "mac_turkish",
+            CloudWatchLogsEncoding::Ptcp154 => "ptcp154",
+            CloudWatchLogsEncoding::ShiftJis => "shift_jis",
+            CloudWatchLogsEncoding::ShiftJis2004 => "shift_jis_2004",
+            CloudWatchLogsEncoding::ShiftJisx0213 => "shift_jisx0213",
+            CloudWatchLogsEncoding::Utf16 => "utf_16",
+            CloudWatchLogsEncoding::Utf16Be => "utf_16_be",
+            CloudWatchLogsEncoding::Utf16Le => "utf_16_le",
+            CloudWatchLogsEncoding::Utf32 => "utf_32",
+            CloudWatchLogsEncoding::Utf32Be => "utf_32_be",
+            CloudWatchLogsEncoding::Utf32Le => "utf_32_le",
+            CloudWatchLogsEncoding::Utf7 => "utf_7",
+            CloudWatchLogsEncoding::Utf8 => "utf_8",
+            CloudWatchLogsEncoding::Utf8Sig => "utf_8_sig",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloudWatchLogsEncoding {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ascii" => Ok(CloudWatchLogsEncoding::Ascii),
+            "big5" => Ok(CloudWatchLogsEncoding::Big5),
+            "big5hkscs" => Ok(CloudWatchLogsEncoding::Big5Hkscs),
+            "cp037" => Ok(CloudWatchLogsEncoding::Cp037),
+            "cp1006" => Ok(CloudWatchLogsEncoding::Cp1006),
+            "cp1026" => Ok(CloudWatchLogsEncoding::Cp1026),
+            "cp1140" => Ok(CloudWatchLogsEncoding::Cp1140),
+            "cp1250" => Ok(CloudWatchLogsEncoding::Cp1250),
+            "cp1251" => Ok(CloudWatchLogsEncoding::Cp1251),
+            "cp1252" => Ok(CloudWatchLogsEncoding::Cp1252),
+            "cp1253" => Ok(CloudWatchLogsEncoding::Cp1253),
+            "cp1254" => Ok(CloudWatchLogsEncoding::Cp1254),
+            "cp1255" => Ok(CloudWatchLogsEncoding::Cp1255),
+            "cp1256" => Ok(CloudWatchLogsEncoding::Cp1256),
+            "cp1257" => Ok(CloudWatchLogsEncoding::Cp1257),
+            "cp1258" => Ok(CloudWatchLogsEncoding::Cp1258),
+            "cp424" => Ok(CloudWatchLogsEncoding::Cp424),
+            "cp437" => Ok(CloudWatchLogsEncoding::Cp437),
+            "cp500" => Ok(CloudWatchLogsEncoding::Cp500),
+            "cp720" => Ok(CloudWatchLogsEncoding::Cp720),
+            "cp737" => Ok(CloudWatchLogsEncoding::Cp737),
+            "cp775" => Ok(CloudWatchLogsEncoding::Cp775),
+            "cp850" => Ok(CloudWatchLogsEncoding::Cp850),
+            "cp852" => Ok(CloudWatchLogsEncoding::Cp852),
+            "cp855" => Ok(CloudWatchLogsEncoding::Cp855),
+            "cp856" => Ok(CloudWatchLogsEncoding::Cp856),
+            "cp857" => Ok(CloudWatchLogsEncoding::Cp857),
+            "cp858" => Ok(CloudWatchLogsEncoding::Cp858),
+            "cp860" => Ok(CloudWatchLogsEncoding::Cp860),
+            "cp861" => Ok(CloudWatchLogsEncoding::Cp861),
+            "cp862" => Ok(CloudWatchLogsEncoding::Cp862),
+            "cp863" => Ok(CloudWatchLogsEncoding::Cp863),
+            "cp864" => Ok(CloudWatchLogsEncoding::Cp864),
+            "cp865" => Ok(CloudWatchLogsEncoding::Cp865),
+            "cp866" => Ok(CloudWatchLogsEncoding::Cp866),
+            "cp869" => Ok(CloudWatchLogsEncoding::Cp869),
+            "cp874" => Ok(CloudWatchLogsEncoding::Cp874),
+            "cp875" => Ok(CloudWatchLogsEncoding::Cp875),
+            "cp932" => Ok(CloudWatchLogsEncoding::Cp932),
+            "cp949" => Ok(CloudWatchLogsEncoding::Cp949),
+            "cp950" => Ok(CloudWatchLogsEncoding::Cp950),
+            "euc_jis_2004" => Ok(CloudWatchLogsEncoding::EucJis2004),
+            "euc_jisx0213" => Ok(CloudWatchLogsEncoding::EucJisx0213),
+            "euc_jp" => Ok(CloudWatchLogsEncoding::EucJp),
+            "euc_kr" => Ok(CloudWatchLogsEncoding::EucKr),
+            "gb18030" => Ok(CloudWatchLogsEncoding::Gb18030),
+            "gb2312" => Ok(CloudWatchLogsEncoding::Gb2312),
+            "gbk" => Ok(CloudWatchLogsEncoding::Gbk),
+            "hz" => Ok(CloudWatchLogsEncoding::Hz),
+            "iso2022_jp" => Ok(CloudWatchLogsEncoding::Iso2022Jp),
+            "iso2022_jp_1" => Ok(CloudWatchLogsEncoding::Iso2022Jp1),
+            "iso2022_jp_2" => Ok(CloudWatchLogsEncoding::Iso2022Jp2),
+            "iso2022_jp_2004" => Ok(CloudWatchLogsEncoding::Iso2022Jp2004),
+            "iso2022_jp_3" => Ok(CloudWatchLogsEncoding::Iso2022Jp3),
+            "iso2022_jp_ext" => Ok(CloudWatchLogsEncoding::Iso2022JpExt),
+            "iso2022_kr" => Ok(CloudWatchLogsEncoding::Iso2022Kr),
+            "iso8859_10" => Ok(CloudWatchLogsEncoding::Iso885910),
+            "iso8859_13" => Ok(CloudWatchLogsEncoding::Iso885913),
+            "iso8859_14" => Ok(CloudWatchLogsEncoding::Iso885914),
+            "iso8859_15" => Ok(CloudWatchLogsEncoding::Iso885915),
+            "iso8859_16" => Ok(CloudWatchLogsEncoding::Iso885916),
+            "iso8859_2" => Ok(CloudWatchLogsEncoding::Iso88592),
+            "iso8859_3" => Ok(CloudWatchLogsEncoding::Iso88593),
+            "iso8859_4" => Ok(CloudWatchLogsEncoding::Iso88594),
+            "iso8859_5" => Ok(CloudWatchLogsEncoding::Iso88595),
+            "iso8859_6" => Ok(CloudWatchLogsEncoding::Iso88596),
+            "iso8859_7" => Ok(CloudWatchLogsEncoding::Iso88597),
+            "iso8859_8" => Ok(CloudWatchLogsEncoding::Iso88598),
+            "iso8859_9" => Ok(CloudWatchLogsEncoding::Iso88599),
+            "johab" => Ok(CloudWatchLogsEncoding::Johab),
+            "koi8_r" => Ok(CloudWatchLogsEncoding::Koi8R),
+            "koi8_u" => Ok(CloudWatchLogsEncoding::Koi8U),
+            "latin_1" => Ok(CloudWatchLogsEncoding::Latin1),
+            "mac_cyrillic" => Ok(CloudWatchLogsEncoding::MacCyrillic),
+            "mac_greek" => Ok(CloudWatchLogsEncoding::MacGreek),
+            "mac_iceland" => Ok(CloudWatchLogsEncoding::MacIceland),
+            "mac_latin2" => Ok(CloudWatchLogsEncoding::MacLatin2),
+            "mac_roman" => Ok(CloudWatchLogsEncoding::MacRoman),
+            "mac_turkish" => Ok(CloudWatchLogsEncoding::MacTurkish),
+            "ptcp154" => Ok(CloudWatchLogsEncoding::Ptcp154),
+            "shift_jis" => Ok(CloudWatchLogsEncoding::ShiftJis),
+            "shift_jis_2004" => Ok(CloudWatchLogsEncoding::ShiftJis2004),
+            "shift_jisx0213" => Ok(CloudWatchLogsEncoding::ShiftJisx0213),
+            "utf_16" => Ok(CloudWatchLogsEncoding::Utf16),
+            "utf_16_be" => Ok(CloudWatchLogsEncoding::Utf16Be),
+            "utf_16_le" => Ok(CloudWatchLogsEncoding::Utf16Le),
+            "utf_32" => Ok(CloudWatchLogsEncoding::Utf32),
+            "utf_32_be" => Ok(CloudWatchLogsEncoding::Utf32Be),
+            "utf_32_le" => Ok(CloudWatchLogsEncoding::Utf32Le),
+            "utf_7" => Ok(CloudWatchLogsEncoding::Utf7),
+            "utf_8" => Ok(CloudWatchLogsEncoding::Utf8),
+            "utf_8_sig" => Ok(CloudWatchLogsEncoding::Utf8Sig),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="<p>Specifies where to start to read data (start_of_file or end_of_file). The default is start_of_file. It's only used if there is no state persisted for that log stream.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloudWatchLogsInitialPosition {
+    EndOfFile,
+    StartOfFile,
+}
+
+impl Into<String> for CloudWatchLogsInitialPosition {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloudWatchLogsInitialPosition {
+    fn into(self) -> &'static str {
+        match self {
+            CloudWatchLogsInitialPosition::EndOfFile => "end_of_file",
+            CloudWatchLogsInitialPosition::StartOfFile => "start_of_file",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloudWatchLogsInitialPosition {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "end_of_file" => Ok(CloudWatchLogsInitialPosition::EndOfFile),
+            "start_of_file" => Ok(CloudWatchLogsInitialPosition::StartOfFile),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the Amazon CloudWatch logs configuration for a layer. For detailed information about members of this data type, see the <a href=\"http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html\">CloudWatch Logs Agent Reference</a>.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloudWatchLogsLogStream {
@@ -369,6 +866,41 @@ pub struct CloudWatchLogsLogStream {
     #[serde(rename="TimeZone")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub time_zone: Option<String>,
+}
+
+#[doc="<p>The preferred time zone for logs streamed to CloudWatch Logs. Valid values are <code>LOCAL</code> and <code>UTC</code>, for Coordinated Universal Time.</p>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloudWatchLogsTimeZone {
+    Local,
+    Utc,
+}
+
+impl Into<String> for CloudWatchLogsTimeZone {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloudWatchLogsTimeZone {
+    fn into(self) -> &'static str {
+        match self {
+            CloudWatchLogsTimeZone::Local => "LOCAL",
+            CloudWatchLogsTimeZone::Utc => "UTC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloudWatchLogsTimeZone {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LOCAL" => Ok(CloudWatchLogsTimeZone::Local),
+            "UTC" => Ok(CloudWatchLogsTimeZone::Utc),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a command.</p>"]
@@ -910,6 +1442,71 @@ pub struct DeploymentCommand {
     #[doc="<p>Specifies the operation. You can specify only one command.</p> <p>For stacks, the following commands are available:</p> <ul> <li> <p> <code>execute_recipes</code>: Execute one or more recipes. To specify the recipes, set an <code>Args</code> parameter named <code>recipes</code> to the list of recipes to be executed. For example, to execute <code>phpapp::appsetup</code>, set <code>Args</code> to <code>{\"recipes\":[\"phpapp::appsetup\"]}</code>.</p> </li> <li> <p> <code>install_dependencies</code>: Install the stack's dependencies.</p> </li> <li> <p> <code>update_custom_cookbooks</code>: Update the stack's custom cookbooks.</p> </li> <li> <p> <code>update_dependencies</code>: Update the stack's dependencies.</p> </li> </ul> <note> <p>The update_dependencies and install_dependencies commands are supported only for Linux instances. You can run the commands successfully on Windows instances, but they do nothing.</p> </note> <p>For apps, the following commands are available:</p> <ul> <li> <p> <code>deploy</code>: Deploy an app. Ruby on Rails apps have an optional <code>Args</code> parameter named <code>migrate</code>. Set <code>Args</code> to {\"migrate\":[\"true\"]} to migrate the database. The default setting is {\"migrate\":[\"false\"]}.</p> </li> <li> <p> <code>rollback</code> Roll the app back to the previous version. When you update an app, AWS OpsWorks Stacks stores the previous version, up to a maximum of five versions. You can use this command to roll an app back as many as four versions.</p> </li> <li> <p> <code>start</code>: Start the app's web or application server.</p> </li> <li> <p> <code>stop</code>: Stop the app's web or application server.</p> </li> <li> <p> <code>restart</code>: Restart the app's web or application server.</p> </li> <li> <p> <code>undeploy</code>: Undeploy the app.</p> </li> </ul>"]
     #[serde(rename="Name")]
     pub name: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DeploymentCommandName {
+    Configure,
+    Deploy,
+    ExecuteRecipes,
+    InstallDependencies,
+    Restart,
+    Rollback,
+    Setup,
+    Start,
+    Stop,
+    Undeploy,
+    UpdateCustomCookbooks,
+    UpdateDependencies,
+}
+
+impl Into<String> for DeploymentCommandName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DeploymentCommandName {
+    fn into(self) -> &'static str {
+        match self {
+            DeploymentCommandName::Configure => "configure",
+            DeploymentCommandName::Deploy => "deploy",
+            DeploymentCommandName::ExecuteRecipes => "execute_recipes",
+            DeploymentCommandName::InstallDependencies => "install_dependencies",
+            DeploymentCommandName::Restart => "restart",
+            DeploymentCommandName::Rollback => "rollback",
+            DeploymentCommandName::Setup => "setup",
+            DeploymentCommandName::Start => "start",
+            DeploymentCommandName::Stop => "stop",
+            DeploymentCommandName::Undeploy => "undeploy",
+            DeploymentCommandName::UpdateCustomCookbooks => "update_custom_cookbooks",
+            DeploymentCommandName::UpdateDependencies => "update_dependencies",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DeploymentCommandName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "configure" => Ok(DeploymentCommandName::Configure),
+            "deploy" => Ok(DeploymentCommandName::Deploy),
+            "execute_recipes" => Ok(DeploymentCommandName::ExecuteRecipes),
+            "install_dependencies" => Ok(DeploymentCommandName::InstallDependencies),
+            "restart" => Ok(DeploymentCommandName::Restart),
+            "rollback" => Ok(DeploymentCommandName::Rollback),
+            "setup" => Ok(DeploymentCommandName::Setup),
+            "start" => Ok(DeploymentCommandName::Start),
+            "stop" => Ok(DeploymentCommandName::Stop),
+            "undeploy" => Ok(DeploymentCommandName::Undeploy),
+            "update_custom_cookbooks" => Ok(DeploymentCommandName::UpdateCustomCookbooks),
+            "update_dependencies" => Ok(DeploymentCommandName::UpdateDependencies),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1936,6 +2533,175 @@ pub struct Layer {
     pub volume_configurations: Option<Vec<VolumeConfiguration>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LayerAttributesKeys {
+    BundlerVersion,
+    EcsClusterArn,
+    EnableHaproxyStats,
+    GangliaPassword,
+    GangliaUrl,
+    GangliaUser,
+    HaproxyHealthCheckMethod,
+    HaproxyHealthCheckUrl,
+    HaproxyStatsPassword,
+    HaproxyStatsUrl,
+    HaproxyStatsUser,
+    JavaAppServer,
+    JavaAppServerVersion,
+    Jvm,
+    JvmOptions,
+    JvmVersion,
+    ManageBundler,
+    MemcachedMemory,
+    MysqlRootPassword,
+    MysqlRootPasswordUbiquitous,
+    NodejsVersion,
+    PassengerVersion,
+    RailsStack,
+    RubyVersion,
+    RubygemsVersion,
+}
+
+impl Into<String> for LayerAttributesKeys {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LayerAttributesKeys {
+    fn into(self) -> &'static str {
+        match self {
+            LayerAttributesKeys::BundlerVersion => "BundlerVersion",
+            LayerAttributesKeys::EcsClusterArn => "EcsClusterArn",
+            LayerAttributesKeys::EnableHaproxyStats => "EnableHaproxyStats",
+            LayerAttributesKeys::GangliaPassword => "GangliaPassword",
+            LayerAttributesKeys::GangliaUrl => "GangliaUrl",
+            LayerAttributesKeys::GangliaUser => "GangliaUser",
+            LayerAttributesKeys::HaproxyHealthCheckMethod => "HaproxyHealthCheckMethod",
+            LayerAttributesKeys::HaproxyHealthCheckUrl => "HaproxyHealthCheckUrl",
+            LayerAttributesKeys::HaproxyStatsPassword => "HaproxyStatsPassword",
+            LayerAttributesKeys::HaproxyStatsUrl => "HaproxyStatsUrl",
+            LayerAttributesKeys::HaproxyStatsUser => "HaproxyStatsUser",
+            LayerAttributesKeys::JavaAppServer => "JavaAppServer",
+            LayerAttributesKeys::JavaAppServerVersion => "JavaAppServerVersion",
+            LayerAttributesKeys::Jvm => "Jvm",
+            LayerAttributesKeys::JvmOptions => "JvmOptions",
+            LayerAttributesKeys::JvmVersion => "JvmVersion",
+            LayerAttributesKeys::ManageBundler => "ManageBundler",
+            LayerAttributesKeys::MemcachedMemory => "MemcachedMemory",
+            LayerAttributesKeys::MysqlRootPassword => "MysqlRootPassword",
+            LayerAttributesKeys::MysqlRootPasswordUbiquitous => "MysqlRootPasswordUbiquitous",
+            LayerAttributesKeys::NodejsVersion => "NodejsVersion",
+            LayerAttributesKeys::PassengerVersion => "PassengerVersion",
+            LayerAttributesKeys::RailsStack => "RailsStack",
+            LayerAttributesKeys::RubyVersion => "RubyVersion",
+            LayerAttributesKeys::RubygemsVersion => "RubygemsVersion",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LayerAttributesKeys {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BundlerVersion" => Ok(LayerAttributesKeys::BundlerVersion),
+            "EcsClusterArn" => Ok(LayerAttributesKeys::EcsClusterArn),
+            "EnableHaproxyStats" => Ok(LayerAttributesKeys::EnableHaproxyStats),
+            "GangliaPassword" => Ok(LayerAttributesKeys::GangliaPassword),
+            "GangliaUrl" => Ok(LayerAttributesKeys::GangliaUrl),
+            "GangliaUser" => Ok(LayerAttributesKeys::GangliaUser),
+            "HaproxyHealthCheckMethod" => Ok(LayerAttributesKeys::HaproxyHealthCheckMethod),
+            "HaproxyHealthCheckUrl" => Ok(LayerAttributesKeys::HaproxyHealthCheckUrl),
+            "HaproxyStatsPassword" => Ok(LayerAttributesKeys::HaproxyStatsPassword),
+            "HaproxyStatsUrl" => Ok(LayerAttributesKeys::HaproxyStatsUrl),
+            "HaproxyStatsUser" => Ok(LayerAttributesKeys::HaproxyStatsUser),
+            "JavaAppServer" => Ok(LayerAttributesKeys::JavaAppServer),
+            "JavaAppServerVersion" => Ok(LayerAttributesKeys::JavaAppServerVersion),
+            "Jvm" => Ok(LayerAttributesKeys::Jvm),
+            "JvmOptions" => Ok(LayerAttributesKeys::JvmOptions),
+            "JvmVersion" => Ok(LayerAttributesKeys::JvmVersion),
+            "ManageBundler" => Ok(LayerAttributesKeys::ManageBundler),
+            "MemcachedMemory" => Ok(LayerAttributesKeys::MemcachedMemory),
+            "MysqlRootPassword" => Ok(LayerAttributesKeys::MysqlRootPassword),
+            "MysqlRootPasswordUbiquitous" => Ok(LayerAttributesKeys::MysqlRootPasswordUbiquitous),
+            "NodejsVersion" => Ok(LayerAttributesKeys::NodejsVersion),
+            "PassengerVersion" => Ok(LayerAttributesKeys::PassengerVersion),
+            "RailsStack" => Ok(LayerAttributesKeys::RailsStack),
+            "RubyVersion" => Ok(LayerAttributesKeys::RubyVersion),
+            "RubygemsVersion" => Ok(LayerAttributesKeys::RubygemsVersion),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LayerType {
+    AwsFlowRuby,
+    Custom,
+    DbMaster,
+    EcsCluster,
+    JavaApp,
+    Lb,
+    Memcached,
+    MonitoringMaster,
+    NodejsApp,
+    PhpApp,
+    RailsApp,
+    Web,
+}
+
+impl Into<String> for LayerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LayerType {
+    fn into(self) -> &'static str {
+        match self {
+            LayerType::AwsFlowRuby => "aws-flow-ruby",
+            LayerType::Custom => "custom",
+            LayerType::DbMaster => "db-master",
+            LayerType::EcsCluster => "ecs-cluster",
+            LayerType::JavaApp => "java-app",
+            LayerType::Lb => "lb",
+            LayerType::Memcached => "memcached",
+            LayerType::MonitoringMaster => "monitoring-master",
+            LayerType::NodejsApp => "nodejs-app",
+            LayerType::PhpApp => "php-app",
+            LayerType::RailsApp => "rails-app",
+            LayerType::Web => "web",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LayerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "aws-flow-ruby" => Ok(LayerType::AwsFlowRuby),
+            "custom" => Ok(LayerType::Custom),
+            "db-master" => Ok(LayerType::DbMaster),
+            "ecs-cluster" => Ok(LayerType::EcsCluster),
+            "java-app" => Ok(LayerType::JavaApp),
+            "lb" => Ok(LayerType::Lb),
+            "memcached" => Ok(LayerType::Memcached),
+            "monitoring-master" => Ok(LayerType::MonitoringMaster),
+            "nodejs-app" => Ok(LayerType::NodejsApp),
+            "php-app" => Ok(LayerType::PhpApp),
+            "rails-app" => Ok(LayerType::RailsApp),
+            "web" => Ok(LayerType::Web),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies the lifecycle event configuration</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LifecycleEventConfiguration {
@@ -2280,6 +3046,41 @@ pub struct ReportedOs {
     pub version: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RootDeviceType {
+    Ebs,
+    InstanceStore,
+}
+
+impl Into<String> for RootDeviceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RootDeviceType {
+    fn into(self) -> &'static str {
+        match self {
+            RootDeviceType::Ebs => "ebs",
+            RootDeviceType::InstanceStore => "instance-store",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RootDeviceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ebs" => Ok(RootDeviceType::Ebs),
+            "instance-store" => Ok(RootDeviceType::InstanceStore),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes a user's SSH information.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct SelfUserProfile {
@@ -2424,6 +3225,47 @@ pub struct Source {
     pub username: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    Archive,
+    Git,
+    S3,
+    Svn,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::Archive => "archive",
+            SourceType::Git => "git",
+            SourceType::S3 => "s3",
+            SourceType::Svn => "svn",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "archive" => Ok(SourceType::Archive),
+            "git" => Ok(SourceType::Git),
+            "s3" => Ok(SourceType::S3),
+            "svn" => Ok(SourceType::Svn),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes an app's SSL configuration.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SslConfiguration {
@@ -2529,6 +3371,38 @@ pub struct Stack {
     #[serde(rename="VpcId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StackAttributesKeys {
+    Color,
+}
+
+impl Into<String> for StackAttributesKeys {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StackAttributesKeys {
+    fn into(self) -> &'static str {
+        match self {
+            StackAttributesKeys::Color => "Color",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StackAttributesKeys {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Color" => Ok(StackAttributesKeys::Color),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes the configuration manager.</p>"]
@@ -3005,6 +3879,41 @@ pub struct UserProfile {
     pub ssh_username: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VirtualizationType {
+    Hvm,
+    Paravirtual,
+}
+
+impl Into<String> for VirtualizationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VirtualizationType {
+    fn into(self) -> &'static str {
+        match self {
+            VirtualizationType::Hvm => "hvm",
+            VirtualizationType::Paravirtual => "paravirtual",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VirtualizationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "hvm" => Ok(VirtualizationType::Hvm),
+            "paravirtual" => Ok(VirtualizationType::Paravirtual),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes an instance's Amazon EBS volume.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Volume {
@@ -3086,6 +3995,44 @@ pub struct VolumeConfiguration {
     #[serde(rename="VolumeType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub volume_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VolumeType {
+    Gp2,
+    Io1,
+    Standard,
+}
+
+impl Into<String> for VolumeType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VolumeType {
+    fn into(self) -> &'static str {
+        match self {
+            VolumeType::Gp2 => "gp2",
+            VolumeType::Io1 => "io1",
+            VolumeType::Standard => "standard",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VolumeType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "gp2" => Ok(VolumeType::Gp2),
+            "io1" => Ok(VolumeType::Io1),
+            "standard" => Ok(VolumeType::Standard),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a time-based instance's auto scaling schedule. The schedule consists of a set of key-value pairs.</p> <ul> <li> <p>The key is the time period (a UTC hour) and must be an integer from 0 - 23.</p> </li> <li> <p>The value indicates whether the instance should be online or offline for the specified period, and must be set to \"on\" or \"off\"</p> </li> </ul> <p>The default setting for all time periods is off, so you use the following parameters primarily to specify the online periods. You don't have to explicitly specify offline periods unless you want to change an online period to an offline period.</p> <p>The following example specifies that the instance should be online for four hours, from UTC 1200 - 1600. It will be off for the remainder of the day.</p> <p> <code> { \"12\":\"on\", \"13\":\"on\", \"14\":\"on\", \"15\":\"on\" } </code> </p>"]
@@ -9352,7 +10299,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9376,7 +10323,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9402,7 +10349,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9429,7 +10376,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9454,7 +10401,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CloneStackResult>(String::from_utf8_lossy(&body)
@@ -9484,7 +10431,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateAppResult>(String::from_utf8_lossy(&body).as_ref())
@@ -9515,7 +10462,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDeploymentResult>(String::from_utf8_lossy(&body)
@@ -9547,7 +10494,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateInstanceResult>(String::from_utf8_lossy(&body)
@@ -9579,7 +10526,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateLayerResult>(String::from_utf8_lossy(&body)
@@ -9611,7 +10558,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateStackResult>(String::from_utf8_lossy(&body)
@@ -9643,7 +10590,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateUserProfileResult>(String::from_utf8_lossy(&body)
@@ -9673,7 +10620,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9697,7 +10644,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9721,7 +10668,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9745,7 +10692,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9771,7 +10718,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9797,7 +10744,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9823,7 +10770,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9849,7 +10796,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9875,7 +10822,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9902,7 +10849,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -9929,7 +10876,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAgentVersionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9959,7 +10906,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAppsResult>(String::from_utf8_lossy(&body)
@@ -9991,7 +10938,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeCommandsResult>(String::from_utf8_lossy(&body)
@@ -10023,7 +10970,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeDeploymentsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10053,7 +11000,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEcsClustersResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10083,7 +11030,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeElasticIpsResult>(String::from_utf8_lossy(&body)
@@ -10117,7 +11064,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeElasticLoadBalancersResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10148,7 +11095,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeInstancesResult>(String::from_utf8_lossy(&body)
@@ -10180,7 +11127,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeLayersResult>(String::from_utf8_lossy(&body)
@@ -10214,7 +11161,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeLoadBasedAutoScalingResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10244,7 +11191,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMyUserProfileResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10274,7 +11221,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribePermissionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10304,7 +11251,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeRaidArraysResult>(String::from_utf8_lossy(&body)
@@ -10337,7 +11284,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeRdsDbInstancesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10368,7 +11315,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeServiceErrorsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10401,7 +11348,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeStackProvisioningParametersResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10431,7 +11378,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeStackSummaryResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10461,7 +11408,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeStacksResult>(String::from_utf8_lossy(&body)
@@ -10495,7 +11442,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTimeBasedAutoScalingResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10526,7 +11473,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeUserProfilesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10556,7 +11503,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeVolumesResult>(String::from_utf8_lossy(&body)
@@ -10589,7 +11536,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10616,7 +11563,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10643,7 +11590,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetHostnameSuggestionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -10673,7 +11620,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GrantAccessResult>(String::from_utf8_lossy(&body)
@@ -10703,7 +11650,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsResult>(String::from_utf8_lossy(&body).as_ref())
@@ -10732,7 +11679,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10758,7 +11705,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterEcsClusterResult>(String::from_utf8_lossy(&body)
@@ -10790,7 +11737,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterElasticIpResult>(String::from_utf8_lossy(&body)
@@ -10822,7 +11769,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterInstanceResult>(String::from_utf8_lossy(&body)
@@ -10854,7 +11801,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10880,7 +11827,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterVolumeResult>(String::from_utf8_lossy(&body)
@@ -10912,7 +11859,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10937,7 +11884,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10963,7 +11910,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -10988,7 +11935,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11012,7 +11959,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11036,7 +11983,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11060,7 +12007,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11084,7 +12031,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11110,7 +12057,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11134,7 +12081,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11158,7 +12105,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11182,7 +12129,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11208,7 +12155,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11232,7 +12179,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11256,7 +12203,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11282,7 +12229,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11308,7 +12255,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11332,7 +12279,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11358,7 +12305,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -11382,7 +12329,7 @@ impl<P, D> OpsWorks for OpsWorksClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -157,6 +153,82 @@ pub struct Backup {
     #[serde(rename="UserArn")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub user_arn: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BackupStatus {
+    Deleting,
+    Failed,
+    InProgress,
+    Ok,
+}
+
+impl Into<String> for BackupStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BackupStatus {
+    fn into(self) -> &'static str {
+        match self {
+            BackupStatus::Deleting => "DELETING",
+            BackupStatus::Failed => "FAILED",
+            BackupStatus::InProgress => "IN_PROGRESS",
+            BackupStatus::Ok => "OK",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BackupStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETING" => Ok(BackupStatus::Deleting),
+            "FAILED" => Ok(BackupStatus::Failed),
+            "IN_PROGRESS" => Ok(BackupStatus::InProgress),
+            "OK" => Ok(BackupStatus::Ok),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BackupType {
+    Automated,
+    Manual,
+}
+
+impl Into<String> for BackupType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BackupType {
+    fn into(self) -> &'static str {
+        match self {
+            BackupType::Automated => "AUTOMATED",
+            BackupType::Manual => "MANUAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BackupType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AUTOMATED" => Ok(BackupType::Automated),
+            "MANUAL" => Ok(BackupType::Manual),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -424,6 +496,79 @@ pub struct EngineAttribute {
     pub value: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MaintenanceStatus {
+    Failed,
+    Success,
+}
+
+impl Into<String> for MaintenanceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MaintenanceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            MaintenanceStatus::Failed => "FAILED",
+            MaintenanceStatus::Success => "SUCCESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MaintenanceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(MaintenanceStatus::Failed),
+            "SUCCESS" => Ok(MaintenanceStatus::Success),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="<p>The status of the association or disassociation request. </p> <p class=\"title\"> <b>Possible values:</b> </p> <ul> <li> <p> <code>SUCCESS</code>: The association or disassociation succeeded. </p> </li> <li> <p> <code>FAILED</code>: The association or disassociation failed. </p> </li> <li> <p> <code>IN_PROGRESS</code>: The association or disassociation is still in progress. </p> </li> </ul>"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NodeAssociationStatus {
+    Failed,
+    InProgress,
+    Success,
+}
+
+impl Into<String> for NodeAssociationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NodeAssociationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            NodeAssociationStatus::Failed => "FAILED",
+            NodeAssociationStatus::InProgress => "IN_PROGRESS",
+            NodeAssociationStatus::Success => "SUCCESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NodeAssociationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(NodeAssociationStatus::Failed),
+            "IN_PROGRESS" => Ok(NodeAssociationStatus::InProgress),
+            "SUCCESS" => Ok(NodeAssociationStatus::Success),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct RestoreServerRequest {
     #[doc="<p> The ID of the backup that you want to use to restore a server. </p>"]
@@ -561,6 +706,74 @@ pub struct ServerEvent {
     #[serde(rename="ServerName")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub server_name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ServerStatus {
+    BackingUp,
+    ConnectionLost,
+    Creating,
+    Deleting,
+    Failed,
+    Healthy,
+    Modifying,
+    Restoring,
+    Running,
+    Setup,
+    Terminated,
+    UnderMaintenance,
+    Unhealthy,
+}
+
+impl Into<String> for ServerStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ServerStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ServerStatus::BackingUp => "BACKING_UP",
+            ServerStatus::ConnectionLost => "CONNECTION_LOST",
+            ServerStatus::Creating => "CREATING",
+            ServerStatus::Deleting => "DELETING",
+            ServerStatus::Failed => "FAILED",
+            ServerStatus::Healthy => "HEALTHY",
+            ServerStatus::Modifying => "MODIFYING",
+            ServerStatus::Restoring => "RESTORING",
+            ServerStatus::Running => "RUNNING",
+            ServerStatus::Setup => "SETUP",
+            ServerStatus::Terminated => "TERMINATED",
+            ServerStatus::UnderMaintenance => "UNDER_MAINTENANCE",
+            ServerStatus::Unhealthy => "UNHEALTHY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ServerStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BACKING_UP" => Ok(ServerStatus::BackingUp),
+            "CONNECTION_LOST" => Ok(ServerStatus::ConnectionLost),
+            "CREATING" => Ok(ServerStatus::Creating),
+            "DELETING" => Ok(ServerStatus::Deleting),
+            "FAILED" => Ok(ServerStatus::Failed),
+            "HEALTHY" => Ok(ServerStatus::Healthy),
+            "MODIFYING" => Ok(ServerStatus::Modifying),
+            "RESTORING" => Ok(ServerStatus::Restoring),
+            "RUNNING" => Ok(ServerStatus::Running),
+            "SETUP" => Ok(ServerStatus::Setup),
+            "TERMINATED" => Ok(ServerStatus::Terminated),
+            "UNDER_MAINTENANCE" => Ok(ServerStatus::UnderMaintenance),
+            "UNHEALTHY" => Ok(ServerStatus::Unhealthy),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -2036,7 +2249,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AssociateNodeResponse>(String::from_utf8_lossy(&body)
@@ -2068,7 +2281,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateBackupResponse>(String::from_utf8_lossy(&body)
@@ -2100,7 +2313,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateServerResponse>(String::from_utf8_lossy(&body)
@@ -2132,7 +2345,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteBackupResponse>(String::from_utf8_lossy(&body)
@@ -2164,7 +2377,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteServerResponse>(String::from_utf8_lossy(&body)
@@ -2196,7 +2409,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAccountAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2227,7 +2440,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeBackupsResponse>(String::from_utf8_lossy(&body)
@@ -2259,7 +2472,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEventsResponse>(String::from_utf8_lossy(&body)
@@ -2293,7 +2506,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeNodeAssociationStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2324,7 +2537,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeServersResponse>(String::from_utf8_lossy(&body)
@@ -2356,7 +2569,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisassociateNodeResponse>(String::from_utf8_lossy(&body)
@@ -2388,7 +2601,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RestoreServerResponse>(String::from_utf8_lossy(&body)
@@ -2420,7 +2633,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartMaintenanceResponse>(String::from_utf8_lossy(&body)
@@ -2452,7 +2665,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateServerResponse>(String::from_utf8_lossy(&body)
@@ -2486,7 +2699,7 @@ impl<P, D> OpsWorksCM for OpsWorksCMClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateServerEngineAttributesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -76,6 +72,114 @@ pub struct Account {
     pub status: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccountJoinedMethod {
+    Created,
+    Invited,
+}
+
+impl Into<String> for AccountJoinedMethod {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccountJoinedMethod {
+    fn into(self) -> &'static str {
+        match self {
+            AccountJoinedMethod::Created => "CREATED",
+            AccountJoinedMethod::Invited => "INVITED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccountJoinedMethod {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATED" => Ok(AccountJoinedMethod::Created),
+            "INVITED" => Ok(AccountJoinedMethod::Invited),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccountStatus {
+    Active,
+    Suspended,
+}
+
+impl Into<String> for AccountStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccountStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AccountStatus::Active => "ACTIVE",
+            AccountStatus::Suspended => "SUSPENDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccountStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(AccountStatus::Active),
+            "SUSPENDED" => Ok(AccountStatus::Suspended),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActionType {
+    ApproveAllFeatures,
+    EnableAllFeatures,
+    Invite,
+}
+
+impl Into<String> for ActionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActionType {
+    fn into(self) -> &'static str {
+        match self {
+            ActionType::ApproveAllFeatures => "APPROVE_ALL_FEATURES",
+            ActionType::EnableAllFeatures => "ENABLE_ALL_FEATURES",
+            ActionType::Invite => "INVITE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "APPROVE_ALL_FEATURES" => Ok(ActionType::ApproveAllFeatures),
+            "ENABLE_ALL_FEATURES" => Ok(ActionType::EnableAllFeatures),
+            "INVITE" => Ok(ActionType::Invite),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct AttachPolicyRequest {
     #[doc="<p>The unique identifier (ID) of the policy that you want to attach to the target. You can get the ID for the policy by calling the <a>ListPolicies</a> operation.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for a policy ID string requires \"p-\" followed by from 8 to 128 lower-case letters or digits.</p>"]
@@ -114,6 +218,208 @@ pub struct Child {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChildType {
+    Account,
+    OrganizationalUnit,
+}
+
+impl Into<String> for ChildType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChildType {
+    fn into(self) -> &'static str {
+        match self {
+            ChildType::Account => "ACCOUNT",
+            ChildType::OrganizationalUnit => "ORGANIZATIONAL_UNIT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChildType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT" => Ok(ChildType::Account),
+            "ORGANIZATIONAL_UNIT" => Ok(ChildType::OrganizationalUnit),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConstraintViolationExceptionReason {
+    AccountCannotLeaveOrganization,
+    AccountCannotLeaveWithoutEula,
+    AccountCannotLeaveWithoutPhoneVerification,
+    AccountCreationRateLimitExceeded,
+    AccountNumberLimitExceeded,
+    HandshakeRateLimitExceeded,
+    MasterAccountAddressDoesNotMatchMarketplace,
+    MasterAccountPaymentInstrumentRequired,
+    MaxPolicyTypeAttachmentLimitExceeded,
+    MemberAccountPaymentInstrumentRequired,
+    MinPolicyTypeAttachmentLimitExceeded,
+    OuDepthLimitExceeded,
+    OuNumberLimitExceeded,
+    PolicyNumberLimitExceeded,
+}
+
+impl Into<String> for ConstraintViolationExceptionReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConstraintViolationExceptionReason {
+    fn into(self) -> &'static str {
+        match self {
+            ConstraintViolationExceptionReason::AccountCannotLeaveOrganization => {
+                "ACCOUNT_CANNOT_LEAVE_ORGANIZATION"
+            }
+            ConstraintViolationExceptionReason::AccountCannotLeaveWithoutEula => {
+                "ACCOUNT_CANNOT_LEAVE_WITHOUT_EULA"
+            }
+            ConstraintViolationExceptionReason::AccountCannotLeaveWithoutPhoneVerification => {
+                "ACCOUNT_CANNOT_LEAVE_WITHOUT_PHONE_VERIFICATION"
+            }
+            ConstraintViolationExceptionReason::AccountCreationRateLimitExceeded => {
+                "ACCOUNT_CREATION_RATE_LIMIT_EXCEEDED"
+            }
+            ConstraintViolationExceptionReason::AccountNumberLimitExceeded => {
+                "ACCOUNT_NUMBER_LIMIT_EXCEEDED"
+            }
+            ConstraintViolationExceptionReason::HandshakeRateLimitExceeded => {
+                "HANDSHAKE_RATE_LIMIT_EXCEEDED"
+            }
+            ConstraintViolationExceptionReason::MasterAccountAddressDoesNotMatchMarketplace => {
+                "MASTER_ACCOUNT_ADDRESS_DOES_NOT_MATCH_MARKETPLACE"
+            }
+            ConstraintViolationExceptionReason::MasterAccountPaymentInstrumentRequired => {
+                "MASTER_ACCOUNT_PAYMENT_INSTRUMENT_REQUIRED"
+            }
+            ConstraintViolationExceptionReason::MaxPolicyTypeAttachmentLimitExceeded => {
+                "MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED"
+            }
+            ConstraintViolationExceptionReason::MemberAccountPaymentInstrumentRequired => {
+                "MEMBER_ACCOUNT_PAYMENT_INSTRUMENT_REQUIRED"
+            }
+            ConstraintViolationExceptionReason::MinPolicyTypeAttachmentLimitExceeded => {
+                "MIN_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED"
+            }
+            ConstraintViolationExceptionReason::OuDepthLimitExceeded => "OU_DEPTH_LIMIT_EXCEEDED",
+            ConstraintViolationExceptionReason::OuNumberLimitExceeded => "OU_NUMBER_LIMIT_EXCEEDED",
+            ConstraintViolationExceptionReason::PolicyNumberLimitExceeded => {
+                "POLICY_NUMBER_LIMIT_EXCEEDED"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConstraintViolationExceptionReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT_CANNOT_LEAVE_ORGANIZATION" => {
+                Ok(ConstraintViolationExceptionReason::AccountCannotLeaveOrganization)
+            }
+            "ACCOUNT_CANNOT_LEAVE_WITHOUT_EULA" => {
+                Ok(ConstraintViolationExceptionReason::AccountCannotLeaveWithoutEula)
+            }
+            "ACCOUNT_CANNOT_LEAVE_WITHOUT_PHONE_VERIFICATION" => {
+                Ok(ConstraintViolationExceptionReason::AccountCannotLeaveWithoutPhoneVerification)
+            }
+            "ACCOUNT_CREATION_RATE_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::AccountCreationRateLimitExceeded)
+            }
+            "ACCOUNT_NUMBER_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::AccountNumberLimitExceeded)
+            }
+            "HANDSHAKE_RATE_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::HandshakeRateLimitExceeded)
+            }
+            "MASTER_ACCOUNT_ADDRESS_DOES_NOT_MATCH_MARKETPLACE" => {
+                Ok(ConstraintViolationExceptionReason::MasterAccountAddressDoesNotMatchMarketplace)
+            }
+            "MASTER_ACCOUNT_PAYMENT_INSTRUMENT_REQUIRED" => {
+                Ok(ConstraintViolationExceptionReason::MasterAccountPaymentInstrumentRequired)
+            }
+            "MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::MaxPolicyTypeAttachmentLimitExceeded)
+            }
+            "MEMBER_ACCOUNT_PAYMENT_INSTRUMENT_REQUIRED" => {
+                Ok(ConstraintViolationExceptionReason::MemberAccountPaymentInstrumentRequired)
+            }
+            "MIN_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::MinPolicyTypeAttachmentLimitExceeded)
+            }
+            "OU_DEPTH_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::OuDepthLimitExceeded)
+            }
+            "OU_NUMBER_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::OuNumberLimitExceeded)
+            }
+            "POLICY_NUMBER_LIMIT_EXCEEDED" => {
+                Ok(ConstraintViolationExceptionReason::PolicyNumberLimitExceeded)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CreateAccountFailureReason {
+    AccountLimitExceeded,
+    EmailAlreadyExists,
+    InternalFailure,
+    InvalidAddress,
+    InvalidEmail,
+}
+
+impl Into<String> for CreateAccountFailureReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CreateAccountFailureReason {
+    fn into(self) -> &'static str {
+        match self {
+            CreateAccountFailureReason::AccountLimitExceeded => "ACCOUNT_LIMIT_EXCEEDED",
+            CreateAccountFailureReason::EmailAlreadyExists => "EMAIL_ALREADY_EXISTS",
+            CreateAccountFailureReason::InternalFailure => "INTERNAL_FAILURE",
+            CreateAccountFailureReason::InvalidAddress => "INVALID_ADDRESS",
+            CreateAccountFailureReason::InvalidEmail => "INVALID_EMAIL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CreateAccountFailureReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT_LIMIT_EXCEEDED" => Ok(CreateAccountFailureReason::AccountLimitExceeded),
+            "EMAIL_ALREADY_EXISTS" => Ok(CreateAccountFailureReason::EmailAlreadyExists),
+            "INTERNAL_FAILURE" => Ok(CreateAccountFailureReason::InternalFailure),
+            "INVALID_ADDRESS" => Ok(CreateAccountFailureReason::InvalidAddress),
+            "INVALID_EMAIL" => Ok(CreateAccountFailureReason::InvalidEmail),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct CreateAccountRequest {
     #[doc="<p>The friendly name of the member account.</p>"]
@@ -138,6 +444,44 @@ pub struct CreateAccountResponse {
     #[serde(rename="CreateAccountStatus")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub create_account_status: Option<CreateAccountStatus>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CreateAccountState {
+    Failed,
+    InProgress,
+    Succeeded,
+}
+
+impl Into<String> for CreateAccountState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CreateAccountState {
+    fn into(self) -> &'static str {
+        match self {
+            CreateAccountState::Failed => "FAILED",
+            CreateAccountState::InProgress => "IN_PROGRESS",
+            CreateAccountState::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CreateAccountState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(CreateAccountState::Failed),
+            "IN_PROGRESS" => Ok(CreateAccountState::InProgress),
+            "SUCCEEDED" => Ok(CreateAccountState::Succeeded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains the status about a <a>CreateAccount</a> request to create an AWS account in an organization.</p>"]
@@ -437,6 +781,81 @@ pub struct Handshake {
     pub state: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HandshakeConstraintViolationExceptionReason {
+    AccountNumberLimitExceeded,
+    AlreadyInAnOrganization,
+    HandshakeRateLimitExceeded,
+    InviteDisabledDuringEnableAllFeatures,
+    OrganizationAlreadyHasAllFeatures,
+    OrganizationFromDifferentSellerOfRecord,
+    OrganizationMembershipChangeRateLimitExceeded,
+    PaymentInstrumentRequired,
+}
+
+impl Into<String> for HandshakeConstraintViolationExceptionReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HandshakeConstraintViolationExceptionReason {
+    fn into(self) -> &'static str {
+        match self {
+            HandshakeConstraintViolationExceptionReason::AccountNumberLimitExceeded => {
+                "ACCOUNT_NUMBER_LIMIT_EXCEEDED"
+            }
+            HandshakeConstraintViolationExceptionReason::AlreadyInAnOrganization => {
+                "ALREADY_IN_AN_ORGANIZATION"
+            }
+            HandshakeConstraintViolationExceptionReason::HandshakeRateLimitExceeded => {
+                "HANDSHAKE_RATE_LIMIT_EXCEEDED"
+            }
+            HandshakeConstraintViolationExceptionReason::InviteDisabledDuringEnableAllFeatures => {
+                "INVITE_DISABLED_DURING_ENABLE_ALL_FEATURES"
+            }
+            HandshakeConstraintViolationExceptionReason::OrganizationAlreadyHasAllFeatures => {
+                "ORGANIZATION_ALREADY_HAS_ALL_FEATURES"
+            }
+            HandshakeConstraintViolationExceptionReason::OrganizationFromDifferentSellerOfRecord => "ORGANIZATION_FROM_DIFFERENT_SELLER_OF_RECORD",
+            HandshakeConstraintViolationExceptionReason::OrganizationMembershipChangeRateLimitExceeded => "ORGANIZATION_MEMBERSHIP_CHANGE_RATE_LIMIT_EXCEEDED",
+            HandshakeConstraintViolationExceptionReason::PaymentInstrumentRequired => {
+                "PAYMENT_INSTRUMENT_REQUIRED"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for HandshakeConstraintViolationExceptionReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT_NUMBER_LIMIT_EXCEEDED" => {
+                Ok(HandshakeConstraintViolationExceptionReason::AccountNumberLimitExceeded)
+            }
+            "ALREADY_IN_AN_ORGANIZATION" => {
+                Ok(HandshakeConstraintViolationExceptionReason::AlreadyInAnOrganization)
+            }
+            "HANDSHAKE_RATE_LIMIT_EXCEEDED" => {
+                Ok(HandshakeConstraintViolationExceptionReason::HandshakeRateLimitExceeded)
+            }
+            "INVITE_DISABLED_DURING_ENABLE_ALL_FEATURES" => Ok(HandshakeConstraintViolationExceptionReason::InviteDisabledDuringEnableAllFeatures),
+            "ORGANIZATION_ALREADY_HAS_ALL_FEATURES" => {
+                Ok(HandshakeConstraintViolationExceptionReason::OrganizationAlreadyHasAllFeatures)
+            }
+            "ORGANIZATION_FROM_DIFFERENT_SELLER_OF_RECORD" => Ok(HandshakeConstraintViolationExceptionReason::OrganizationFromDifferentSellerOfRecord),
+            "ORGANIZATION_MEMBERSHIP_CHANGE_RATE_LIMIT_EXCEEDED" => Ok(HandshakeConstraintViolationExceptionReason::OrganizationMembershipChangeRateLimitExceeded),
+            "PAYMENT_INSTRUMENT_REQUIRED" => {
+                Ok(HandshakeConstraintViolationExceptionReason::PaymentInstrumentRequired)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies the criteria that are used to select the handshakes for the operation.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct HandshakeFilter {
@@ -463,6 +882,44 @@ pub struct HandshakeParty {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HandshakePartyType {
+    Account,
+    Email,
+    Organization,
+}
+
+impl Into<String> for HandshakePartyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HandshakePartyType {
+    fn into(self) -> &'static str {
+        match self {
+            HandshakePartyType::Account => "ACCOUNT",
+            HandshakePartyType::Email => "EMAIL",
+            HandshakePartyType::Organization => "ORGANIZATION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HandshakePartyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT" => Ok(HandshakePartyType::Account),
+            "EMAIL" => Ok(HandshakePartyType::Email),
+            "ORGANIZATION" => Ok(HandshakePartyType::Organization),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains additional data that is needed to process a handshake.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct HandshakeResource {
@@ -478,6 +935,229 @@ pub struct HandshakeResource {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HandshakeResourceType {
+    Account,
+    Email,
+    MasterEmail,
+    MasterName,
+    Notes,
+    Organization,
+    OrganizationFeatureSet,
+    ParentHandshake,
+}
+
+impl Into<String> for HandshakeResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HandshakeResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            HandshakeResourceType::Account => "ACCOUNT",
+            HandshakeResourceType::Email => "EMAIL",
+            HandshakeResourceType::MasterEmail => "MASTER_EMAIL",
+            HandshakeResourceType::MasterName => "MASTER_NAME",
+            HandshakeResourceType::Notes => "NOTES",
+            HandshakeResourceType::Organization => "ORGANIZATION",
+            HandshakeResourceType::OrganizationFeatureSet => "ORGANIZATION_FEATURE_SET",
+            HandshakeResourceType::ParentHandshake => "PARENT_HANDSHAKE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HandshakeResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT" => Ok(HandshakeResourceType::Account),
+            "EMAIL" => Ok(HandshakeResourceType::Email),
+            "MASTER_EMAIL" => Ok(HandshakeResourceType::MasterEmail),
+            "MASTER_NAME" => Ok(HandshakeResourceType::MasterName),
+            "NOTES" => Ok(HandshakeResourceType::Notes),
+            "ORGANIZATION" => Ok(HandshakeResourceType::Organization),
+            "ORGANIZATION_FEATURE_SET" => Ok(HandshakeResourceType::OrganizationFeatureSet),
+            "PARENT_HANDSHAKE" => Ok(HandshakeResourceType::ParentHandshake),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HandshakeState {
+    Accepted,
+    Canceled,
+    Declined,
+    Expired,
+    Open,
+    Requested,
+}
+
+impl Into<String> for HandshakeState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HandshakeState {
+    fn into(self) -> &'static str {
+        match self {
+            HandshakeState::Accepted => "ACCEPTED",
+            HandshakeState::Canceled => "CANCELED",
+            HandshakeState::Declined => "DECLINED",
+            HandshakeState::Expired => "EXPIRED",
+            HandshakeState::Open => "OPEN",
+            HandshakeState::Requested => "REQUESTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HandshakeState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCEPTED" => Ok(HandshakeState::Accepted),
+            "CANCELED" => Ok(HandshakeState::Canceled),
+            "DECLINED" => Ok(HandshakeState::Declined),
+            "EXPIRED" => Ok(HandshakeState::Expired),
+            "OPEN" => Ok(HandshakeState::Open),
+            "REQUESTED" => Ok(HandshakeState::Requested),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IAMUserAccessToBilling {
+    Allow,
+    Deny,
+}
+
+impl Into<String> for IAMUserAccessToBilling {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IAMUserAccessToBilling {
+    fn into(self) -> &'static str {
+        match self {
+            IAMUserAccessToBilling::Allow => "ALLOW",
+            IAMUserAccessToBilling::Deny => "DENY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IAMUserAccessToBilling {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALLOW" => Ok(IAMUserAccessToBilling::Allow),
+            "DENY" => Ok(IAMUserAccessToBilling::Deny),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InvalidInputExceptionReason {
+    ImmutablePolicy,
+    InputRequired,
+    InvalidEnum,
+    InvalidFullNameTarget,
+    InvalidListMember,
+    InvalidNextToken,
+    InvalidPartyTypeTarget,
+    InvalidPattern,
+    InvalidPatternTargetId,
+    InvalidSyntaxOrganizationArn,
+    InvalidSyntaxPolicyId,
+    MaxLengthExceeded,
+    MaxLimitExceededFilter,
+    MaxValueExceeded,
+    MinLengthExceeded,
+    MinValueExceeded,
+    MovingAccountBetweenDifferentRoots,
+}
+
+impl Into<String> for InvalidInputExceptionReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InvalidInputExceptionReason {
+    fn into(self) -> &'static str {
+        match self {
+            InvalidInputExceptionReason::ImmutablePolicy => "IMMUTABLE_POLICY",
+            InvalidInputExceptionReason::InputRequired => "INPUT_REQUIRED",
+            InvalidInputExceptionReason::InvalidEnum => "INVALID_ENUM",
+            InvalidInputExceptionReason::InvalidFullNameTarget => "INVALID_FULL_NAME_TARGET",
+            InvalidInputExceptionReason::InvalidListMember => "INVALID_LIST_MEMBER",
+            InvalidInputExceptionReason::InvalidNextToken => "INVALID_NEXT_TOKEN",
+            InvalidInputExceptionReason::InvalidPartyTypeTarget => "INVALID_PARTY_TYPE_TARGET",
+            InvalidInputExceptionReason::InvalidPattern => "INVALID_PATTERN",
+            InvalidInputExceptionReason::InvalidPatternTargetId => "INVALID_PATTERN_TARGET_ID",
+            InvalidInputExceptionReason::InvalidSyntaxOrganizationArn => {
+                "INVALID_SYNTAX_ORGANIZATION_ARN"
+            }
+            InvalidInputExceptionReason::InvalidSyntaxPolicyId => "INVALID_SYNTAX_POLICY_ID",
+            InvalidInputExceptionReason::MaxLengthExceeded => "MAX_LENGTH_EXCEEDED",
+            InvalidInputExceptionReason::MaxLimitExceededFilter => "MAX_LIMIT_EXCEEDED_FILTER",
+            InvalidInputExceptionReason::MaxValueExceeded => "MAX_VALUE_EXCEEDED",
+            InvalidInputExceptionReason::MinLengthExceeded => "MIN_LENGTH_EXCEEDED",
+            InvalidInputExceptionReason::MinValueExceeded => "MIN_VALUE_EXCEEDED",
+            InvalidInputExceptionReason::MovingAccountBetweenDifferentRoots => {
+                "MOVING_ACCOUNT_BETWEEN_DIFFERENT_ROOTS"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for InvalidInputExceptionReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IMMUTABLE_POLICY" => Ok(InvalidInputExceptionReason::ImmutablePolicy),
+            "INPUT_REQUIRED" => Ok(InvalidInputExceptionReason::InputRequired),
+            "INVALID_ENUM" => Ok(InvalidInputExceptionReason::InvalidEnum),
+            "INVALID_FULL_NAME_TARGET" => Ok(InvalidInputExceptionReason::InvalidFullNameTarget),
+            "INVALID_LIST_MEMBER" => Ok(InvalidInputExceptionReason::InvalidListMember),
+            "INVALID_NEXT_TOKEN" => Ok(InvalidInputExceptionReason::InvalidNextToken),
+            "INVALID_PARTY_TYPE_TARGET" => Ok(InvalidInputExceptionReason::InvalidPartyTypeTarget),
+            "INVALID_PATTERN" => Ok(InvalidInputExceptionReason::InvalidPattern),
+            "INVALID_PATTERN_TARGET_ID" => Ok(InvalidInputExceptionReason::InvalidPatternTargetId),
+            "INVALID_SYNTAX_ORGANIZATION_ARN" => {
+                Ok(InvalidInputExceptionReason::InvalidSyntaxOrganizationArn)
+            }
+            "INVALID_SYNTAX_POLICY_ID" => Ok(InvalidInputExceptionReason::InvalidSyntaxPolicyId),
+            "MAX_LENGTH_EXCEEDED" => Ok(InvalidInputExceptionReason::MaxLengthExceeded),
+            "MAX_LIMIT_EXCEEDED_FILTER" => Ok(InvalidInputExceptionReason::MaxLimitExceededFilter),
+            "MAX_VALUE_EXCEEDED" => Ok(InvalidInputExceptionReason::MaxValueExceeded),
+            "MIN_LENGTH_EXCEEDED" => Ok(InvalidInputExceptionReason::MinLengthExceeded),
+            "MIN_VALUE_EXCEEDED" => Ok(InvalidInputExceptionReason::MinValueExceeded),
+            "MOVING_ACCOUNT_BETWEEN_DIFFERENT_ROOTS" => {
+                Ok(InvalidInputExceptionReason::MovingAccountBetweenDifferentRoots)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -872,6 +1552,41 @@ pub struct Organization {
     pub master_account_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OrganizationFeatureSet {
+    All,
+    ConsolidatedBilling,
+}
+
+impl Into<String> for OrganizationFeatureSet {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OrganizationFeatureSet {
+    fn into(self) -> &'static str {
+        match self {
+            OrganizationFeatureSet::All => "ALL",
+            OrganizationFeatureSet::ConsolidatedBilling => "CONSOLIDATED_BILLING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OrganizationFeatureSet {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL" => Ok(OrganizationFeatureSet::All),
+            "CONSOLIDATED_BILLING" => Ok(OrganizationFeatureSet::ConsolidatedBilling),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains details about an organizational unit (OU). An OU is a container of AWS accounts within a root of an organization. Policies that are attached to an OU apply to all accounts contained in that OU and in any child OUs.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct OrganizationalUnit {
@@ -900,6 +1615,41 @@ pub struct Parent {
     #[serde(rename="Type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParentType {
+    OrganizationalUnit,
+    Root,
+}
+
+impl Into<String> for ParentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParentType {
+    fn into(self) -> &'static str {
+        match self {
+            ParentType::OrganizationalUnit => "ORGANIZATIONAL_UNIT",
+            ParentType::Root => "ROOT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ORGANIZATIONAL_UNIT" => Ok(ParentType::OrganizationalUnit),
+            "ROOT" => Ok(ParentType::Root),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains rules to be applied to the affected accounts. Policies can be attached directly to accounts, or to roots and OUs to affect all accounts in those hierarchies.</p>"]
@@ -965,6 +1715,76 @@ pub struct PolicyTargetSummary {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PolicyType {
+    ServiceControlPolicy,
+}
+
+impl Into<String> for PolicyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PolicyType {
+    fn into(self) -> &'static str {
+        match self {
+            PolicyType::ServiceControlPolicy => "SERVICE_CONTROL_POLICY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PolicyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SERVICE_CONTROL_POLICY" => Ok(PolicyType::ServiceControlPolicy),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PolicyTypeStatus {
+    Enabled,
+    PendingDisable,
+    PendingEnable,
+}
+
+impl Into<String> for PolicyTypeStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PolicyTypeStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PolicyTypeStatus::Enabled => "ENABLED",
+            PolicyTypeStatus::PendingDisable => "PENDING_DISABLE",
+            PolicyTypeStatus::PendingEnable => "PENDING_ENABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PolicyTypeStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ENABLED" => Ok(PolicyTypeStatus::Enabled),
+            "PENDING_DISABLE" => Ok(PolicyTypeStatus::PendingDisable),
+            "PENDING_ENABLE" => Ok(PolicyTypeStatus::PendingEnable),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about a policy type and its status in the associated root.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct PolicyTypeSummary {
@@ -1004,6 +1824,44 @@ pub struct Root {
     #[serde(rename="PolicyTypes")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub policy_types: Option<Vec<PolicyTypeSummary>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TargetType {
+    Account,
+    OrganizationalUnit,
+    Root,
+}
+
+impl Into<String> for TargetType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TargetType {
+    fn into(self) -> &'static str {
+        match self {
+            TargetType::Account => "ACCOUNT",
+            TargetType::OrganizationalUnit => "ORGANIZATIONAL_UNIT",
+            TargetType::Root => "ROOT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TargetType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT" => Ok(TargetType::Account),
+            "ORGANIZATIONAL_UNIT" => Ok(TargetType::OrganizationalUnit),
+            "ROOT" => Ok(TargetType::Root),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -5786,7 +6644,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AcceptHandshakeResponse>(String::from_utf8_lossy(&body)
@@ -5816,7 +6674,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5842,7 +6700,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CancelHandshakeResponse>(String::from_utf8_lossy(&body)
@@ -5874,7 +6732,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateAccountResponse>(String::from_utf8_lossy(&body)
@@ -5907,7 +6765,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateOrganizationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5939,7 +6797,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateOrganizationalUnitResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -5970,7 +6828,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreatePolicyResponse>(String::from_utf8_lossy(&body)
@@ -6002,7 +6860,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeclineHandshakeResponse>(String::from_utf8_lossy(&body)
@@ -6032,7 +6890,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6059,7 +6917,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6084,7 +6942,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6110,7 +6968,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAccountResponse>(String::from_utf8_lossy(&body)
@@ -6144,7 +7002,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeCreateAccountStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6176,7 +7034,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeHandshakeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6205,7 +7063,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeOrganizationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6237,7 +7095,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeOrganizationalUnitResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6268,7 +7126,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribePolicyResponse>(String::from_utf8_lossy(&body)
@@ -6298,7 +7156,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6325,7 +7183,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisablePolicyTypeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6353,7 +7211,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<EnableAllFeaturesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6383,7 +7241,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<EnablePolicyTypeResponse>(String::from_utf8_lossy(&body)
@@ -6417,7 +7275,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<InviteAccountToOrganizationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6446,7 +7304,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6472,7 +7330,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAccountsResponse>(String::from_utf8_lossy(&body)
@@ -6506,7 +7364,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAccountsForParentResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6536,7 +7394,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListChildrenResponse>(String::from_utf8_lossy(&body)
@@ -6570,7 +7428,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListCreateAccountStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6603,7 +7461,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListHandshakesForAccountResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6636,7 +7494,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListHandshakesForOrganizationResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6669,7 +7527,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListOrganizationalUnitsForParentResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6699,7 +7557,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListParentsResponse>(String::from_utf8_lossy(&body)
@@ -6731,7 +7589,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListPoliciesResponse>(String::from_utf8_lossy(&body)
@@ -6765,7 +7623,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListPoliciesForTargetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6793,7 +7651,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRootsResponse>(String::from_utf8_lossy(&body)
@@ -6827,7 +7685,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTargetsForPolicyResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6855,7 +7713,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6882,7 +7740,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6911,7 +7769,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateOrganizationalUnitResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6942,7 +7800,7 @@ impl<P, D> Organizations for OrganizationsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdatePolicyResponse>(String::from_utf8_lossy(&body)

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -63,6 +59,41 @@ pub struct DescribeVoicesOutput {
     pub voices: Option<Vec<Voice>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Gender {
+    Female,
+    Male,
+}
+
+impl Into<String> for Gender {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Gender {
+    fn into(self) -> &'static str {
+        match self {
+            Gender::Female => "Female",
+            Gender::Male => "Male",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Gender {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Female" => Ok(Gender::Female),
+            "Male" => Ok(Gender::Male),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct GetLexiconInput {
     #[doc="<p>Name of the lexicon.</p>"]
@@ -80,6 +111,107 @@ pub struct GetLexiconOutput {
     #[serde(rename="LexiconAttributes")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub lexicon_attributes: Option<LexiconAttributes>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LanguageCode {
+    CyGB,
+    DaDK,
+    DeDE,
+    EnAU,
+    EnGB,
+    EnGBWLS,
+    EnIN,
+    EnUS,
+    EsES,
+    EsUS,
+    FrCA,
+    FrFR,
+    IsIS,
+    ItIT,
+    JaJP,
+    NbNO,
+    NlNL,
+    PlPL,
+    PtBR,
+    PtPT,
+    RoRO,
+    RuRU,
+    SvSE,
+    TrTR,
+}
+
+impl Into<String> for LanguageCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LanguageCode {
+    fn into(self) -> &'static str {
+        match self {
+            LanguageCode::CyGB => "cy-GB",
+            LanguageCode::DaDK => "da-DK",
+            LanguageCode::DeDE => "de-DE",
+            LanguageCode::EnAU => "en-AU",
+            LanguageCode::EnGB => "en-GB",
+            LanguageCode::EnGBWLS => "en-GB-WLS",
+            LanguageCode::EnIN => "en-IN",
+            LanguageCode::EnUS => "en-US",
+            LanguageCode::EsES => "es-ES",
+            LanguageCode::EsUS => "es-US",
+            LanguageCode::FrCA => "fr-CA",
+            LanguageCode::FrFR => "fr-FR",
+            LanguageCode::IsIS => "is-IS",
+            LanguageCode::ItIT => "it-IT",
+            LanguageCode::JaJP => "ja-JP",
+            LanguageCode::NbNO => "nb-NO",
+            LanguageCode::NlNL => "nl-NL",
+            LanguageCode::PlPL => "pl-PL",
+            LanguageCode::PtBR => "pt-BR",
+            LanguageCode::PtPT => "pt-PT",
+            LanguageCode::RoRO => "ro-RO",
+            LanguageCode::RuRU => "ru-RU",
+            LanguageCode::SvSE => "sv-SE",
+            LanguageCode::TrTR => "tr-TR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LanguageCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cy-GB" => Ok(LanguageCode::CyGB),
+            "da-DK" => Ok(LanguageCode::DaDK),
+            "de-DE" => Ok(LanguageCode::DeDE),
+            "en-AU" => Ok(LanguageCode::EnAU),
+            "en-GB" => Ok(LanguageCode::EnGB),
+            "en-GB-WLS" => Ok(LanguageCode::EnGBWLS),
+            "en-IN" => Ok(LanguageCode::EnIN),
+            "en-US" => Ok(LanguageCode::EnUS),
+            "es-ES" => Ok(LanguageCode::EsES),
+            "es-US" => Ok(LanguageCode::EsUS),
+            "fr-CA" => Ok(LanguageCode::FrCA),
+            "fr-FR" => Ok(LanguageCode::FrFR),
+            "is-IS" => Ok(LanguageCode::IsIS),
+            "it-IT" => Ok(LanguageCode::ItIT),
+            "ja-JP" => Ok(LanguageCode::JaJP),
+            "nb-NO" => Ok(LanguageCode::NbNO),
+            "nl-NL" => Ok(LanguageCode::NlNL),
+            "pl-PL" => Ok(LanguageCode::PlPL),
+            "pt-BR" => Ok(LanguageCode::PtBR),
+            "pt-PT" => Ok(LanguageCode::PtPT),
+            "ro-RO" => Ok(LanguageCode::RoRO),
+            "ru-RU" => Ok(LanguageCode::RuRU),
+            "sv-SE" => Ok(LanguageCode::SvSE),
+            "tr-TR" => Ok(LanguageCode::TrTR),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides lexicon name and lexicon content in string format. For more information, see <a href=\"https://www.w3.org/TR/pronunciation-lexicon/\">Pronunciation Lexicon Specification (PLS) Version 1.0</a>.</p>"]
@@ -157,6 +289,47 @@ pub struct ListLexiconsOutput {
     pub next_token: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OutputFormat {
+    Json,
+    Mp3,
+    OggVorbis,
+    Pcm,
+}
+
+impl Into<String> for OutputFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OutputFormat {
+    fn into(self) -> &'static str {
+        match self {
+            OutputFormat::Json => "json",
+            OutputFormat::Mp3 => "mp3",
+            OutputFormat::OggVorbis => "ogg_vorbis",
+            OutputFormat::Pcm => "pcm",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OutputFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "json" => Ok(OutputFormat::Json),
+            "mp3" => Ok(OutputFormat::Mp3),
+            "ogg_vorbis" => Ok(OutputFormat::OggVorbis),
+            "pcm" => Ok(OutputFormat::Pcm),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct PutLexiconInput {
     #[doc="<p>Content of the PLS lexicon as string data.</p>"]
@@ -169,6 +342,47 @@ pub struct PutLexiconInput {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct PutLexiconOutput;
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SpeechMarkType {
+    Sentence,
+    Ssml,
+    Viseme,
+    Word,
+}
+
+impl Into<String> for SpeechMarkType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SpeechMarkType {
+    fn into(self) -> &'static str {
+        match self {
+            SpeechMarkType::Sentence => "sentence",
+            SpeechMarkType::Ssml => "ssml",
+            SpeechMarkType::Viseme => "viseme",
+            SpeechMarkType::Word => "word",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SpeechMarkType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "sentence" => Ok(SpeechMarkType::Sentence),
+            "ssml" => Ok(SpeechMarkType::Ssml),
+            "viseme" => Ok(SpeechMarkType::Viseme),
+            "word" => Ok(SpeechMarkType::Word),
+            _ => Err(()),
+        }
+    }
+}
 
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct SynthesizeSpeechInput {
@@ -209,6 +423,41 @@ pub struct SynthesizeSpeechOutput {
     pub request_characters: Option<i64>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TextType {
+    Ssml,
+    Text,
+}
+
+impl Into<String> for TextType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TextType {
+    fn into(self) -> &'static str {
+        match self {
+            TextType::Ssml => "ssml",
+            TextType::Text => "text",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TextType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ssml" => Ok(TextType::Ssml),
+            "text" => Ok(TextType::Text),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Description of the voice.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Voice {
@@ -232,6 +481,179 @@ pub struct Voice {
     #[serde(rename="Name")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VoiceId {
+    Amy,
+    Astrid,
+    Brian,
+    Carla,
+    Carmen,
+    Celine,
+    Chantal,
+    Conchita,
+    Cristiano,
+    Dora,
+    Emma,
+    Enrique,
+    Ewa,
+    Filiz,
+    Geraint,
+    Giorgio,
+    Gwyneth,
+    Hans,
+    Ines,
+    Ivy,
+    Jacek,
+    Jan,
+    Joanna,
+    Joey,
+    Justin,
+    Karl,
+    Kendra,
+    Kimberly,
+    Liv,
+    Lotte,
+    Mads,
+    Maja,
+    Marlene,
+    Mathieu,
+    Maxim,
+    Miguel,
+    Mizuki,
+    Naja,
+    Nicole,
+    Penelope,
+    Raveena,
+    Ricardo,
+    Ruben,
+    Russell,
+    Salli,
+    Tatyana,
+    Vicki,
+    Vitoria,
+}
+
+impl Into<String> for VoiceId {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VoiceId {
+    fn into(self) -> &'static str {
+        match self {
+            VoiceId::Amy => "Amy",
+            VoiceId::Astrid => "Astrid",
+            VoiceId::Brian => "Brian",
+            VoiceId::Carla => "Carla",
+            VoiceId::Carmen => "Carmen",
+            VoiceId::Celine => "Celine",
+            VoiceId::Chantal => "Chantal",
+            VoiceId::Conchita => "Conchita",
+            VoiceId::Cristiano => "Cristiano",
+            VoiceId::Dora => "Dora",
+            VoiceId::Emma => "Emma",
+            VoiceId::Enrique => "Enrique",
+            VoiceId::Ewa => "Ewa",
+            VoiceId::Filiz => "Filiz",
+            VoiceId::Geraint => "Geraint",
+            VoiceId::Giorgio => "Giorgio",
+            VoiceId::Gwyneth => "Gwyneth",
+            VoiceId::Hans => "Hans",
+            VoiceId::Ines => "Ines",
+            VoiceId::Ivy => "Ivy",
+            VoiceId::Jacek => "Jacek",
+            VoiceId::Jan => "Jan",
+            VoiceId::Joanna => "Joanna",
+            VoiceId::Joey => "Joey",
+            VoiceId::Justin => "Justin",
+            VoiceId::Karl => "Karl",
+            VoiceId::Kendra => "Kendra",
+            VoiceId::Kimberly => "Kimberly",
+            VoiceId::Liv => "Liv",
+            VoiceId::Lotte => "Lotte",
+            VoiceId::Mads => "Mads",
+            VoiceId::Maja => "Maja",
+            VoiceId::Marlene => "Marlene",
+            VoiceId::Mathieu => "Mathieu",
+            VoiceId::Maxim => "Maxim",
+            VoiceId::Miguel => "Miguel",
+            VoiceId::Mizuki => "Mizuki",
+            VoiceId::Naja => "Naja",
+            VoiceId::Nicole => "Nicole",
+            VoiceId::Penelope => "Penelope",
+            VoiceId::Raveena => "Raveena",
+            VoiceId::Ricardo => "Ricardo",
+            VoiceId::Ruben => "Ruben",
+            VoiceId::Russell => "Russell",
+            VoiceId::Salli => "Salli",
+            VoiceId::Tatyana => "Tatyana",
+            VoiceId::Vicki => "Vicki",
+            VoiceId::Vitoria => "Vitoria",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VoiceId {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Amy" => Ok(VoiceId::Amy),
+            "Astrid" => Ok(VoiceId::Astrid),
+            "Brian" => Ok(VoiceId::Brian),
+            "Carla" => Ok(VoiceId::Carla),
+            "Carmen" => Ok(VoiceId::Carmen),
+            "Celine" => Ok(VoiceId::Celine),
+            "Chantal" => Ok(VoiceId::Chantal),
+            "Conchita" => Ok(VoiceId::Conchita),
+            "Cristiano" => Ok(VoiceId::Cristiano),
+            "Dora" => Ok(VoiceId::Dora),
+            "Emma" => Ok(VoiceId::Emma),
+            "Enrique" => Ok(VoiceId::Enrique),
+            "Ewa" => Ok(VoiceId::Ewa),
+            "Filiz" => Ok(VoiceId::Filiz),
+            "Geraint" => Ok(VoiceId::Geraint),
+            "Giorgio" => Ok(VoiceId::Giorgio),
+            "Gwyneth" => Ok(VoiceId::Gwyneth),
+            "Hans" => Ok(VoiceId::Hans),
+            "Ines" => Ok(VoiceId::Ines),
+            "Ivy" => Ok(VoiceId::Ivy),
+            "Jacek" => Ok(VoiceId::Jacek),
+            "Jan" => Ok(VoiceId::Jan),
+            "Joanna" => Ok(VoiceId::Joanna),
+            "Joey" => Ok(VoiceId::Joey),
+            "Justin" => Ok(VoiceId::Justin),
+            "Karl" => Ok(VoiceId::Karl),
+            "Kendra" => Ok(VoiceId::Kendra),
+            "Kimberly" => Ok(VoiceId::Kimberly),
+            "Liv" => Ok(VoiceId::Liv),
+            "Lotte" => Ok(VoiceId::Lotte),
+            "Mads" => Ok(VoiceId::Mads),
+            "Maja" => Ok(VoiceId::Maja),
+            "Marlene" => Ok(VoiceId::Marlene),
+            "Mathieu" => Ok(VoiceId::Mathieu),
+            "Maxim" => Ok(VoiceId::Maxim),
+            "Miguel" => Ok(VoiceId::Miguel),
+            "Mizuki" => Ok(VoiceId::Mizuki),
+            "Naja" => Ok(VoiceId::Naja),
+            "Nicole" => Ok(VoiceId::Nicole),
+            "Penelope" => Ok(VoiceId::Penelope),
+            "Raveena" => Ok(VoiceId::Raveena),
+            "Ricardo" => Ok(VoiceId::Ricardo),
+            "Ruben" => Ok(VoiceId::Ruben),
+            "Russell" => Ok(VoiceId::Russell),
+            "Salli" => Ok(VoiceId::Salli),
+            "Tatyana" => Ok(VoiceId::Tatyana),
+            "Vicki" => Ok(VoiceId::Vicki),
+            "Vitoria" => Ok(VoiceId::Vitoria),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by DeleteLexicon
@@ -874,7 +1296,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -925,7 +1347,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -967,7 +1389,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1015,7 +1437,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1058,7 +1480,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1103,7 +1525,7 @@ impl<P, D> Polly for PollyClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut result = SynthesizeSpeechOutput::default();
 

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -316,6 +312,41 @@ impl AddTagsToResourceMessageSerializer {
                    &obj.resource_name.replace("+", "%2B"));
         TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tags"), &obj.tags);
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ApplyMethod {
+    Immediate,
+    PendingReboot,
+}
+
+impl Into<String> for ApplyMethod {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ApplyMethod {
+    fn into(self) -> &'static str {
+        match self {
+            ApplyMethod::Immediate => "immediate",
+            ApplyMethod::PendingReboot => "pending-reboot",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ApplyMethod {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "immediate" => Ok(ApplyMethod::Immediate),
+            "pending-reboot" => Ok(ApplyMethod::PendingReboot),
+            _ => Err(()),
+        }
     }
 }
 
@@ -710,7 +741,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -724,7 +755,7 @@ impl BooleanOptionalDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -15250,6 +15281,53 @@ impl SourceRegionMessageDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    DbCluster,
+    DbClusterSnapshot,
+    DbInstance,
+    DbParameterGroup,
+    DbSecurityGroup,
+    DbSnapshot,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::DbCluster => "db-cluster",
+            SourceType::DbClusterSnapshot => "db-cluster-snapshot",
+            SourceType::DbInstance => "db-instance",
+            SourceType::DbParameterGroup => "db-parameter-group",
+            SourceType::DbSecurityGroup => "db-security-group",
+            SourceType::DbSnapshot => "db-snapshot",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "db-cluster" => Ok(SourceType::DbCluster),
+            "db-cluster-snapshot" => Ok(SourceType::DbClusterSnapshot),
+            "db-instance" => Ok(SourceType::DbInstance),
+            "db-parameter-group" => Ok(SourceType::DbParameterGroup),
+            "db-security-group" => Ok(SourceType::DbSecurityGroup),
+            "db-snapshot" => Ok(SourceType::DbSnapshot),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
     #[allow(unused_variables)]
@@ -24250,7 +24328,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24279,7 +24357,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24325,7 +24403,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -24354,7 +24432,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24402,7 +24480,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24450,7 +24528,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24498,7 +24576,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24545,7 +24623,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24592,7 +24670,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24639,7 +24717,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24686,7 +24764,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24734,7 +24812,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24782,7 +24860,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24831,7 +24909,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24879,7 +24957,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24927,7 +25005,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -24976,7 +25054,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25023,7 +25101,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25070,7 +25148,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25118,7 +25196,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25167,7 +25245,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25214,7 +25292,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25261,7 +25339,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25291,7 +25369,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25340,7 +25418,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25387,7 +25465,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25415,7 +25493,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25443,7 +25521,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25490,7 +25568,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25519,7 +25597,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25568,7 +25646,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -25597,7 +25675,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25645,7 +25723,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25693,7 +25771,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25742,7 +25820,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25793,7 +25871,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25840,7 +25918,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25888,7 +25966,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25936,7 +26014,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -25984,7 +26062,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26031,7 +26109,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26079,7 +26157,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26127,7 +26205,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26175,7 +26253,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26224,7 +26302,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26271,7 +26349,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26318,7 +26396,7 @@ impl<P, D> Rds for RdsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26363,7 +26441,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26410,7 +26488,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26458,7 +26536,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26507,7 +26585,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26555,7 +26633,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26603,7 +26681,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26651,7 +26729,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26699,7 +26777,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26746,7 +26824,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26795,7 +26873,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26844,7 +26922,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26890,7 +26968,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26938,7 +27016,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -26987,7 +27065,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27034,7 +27112,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27081,7 +27159,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27129,7 +27207,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27177,7 +27255,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27223,7 +27301,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27271,7 +27349,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27318,7 +27396,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27366,7 +27444,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27415,7 +27493,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27463,7 +27541,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27512,7 +27590,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27559,7 +27637,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27607,7 +27685,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27656,7 +27734,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27702,7 +27780,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27749,7 +27827,7 @@ fn describe_engine_default_cluster_parameters(&self, input: &DescribeEngineDefau
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27776,7 +27854,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27822,7 +27900,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -27851,7 +27929,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27899,7 +27977,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27947,7 +28025,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -27996,7 +28074,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -28044,7 +28122,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -28092,7 +28170,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -28140,7 +28218,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -28188,7 +28266,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -28235,7 +28313,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -28282,7 +28360,7 @@ fn remove_source_identifier_from_subscription(&self, input: &RemoveSourceIdentif
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -404,7 +400,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -418,7 +414,7 @@ impl BooleanOptionalDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7458,6 +7454,41 @@ impl ParameterSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterApplyType {
+    Dynamic,
+    Static,
+}
+
+impl Into<String> for ParameterApplyType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterApplyType {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterApplyType::Dynamic => "dynamic",
+            ParameterApplyType::Static => "static",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterApplyType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dynamic" => Ok(ParameterApplyType::Dynamic),
+            "static" => Ok(ParameterApplyType::Static),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ParameterApplyTypeDeserializer;
 impl ParameterApplyTypeDeserializer {
     #[allow(unused_variables)]
@@ -9708,6 +9739,47 @@ impl SourceIdsListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SourceType {
+    Cluster,
+    ClusterParameterGroup,
+    ClusterSecurityGroup,
+    ClusterSnapshot,
+}
+
+impl Into<String> for SourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SourceType::Cluster => "cluster",
+            SourceType::ClusterParameterGroup => "cluster-parameter-group",
+            SourceType::ClusterSecurityGroup => "cluster-security-group",
+            SourceType::ClusterSnapshot => "cluster-snapshot",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cluster" => Ok(SourceType::Cluster),
+            "cluster-parameter-group" => Ok(SourceType::ClusterParameterGroup),
+            "cluster-security-group" => Ok(SourceType::ClusterSecurityGroup),
+            "cluster-snapshot" => Ok(SourceType::ClusterSnapshot),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
     #[allow(unused_variables)]
@@ -10100,6 +10172,50 @@ impl TableRestoreStatusMessageDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TableRestoreStatusType {
+    Canceled,
+    Failed,
+    InProgress,
+    Pending,
+    Succeeded,
+}
+
+impl Into<String> for TableRestoreStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TableRestoreStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            TableRestoreStatusType::Canceled => "CANCELED",
+            TableRestoreStatusType::Failed => "FAILED",
+            TableRestoreStatusType::InProgress => "IN_PROGRESS",
+            TableRestoreStatusType::Pending => "PENDING",
+            TableRestoreStatusType::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TableRestoreStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELED" => Ok(TableRestoreStatusType::Canceled),
+            "FAILED" => Ok(TableRestoreStatusType::Failed),
+            "IN_PROGRESS" => Ok(TableRestoreStatusType::InProgress),
+            "PENDING" => Ok(TableRestoreStatusType::Pending),
+            "SUCCEEDED" => Ok(TableRestoreStatusType::Succeeded),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TableRestoreStatusTypeDeserializer;
 impl TableRestoreStatusTypeDeserializer {
     #[allow(unused_variables)]
@@ -16366,7 +16482,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16413,7 +16529,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16462,7 +16578,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16509,7 +16625,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16557,7 +16673,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16605,7 +16721,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16655,7 +16771,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16703,7 +16819,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16753,7 +16869,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16803,7 +16919,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16853,7 +16969,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16902,7 +17018,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -16949,7 +17065,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -16977,7 +17093,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17024,7 +17140,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -17053,7 +17169,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -17083,7 +17199,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17130,7 +17246,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -17159,7 +17275,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -17188,7 +17304,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -17217,7 +17333,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -17245,7 +17361,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -17272,7 +17388,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -17301,7 +17417,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17351,7 +17467,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17401,7 +17517,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17449,7 +17565,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17498,7 +17614,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17547,7 +17663,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17595,7 +17711,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17643,7 +17759,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17690,7 +17806,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17739,7 +17855,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17787,7 +17903,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17835,7 +17951,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17884,7 +18000,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17932,7 +18048,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -17980,7 +18096,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18030,7 +18146,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18079,7 +18195,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18126,7 +18242,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18174,7 +18290,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18223,7 +18339,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18271,7 +18387,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18318,7 +18434,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18365,7 +18481,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18412,7 +18528,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18459,7 +18575,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18506,7 +18622,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18553,7 +18669,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18601,7 +18717,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18649,7 +18765,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18699,7 +18815,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18749,7 +18865,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18799,7 +18915,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18846,7 +18962,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18893,7 +19009,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18941,7 +19057,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18991,7 +19107,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19041,7 +19157,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19089,7 +19205,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19135,7 +19251,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19182,7 +19298,7 @@ impl<P, D> Redshift for RedshiftClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -39,6 +35,41 @@ pub struct AgeRange {
     #[serde(rename="Low")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub low: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Attribute {
+    All,
+    Default,
+}
+
+impl Into<String> for Attribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Attribute {
+    fn into(self) -> &'static str {
+        match self {
+            Attribute::All => "ALL",
+            Attribute::Default => "DEFAULT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Attribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL" => Ok(Attribute::All),
+            "DEFAULT" => Ok(Attribute::Default),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Indicates whether or not the face has a beard, and the confidence level in the determination.</p>"]
@@ -323,6 +354,59 @@ pub struct Emotion {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EmotionName {
+    Angry,
+    Calm,
+    Confused,
+    Disgusted,
+    Happy,
+    Sad,
+    Surprised,
+    Unknown,
+}
+
+impl Into<String> for EmotionName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EmotionName {
+    fn into(self) -> &'static str {
+        match self {
+            EmotionName::Angry => "ANGRY",
+            EmotionName::Calm => "CALM",
+            EmotionName::Confused => "CONFUSED",
+            EmotionName::Disgusted => "DISGUSTED",
+            EmotionName::Happy => "HAPPY",
+            EmotionName::Sad => "SAD",
+            EmotionName::Surprised => "SURPRISED",
+            EmotionName::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EmotionName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ANGRY" => Ok(EmotionName::Angry),
+            "CALM" => Ok(EmotionName::Calm),
+            "CONFUSED" => Ok(EmotionName::Confused),
+            "DISGUSTED" => Ok(EmotionName::Disgusted),
+            "HAPPY" => Ok(EmotionName::Happy),
+            "SAD" => Ok(EmotionName::Sad),
+            "SURPRISED" => Ok(EmotionName::Surprised),
+            "UNKNOWN" => Ok(EmotionName::Unknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Indicates whether or not the eyes on the face are open, and the confidence level in the determination.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct EyeOpen {
@@ -478,6 +562,41 @@ pub struct Gender {
     pub value: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum GenderType {
+    Female,
+    Male,
+}
+
+impl Into<String> for GenderType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for GenderType {
+    fn into(self) -> &'static str {
+        match self {
+            GenderType::Female => "Female",
+            GenderType::Male => "Male",
+        }
+    }
+}
+
+impl ::std::str::FromStr for GenderType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Female" => Ok(GenderType::Female),
+            "Male" => Ok(GenderType::Male),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct GetCelebrityInfoRequest {
     #[doc="<p>The ID for the celebrity. You get the celebrity ID from a call to the operation, which recognizes celebrities in an image. </p>"]
@@ -587,6 +706,110 @@ pub struct Landmark {
     pub y: Option<f32>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LandmarkType {
+    EyeLeft,
+    EyeRight,
+    LeftEyeBrowLeft,
+    LeftEyeBrowRight,
+    LeftEyeBrowUp,
+    LeftEyeDown,
+    LeftEyeLeft,
+    LeftEyeRight,
+    LeftEyeUp,
+    LeftPupil,
+    MouthDown,
+    MouthLeft,
+    MouthRight,
+    MouthUp,
+    Nose,
+    NoseLeft,
+    NoseRight,
+    RightEyeBrowLeft,
+    RightEyeBrowRight,
+    RightEyeBrowUp,
+    RightEyeDown,
+    RightEyeLeft,
+    RightEyeRight,
+    RightEyeUp,
+    RightPupil,
+}
+
+impl Into<String> for LandmarkType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LandmarkType {
+    fn into(self) -> &'static str {
+        match self {
+            LandmarkType::EyeLeft => "eyeLeft",
+            LandmarkType::EyeRight => "eyeRight",
+            LandmarkType::LeftEyeBrowLeft => "leftEyeBrowLeft",
+            LandmarkType::LeftEyeBrowRight => "leftEyeBrowRight",
+            LandmarkType::LeftEyeBrowUp => "leftEyeBrowUp",
+            LandmarkType::LeftEyeDown => "leftEyeDown",
+            LandmarkType::LeftEyeLeft => "leftEyeLeft",
+            LandmarkType::LeftEyeRight => "leftEyeRight",
+            LandmarkType::LeftEyeUp => "leftEyeUp",
+            LandmarkType::LeftPupil => "leftPupil",
+            LandmarkType::MouthDown => "mouthDown",
+            LandmarkType::MouthLeft => "mouthLeft",
+            LandmarkType::MouthRight => "mouthRight",
+            LandmarkType::MouthUp => "mouthUp",
+            LandmarkType::Nose => "nose",
+            LandmarkType::NoseLeft => "noseLeft",
+            LandmarkType::NoseRight => "noseRight",
+            LandmarkType::RightEyeBrowLeft => "rightEyeBrowLeft",
+            LandmarkType::RightEyeBrowRight => "rightEyeBrowRight",
+            LandmarkType::RightEyeBrowUp => "rightEyeBrowUp",
+            LandmarkType::RightEyeDown => "rightEyeDown",
+            LandmarkType::RightEyeLeft => "rightEyeLeft",
+            LandmarkType::RightEyeRight => "rightEyeRight",
+            LandmarkType::RightEyeUp => "rightEyeUp",
+            LandmarkType::RightPupil => "rightPupil",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LandmarkType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "eyeLeft" => Ok(LandmarkType::EyeLeft),
+            "eyeRight" => Ok(LandmarkType::EyeRight),
+            "leftEyeBrowLeft" => Ok(LandmarkType::LeftEyeBrowLeft),
+            "leftEyeBrowRight" => Ok(LandmarkType::LeftEyeBrowRight),
+            "leftEyeBrowUp" => Ok(LandmarkType::LeftEyeBrowUp),
+            "leftEyeDown" => Ok(LandmarkType::LeftEyeDown),
+            "leftEyeLeft" => Ok(LandmarkType::LeftEyeLeft),
+            "leftEyeRight" => Ok(LandmarkType::LeftEyeRight),
+            "leftEyeUp" => Ok(LandmarkType::LeftEyeUp),
+            "leftPupil" => Ok(LandmarkType::LeftPupil),
+            "mouthDown" => Ok(LandmarkType::MouthDown),
+            "mouthLeft" => Ok(LandmarkType::MouthLeft),
+            "mouthRight" => Ok(LandmarkType::MouthRight),
+            "mouthUp" => Ok(LandmarkType::MouthUp),
+            "nose" => Ok(LandmarkType::Nose),
+            "noseLeft" => Ok(LandmarkType::NoseLeft),
+            "noseRight" => Ok(LandmarkType::NoseRight),
+            "rightEyeBrowLeft" => Ok(LandmarkType::RightEyeBrowLeft),
+            "rightEyeBrowRight" => Ok(LandmarkType::RightEyeBrowRight),
+            "rightEyeBrowUp" => Ok(LandmarkType::RightEyeBrowUp),
+            "rightEyeDown" => Ok(LandmarkType::RightEyeDown),
+            "rightEyeLeft" => Ok(LandmarkType::RightEyeLeft),
+            "rightEyeRight" => Ok(LandmarkType::RightEyeRight),
+            "rightEyeUp" => Ok(LandmarkType::RightEyeUp),
+            "rightPupil" => Ok(LandmarkType::RightPupil),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListCollectionsRequest {
     #[doc="<p>Maximum number of collection IDs to return.</p>"]
@@ -679,6 +902,47 @@ pub struct Mustache {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<bool>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OrientationCorrection {
+    Rotate0,
+    Rotate180,
+    Rotate270,
+    Rotate90,
+}
+
+impl Into<String> for OrientationCorrection {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OrientationCorrection {
+    fn into(self) -> &'static str {
+        match self {
+            OrientationCorrection::Rotate0 => "ROTATE_0",
+            OrientationCorrection::Rotate180 => "ROTATE_180",
+            OrientationCorrection::Rotate270 => "ROTATE_270",
+            OrientationCorrection::Rotate90 => "ROTATE_90",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OrientationCorrection {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ROTATE_0" => Ok(OrientationCorrection::Rotate0),
+            "ROTATE_180" => Ok(OrientationCorrection::Rotate180),
+            "ROTATE_270" => Ok(OrientationCorrection::Rotate270),
+            "ROTATE_90" => Ok(OrientationCorrection::Rotate90),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Indicates the pose of the face as determined by its pitch, roll, and yaw.</p>"]
@@ -2571,7 +2835,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CompareFacesResponse>(String::from_utf8_lossy(&body)
@@ -2603,7 +2867,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateCollectionResponse>(String::from_utf8_lossy(&body)
@@ -2635,7 +2899,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteCollectionResponse>(String::from_utf8_lossy(&body)
@@ -2667,7 +2931,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteFacesResponse>(String::from_utf8_lossy(&body)
@@ -2699,7 +2963,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DetectFacesResponse>(String::from_utf8_lossy(&body)
@@ -2731,7 +2995,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DetectLabelsResponse>(String::from_utf8_lossy(&body)
@@ -2764,7 +3028,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DetectModerationLabelsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2794,7 +3058,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetCelebrityInfoResponse>(String::from_utf8_lossy(&body)
@@ -2826,7 +3090,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<IndexFacesResponse>(String::from_utf8_lossy(&body)
@@ -2858,7 +3122,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListCollectionsResponse>(String::from_utf8_lossy(&body)
@@ -2888,7 +3152,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListFacesResponse>(String::from_utf8_lossy(&body)
@@ -2920,7 +3184,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RecognizeCelebritiesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2950,7 +3214,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SearchFacesResponse>(String::from_utf8_lossy(&body)
@@ -2982,7 +3246,7 @@ impl<P, D> Rekognition for RekognitionClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SearchFacesByImageResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/resourcegroupstaggingapi/src/generated.rs
+++ b/rusoto/services/resourcegroupstaggingapi/src/generated.rs
@@ -11,23 +11,54 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ErrorCode {
+    InternalServiceException,
+    InvalidParameterException,
+}
+
+impl Into<String> for ErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            ErrorCode::InternalServiceException => "InternalServiceException",
+            ErrorCode::InvalidParameterException => "InvalidParameterException",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "InternalServiceException" => Ok(ErrorCode::InternalServiceException),
+            "InvalidParameterException" => Ok(ErrorCode::InvalidParameterException),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Details of the common errors that all actions return.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct FailureInfo {
@@ -739,7 +770,7 @@ impl<P, D> ResourceGroupsTaggingApi for ResourceGroupsTaggingApiClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetResourcesOutput>(String::from_utf8_lossy(&body)
@@ -770,7 +801,7 @@ impl<P, D> ResourceGroupsTaggingApi for ResourceGroupsTaggingApiClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetTagKeysOutput>(String::from_utf8_lossy(&body)
@@ -803,7 +834,7 @@ impl<P, D> ResourceGroupsTaggingApi for ResourceGroupsTaggingApiClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetTagValuesOutput>(String::from_utf8_lossy(&body)
@@ -836,7 +867,7 @@ impl<P, D> ResourceGroupsTaggingApi for ResourceGroupsTaggingApiClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<TagResourcesOutput>(String::from_utf8_lossy(&body)
@@ -869,7 +900,7 @@ impl<P, D> ResourceGroupsTaggingApi for ResourceGroupsTaggingApiClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UntagResourcesOutput>(String::from_utf8_lossy(&body)

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 
@@ -159,7 +155,7 @@ impl AliasHealthEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -408,6 +404,44 @@ impl ChangeSerializer {
 }
 
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeAction {
+    Create,
+    Delete,
+    Upsert,
+}
+
+impl Into<String> for ChangeAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeAction {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeAction::Create => "CREATE",
+            ChangeAction::Delete => "DELETE",
+            ChangeAction::Upsert => "UPSERT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATE" => Ok(ChangeAction::Create),
+            "DELETE" => Ok(ChangeAction::Delete),
+            "UPSERT" => Ok(ChangeAction::Upsert),
+            _ => Err(()),
+        }
+    }
+}
+
+
 pub struct ChangeActionSerializer;
 impl ChangeActionSerializer {
     #[allow(unused_variables, warnings)]
@@ -598,6 +632,41 @@ impl ChangeResourceRecordSetsResponseDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeStatus {
+    Insync,
+    Pending,
+}
+
+impl Into<String> for ChangeStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeStatus::Insync => "INSYNC",
+            ChangeStatus::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSYNC" => Ok(ChangeStatus::Insync),
+            "PENDING" => Ok(ChangeStatus::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ChangeStatusDeserializer;
 impl ChangeStatusDeserializer {
     #[allow(unused_variables)]
@@ -880,6 +949,77 @@ impl CloudWatchAlarmConfigurationDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloudWatchRegion {
+    ApNortheast1,
+    ApNortheast2,
+    ApSouth1,
+    ApSoutheast1,
+    ApSoutheast2,
+    CaCentral1,
+    EuCentral1,
+    EuWest1,
+    EuWest2,
+    SaEast1,
+    UsEast1,
+    UsEast2,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for CloudWatchRegion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloudWatchRegion {
+    fn into(self) -> &'static str {
+        match self {
+            CloudWatchRegion::ApNortheast1 => "ap-northeast-1",
+            CloudWatchRegion::ApNortheast2 => "ap-northeast-2",
+            CloudWatchRegion::ApSouth1 => "ap-south-1",
+            CloudWatchRegion::ApSoutheast1 => "ap-southeast-1",
+            CloudWatchRegion::ApSoutheast2 => "ap-southeast-2",
+            CloudWatchRegion::CaCentral1 => "ca-central-1",
+            CloudWatchRegion::EuCentral1 => "eu-central-1",
+            CloudWatchRegion::EuWest1 => "eu-west-1",
+            CloudWatchRegion::EuWest2 => "eu-west-2",
+            CloudWatchRegion::SaEast1 => "sa-east-1",
+            CloudWatchRegion::UsEast1 => "us-east-1",
+            CloudWatchRegion::UsEast2 => "us-east-2",
+            CloudWatchRegion::UsWest1 => "us-west-1",
+            CloudWatchRegion::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloudWatchRegion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(CloudWatchRegion::ApNortheast1),
+            "ap-northeast-2" => Ok(CloudWatchRegion::ApNortheast2),
+            "ap-south-1" => Ok(CloudWatchRegion::ApSouth1),
+            "ap-southeast-1" => Ok(CloudWatchRegion::ApSoutheast1),
+            "ap-southeast-2" => Ok(CloudWatchRegion::ApSoutheast2),
+            "ca-central-1" => Ok(CloudWatchRegion::CaCentral1),
+            "eu-central-1" => Ok(CloudWatchRegion::EuCentral1),
+            "eu-west-1" => Ok(CloudWatchRegion::EuWest1),
+            "eu-west-2" => Ok(CloudWatchRegion::EuWest2),
+            "sa-east-1" => Ok(CloudWatchRegion::SaEast1),
+            "us-east-1" => Ok(CloudWatchRegion::UsEast1),
+            "us-east-2" => Ok(CloudWatchRegion::UsEast2),
+            "us-west-1" => Ok(CloudWatchRegion::UsWest1),
+            "us-west-2" => Ok(CloudWatchRegion::UsWest2),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CloudWatchRegionDeserializer;
 impl CloudWatchRegionDeserializer {
     #[allow(unused_variables)]
@@ -909,6 +1049,49 @@ impl CloudWatchRegionSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperator {
+    GreaterThanOrEqualToThreshold,
+    GreaterThanThreshold,
+    LessThanOrEqualToThreshold,
+    LessThanThreshold,
+}
+
+impl Into<String> for ComparisonOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperator::GreaterThanOrEqualToThreshold => "GreaterThanOrEqualToThreshold",
+            ComparisonOperator::GreaterThanThreshold => "GreaterThanThreshold",
+            ComparisonOperator::LessThanOrEqualToThreshold => "LessThanOrEqualToThreshold",
+            ComparisonOperator::LessThanThreshold => "LessThanThreshold",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GreaterThanOrEqualToThreshold" => {
+                Ok(ComparisonOperator::GreaterThanOrEqualToThreshold)
+            }
+            "GreaterThanThreshold" => Ok(ComparisonOperator::GreaterThanThreshold),
+            "LessThanOrEqualToThreshold" => Ok(ComparisonOperator::LessThanOrEqualToThreshold),
+            "LessThanThreshold" => Ok(ComparisonOperator::LessThanThreshold),
+            _ => Err(()),
+        }
     }
 }
 
@@ -2153,7 +2336,7 @@ impl EnableSNIDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3850,6 +4033,59 @@ impl HealthCheckObservationsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HealthCheckRegion {
+    ApNortheast1,
+    ApSoutheast1,
+    ApSoutheast2,
+    EuWest1,
+    SaEast1,
+    UsEast1,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for HealthCheckRegion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HealthCheckRegion {
+    fn into(self) -> &'static str {
+        match self {
+            HealthCheckRegion::ApNortheast1 => "ap-northeast-1",
+            HealthCheckRegion::ApSoutheast1 => "ap-southeast-1",
+            HealthCheckRegion::ApSoutheast2 => "ap-southeast-2",
+            HealthCheckRegion::EuWest1 => "eu-west-1",
+            HealthCheckRegion::SaEast1 => "sa-east-1",
+            HealthCheckRegion::UsEast1 => "us-east-1",
+            HealthCheckRegion::UsWest1 => "us-west-1",
+            HealthCheckRegion::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HealthCheckRegion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(HealthCheckRegion::ApNortheast1),
+            "ap-southeast-1" => Ok(HealthCheckRegion::ApSoutheast1),
+            "ap-southeast-2" => Ok(HealthCheckRegion::ApSoutheast2),
+            "eu-west-1" => Ok(HealthCheckRegion::EuWest1),
+            "sa-east-1" => Ok(HealthCheckRegion::SaEast1),
+            "us-east-1" => Ok(HealthCheckRegion::UsEast1),
+            "us-west-1" => Ok(HealthCheckRegion::UsWest1),
+            "us-west-2" => Ok(HealthCheckRegion::UsWest2),
+            _ => Err(()),
+        }
+    }
+}
+
 struct HealthCheckRegionDeserializer;
 impl HealthCheckRegionDeserializer {
     #[allow(unused_variables)]
@@ -3939,6 +4175,56 @@ impl HealthCheckRegionListSerializer {
         }
         writer.write(xml::writer::XmlEvent::end_element())?;
         Ok(())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HealthCheckType {
+    Calculated,
+    CloudwatchMetric,
+    Http,
+    Https,
+    HttpsStrMatch,
+    HttpStrMatch,
+    Tcp,
+}
+
+impl Into<String> for HealthCheckType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HealthCheckType {
+    fn into(self) -> &'static str {
+        match self {
+            HealthCheckType::Calculated => "CALCULATED",
+            HealthCheckType::CloudwatchMetric => "CLOUDWATCH_METRIC",
+            HealthCheckType::Http => "HTTP",
+            HealthCheckType::Https => "HTTPS",
+            HealthCheckType::HttpsStrMatch => "HTTPS_STR_MATCH",
+            HealthCheckType::HttpStrMatch => "HTTP_STR_MATCH",
+            HealthCheckType::Tcp => "TCP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HealthCheckType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CALCULATED" => Ok(HealthCheckType::Calculated),
+            "CLOUDWATCH_METRIC" => Ok(HealthCheckType::CloudwatchMetric),
+            "HTTP" => Ok(HealthCheckType::Http),
+            "HTTPS" => Ok(HealthCheckType::Https),
+            "HTTPS_STR_MATCH" => Ok(HealthCheckType::HttpsStrMatch),
+            "HTTP_STR_MATCH" => Ok(HealthCheckType::HttpStrMatch),
+            "TCP" => Ok(HealthCheckType::Tcp),
+            _ => Err(()),
+        }
     }
 }
 
@@ -4351,6 +4637,44 @@ impl IPAddressCidrDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InsufficientDataHealthStatus {
+    Healthy,
+    LastKnownStatus,
+    Unhealthy,
+}
+
+impl Into<String> for InsufficientDataHealthStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InsufficientDataHealthStatus {
+    fn into(self) -> &'static str {
+        match self {
+            InsufficientDataHealthStatus::Healthy => "Healthy",
+            InsufficientDataHealthStatus::LastKnownStatus => "LastKnownStatus",
+            InsufficientDataHealthStatus::Unhealthy => "Unhealthy",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InsufficientDataHealthStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Healthy" => Ok(InsufficientDataHealthStatus::Healthy),
+            "LastKnownStatus" => Ok(InsufficientDataHealthStatus::LastKnownStatus),
+            "Unhealthy" => Ok(InsufficientDataHealthStatus::Unhealthy),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InsufficientDataHealthStatusDeserializer;
 impl InsufficientDataHealthStatusDeserializer {
     #[allow(unused_variables)]
@@ -4390,7 +4714,7 @@ impl InvertedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -4422,7 +4746,7 @@ impl IsPrivateZoneDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5661,7 +5985,7 @@ impl MeasureLatencyDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5845,7 +6169,7 @@ impl PageTruncatedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5959,6 +6283,71 @@ impl RDataSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RRType {
+    A,
+    Aaaa,
+    Caa,
+    Cname,
+    Mx,
+    Naptr,
+    Ns,
+    Ptr,
+    Soa,
+    Spf,
+    Srv,
+    Txt,
+}
+
+impl Into<String> for RRType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RRType {
+    fn into(self) -> &'static str {
+        match self {
+            RRType::A => "A",
+            RRType::Aaaa => "AAAA",
+            RRType::Caa => "CAA",
+            RRType::Cname => "CNAME",
+            RRType::Mx => "MX",
+            RRType::Naptr => "NAPTR",
+            RRType::Ns => "NS",
+            RRType::Ptr => "PTR",
+            RRType::Soa => "SOA",
+            RRType::Spf => "SPF",
+            RRType::Srv => "SRV",
+            RRType::Txt => "TXT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RRType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "A" => Ok(RRType::A),
+            "AAAA" => Ok(RRType::Aaaa),
+            "CAA" => Ok(RRType::Caa),
+            "CNAME" => Ok(RRType::Cname),
+            "MX" => Ok(RRType::Mx),
+            "NAPTR" => Ok(RRType::Naptr),
+            "NS" => Ok(RRType::Ns),
+            "PTR" => Ok(RRType::Ptr),
+            "SOA" => Ok(RRType::Soa),
+            "SPF" => Ok(RRType::Spf),
+            "SRV" => Ok(RRType::Srv),
+            "TXT" => Ok(RRType::Txt),
+            _ => Err(()),
+        }
     }
 }
 
@@ -6446,6 +6835,41 @@ impl ResourceRecordSetSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceRecordSetFailover {
+    Primary,
+    Secondary,
+}
+
+impl Into<String> for ResourceRecordSetFailover {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceRecordSetFailover {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceRecordSetFailover::Primary => "PRIMARY",
+            ResourceRecordSetFailover::Secondary => "SECONDARY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceRecordSetFailover {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PRIMARY" => Ok(ResourceRecordSetFailover::Primary),
+            "SECONDARY" => Ok(ResourceRecordSetFailover::Secondary),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ResourceRecordSetFailoverDeserializer;
 impl ResourceRecordSetFailoverDeserializer {
     #[allow(unused_variables)]
@@ -6517,7 +6941,7 @@ impl ResourceRecordSetMultiValueAnswerDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6539,6 +6963,80 @@ impl ResourceRecordSetMultiValueAnswerSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceRecordSetRegion {
+    ApNortheast1,
+    ApNortheast2,
+    ApSouth1,
+    ApSoutheast1,
+    ApSoutheast2,
+    CaCentral1,
+    CnNorth1,
+    EuCentral1,
+    EuWest1,
+    EuWest2,
+    SaEast1,
+    UsEast1,
+    UsEast2,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for ResourceRecordSetRegion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceRecordSetRegion {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceRecordSetRegion::ApNortheast1 => "ap-northeast-1",
+            ResourceRecordSetRegion::ApNortheast2 => "ap-northeast-2",
+            ResourceRecordSetRegion::ApSouth1 => "ap-south-1",
+            ResourceRecordSetRegion::ApSoutheast1 => "ap-southeast-1",
+            ResourceRecordSetRegion::ApSoutheast2 => "ap-southeast-2",
+            ResourceRecordSetRegion::CaCentral1 => "ca-central-1",
+            ResourceRecordSetRegion::CnNorth1 => "cn-north-1",
+            ResourceRecordSetRegion::EuCentral1 => "eu-central-1",
+            ResourceRecordSetRegion::EuWest1 => "eu-west-1",
+            ResourceRecordSetRegion::EuWest2 => "eu-west-2",
+            ResourceRecordSetRegion::SaEast1 => "sa-east-1",
+            ResourceRecordSetRegion::UsEast1 => "us-east-1",
+            ResourceRecordSetRegion::UsEast2 => "us-east-2",
+            ResourceRecordSetRegion::UsWest1 => "us-west-1",
+            ResourceRecordSetRegion::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceRecordSetRegion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(ResourceRecordSetRegion::ApNortheast1),
+            "ap-northeast-2" => Ok(ResourceRecordSetRegion::ApNortheast2),
+            "ap-south-1" => Ok(ResourceRecordSetRegion::ApSouth1),
+            "ap-southeast-1" => Ok(ResourceRecordSetRegion::ApSoutheast1),
+            "ap-southeast-2" => Ok(ResourceRecordSetRegion::ApSoutheast2),
+            "ca-central-1" => Ok(ResourceRecordSetRegion::CaCentral1),
+            "cn-north-1" => Ok(ResourceRecordSetRegion::CnNorth1),
+            "eu-central-1" => Ok(ResourceRecordSetRegion::EuCentral1),
+            "eu-west-1" => Ok(ResourceRecordSetRegion::EuWest1),
+            "eu-west-2" => Ok(ResourceRecordSetRegion::EuWest2),
+            "sa-east-1" => Ok(ResourceRecordSetRegion::SaEast1),
+            "us-east-1" => Ok(ResourceRecordSetRegion::UsEast1),
+            "us-east-2" => Ok(ResourceRecordSetRegion::UsEast2),
+            "us-west-1" => Ok(ResourceRecordSetRegion::UsWest1),
+            "us-west-2" => Ok(ResourceRecordSetRegion::UsWest2),
+            _ => Err(()),
+        }
     }
 }
 
@@ -6841,6 +7339,50 @@ impl SearchStringSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Statistic {
+    Average,
+    Maximum,
+    Minimum,
+    SampleCount,
+    Sum,
+}
+
+impl Into<String> for Statistic {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Statistic {
+    fn into(self) -> &'static str {
+        match self {
+            Statistic::Average => "Average",
+            Statistic::Maximum => "Maximum",
+            Statistic::Minimum => "Minimum",
+            Statistic::SampleCount => "SampleCount",
+            Statistic::Sum => "Sum",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Statistic {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Average" => Ok(Statistic::Average),
+            "Maximum" => Ok(Statistic::Maximum),
+            "Minimum" => Ok(Statistic::Minimum),
+            "SampleCount" => Ok(Statistic::SampleCount),
+            "Sum" => Ok(Statistic::Sum),
+            _ => Err(()),
+        }
     }
 }
 
@@ -7216,6 +7758,41 @@ impl TagResourceIdListSerializer {
         }
         writer.write(xml::writer::XmlEvent::end_element())?;
         Ok(())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TagResourceType {
+    Healthcheck,
+    Hostedzone,
+}
+
+impl Into<String> for TagResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TagResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            TagResourceType::Healthcheck => "healthcheck",
+            TagResourceType::Hostedzone => "hostedzone",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TagResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "healthcheck" => Ok(TagResourceType::Healthcheck),
+            "hostedzone" => Ok(TagResourceType::Hostedzone),
+            _ => Err(()),
+        }
     }
 }
 
@@ -8537,6 +9114,80 @@ impl VPCIdSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VPCRegion {
+    ApNortheast1,
+    ApNortheast2,
+    ApSouth1,
+    ApSoutheast1,
+    ApSoutheast2,
+    CaCentral1,
+    CnNorth1,
+    EuCentral1,
+    EuWest1,
+    EuWest2,
+    SaEast1,
+    UsEast1,
+    UsEast2,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for VPCRegion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VPCRegion {
+    fn into(self) -> &'static str {
+        match self {
+            VPCRegion::ApNortheast1 => "ap-northeast-1",
+            VPCRegion::ApNortheast2 => "ap-northeast-2",
+            VPCRegion::ApSouth1 => "ap-south-1",
+            VPCRegion::ApSoutheast1 => "ap-southeast-1",
+            VPCRegion::ApSoutheast2 => "ap-southeast-2",
+            VPCRegion::CaCentral1 => "ca-central-1",
+            VPCRegion::CnNorth1 => "cn-north-1",
+            VPCRegion::EuCentral1 => "eu-central-1",
+            VPCRegion::EuWest1 => "eu-west-1",
+            VPCRegion::EuWest2 => "eu-west-2",
+            VPCRegion::SaEast1 => "sa-east-1",
+            VPCRegion::UsEast1 => "us-east-1",
+            VPCRegion::UsEast2 => "us-east-2",
+            VPCRegion::UsWest1 => "us-west-1",
+            VPCRegion::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VPCRegion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ap-northeast-1" => Ok(VPCRegion::ApNortheast1),
+            "ap-northeast-2" => Ok(VPCRegion::ApNortheast2),
+            "ap-south-1" => Ok(VPCRegion::ApSouth1),
+            "ap-southeast-1" => Ok(VPCRegion::ApSoutheast1),
+            "ap-southeast-2" => Ok(VPCRegion::ApSoutheast2),
+            "ca-central-1" => Ok(VPCRegion::CaCentral1),
+            "cn-north-1" => Ok(VPCRegion::CnNorth1),
+            "eu-central-1" => Ok(VPCRegion::EuCentral1),
+            "eu-west-1" => Ok(VPCRegion::EuWest1),
+            "eu-west-2" => Ok(VPCRegion::EuWest2),
+            "sa-east-1" => Ok(VPCRegion::SaEast1),
+            "us-east-1" => Ok(VPCRegion::UsEast1),
+            "us-east-2" => Ok(VPCRegion::UsEast2),
+            "us-west-1" => Ok(VPCRegion::UsWest1),
+            "us-west-2" => Ok(VPCRegion::UsWest2),
+            _ => Err(()),
+        }
     }
 }
 
@@ -13042,9 +13693,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13099,9 +13750,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13157,9 +13808,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13211,9 +13862,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13268,9 +13919,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13326,9 +13977,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13382,9 +14033,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13438,9 +14089,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13495,9 +14146,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13554,9 +14205,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13603,9 +14254,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13653,9 +14304,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13704,9 +14355,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13755,9 +14406,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13804,9 +14455,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13862,9 +14513,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13918,9 +14569,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -13965,9 +14616,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14014,9 +14665,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14074,9 +14725,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14125,9 +14776,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14175,9 +14826,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14225,9 +14876,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14276,9 +14927,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14324,9 +14975,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14373,9 +15024,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14424,9 +15075,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14475,9 +15126,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14526,9 +15177,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14576,9 +15227,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14638,9 +15289,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14695,9 +15346,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14755,9 +15406,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14816,9 +15467,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14879,9 +15530,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14935,9 +15586,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -14986,9 +15637,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15042,9 +15693,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15097,9 +15748,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15159,9 +15810,9 @@ impl<P, D> Route53 for Route53Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15217,9 +15868,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15282,9 +15933,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15338,9 +15989,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15396,9 +16047,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15457,9 +16108,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15513,9 +16164,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15570,9 +16221,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15628,9 +16279,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -15684,9 +16335,9 @@ fn list_traffic_policy_instances_by_hosted_zone(&self, input: &ListTrafficPolicy
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -134,6 +130,766 @@ pub struct ContactDetail {
     pub zip_code: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContactType {
+    Association,
+    Company,
+    Person,
+    PublicBody,
+    Reseller,
+}
+
+impl Into<String> for ContactType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContactType {
+    fn into(self) -> &'static str {
+        match self {
+            ContactType::Association => "ASSOCIATION",
+            ContactType::Company => "COMPANY",
+            ContactType::Person => "PERSON",
+            ContactType::PublicBody => "PUBLIC_BODY",
+            ContactType::Reseller => "RESELLER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContactType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSOCIATION" => Ok(ContactType::Association),
+            "COMPANY" => Ok(ContactType::Company),
+            "PERSON" => Ok(ContactType::Person),
+            "PUBLIC_BODY" => Ok(ContactType::PublicBody),
+            "RESELLER" => Ok(ContactType::Reseller),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CountryCode {
+    Ad,
+    Ae,
+    Af,
+    Ag,
+    Ai,
+    Al,
+    Am,
+    An,
+    Ao,
+    Aq,
+    Ar,
+    As,
+    At,
+    Au,
+    Aw,
+    Az,
+    Ba,
+    Bb,
+    Bd,
+    Be,
+    Bf,
+    Bg,
+    Bh,
+    Bi,
+    Bj,
+    Bl,
+    Bm,
+    Bn,
+    Bo,
+    Br,
+    Bs,
+    Bt,
+    Bw,
+    By,
+    Bz,
+    Ca,
+    Cc,
+    Cd,
+    Cf,
+    Cg,
+    Ch,
+    Ci,
+    Ck,
+    Cl,
+    Cm,
+    Cn,
+    Co,
+    Cr,
+    Cu,
+    Cv,
+    Cx,
+    Cy,
+    Cz,
+    De,
+    Dj,
+    Dk,
+    Dm,
+    Do,
+    Dz,
+    Ec,
+    Ee,
+    Eg,
+    Er,
+    Es,
+    Et,
+    Fi,
+    Fj,
+    Fk,
+    Fm,
+    Fo,
+    Fr,
+    Ga,
+    Gb,
+    Gd,
+    Ge,
+    Gh,
+    Gi,
+    Gl,
+    Gm,
+    Gn,
+    Gq,
+    Gr,
+    Gt,
+    Gu,
+    Gw,
+    Gy,
+    Hk,
+    Hn,
+    Hr,
+    Ht,
+    Hu,
+    Id,
+    Ie,
+    Il,
+    Im,
+    In,
+    Iq,
+    Ir,
+    Is,
+    It,
+    Jm,
+    Jo,
+    Jp,
+    Ke,
+    Kg,
+    Kh,
+    Ki,
+    Km,
+    Kn,
+    Kp,
+    Kr,
+    Kw,
+    Ky,
+    Kz,
+    La,
+    Lb,
+    Lc,
+    Li,
+    Lk,
+    Lr,
+    Ls,
+    Lt,
+    Lu,
+    Lv,
+    Ly,
+    Ma,
+    Mc,
+    Md,
+    Me,
+    Mf,
+    Mg,
+    Mh,
+    Mk,
+    Ml,
+    Mm,
+    Mn,
+    Mo,
+    Mp,
+    Mr,
+    Ms,
+    Mt,
+    Mu,
+    Mv,
+    Mw,
+    Mx,
+    My,
+    Mz,
+    Na,
+    Nc,
+    Ne,
+    Ng,
+    Ni,
+    Nl,
+    No,
+    Np,
+    Nr,
+    Nu,
+    Nz,
+    Om,
+    Pa,
+    Pe,
+    Pf,
+    Pg,
+    Ph,
+    Pk,
+    Pl,
+    Pm,
+    Pn,
+    Pr,
+    Pt,
+    Pw,
+    Py,
+    Qa,
+    Ro,
+    Rs,
+    Ru,
+    Rw,
+    Sa,
+    Sb,
+    Sc,
+    Sd,
+    Se,
+    Sg,
+    Sh,
+    Si,
+    Sk,
+    Sl,
+    Sm,
+    Sn,
+    So,
+    Sr,
+    St,
+    Sv,
+    Sy,
+    Sz,
+    Tc,
+    Td,
+    Tg,
+    Th,
+    Tj,
+    Tk,
+    Tl,
+    Tm,
+    Tn,
+    To,
+    Tr,
+    Tt,
+    Tv,
+    Tw,
+    Tz,
+    Ua,
+    Ug,
+    Us,
+    Uy,
+    Uz,
+    Va,
+    Vc,
+    Ve,
+    Vg,
+    Vi,
+    Vn,
+    Vu,
+    Wf,
+    Ws,
+    Ye,
+    Yt,
+    Za,
+    Zm,
+    Zw,
+}
+
+impl Into<String> for CountryCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CountryCode {
+    fn into(self) -> &'static str {
+        match self {
+            CountryCode::Ad => "AD",
+            CountryCode::Ae => "AE",
+            CountryCode::Af => "AF",
+            CountryCode::Ag => "AG",
+            CountryCode::Ai => "AI",
+            CountryCode::Al => "AL",
+            CountryCode::Am => "AM",
+            CountryCode::An => "AN",
+            CountryCode::Ao => "AO",
+            CountryCode::Aq => "AQ",
+            CountryCode::Ar => "AR",
+            CountryCode::As => "AS",
+            CountryCode::At => "AT",
+            CountryCode::Au => "AU",
+            CountryCode::Aw => "AW",
+            CountryCode::Az => "AZ",
+            CountryCode::Ba => "BA",
+            CountryCode::Bb => "BB",
+            CountryCode::Bd => "BD",
+            CountryCode::Be => "BE",
+            CountryCode::Bf => "BF",
+            CountryCode::Bg => "BG",
+            CountryCode::Bh => "BH",
+            CountryCode::Bi => "BI",
+            CountryCode::Bj => "BJ",
+            CountryCode::Bl => "BL",
+            CountryCode::Bm => "BM",
+            CountryCode::Bn => "BN",
+            CountryCode::Bo => "BO",
+            CountryCode::Br => "BR",
+            CountryCode::Bs => "BS",
+            CountryCode::Bt => "BT",
+            CountryCode::Bw => "BW",
+            CountryCode::By => "BY",
+            CountryCode::Bz => "BZ",
+            CountryCode::Ca => "CA",
+            CountryCode::Cc => "CC",
+            CountryCode::Cd => "CD",
+            CountryCode::Cf => "CF",
+            CountryCode::Cg => "CG",
+            CountryCode::Ch => "CH",
+            CountryCode::Ci => "CI",
+            CountryCode::Ck => "CK",
+            CountryCode::Cl => "CL",
+            CountryCode::Cm => "CM",
+            CountryCode::Cn => "CN",
+            CountryCode::Co => "CO",
+            CountryCode::Cr => "CR",
+            CountryCode::Cu => "CU",
+            CountryCode::Cv => "CV",
+            CountryCode::Cx => "CX",
+            CountryCode::Cy => "CY",
+            CountryCode::Cz => "CZ",
+            CountryCode::De => "DE",
+            CountryCode::Dj => "DJ",
+            CountryCode::Dk => "DK",
+            CountryCode::Dm => "DM",
+            CountryCode::Do => "DO",
+            CountryCode::Dz => "DZ",
+            CountryCode::Ec => "EC",
+            CountryCode::Ee => "EE",
+            CountryCode::Eg => "EG",
+            CountryCode::Er => "ER",
+            CountryCode::Es => "ES",
+            CountryCode::Et => "ET",
+            CountryCode::Fi => "FI",
+            CountryCode::Fj => "FJ",
+            CountryCode::Fk => "FK",
+            CountryCode::Fm => "FM",
+            CountryCode::Fo => "FO",
+            CountryCode::Fr => "FR",
+            CountryCode::Ga => "GA",
+            CountryCode::Gb => "GB",
+            CountryCode::Gd => "GD",
+            CountryCode::Ge => "GE",
+            CountryCode::Gh => "GH",
+            CountryCode::Gi => "GI",
+            CountryCode::Gl => "GL",
+            CountryCode::Gm => "GM",
+            CountryCode::Gn => "GN",
+            CountryCode::Gq => "GQ",
+            CountryCode::Gr => "GR",
+            CountryCode::Gt => "GT",
+            CountryCode::Gu => "GU",
+            CountryCode::Gw => "GW",
+            CountryCode::Gy => "GY",
+            CountryCode::Hk => "HK",
+            CountryCode::Hn => "HN",
+            CountryCode::Hr => "HR",
+            CountryCode::Ht => "HT",
+            CountryCode::Hu => "HU",
+            CountryCode::Id => "ID",
+            CountryCode::Ie => "IE",
+            CountryCode::Il => "IL",
+            CountryCode::Im => "IM",
+            CountryCode::In => "IN",
+            CountryCode::Iq => "IQ",
+            CountryCode::Ir => "IR",
+            CountryCode::Is => "IS",
+            CountryCode::It => "IT",
+            CountryCode::Jm => "JM",
+            CountryCode::Jo => "JO",
+            CountryCode::Jp => "JP",
+            CountryCode::Ke => "KE",
+            CountryCode::Kg => "KG",
+            CountryCode::Kh => "KH",
+            CountryCode::Ki => "KI",
+            CountryCode::Km => "KM",
+            CountryCode::Kn => "KN",
+            CountryCode::Kp => "KP",
+            CountryCode::Kr => "KR",
+            CountryCode::Kw => "KW",
+            CountryCode::Ky => "KY",
+            CountryCode::Kz => "KZ",
+            CountryCode::La => "LA",
+            CountryCode::Lb => "LB",
+            CountryCode::Lc => "LC",
+            CountryCode::Li => "LI",
+            CountryCode::Lk => "LK",
+            CountryCode::Lr => "LR",
+            CountryCode::Ls => "LS",
+            CountryCode::Lt => "LT",
+            CountryCode::Lu => "LU",
+            CountryCode::Lv => "LV",
+            CountryCode::Ly => "LY",
+            CountryCode::Ma => "MA",
+            CountryCode::Mc => "MC",
+            CountryCode::Md => "MD",
+            CountryCode::Me => "ME",
+            CountryCode::Mf => "MF",
+            CountryCode::Mg => "MG",
+            CountryCode::Mh => "MH",
+            CountryCode::Mk => "MK",
+            CountryCode::Ml => "ML",
+            CountryCode::Mm => "MM",
+            CountryCode::Mn => "MN",
+            CountryCode::Mo => "MO",
+            CountryCode::Mp => "MP",
+            CountryCode::Mr => "MR",
+            CountryCode::Ms => "MS",
+            CountryCode::Mt => "MT",
+            CountryCode::Mu => "MU",
+            CountryCode::Mv => "MV",
+            CountryCode::Mw => "MW",
+            CountryCode::Mx => "MX",
+            CountryCode::My => "MY",
+            CountryCode::Mz => "MZ",
+            CountryCode::Na => "NA",
+            CountryCode::Nc => "NC",
+            CountryCode::Ne => "NE",
+            CountryCode::Ng => "NG",
+            CountryCode::Ni => "NI",
+            CountryCode::Nl => "NL",
+            CountryCode::No => "NO",
+            CountryCode::Np => "NP",
+            CountryCode::Nr => "NR",
+            CountryCode::Nu => "NU",
+            CountryCode::Nz => "NZ",
+            CountryCode::Om => "OM",
+            CountryCode::Pa => "PA",
+            CountryCode::Pe => "PE",
+            CountryCode::Pf => "PF",
+            CountryCode::Pg => "PG",
+            CountryCode::Ph => "PH",
+            CountryCode::Pk => "PK",
+            CountryCode::Pl => "PL",
+            CountryCode::Pm => "PM",
+            CountryCode::Pn => "PN",
+            CountryCode::Pr => "PR",
+            CountryCode::Pt => "PT",
+            CountryCode::Pw => "PW",
+            CountryCode::Py => "PY",
+            CountryCode::Qa => "QA",
+            CountryCode::Ro => "RO",
+            CountryCode::Rs => "RS",
+            CountryCode::Ru => "RU",
+            CountryCode::Rw => "RW",
+            CountryCode::Sa => "SA",
+            CountryCode::Sb => "SB",
+            CountryCode::Sc => "SC",
+            CountryCode::Sd => "SD",
+            CountryCode::Se => "SE",
+            CountryCode::Sg => "SG",
+            CountryCode::Sh => "SH",
+            CountryCode::Si => "SI",
+            CountryCode::Sk => "SK",
+            CountryCode::Sl => "SL",
+            CountryCode::Sm => "SM",
+            CountryCode::Sn => "SN",
+            CountryCode::So => "SO",
+            CountryCode::Sr => "SR",
+            CountryCode::St => "ST",
+            CountryCode::Sv => "SV",
+            CountryCode::Sy => "SY",
+            CountryCode::Sz => "SZ",
+            CountryCode::Tc => "TC",
+            CountryCode::Td => "TD",
+            CountryCode::Tg => "TG",
+            CountryCode::Th => "TH",
+            CountryCode::Tj => "TJ",
+            CountryCode::Tk => "TK",
+            CountryCode::Tl => "TL",
+            CountryCode::Tm => "TM",
+            CountryCode::Tn => "TN",
+            CountryCode::To => "TO",
+            CountryCode::Tr => "TR",
+            CountryCode::Tt => "TT",
+            CountryCode::Tv => "TV",
+            CountryCode::Tw => "TW",
+            CountryCode::Tz => "TZ",
+            CountryCode::Ua => "UA",
+            CountryCode::Ug => "UG",
+            CountryCode::Us => "US",
+            CountryCode::Uy => "UY",
+            CountryCode::Uz => "UZ",
+            CountryCode::Va => "VA",
+            CountryCode::Vc => "VC",
+            CountryCode::Ve => "VE",
+            CountryCode::Vg => "VG",
+            CountryCode::Vi => "VI",
+            CountryCode::Vn => "VN",
+            CountryCode::Vu => "VU",
+            CountryCode::Wf => "WF",
+            CountryCode::Ws => "WS",
+            CountryCode::Ye => "YE",
+            CountryCode::Yt => "YT",
+            CountryCode::Za => "ZA",
+            CountryCode::Zm => "ZM",
+            CountryCode::Zw => "ZW",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CountryCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AD" => Ok(CountryCode::Ad),
+            "AE" => Ok(CountryCode::Ae),
+            "AF" => Ok(CountryCode::Af),
+            "AG" => Ok(CountryCode::Ag),
+            "AI" => Ok(CountryCode::Ai),
+            "AL" => Ok(CountryCode::Al),
+            "AM" => Ok(CountryCode::Am),
+            "AN" => Ok(CountryCode::An),
+            "AO" => Ok(CountryCode::Ao),
+            "AQ" => Ok(CountryCode::Aq),
+            "AR" => Ok(CountryCode::Ar),
+            "AS" => Ok(CountryCode::As),
+            "AT" => Ok(CountryCode::At),
+            "AU" => Ok(CountryCode::Au),
+            "AW" => Ok(CountryCode::Aw),
+            "AZ" => Ok(CountryCode::Az),
+            "BA" => Ok(CountryCode::Ba),
+            "BB" => Ok(CountryCode::Bb),
+            "BD" => Ok(CountryCode::Bd),
+            "BE" => Ok(CountryCode::Be),
+            "BF" => Ok(CountryCode::Bf),
+            "BG" => Ok(CountryCode::Bg),
+            "BH" => Ok(CountryCode::Bh),
+            "BI" => Ok(CountryCode::Bi),
+            "BJ" => Ok(CountryCode::Bj),
+            "BL" => Ok(CountryCode::Bl),
+            "BM" => Ok(CountryCode::Bm),
+            "BN" => Ok(CountryCode::Bn),
+            "BO" => Ok(CountryCode::Bo),
+            "BR" => Ok(CountryCode::Br),
+            "BS" => Ok(CountryCode::Bs),
+            "BT" => Ok(CountryCode::Bt),
+            "BW" => Ok(CountryCode::Bw),
+            "BY" => Ok(CountryCode::By),
+            "BZ" => Ok(CountryCode::Bz),
+            "CA" => Ok(CountryCode::Ca),
+            "CC" => Ok(CountryCode::Cc),
+            "CD" => Ok(CountryCode::Cd),
+            "CF" => Ok(CountryCode::Cf),
+            "CG" => Ok(CountryCode::Cg),
+            "CH" => Ok(CountryCode::Ch),
+            "CI" => Ok(CountryCode::Ci),
+            "CK" => Ok(CountryCode::Ck),
+            "CL" => Ok(CountryCode::Cl),
+            "CM" => Ok(CountryCode::Cm),
+            "CN" => Ok(CountryCode::Cn),
+            "CO" => Ok(CountryCode::Co),
+            "CR" => Ok(CountryCode::Cr),
+            "CU" => Ok(CountryCode::Cu),
+            "CV" => Ok(CountryCode::Cv),
+            "CX" => Ok(CountryCode::Cx),
+            "CY" => Ok(CountryCode::Cy),
+            "CZ" => Ok(CountryCode::Cz),
+            "DE" => Ok(CountryCode::De),
+            "DJ" => Ok(CountryCode::Dj),
+            "DK" => Ok(CountryCode::Dk),
+            "DM" => Ok(CountryCode::Dm),
+            "DO" => Ok(CountryCode::Do),
+            "DZ" => Ok(CountryCode::Dz),
+            "EC" => Ok(CountryCode::Ec),
+            "EE" => Ok(CountryCode::Ee),
+            "EG" => Ok(CountryCode::Eg),
+            "ER" => Ok(CountryCode::Er),
+            "ES" => Ok(CountryCode::Es),
+            "ET" => Ok(CountryCode::Et),
+            "FI" => Ok(CountryCode::Fi),
+            "FJ" => Ok(CountryCode::Fj),
+            "FK" => Ok(CountryCode::Fk),
+            "FM" => Ok(CountryCode::Fm),
+            "FO" => Ok(CountryCode::Fo),
+            "FR" => Ok(CountryCode::Fr),
+            "GA" => Ok(CountryCode::Ga),
+            "GB" => Ok(CountryCode::Gb),
+            "GD" => Ok(CountryCode::Gd),
+            "GE" => Ok(CountryCode::Ge),
+            "GH" => Ok(CountryCode::Gh),
+            "GI" => Ok(CountryCode::Gi),
+            "GL" => Ok(CountryCode::Gl),
+            "GM" => Ok(CountryCode::Gm),
+            "GN" => Ok(CountryCode::Gn),
+            "GQ" => Ok(CountryCode::Gq),
+            "GR" => Ok(CountryCode::Gr),
+            "GT" => Ok(CountryCode::Gt),
+            "GU" => Ok(CountryCode::Gu),
+            "GW" => Ok(CountryCode::Gw),
+            "GY" => Ok(CountryCode::Gy),
+            "HK" => Ok(CountryCode::Hk),
+            "HN" => Ok(CountryCode::Hn),
+            "HR" => Ok(CountryCode::Hr),
+            "HT" => Ok(CountryCode::Ht),
+            "HU" => Ok(CountryCode::Hu),
+            "ID" => Ok(CountryCode::Id),
+            "IE" => Ok(CountryCode::Ie),
+            "IL" => Ok(CountryCode::Il),
+            "IM" => Ok(CountryCode::Im),
+            "IN" => Ok(CountryCode::In),
+            "IQ" => Ok(CountryCode::Iq),
+            "IR" => Ok(CountryCode::Ir),
+            "IS" => Ok(CountryCode::Is),
+            "IT" => Ok(CountryCode::It),
+            "JM" => Ok(CountryCode::Jm),
+            "JO" => Ok(CountryCode::Jo),
+            "JP" => Ok(CountryCode::Jp),
+            "KE" => Ok(CountryCode::Ke),
+            "KG" => Ok(CountryCode::Kg),
+            "KH" => Ok(CountryCode::Kh),
+            "KI" => Ok(CountryCode::Ki),
+            "KM" => Ok(CountryCode::Km),
+            "KN" => Ok(CountryCode::Kn),
+            "KP" => Ok(CountryCode::Kp),
+            "KR" => Ok(CountryCode::Kr),
+            "KW" => Ok(CountryCode::Kw),
+            "KY" => Ok(CountryCode::Ky),
+            "KZ" => Ok(CountryCode::Kz),
+            "LA" => Ok(CountryCode::La),
+            "LB" => Ok(CountryCode::Lb),
+            "LC" => Ok(CountryCode::Lc),
+            "LI" => Ok(CountryCode::Li),
+            "LK" => Ok(CountryCode::Lk),
+            "LR" => Ok(CountryCode::Lr),
+            "LS" => Ok(CountryCode::Ls),
+            "LT" => Ok(CountryCode::Lt),
+            "LU" => Ok(CountryCode::Lu),
+            "LV" => Ok(CountryCode::Lv),
+            "LY" => Ok(CountryCode::Ly),
+            "MA" => Ok(CountryCode::Ma),
+            "MC" => Ok(CountryCode::Mc),
+            "MD" => Ok(CountryCode::Md),
+            "ME" => Ok(CountryCode::Me),
+            "MF" => Ok(CountryCode::Mf),
+            "MG" => Ok(CountryCode::Mg),
+            "MH" => Ok(CountryCode::Mh),
+            "MK" => Ok(CountryCode::Mk),
+            "ML" => Ok(CountryCode::Ml),
+            "MM" => Ok(CountryCode::Mm),
+            "MN" => Ok(CountryCode::Mn),
+            "MO" => Ok(CountryCode::Mo),
+            "MP" => Ok(CountryCode::Mp),
+            "MR" => Ok(CountryCode::Mr),
+            "MS" => Ok(CountryCode::Ms),
+            "MT" => Ok(CountryCode::Mt),
+            "MU" => Ok(CountryCode::Mu),
+            "MV" => Ok(CountryCode::Mv),
+            "MW" => Ok(CountryCode::Mw),
+            "MX" => Ok(CountryCode::Mx),
+            "MY" => Ok(CountryCode::My),
+            "MZ" => Ok(CountryCode::Mz),
+            "NA" => Ok(CountryCode::Na),
+            "NC" => Ok(CountryCode::Nc),
+            "NE" => Ok(CountryCode::Ne),
+            "NG" => Ok(CountryCode::Ng),
+            "NI" => Ok(CountryCode::Ni),
+            "NL" => Ok(CountryCode::Nl),
+            "NO" => Ok(CountryCode::No),
+            "NP" => Ok(CountryCode::Np),
+            "NR" => Ok(CountryCode::Nr),
+            "NU" => Ok(CountryCode::Nu),
+            "NZ" => Ok(CountryCode::Nz),
+            "OM" => Ok(CountryCode::Om),
+            "PA" => Ok(CountryCode::Pa),
+            "PE" => Ok(CountryCode::Pe),
+            "PF" => Ok(CountryCode::Pf),
+            "PG" => Ok(CountryCode::Pg),
+            "PH" => Ok(CountryCode::Ph),
+            "PK" => Ok(CountryCode::Pk),
+            "PL" => Ok(CountryCode::Pl),
+            "PM" => Ok(CountryCode::Pm),
+            "PN" => Ok(CountryCode::Pn),
+            "PR" => Ok(CountryCode::Pr),
+            "PT" => Ok(CountryCode::Pt),
+            "PW" => Ok(CountryCode::Pw),
+            "PY" => Ok(CountryCode::Py),
+            "QA" => Ok(CountryCode::Qa),
+            "RO" => Ok(CountryCode::Ro),
+            "RS" => Ok(CountryCode::Rs),
+            "RU" => Ok(CountryCode::Ru),
+            "RW" => Ok(CountryCode::Rw),
+            "SA" => Ok(CountryCode::Sa),
+            "SB" => Ok(CountryCode::Sb),
+            "SC" => Ok(CountryCode::Sc),
+            "SD" => Ok(CountryCode::Sd),
+            "SE" => Ok(CountryCode::Se),
+            "SG" => Ok(CountryCode::Sg),
+            "SH" => Ok(CountryCode::Sh),
+            "SI" => Ok(CountryCode::Si),
+            "SK" => Ok(CountryCode::Sk),
+            "SL" => Ok(CountryCode::Sl),
+            "SM" => Ok(CountryCode::Sm),
+            "SN" => Ok(CountryCode::Sn),
+            "SO" => Ok(CountryCode::So),
+            "SR" => Ok(CountryCode::Sr),
+            "ST" => Ok(CountryCode::St),
+            "SV" => Ok(CountryCode::Sv),
+            "SY" => Ok(CountryCode::Sy),
+            "SZ" => Ok(CountryCode::Sz),
+            "TC" => Ok(CountryCode::Tc),
+            "TD" => Ok(CountryCode::Td),
+            "TG" => Ok(CountryCode::Tg),
+            "TH" => Ok(CountryCode::Th),
+            "TJ" => Ok(CountryCode::Tj),
+            "TK" => Ok(CountryCode::Tk),
+            "TL" => Ok(CountryCode::Tl),
+            "TM" => Ok(CountryCode::Tm),
+            "TN" => Ok(CountryCode::Tn),
+            "TO" => Ok(CountryCode::To),
+            "TR" => Ok(CountryCode::Tr),
+            "TT" => Ok(CountryCode::Tt),
+            "TV" => Ok(CountryCode::Tv),
+            "TW" => Ok(CountryCode::Tw),
+            "TZ" => Ok(CountryCode::Tz),
+            "UA" => Ok(CountryCode::Ua),
+            "UG" => Ok(CountryCode::Ug),
+            "US" => Ok(CountryCode::Us),
+            "UY" => Ok(CountryCode::Uy),
+            "UZ" => Ok(CountryCode::Uz),
+            "VA" => Ok(CountryCode::Va),
+            "VC" => Ok(CountryCode::Vc),
+            "VE" => Ok(CountryCode::Ve),
+            "VG" => Ok(CountryCode::Vg),
+            "VI" => Ok(CountryCode::Vi),
+            "VN" => Ok(CountryCode::Vn),
+            "VU" => Ok(CountryCode::Vu),
+            "WF" => Ok(CountryCode::Wf),
+            "WS" => Ok(CountryCode::Ws),
+            "YE" => Ok(CountryCode::Ye),
+            "YT" => Ok(CountryCode::Yt),
+            "ZA" => Ok(CountryCode::Za),
+            "ZM" => Ok(CountryCode::Zm),
+            "ZW" => Ok(CountryCode::Zw),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The DeleteTagsForDomainRequest includes the following elements.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DeleteTagsForDomainRequest {
@@ -172,6 +928,59 @@ pub struct DisableDomainTransferLockResponse {
     #[doc="<p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>"]
     #[serde(rename="OperationId")]
     pub operation_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DomainAvailability {
+    Available,
+    AvailablePreorder,
+    AvailableReserved,
+    DontKnow,
+    Reserved,
+    Unavailable,
+    UnavailablePremium,
+    UnavailableRestricted,
+}
+
+impl Into<String> for DomainAvailability {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DomainAvailability {
+    fn into(self) -> &'static str {
+        match self {
+            DomainAvailability::Available => "AVAILABLE",
+            DomainAvailability::AvailablePreorder => "AVAILABLE_PREORDER",
+            DomainAvailability::AvailableReserved => "AVAILABLE_RESERVED",
+            DomainAvailability::DontKnow => "DONT_KNOW",
+            DomainAvailability::Reserved => "RESERVED",
+            DomainAvailability::Unavailable => "UNAVAILABLE",
+            DomainAvailability::UnavailablePremium => "UNAVAILABLE_PREMIUM",
+            DomainAvailability::UnavailableRestricted => "UNAVAILABLE_RESTRICTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DomainAvailability {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(DomainAvailability::Available),
+            "AVAILABLE_PREORDER" => Ok(DomainAvailability::AvailablePreorder),
+            "AVAILABLE_RESERVED" => Ok(DomainAvailability::AvailableReserved),
+            "DONT_KNOW" => Ok(DomainAvailability::DontKnow),
+            "RESERVED" => Ok(DomainAvailability::Reserved),
+            "UNAVAILABLE" => Ok(DomainAvailability::Unavailable),
+            "UNAVAILABLE_PREMIUM" => Ok(DomainAvailability::UnavailablePremium),
+            "UNAVAILABLE_RESTRICTED" => Ok(DomainAvailability::UnavailableRestricted),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about one suggested domain name.</p>"]
@@ -242,6 +1051,98 @@ pub struct ExtraParam {
     #[doc="<p>Values corresponding to the additional parameter names required by some top-level domains.</p>"]
     #[serde(rename="Value")]
     pub value: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExtraParamName {
+    AuIdNumber,
+    AuIdType,
+    BirthCity,
+    BirthCountry,
+    BirthDateInYyyyMmDd,
+    BirthDepartment,
+    BrandNumber,
+    CaBusinessEntityType,
+    CaLegalType,
+    DocumentNumber,
+    DunsNumber,
+    EsIdentification,
+    EsIdentificationType,
+    EsLegalForm,
+    FiBusinessNumber,
+    FiIdNumber,
+    ItPin,
+    RuPassportData,
+    SeIdNumber,
+    SgIdNumber,
+    VatNumber,
+}
+
+impl Into<String> for ExtraParamName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExtraParamName {
+    fn into(self) -> &'static str {
+        match self {
+            ExtraParamName::AuIdNumber => "AU_ID_NUMBER",
+            ExtraParamName::AuIdType => "AU_ID_TYPE",
+            ExtraParamName::BirthCity => "BIRTH_CITY",
+            ExtraParamName::BirthCountry => "BIRTH_COUNTRY",
+            ExtraParamName::BirthDateInYyyyMmDd => "BIRTH_DATE_IN_YYYY_MM_DD",
+            ExtraParamName::BirthDepartment => "BIRTH_DEPARTMENT",
+            ExtraParamName::BrandNumber => "BRAND_NUMBER",
+            ExtraParamName::CaBusinessEntityType => "CA_BUSINESS_ENTITY_TYPE",
+            ExtraParamName::CaLegalType => "CA_LEGAL_TYPE",
+            ExtraParamName::DocumentNumber => "DOCUMENT_NUMBER",
+            ExtraParamName::DunsNumber => "DUNS_NUMBER",
+            ExtraParamName::EsIdentification => "ES_IDENTIFICATION",
+            ExtraParamName::EsIdentificationType => "ES_IDENTIFICATION_TYPE",
+            ExtraParamName::EsLegalForm => "ES_LEGAL_FORM",
+            ExtraParamName::FiBusinessNumber => "FI_BUSINESS_NUMBER",
+            ExtraParamName::FiIdNumber => "FI_ID_NUMBER",
+            ExtraParamName::ItPin => "IT_PIN",
+            ExtraParamName::RuPassportData => "RU_PASSPORT_DATA",
+            ExtraParamName::SeIdNumber => "SE_ID_NUMBER",
+            ExtraParamName::SgIdNumber => "SG_ID_NUMBER",
+            ExtraParamName::VatNumber => "VAT_NUMBER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExtraParamName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AU_ID_NUMBER" => Ok(ExtraParamName::AuIdNumber),
+            "AU_ID_TYPE" => Ok(ExtraParamName::AuIdType),
+            "BIRTH_CITY" => Ok(ExtraParamName::BirthCity),
+            "BIRTH_COUNTRY" => Ok(ExtraParamName::BirthCountry),
+            "BIRTH_DATE_IN_YYYY_MM_DD" => Ok(ExtraParamName::BirthDateInYyyyMmDd),
+            "BIRTH_DEPARTMENT" => Ok(ExtraParamName::BirthDepartment),
+            "BRAND_NUMBER" => Ok(ExtraParamName::BrandNumber),
+            "CA_BUSINESS_ENTITY_TYPE" => Ok(ExtraParamName::CaBusinessEntityType),
+            "CA_LEGAL_TYPE" => Ok(ExtraParamName::CaLegalType),
+            "DOCUMENT_NUMBER" => Ok(ExtraParamName::DocumentNumber),
+            "DUNS_NUMBER" => Ok(ExtraParamName::DunsNumber),
+            "ES_IDENTIFICATION" => Ok(ExtraParamName::EsIdentification),
+            "ES_IDENTIFICATION_TYPE" => Ok(ExtraParamName::EsIdentificationType),
+            "ES_LEGAL_FORM" => Ok(ExtraParamName::EsLegalForm),
+            "FI_BUSINESS_NUMBER" => Ok(ExtraParamName::FiBusinessNumber),
+            "FI_ID_NUMBER" => Ok(ExtraParamName::FiIdNumber),
+            "IT_PIN" => Ok(ExtraParamName::ItPin),
+            "RU_PASSPORT_DATA" => Ok(ExtraParamName::RuPassportData),
+            "SE_ID_NUMBER" => Ok(ExtraParamName::SeIdNumber),
+            "SG_ID_NUMBER" => Ok(ExtraParamName::SgIdNumber),
+            "VAT_NUMBER" => Ok(ExtraParamName::VatNumber),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -492,6 +1393,50 @@ pub struct Nameserver {
     pub name: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationStatus {
+    Error,
+    Failed,
+    InProgress,
+    Submitted,
+    Successful,
+}
+
+impl Into<String> for OperationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            OperationStatus::Error => "ERROR",
+            OperationStatus::Failed => "FAILED",
+            OperationStatus::InProgress => "IN_PROGRESS",
+            OperationStatus::Submitted => "SUBMITTED",
+            OperationStatus::Successful => "SUCCESSFUL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ERROR" => Ok(OperationStatus::Error),
+            "FAILED" => Ok(OperationStatus::Failed),
+            "IN_PROGRESS" => Ok(OperationStatus::InProgress),
+            "SUBMITTED" => Ok(OperationStatus::Submitted),
+            "SUCCESSFUL" => Ok(OperationStatus::Successful),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>OperationSummary includes the following elements.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct OperationSummary {
@@ -507,6 +1452,94 @@ pub struct OperationSummary {
     #[doc="<p>Type of the action requested.</p>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperationType {
+    ChangePrivacyProtection,
+    DeleteDomain,
+    DomainLock,
+    RegisterDomain,
+    TransferInDomain,
+    UpdateDomainContact,
+    UpdateNameserver,
+}
+
+impl Into<String> for OperationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperationType {
+    fn into(self) -> &'static str {
+        match self {
+            OperationType::ChangePrivacyProtection => "CHANGE_PRIVACY_PROTECTION",
+            OperationType::DeleteDomain => "DELETE_DOMAIN",
+            OperationType::DomainLock => "DOMAIN_LOCK",
+            OperationType::RegisterDomain => "REGISTER_DOMAIN",
+            OperationType::TransferInDomain => "TRANSFER_IN_DOMAIN",
+            OperationType::UpdateDomainContact => "UPDATE_DOMAIN_CONTACT",
+            OperationType::UpdateNameserver => "UPDATE_NAMESERVER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHANGE_PRIVACY_PROTECTION" => Ok(OperationType::ChangePrivacyProtection),
+            "DELETE_DOMAIN" => Ok(OperationType::DeleteDomain),
+            "DOMAIN_LOCK" => Ok(OperationType::DomainLock),
+            "REGISTER_DOMAIN" => Ok(OperationType::RegisterDomain),
+            "TRANSFER_IN_DOMAIN" => Ok(OperationType::TransferInDomain),
+            "UPDATE_DOMAIN_CONTACT" => Ok(OperationType::UpdateDomainContact),
+            "UPDATE_NAMESERVER" => Ok(OperationType::UpdateNameserver),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReachabilityStatus {
+    Done,
+    Expired,
+    Pending,
+}
+
+impl Into<String> for ReachabilityStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReachabilityStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReachabilityStatus::Done => "DONE",
+            ReachabilityStatus::Expired => "EXPIRED",
+            ReachabilityStatus::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReachabilityStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DONE" => Ok(ReachabilityStatus::Done),
+            "EXPIRED" => Ok(ReachabilityStatus::Expired),
+            "PENDING" => Ok(ReachabilityStatus::Pending),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The RegisterDomain request includes the following elements.</p>"]
@@ -3126,7 +4159,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CheckDomainAvailabilityResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3158,7 +4191,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteTagsForDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3190,7 +4223,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisableDomainAutoRenewResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3222,7 +4255,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisableDomainTransferLockResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3255,7 +4288,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<EnableDomainAutoRenewResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3287,7 +4320,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<EnableDomainTransferLockResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3320,7 +4353,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetContactReachabilityStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3351,7 +4384,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDomainDetailResponse>(String::from_utf8_lossy(&body)
@@ -3385,7 +4418,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDomainSuggestionsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3416,7 +4449,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetOperationDetailResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3446,7 +4479,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListDomainsResponse>(String::from_utf8_lossy(&body)
@@ -3478,7 +4511,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListOperationsResponse>(String::from_utf8_lossy(&body)
@@ -3510,7 +4543,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsForDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3540,7 +4573,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterDomainResponse>(String::from_utf8_lossy(&body)
@@ -3572,7 +4605,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RenewDomainResponse>(String::from_utf8_lossy(&body)
@@ -3606,7 +4639,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ResendContactReachabilityEmailResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3639,7 +4672,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RetrieveDomainAuthCodeResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3669,7 +4702,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<TransferDomainResponse>(String::from_utf8_lossy(&body)
@@ -3702,7 +4735,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDomainContactResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3734,7 +4767,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDomainContactPrivacyResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3767,7 +4800,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDomainNameserversResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3799,7 +4832,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateTagsForDomainResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -3829,7 +4862,7 @@ impl<P, D> Route53Domains for Route53DomainsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ViewBillingResponse>(String::from_utf8_lossy(&body)

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 
@@ -946,6 +942,38 @@ impl AnalyticsS3BucketDestinationSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AnalyticsS3ExportFileFormat {
+    Csv,
+}
+
+impl Into<String> for AnalyticsS3ExportFileFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AnalyticsS3ExportFileFormat {
+    fn into(self) -> &'static str {
+        match self {
+            AnalyticsS3ExportFileFormat::Csv => "CSV",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AnalyticsS3ExportFileFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CSV" => Ok(AnalyticsS3ExportFileFormat::Csv),
+            _ => Err(()),
+        }
+    }
+}
+
 struct AnalyticsS3ExportFileFormatDeserializer;
 impl AnalyticsS3ExportFileFormatDeserializer {
     #[allow(unused_variables)]
@@ -1078,6 +1106,41 @@ impl BucketDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BucketAccelerateStatus {
+    Enabled,
+    Suspended,
+}
+
+impl Into<String> for BucketAccelerateStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BucketAccelerateStatus {
+    fn into(self) -> &'static str {
+        match self {
+            BucketAccelerateStatus::Enabled => "Enabled",
+            BucketAccelerateStatus::Suspended => "Suspended",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BucketAccelerateStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Enabled" => Ok(BucketAccelerateStatus::Enabled),
+            "Suspended" => Ok(BucketAccelerateStatus::Suspended),
+            _ => Err(()),
+        }
+    }
+}
+
 struct BucketAccelerateStatusDeserializer;
 impl BucketAccelerateStatusDeserializer {
     #[allow(unused_variables)]
@@ -1110,6 +1173,47 @@ impl BucketAccelerateStatusSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BucketCannedACL {
+    AuthenticatedRead,
+    Private,
+    PublicRead,
+    PublicReadWrite,
+}
+
+impl Into<String> for BucketCannedACL {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BucketCannedACL {
+    fn into(self) -> &'static str {
+        match self {
+            BucketCannedACL::AuthenticatedRead => "authenticated-read",
+            BucketCannedACL::Private => "private",
+            BucketCannedACL::PublicRead => "public-read",
+            BucketCannedACL::PublicReadWrite => "public-read-write",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BucketCannedACL {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "authenticated-read" => Ok(BucketCannedACL::AuthenticatedRead),
+            "private" => Ok(BucketCannedACL::Private),
+            "public-read" => Ok(BucketCannedACL::PublicRead),
+            "public-read-write" => Ok(BucketCannedACL::PublicReadWrite),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug)]
 pub struct BucketLifecycleConfiguration {
     pub rules: Vec<LifecycleRule>,
@@ -1128,6 +1232,68 @@ impl BucketLifecycleConfigurationSerializer {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         LifecycleRulesSerializer::serialize(&mut writer, "Rule", &obj.rules)?;
         writer.write(xml::writer::XmlEvent::end_element())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BucketLocationConstraint {
+    Eu,
+    ApNortheast1,
+    ApSouth1,
+    ApSoutheast1,
+    ApSoutheast2,
+    CnNorth1,
+    EuCentral1,
+    EuWest1,
+    SaEast1,
+    UsWest1,
+    UsWest2,
+}
+
+impl Into<String> for BucketLocationConstraint {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BucketLocationConstraint {
+    fn into(self) -> &'static str {
+        match self {
+            BucketLocationConstraint::Eu => "EU",
+            BucketLocationConstraint::ApNortheast1 => "ap-northeast-1",
+            BucketLocationConstraint::ApSouth1 => "ap-south-1",
+            BucketLocationConstraint::ApSoutheast1 => "ap-southeast-1",
+            BucketLocationConstraint::ApSoutheast2 => "ap-southeast-2",
+            BucketLocationConstraint::CnNorth1 => "cn-north-1",
+            BucketLocationConstraint::EuCentral1 => "eu-central-1",
+            BucketLocationConstraint::EuWest1 => "eu-west-1",
+            BucketLocationConstraint::SaEast1 => "sa-east-1",
+            BucketLocationConstraint::UsWest1 => "us-west-1",
+            BucketLocationConstraint::UsWest2 => "us-west-2",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BucketLocationConstraint {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EU" => Ok(BucketLocationConstraint::Eu),
+            "ap-northeast-1" => Ok(BucketLocationConstraint::ApNortheast1),
+            "ap-south-1" => Ok(BucketLocationConstraint::ApSouth1),
+            "ap-southeast-1" => Ok(BucketLocationConstraint::ApSoutheast1),
+            "ap-southeast-2" => Ok(BucketLocationConstraint::ApSoutheast2),
+            "cn-north-1" => Ok(BucketLocationConstraint::CnNorth1),
+            "eu-central-1" => Ok(BucketLocationConstraint::EuCentral1),
+            "eu-west-1" => Ok(BucketLocationConstraint::EuWest1),
+            "sa-east-1" => Ok(BucketLocationConstraint::SaEast1),
+            "us-west-1" => Ok(BucketLocationConstraint::UsWest1),
+            "us-west-2" => Ok(BucketLocationConstraint::UsWest2),
+            _ => Err(()),
+        }
     }
 }
 
@@ -1183,6 +1349,44 @@ impl BucketLoggingStatusSerializer {
             &LoggingEnabledSerializer::serialize(&mut writer, "LoggingEnabled", value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BucketLogsPermission {
+    FullControl,
+    Read,
+    Write,
+}
+
+impl Into<String> for BucketLogsPermission {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BucketLogsPermission {
+    fn into(self) -> &'static str {
+        match self {
+            BucketLogsPermission::FullControl => "FULL_CONTROL",
+            BucketLogsPermission::Read => "READ",
+            BucketLogsPermission::Write => "WRITE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BucketLogsPermission {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FULL_CONTROL" => Ok(BucketLogsPermission::FullControl),
+            "READ" => Ok(BucketLogsPermission::Read),
+            "WRITE" => Ok(BucketLogsPermission::Write),
+            _ => Err(()),
+        }
     }
 }
 
@@ -1247,6 +1451,41 @@ impl BucketNameSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BucketVersioningStatus {
+    Enabled,
+    Suspended,
+}
+
+impl Into<String> for BucketVersioningStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BucketVersioningStatus {
+    fn into(self) -> &'static str {
+        match self {
+            BucketVersioningStatus::Enabled => "Enabled",
+            BucketVersioningStatus::Suspended => "Suspended",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BucketVersioningStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Enabled" => Ok(BucketVersioningStatus::Enabled),
+            "Suspended" => Ok(BucketVersioningStatus::Suspended),
+            _ => Err(()),
+        }
     }
 }
 
@@ -2606,7 +2845,7 @@ impl DeleteMarkerDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3155,6 +3394,38 @@ impl EmailAddressSerializer {
     }
 }
 
+#[doc="Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EncodingType {
+    Url,
+}
+
+impl Into<String> for EncodingType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EncodingType {
+    fn into(self) -> &'static str {
+        match self {
+            EncodingType::Url => "url",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EncodingType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "url" => Ok(EncodingType::Url),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EncodingTypeDeserializer;
 impl EncodingTypeDeserializer {
     #[allow(unused_variables)]
@@ -3342,6 +3613,66 @@ impl ErrorsDeserializer {
 
     }
 }
+#[doc="Bucket event for which to send notifications."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Event {
+    S3ObjectCreated,
+    S3ObjectCreatedCompleteMultipartUpload,
+    S3ObjectCreatedCopy,
+    S3ObjectCreatedPost,
+    S3ObjectCreatedPut,
+    S3ObjectRemoved,
+    S3ObjectRemovedDelete,
+    S3ObjectRemovedDeleteMarkerCreated,
+    S3ReducedRedundancyLostObject,
+}
+
+impl Into<String> for Event {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Event {
+    fn into(self) -> &'static str {
+        match self {
+            Event::S3ObjectCreated => "s3:ObjectCreated:*",
+            Event::S3ObjectCreatedCompleteMultipartUpload => {
+                "s3:ObjectCreated:CompleteMultipartUpload"
+            }
+            Event::S3ObjectCreatedCopy => "s3:ObjectCreated:Copy",
+            Event::S3ObjectCreatedPost => "s3:ObjectCreated:Post",
+            Event::S3ObjectCreatedPut => "s3:ObjectCreated:Put",
+            Event::S3ObjectRemoved => "s3:ObjectRemoved:*",
+            Event::S3ObjectRemovedDelete => "s3:ObjectRemoved:Delete",
+            Event::S3ObjectRemovedDeleteMarkerCreated => "s3:ObjectRemoved:DeleteMarkerCreated",
+            Event::S3ReducedRedundancyLostObject => "s3:ReducedRedundancyLostObject",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Event {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "s3:ObjectCreated:*" => Ok(Event::S3ObjectCreated),
+            "s3:ObjectCreated:CompleteMultipartUpload" => {
+                Ok(Event::S3ObjectCreatedCompleteMultipartUpload)
+            }
+            "s3:ObjectCreated:Copy" => Ok(Event::S3ObjectCreatedCopy),
+            "s3:ObjectCreated:Post" => Ok(Event::S3ObjectCreatedPost),
+            "s3:ObjectCreated:Put" => Ok(Event::S3ObjectCreatedPut),
+            "s3:ObjectRemoved:*" => Ok(Event::S3ObjectRemoved),
+            "s3:ObjectRemoved:Delete" => Ok(Event::S3ObjectRemovedDelete),
+            "s3:ObjectRemoved:DeleteMarkerCreated" => Ok(Event::S3ObjectRemovedDeleteMarkerCreated),
+            "s3:ReducedRedundancyLostObject" => Ok(Event::S3ReducedRedundancyLostObject),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventDeserializer;
 impl EventDeserializer {
     #[allow(unused_variables)]
@@ -3420,6 +3751,41 @@ impl EventListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExpirationStatus {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for ExpirationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExpirationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ExpirationStatus::Disabled => "Disabled",
+            ExpirationStatus::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExpirationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(ExpirationStatus::Disabled),
+            "Enabled" => Ok(ExpirationStatus::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ExpirationStatusDeserializer;
 impl ExpirationStatusDeserializer {
     #[allow(unused_variables)]
@@ -3459,7 +3825,7 @@ impl ExpiredObjectDeleteMarkerDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -3702,6 +4068,41 @@ impl FilterRuleListSerializer {
             FilterRuleSerializer::serialize(writer, name, element)?;
         }
         Ok(())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FilterRuleName {
+    Prefix,
+    Suffix,
+}
+
+impl Into<String> for FilterRuleName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FilterRuleName {
+    fn into(self) -> &'static str {
+        match self {
+            FilterRuleName::Prefix => "prefix",
+            FilterRuleName::Suffix => "suffix",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FilterRuleName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "prefix" => Ok(FilterRuleName::Prefix),
+            "suffix" => Ok(FilterRuleName::Suffix),
+            _ => Err(()),
+        }
     }
 }
 
@@ -5737,6 +6138,38 @@ impl InventoryFilterSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryFormat {
+    Csv,
+}
+
+impl Into<String> for InventoryFormat {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryFormat {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryFormat::Csv => "CSV",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryFormat {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CSV" => Ok(InventoryFormat::Csv),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InventoryFormatDeserializer;
 impl InventoryFormatDeserializer {
     #[allow(unused_variables)]
@@ -5766,6 +6199,41 @@ impl InventoryFormatSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryFrequency {
+    Daily,
+    Weekly,
+}
+
+impl Into<String> for InventoryFrequency {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryFrequency {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryFrequency::Daily => "Daily",
+            InventoryFrequency::Weekly => "Weekly",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryFrequency {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Daily" => Ok(InventoryFrequency::Daily),
+            "Weekly" => Ok(InventoryFrequency::Weekly),
+            _ => Err(()),
+        }
     }
 }
 
@@ -5833,6 +6301,41 @@ impl InventoryIdSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryIncludedObjectVersions {
+    All,
+    Current,
+}
+
+impl Into<String> for InventoryIncludedObjectVersions {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryIncludedObjectVersions {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryIncludedObjectVersions::All => "All",
+            InventoryIncludedObjectVersions::Current => "Current",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryIncludedObjectVersions {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(InventoryIncludedObjectVersions::All),
+            "Current" => Ok(InventoryIncludedObjectVersions::Current),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InventoryIncludedObjectVersionsDeserializer;
 impl InventoryIncludedObjectVersionsDeserializer {
     #[allow(unused_variables)]
@@ -5862,6 +6365,53 @@ impl InventoryIncludedObjectVersionsSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryOptionalField {
+    Etag,
+    IsMultipartUploaded,
+    LastModifiedDate,
+    ReplicationStatus,
+    Size,
+    StorageClass,
+}
+
+impl Into<String> for InventoryOptionalField {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryOptionalField {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryOptionalField::Etag => "ETag",
+            InventoryOptionalField::IsMultipartUploaded => "IsMultipartUploaded",
+            InventoryOptionalField::LastModifiedDate => "LastModifiedDate",
+            InventoryOptionalField::ReplicationStatus => "ReplicationStatus",
+            InventoryOptionalField::Size => "Size",
+            InventoryOptionalField::StorageClass => "StorageClass",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryOptionalField {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ETag" => Ok(InventoryOptionalField::Etag),
+            "IsMultipartUploaded" => Ok(InventoryOptionalField::IsMultipartUploaded),
+            "LastModifiedDate" => Ok(InventoryOptionalField::LastModifiedDate),
+            "ReplicationStatus" => Ok(InventoryOptionalField::ReplicationStatus),
+            "Size" => Ok(InventoryOptionalField::Size),
+            "StorageClass" => Ok(InventoryOptionalField::StorageClass),
+            _ => Err(()),
+        }
     }
 }
 
@@ -6136,7 +6686,7 @@ impl IsEnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6168,7 +6718,7 @@ impl IsLatestDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -6182,7 +6732,7 @@ impl IsTruncatedDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -7946,6 +8496,41 @@ impl LoggingEnabledSerializer {
 }
 
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MFADelete {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for MFADelete {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MFADelete {
+    fn into(self) -> &'static str {
+        match self {
+            MFADelete::Disabled => "Disabled",
+            MFADelete::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MFADelete {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(MFADelete::Disabled),
+            "Enabled" => Ok(MFADelete::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
+
 pub struct MFADeleteSerializer;
 impl MFADeleteSerializer {
     #[allow(unused_variables, warnings)]
@@ -7960,6 +8545,41 @@ impl MFADeleteSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MFADeleteStatus {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for MFADeleteStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MFADeleteStatus {
+    fn into(self) -> &'static str {
+        match self {
+            MFADeleteStatus::Disabled => "Disabled",
+            MFADeleteStatus::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MFADeleteStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(MFADeleteStatus::Disabled),
+            "Enabled" => Ok(MFADeleteStatus::Enabled),
+            _ => Err(()),
+        }
     }
 }
 
@@ -8151,6 +8771,41 @@ impl MessageDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MetadataDirective {
+    Copy,
+    Replace,
+}
+
+impl Into<String> for MetadataDirective {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MetadataDirective {
+    fn into(self) -> &'static str {
+        match self {
+            MetadataDirective::Copy => "COPY",
+            MetadataDirective::Replace => "REPLACE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MetadataDirective {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COPY" => Ok(MetadataDirective::Copy),
+            "REPLACE" => Ok(MetadataDirective::Replace),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug)]
 pub struct MetricsAndOperator {
     #[doc="The prefix used when evaluating an AND predicate."]
@@ -9212,6 +9867,56 @@ impl ObjectDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ObjectCannedACL {
+    AuthenticatedRead,
+    AwsExecRead,
+    BucketOwnerFullControl,
+    BucketOwnerRead,
+    Private,
+    PublicRead,
+    PublicReadWrite,
+}
+
+impl Into<String> for ObjectCannedACL {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ObjectCannedACL {
+    fn into(self) -> &'static str {
+        match self {
+            ObjectCannedACL::AuthenticatedRead => "authenticated-read",
+            ObjectCannedACL::AwsExecRead => "aws-exec-read",
+            ObjectCannedACL::BucketOwnerFullControl => "bucket-owner-full-control",
+            ObjectCannedACL::BucketOwnerRead => "bucket-owner-read",
+            ObjectCannedACL::Private => "private",
+            ObjectCannedACL::PublicRead => "public-read",
+            ObjectCannedACL::PublicReadWrite => "public-read-write",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ObjectCannedACL {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "authenticated-read" => Ok(ObjectCannedACL::AuthenticatedRead),
+            "aws-exec-read" => Ok(ObjectCannedACL::AwsExecRead),
+            "bucket-owner-full-control" => Ok(ObjectCannedACL::BucketOwnerFullControl),
+            "bucket-owner-read" => Ok(ObjectCannedACL::BucketOwnerRead),
+            "private" => Ok(ObjectCannedACL::Private),
+            "public-read" => Ok(ObjectCannedACL::PublicRead),
+            "public-read-write" => Ok(ObjectCannedACL::PublicReadWrite),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug)]
 pub struct ObjectIdentifier {
     #[doc="Key name of the object to delete."]
@@ -9323,6 +10028,44 @@ impl ObjectListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ObjectStorageClass {
+    Glacier,
+    ReducedRedundancy,
+    Standard,
+}
+
+impl Into<String> for ObjectStorageClass {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ObjectStorageClass {
+    fn into(self) -> &'static str {
+        match self {
+            ObjectStorageClass::Glacier => "GLACIER",
+            ObjectStorageClass::ReducedRedundancy => "REDUCED_REDUNDANCY",
+            ObjectStorageClass::Standard => "STANDARD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ObjectStorageClass {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GLACIER" => Ok(ObjectStorageClass::Glacier),
+            "REDUCED_REDUNDANCY" => Ok(ObjectStorageClass::ReducedRedundancy),
+            "STANDARD" => Ok(ObjectStorageClass::Standard),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ObjectStorageClassDeserializer;
 impl ObjectStorageClassDeserializer {
     #[allow(unused_variables)]
@@ -9482,6 +10225,38 @@ impl ObjectVersionListDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ObjectVersionStorageClass {
+    Standard,
+}
+
+impl Into<String> for ObjectVersionStorageClass {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ObjectVersionStorageClass {
+    fn into(self) -> &'static str {
+        match self {
+            ObjectVersionStorageClass::Standard => "STANDARD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ObjectVersionStorageClass {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "STANDARD" => Ok(ObjectVersionStorageClass::Standard),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ObjectVersionStorageClassDeserializer;
 impl ObjectVersionStorageClassDeserializer {
     #[allow(unused_variables)]
@@ -9732,6 +10507,41 @@ impl PartsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Payer {
+    BucketOwner,
+    Requester,
+}
+
+impl Into<String> for Payer {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Payer {
+    fn into(self) -> &'static str {
+        match self {
+            Payer::BucketOwner => "BucketOwner",
+            Payer::Requester => "Requester",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Payer {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BucketOwner" => Ok(Payer::BucketOwner),
+            "Requester" => Ok(Payer::Requester),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PayerDeserializer;
 impl PayerDeserializer {
     #[allow(unused_variables)]
@@ -9761,6 +10571,50 @@ impl PayerSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Permission {
+    FullControl,
+    Read,
+    ReadAcp,
+    Write,
+    WriteAcp,
+}
+
+impl Into<String> for Permission {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Permission {
+    fn into(self) -> &'static str {
+        match self {
+            Permission::FullControl => "FULL_CONTROL",
+            Permission::Read => "READ",
+            Permission::ReadAcp => "READ_ACP",
+            Permission::Write => "WRITE",
+            Permission::WriteAcp => "WRITE_ACP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Permission {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FULL_CONTROL" => Ok(Permission::FullControl),
+            "READ" => Ok(Permission::Read),
+            "READ_ACP" => Ok(Permission::ReadAcp),
+            "WRITE" => Ok(Permission::Write),
+            "WRITE_ACP" => Ok(Permission::WriteAcp),
+            _ => Err(()),
+        }
     }
 }
 
@@ -9843,6 +10697,41 @@ impl PrefixSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Protocol {
+    Http,
+    Https,
+}
+
+impl Into<String> for Protocol {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Protocol {
+    fn into(self) -> &'static str {
+        match self {
+            Protocol::Http => "http",
+            Protocol::Https => "https",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Protocol {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "http" => Ok(Protocol::Http),
+            "https" => Ok(Protocol::Https),
+            _ => Err(()),
+        }
     }
 }
 
@@ -10887,6 +11776,41 @@ impl ReplicationRuleSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationRuleStatus {
+    Disabled,
+    Enabled,
+}
+
+impl Into<String> for ReplicationRuleStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationRuleStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationRuleStatus::Disabled => "Disabled",
+            ReplicationRuleStatus::Enabled => "Enabled",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationRuleStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Disabled" => Ok(ReplicationRuleStatus::Disabled),
+            "Enabled" => Ok(ReplicationRuleStatus::Enabled),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReplicationRuleStatusDeserializer;
 impl ReplicationRuleStatusDeserializer {
     #[allow(unused_variables)]
@@ -10962,6 +11886,111 @@ impl ReplicationRulesSerializer {
             ReplicationRuleSerializer::serialize(writer, name, element)?;
         }
         Ok(())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationStatus {
+    Complete,
+    Failed,
+    Pending,
+    Replica,
+}
+
+impl Into<String> for ReplicationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationStatus::Complete => "COMPLETE",
+            ReplicationStatus::Failed => "FAILED",
+            ReplicationStatus::Pending => "PENDING",
+            ReplicationStatus::Replica => "REPLICA",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLETE" => Ok(ReplicationStatus::Complete),
+            "FAILED" => Ok(ReplicationStatus::Failed),
+            "PENDING" => Ok(ReplicationStatus::Pending),
+            "REPLICA" => Ok(ReplicationStatus::Replica),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="If present, indicates that the requester was successfully charged for the request."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RequestCharged {
+    Requester,
+}
+
+impl Into<String> for RequestCharged {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RequestCharged {
+    fn into(self) -> &'static str {
+        match self {
+            RequestCharged::Requester => "requester",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RequestCharged {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "requester" => Ok(RequestCharged::Requester),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Confirms that the requester knows that she or he will be charged for the request. Bucket owners need not specify this parameter in their requests. Documentation on downloading objects from requester pays buckets can be found at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RequestPayer {
+    Requester,
+}
+
+impl Into<String> for RequestPayer {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RequestPayer {
+    fn into(self) -> &'static str {
+        match self {
+            RequestPayer::Requester => "requester",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RequestPayer {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "requester" => Ok(RequestPayer::Requester),
+            _ => Err(()),
+        }
     }
 }
 
@@ -11568,6 +12597,41 @@ impl S3KeyFilterSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ServerSideEncryption {
+    Aes256,
+    AwsKms,
+}
+
+impl Into<String> for ServerSideEncryption {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ServerSideEncryption {
+    fn into(self) -> &'static str {
+        match self {
+            ServerSideEncryption::Aes256 => "AES256",
+            ServerSideEncryption::AwsKms => "aws:kms",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ServerSideEncryption {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AES256" => Ok(ServerSideEncryption::Aes256),
+            "aws:kms" => Ok(ServerSideEncryption::AwsKms),
+            _ => Err(()),
+        }
+    }
+}
+
 struct SizeDeserializer;
 impl SizeDeserializer {
     #[allow(unused_variables)]
@@ -11611,6 +12675,44 @@ impl StartAfterSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StorageClass {
+    ReducedRedundancy,
+    Standard,
+    StandardIa,
+}
+
+impl Into<String> for StorageClass {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StorageClass {
+    fn into(self) -> &'static str {
+        match self {
+            StorageClass::ReducedRedundancy => "REDUCED_REDUNDANCY",
+            StorageClass::Standard => "STANDARD",
+            StorageClass::StandardIa => "STANDARD_IA",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StorageClass {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "REDUCED_REDUNDANCY" => Ok(StorageClass::ReducedRedundancy),
+            "STANDARD" => Ok(StorageClass::Standard),
+            "STANDARD_IA" => Ok(StorageClass::StandardIa),
+            _ => Err(()),
+        }
     }
 }
 
@@ -11786,6 +12888,38 @@ impl StorageClassAnalysisDataExportSerializer {
                                                              value = obj.output_schema_version)))?;
         writer.write(xml::writer::XmlEvent::end_element())?;
         writer.write(xml::writer::XmlEvent::end_element())
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StorageClassAnalysisSchemaVersion {
+    V1,
+}
+
+impl Into<String> for StorageClassAnalysisSchemaVersion {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StorageClassAnalysisSchemaVersion {
+    fn into(self) -> &'static str {
+        match self {
+            StorageClassAnalysisSchemaVersion::V1 => "V_1",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StorageClassAnalysisSchemaVersion {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "V_1" => Ok(StorageClassAnalysisSchemaVersion::V1),
+            _ => Err(()),
+        }
     }
 }
 
@@ -12009,6 +13143,41 @@ impl TaggingSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TaggingDirective {
+    Copy,
+    Replace,
+}
+
+impl Into<String> for TaggingDirective {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TaggingDirective {
+    fn into(self) -> &'static str {
+        match self {
+            TaggingDirective::Copy => "COPY",
+            TaggingDirective::Replace => "REPLACE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TaggingDirective {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COPY" => Ok(TaggingDirective::Copy),
+            "REPLACE" => Ok(TaggingDirective::Replace),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TargetBucketDeserializer;
 impl TargetBucketDeserializer {
     #[allow(unused_variables)]
@@ -12208,6 +13377,44 @@ impl TargetPrefixSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Tier {
+    Bulk,
+    Expedited,
+    Standard,
+}
+
+impl Into<String> for Tier {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Tier {
+    fn into(self) -> &'static str {
+        match self {
+            Tier::Bulk => "Bulk",
+            Tier::Expedited => "Expedited",
+            Tier::Standard => "Standard",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Tier {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Bulk" => Ok(Tier::Bulk),
+            "Expedited" => Ok(Tier::Expedited),
+            "Standard" => Ok(Tier::Standard),
+            _ => Err(()),
+        }
     }
 }
 
@@ -12650,6 +13857,41 @@ impl TransitionListSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TransitionStorageClass {
+    Glacier,
+    StandardIa,
+}
+
+impl Into<String> for TransitionStorageClass {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TransitionStorageClass {
+    fn into(self) -> &'static str {
+        match self {
+            TransitionStorageClass::Glacier => "GLACIER",
+            TransitionStorageClass::StandardIa => "STANDARD_IA",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TransitionStorageClass {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GLACIER" => Ok(TransitionStorageClass::Glacier),
+            "STANDARD_IA" => Ok(TransitionStorageClass::StandardIa),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TransitionStorageClassDeserializer;
 impl TransitionStorageClassDeserializer {
     #[allow(unused_variables)]
@@ -12679,6 +13921,44 @@ impl TransitionStorageClassSerializer {
         writer.write(xml::writer::XmlEvent::characters(&format!("{value}", value = obj.to_string())))?;
         writer.write(xml::writer::XmlEvent::end_element())
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Type {
+    AmazonCustomerByEmail,
+    CanonicalUser,
+    Group,
+}
+
+impl Into<String> for Type {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Type {
+    fn into(self) -> &'static str {
+        match self {
+            Type::AmazonCustomerByEmail => "AmazonCustomerByEmail",
+            Type::CanonicalUser => "CanonicalUser",
+            Type::Group => "Group",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Type {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AmazonCustomerByEmail" => Ok(Type::AmazonCustomerByEmail),
+            "CanonicalUser" => Ok(Type::CanonicalUser),
+            "Group" => Ok(Type::Group),
+            _ => Err(()),
+        }
     }
 }
 
@@ -18649,9 +19929,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18719,9 +19999,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -18927,9 +20207,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19055,9 +20335,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19203,9 +20483,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19286,9 +20566,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -19323,9 +20603,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -19358,9 +20638,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -19395,9 +20675,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -19430,9 +20710,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -19466,9 +20746,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -19501,9 +20781,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -19536,9 +20816,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -19572,9 +20852,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -19607,9 +20887,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -19651,9 +20931,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19716,9 +20996,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19785,9 +21065,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19840,9 +21120,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19890,9 +21170,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19943,9 +21223,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -19994,9 +21274,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20047,9 +21327,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20098,9 +21378,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20151,9 +21431,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20202,9 +21482,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20254,9 +21534,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20308,9 +21588,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20360,9 +21640,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20411,9 +21691,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20463,9 +21743,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -20504,9 +21784,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20557,9 +21837,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20608,9 +21888,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20660,9 +21940,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20712,9 +21992,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -20823,9 +22103,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
 
 
@@ -20991,9 +22271,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21048,9 +22328,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21106,9 +22386,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
 
 
@@ -21145,9 +22425,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -21221,9 +22501,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21390,9 +22670,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21444,9 +22724,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21498,9 +22778,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21545,9 +22825,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21614,9 +22894,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21684,9 +22964,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21753,9 +23033,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21828,9 +23108,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21886,9 +23166,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -21955,9 +23235,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22026,9 +23306,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22069,9 +23349,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22115,9 +23395,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22158,9 +23438,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22213,9 +23493,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22264,9 +23544,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22310,9 +23590,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22353,9 +23633,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22397,9 +23677,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22440,9 +23720,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22483,9 +23763,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22530,9 +23810,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22575,9 +23855,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22621,9 +23901,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22670,9 +23950,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22715,9 +23995,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
                 let result = ();
 
                 Ok(result)
@@ -22850,9 +24130,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -22987,9 +24267,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23052,9 +24332,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23124,9 +24404,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23206,9 +24486,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();
@@ -23350,9 +24630,9 @@ impl<P, D> S3 for S3Client<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok |
-            StatusCode::NoContent |
-            StatusCode::PartialContent => {
+            ::hyper::status::StatusCode::Ok |
+            ::hyper::status::StatusCode::NoContent |
+            ::hyper::status::StatusCode::PartialContent => {
 
                 let mut result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -2027,7 +2023,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -2055,7 +2051,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -2081,7 +2077,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -2109,7 +2105,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -2135,7 +2131,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -2163,7 +2159,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -2210,7 +2206,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -2257,7 +2253,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -2302,7 +2298,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -2328,7 +2324,7 @@ impl<P, D> SimpleDb for SimpleDbClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -53,6 +49,44 @@ pub struct AccessLevelFilter {
     #[serde(rename="Value")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AccessLevelFilterKey {
+    Account,
+    Role,
+    User,
+}
+
+impl Into<String> for AccessLevelFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AccessLevelFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            AccessLevelFilterKey::Account => "Account",
+            AccessLevelFilterKey::Role => "Role",
+            AccessLevelFilterKey::User => "User",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AccessLevelFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Account" => Ok(AccessLevelFilterKey::Account),
+            "Role" => Ok(AccessLevelFilterKey::Role),
+            "User" => Ok(AccessLevelFilterKey::User),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1176,6 +1210,105 @@ pub struct Principal {
     pub principal_type: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PrincipalType {
+    Iam,
+}
+
+impl Into<String> for PrincipalType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PrincipalType {
+    fn into(self) -> &'static str {
+        match self {
+            PrincipalType::Iam => "IAM",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PrincipalType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IAM" => Ok(PrincipalType::Iam),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProductSource {
+    Account,
+}
+
+impl Into<String> for ProductSource {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProductSource {
+    fn into(self) -> &'static str {
+        match self {
+            ProductSource::Account => "ACCOUNT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProductSource {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACCOUNT" => Ok(ProductSource::Account),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProductType {
+    CloudFormationTemplate,
+    Marketplace,
+}
+
+impl Into<String> for ProductType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProductType {
+    fn into(self) -> &'static str {
+        match self {
+            ProductType::CloudFormationTemplate => "CLOUD_FORMATION_TEMPLATE",
+            ProductType::Marketplace => "MARKETPLACE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProductType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLOUD_FORMATION_TEMPLATE" => Ok(ProductType::CloudFormationTemplate),
+            "MARKETPLACE" => Ok(ProductType::Marketplace),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>A single product view aggregation value/count pair, containing metadata about each product to which the calling user has access.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ProductViewAggregationValue {
@@ -1208,6 +1341,85 @@ pub struct ProductViewDetail {
     #[serde(rename="Status")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProductViewFilterBy {
+    FullTextSearch,
+    Owner,
+    ProductType,
+    SourceProductId,
+}
+
+impl Into<String> for ProductViewFilterBy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProductViewFilterBy {
+    fn into(self) -> &'static str {
+        match self {
+            ProductViewFilterBy::FullTextSearch => "FullTextSearch",
+            ProductViewFilterBy::Owner => "Owner",
+            ProductViewFilterBy::ProductType => "ProductType",
+            ProductViewFilterBy::SourceProductId => "SourceProductId",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProductViewFilterBy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FullTextSearch" => Ok(ProductViewFilterBy::FullTextSearch),
+            "Owner" => Ok(ProductViewFilterBy::Owner),
+            "ProductType" => Ok(ProductViewFilterBy::ProductType),
+            "SourceProductId" => Ok(ProductViewFilterBy::SourceProductId),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProductViewSortBy {
+    CreationDate,
+    Title,
+    VersionCount,
+}
+
+impl Into<String> for ProductViewSortBy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProductViewSortBy {
+    fn into(self) -> &'static str {
+        match self {
+            ProductViewSortBy::CreationDate => "CreationDate",
+            ProductViewSortBy::Title => "Title",
+            ProductViewSortBy::VersionCount => "VersionCount",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProductViewSortBy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CreationDate" => Ok(ProductViewSortBy::CreationDate),
+            "Title" => Ok(ProductViewSortBy::Title),
+            "VersionCount" => Ok(ProductViewSortBy::VersionCount),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The summary metadata about the specified product.</p>"]
@@ -1344,6 +1556,47 @@ pub struct ProvisionedProductDetail {
     pub type_: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProvisionedProductStatus {
+    Available,
+    Error,
+    Tainted,
+    UnderChange,
+}
+
+impl Into<String> for ProvisionedProductStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProvisionedProductStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ProvisionedProductStatus::Available => "AVAILABLE",
+            ProvisionedProductStatus::Error => "ERROR",
+            ProvisionedProductStatus::Tainted => "TAINTED",
+            ProvisionedProductStatus::UnderChange => "UNDER_CHANGE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProvisionedProductStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(ProvisionedProductStatus::Available),
+            "ERROR" => Ok(ProvisionedProductStatus::Error),
+            "TAINTED" => Ok(ProvisionedProductStatus::Tainted),
+            "UNDER_CHANGE" => Ok(ProvisionedProductStatus::UnderChange),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information indicating the ways in which a product can be provisioned.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ProvisioningArtifact {
@@ -1464,6 +1717,44 @@ pub struct ProvisioningArtifactSummary {
     pub provisioning_artifact_metadata: Option<::std::collections::HashMap<String, String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ProvisioningArtifactType {
+    CloudFormationTemplate,
+    MarketplaceAmi,
+    MarketplaceCar,
+}
+
+impl Into<String> for ProvisioningArtifactType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ProvisioningArtifactType {
+    fn into(self) -> &'static str {
+        match self {
+            ProvisioningArtifactType::CloudFormationTemplate => "CLOUD_FORMATION_TEMPLATE",
+            ProvisioningArtifactType::MarketplaceAmi => "MARKETPLACE_AMI",
+            ProvisioningArtifactType::MarketplaceCar => "MARKETPLACE_CAR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ProvisioningArtifactType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLOUD_FORMATION_TEMPLATE" => Ok(ProvisioningArtifactType::CloudFormationTemplate),
+            "MARKETPLACE_AMI" => Ok(ProvisioningArtifactType::MarketplaceAmi),
+            "MARKETPLACE_CAR" => Ok(ProvisioningArtifactType::MarketplaceCar),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The parameter key-value pairs used to provision a product.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ProvisioningParameter {
@@ -1562,6 +1853,50 @@ pub struct RecordOutput {
     #[serde(rename="OutputValue")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub output_value: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RecordStatus {
+    Created,
+    Failed,
+    InProgress,
+    InProgressInError,
+    Succeeded,
+}
+
+impl Into<String> for RecordStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RecordStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RecordStatus::Created => "CREATED",
+            RecordStatus::Failed => "FAILED",
+            RecordStatus::InProgress => "IN_PROGRESS",
+            RecordStatus::InProgressInError => "IN_PROGRESS_IN_ERROR",
+            RecordStatus::Succeeded => "SUCCEEDED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RecordStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CREATED" => Ok(RecordStatus::Created),
+            "FAILED" => Ok(RecordStatus::Failed),
+            "IN_PROGRESS" => Ok(RecordStatus::InProgress),
+            "IN_PROGRESS_IN_ERROR" => Ok(RecordStatus::InProgressInError),
+            "SUCCEEDED" => Ok(RecordStatus::Succeeded),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A tag associated with the record, stored as a key-value pair.</p>"]
@@ -1739,6 +2074,79 @@ pub struct SearchProductsOutput {
     #[serde(rename="ProductViewSummaries")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub product_view_summaries: Option<Vec<ProductViewSummary>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SortOrder {
+    Ascending,
+    Descending,
+}
+
+impl Into<String> for SortOrder {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SortOrder {
+    fn into(self) -> &'static str {
+        match self {
+            SortOrder::Ascending => "ASCENDING",
+            SortOrder::Descending => "DESCENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SortOrder {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASCENDING" => Ok(SortOrder::Ascending),
+            "DESCENDING" => Ok(SortOrder::Descending),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Status {
+    Available,
+    Creating,
+    Failed,
+}
+
+impl Into<String> for Status {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Status {
+    fn into(self) -> &'static str {
+        match self {
+            Status::Available => "AVAILABLE",
+            Status::Creating => "CREATING",
+            Status::Failed => "FAILED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Status {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(Status::Available),
+            "CREATING" => Ok(Status::Creating),
+            "FAILED" => Ok(Status::Failed),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Key-value pairs to associate with this provisioning. These tags are entirely discretionary and are propagated to the resources created in the provisioning.</p>"]
@@ -6850,7 +7258,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AcceptPortfolioShareOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6882,7 +7290,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AssociatePrincipalWithPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6915,7 +7323,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AssociateProductWithPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6948,7 +7356,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AssociateTagOptionWithResourceOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6980,7 +7388,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateConstraintOutput>(String::from_utf8_lossy(&body)
@@ -7013,7 +7421,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreatePortfolioOutput>(String::from_utf8_lossy(&body)
@@ -7046,7 +7454,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreatePortfolioShareOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7076,7 +7484,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateProductOutput>(String::from_utf8_lossy(&body)
@@ -7110,7 +7518,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateProvisioningArtifactOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7142,7 +7550,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateTagOptionOutput>(String::from_utf8_lossy(&body)
@@ -7175,7 +7583,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteConstraintOutput>(String::from_utf8_lossy(&body)
@@ -7208,7 +7616,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeletePortfolioOutput>(String::from_utf8_lossy(&body)
@@ -7241,7 +7649,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeletePortfolioShareOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7271,7 +7679,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteProductOutput>(String::from_utf8_lossy(&body)
@@ -7305,7 +7713,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteProvisioningArtifactOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7337,7 +7745,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeConstraintOutput>(String::from_utf8_lossy(&body)
@@ -7370,7 +7778,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribePortfolioOutput>(String::from_utf8_lossy(&body)
@@ -7403,7 +7811,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeProductOutput>(String::from_utf8_lossy(&body)
@@ -7437,7 +7845,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeProductAsAdminOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7468,7 +7876,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeProductViewOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7500,7 +7908,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeProvisionedProductOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7533,7 +7941,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeProvisioningArtifactOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7566,7 +7974,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeProvisioningParametersOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7597,7 +8005,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeRecordOutput>(String::from_utf8_lossy(&body)
@@ -7630,7 +8038,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTagOptionOutput>(String::from_utf8_lossy(&body)
@@ -7665,7 +8073,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisassociatePrincipalFromPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7697,7 +8105,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisassociateProductFromPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7729,7 +8137,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisassociateTagOptionFromResourceOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7761,7 +8169,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAcceptedPortfolioSharesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7794,7 +8202,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListConstraintsForPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7826,7 +8234,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListLaunchPathsOutput>(String::from_utf8_lossy(&body)
@@ -7859,7 +8267,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListPortfolioAccessOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7889,7 +8297,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListPortfoliosOutput>(String::from_utf8_lossy(&body)
@@ -7923,7 +8331,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListPortfoliosForProductOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7956,7 +8364,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListPrincipalsForPortfolioOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7989,7 +8397,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListProvisioningArtifactsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8021,7 +8429,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRecordHistoryOutput>(String::from_utf8_lossy(&body)
@@ -8055,7 +8463,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListResourcesForTagOptionOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8086,7 +8494,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagOptionsOutput>(String::from_utf8_lossy(&body)
@@ -8119,7 +8527,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ProvisionProductOutput>(String::from_utf8_lossy(&body)
@@ -8152,7 +8560,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RejectPortfolioShareOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8184,7 +8592,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ScanProvisionedProductsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8215,7 +8623,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SearchProductsOutput>(String::from_utf8_lossy(&body)
@@ -8249,7 +8657,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SearchProductsAsAdminOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8281,7 +8689,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<TerminateProvisionedProductOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8313,7 +8721,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateConstraintOutput>(String::from_utf8_lossy(&body)
@@ -8346,7 +8754,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdatePortfolioOutput>(String::from_utf8_lossy(&body)
@@ -8378,7 +8786,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateProductOutput>(String::from_utf8_lossy(&body)
@@ -8412,7 +8820,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateProvisionedProductOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8445,7 +8853,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateProvisioningArtifactOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8477,7 +8885,7 @@ impl<P, D> ServiceCatalog for ServiceCatalogClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateTagOptionOutput>(String::from_utf8_lossy(&body)

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -193,6 +189,41 @@ impl AmazonResourceNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BehaviorOnMXFailure {
+    RejectMessage,
+    UseDefaultValue,
+}
+
+impl Into<String> for BehaviorOnMXFailure {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BehaviorOnMXFailure {
+    fn into(self) -> &'static str {
+        match self {
+            BehaviorOnMXFailure::RejectMessage => "RejectMessage",
+            BehaviorOnMXFailure::UseDefaultValue => "UseDefaultValue",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BehaviorOnMXFailure {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RejectMessage" => Ok(BehaviorOnMXFailure::RejectMessage),
+            "UseDefaultValue" => Ok(BehaviorOnMXFailure::UseDefaultValue),
+            _ => Err(()),
+        }
+    }
+}
+
 struct BehaviorOnMXFailureDeserializer;
 impl BehaviorOnMXFailureDeserializer {
     #[allow(unused_variables)]
@@ -381,6 +412,53 @@ impl BounceStatusCodeDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum BounceType {
+    ContentRejected,
+    DoesNotExist,
+    ExceededQuota,
+    MessageTooLarge,
+    TemporaryFailure,
+    Undefined,
+}
+
+impl Into<String> for BounceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for BounceType {
+    fn into(self) -> &'static str {
+        match self {
+            BounceType::ContentRejected => "ContentRejected",
+            BounceType::DoesNotExist => "DoesNotExist",
+            BounceType::ExceededQuota => "ExceededQuota",
+            BounceType::MessageTooLarge => "MessageTooLarge",
+            BounceType::TemporaryFailure => "TemporaryFailure",
+            BounceType::Undefined => "Undefined",
+        }
+    }
+}
+
+impl ::std::str::FromStr for BounceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ContentRejected" => Ok(BounceType::ContentRejected),
+            "DoesNotExist" => Ok(BounceType::DoesNotExist),
+            "ExceededQuota" => Ok(BounceType::ExceededQuota),
+            "MessageTooLarge" => Ok(BounceType::MessageTooLarge),
+            "TemporaryFailure" => Ok(BounceType::TemporaryFailure),
+            "Undefined" => Ok(BounceType::Undefined),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Recipient-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html\">Amazon SES Developer Guide</a>.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct BouncedRecipientInfo {
@@ -768,6 +846,38 @@ impl ConfigurationSetSerializer {
 }
 
 
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConfigurationSetAttribute {
+    EventDestinations,
+}
+
+impl Into<String> for ConfigurationSetAttribute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConfigurationSetAttribute {
+    fn into(self) -> &'static str {
+        match self {
+            ConfigurationSetAttribute::EventDestinations => "eventDestinations",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConfigurationSetAttribute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "eventDestinations" => Ok(ConfigurationSetAttribute::EventDestinations),
+            _ => Err(()),
+        }
+    }
+}
+
+
 /// Serialize `ConfigurationSetAttributeList` contents to a `SignedRequest`.
 struct ConfigurationSetAttributeListSerializer;
 impl ConfigurationSetAttributeListSerializer {
@@ -1109,6 +1219,47 @@ impl CreateReceiptRuleSetResponseDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CustomMailFromStatus {
+    Failed,
+    Pending,
+    Success,
+    TemporaryFailure,
+}
+
+impl Into<String> for CustomMailFromStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CustomMailFromStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CustomMailFromStatus::Failed => "Failed",
+            CustomMailFromStatus::Pending => "Pending",
+            CustomMailFromStatus::Success => "Success",
+            CustomMailFromStatus::TemporaryFailure => "TemporaryFailure",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CustomMailFromStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(CustomMailFromStatus::Failed),
+            "Pending" => Ok(CustomMailFromStatus::Pending),
+            "Success" => Ok(CustomMailFromStatus::Success),
+            "TemporaryFailure" => Ok(CustomMailFromStatus::TemporaryFailure),
+            _ => Err(()),
+        }
+    }
+}
+
 struct CustomMailFromStatusDeserializer;
 impl CustomMailFromStatusDeserializer {
     #[allow(unused_variables)]
@@ -1853,6 +2004,44 @@ impl DimensionNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DimensionValueSource {
+    EmailHeader,
+    LinkTag,
+    MessageTag,
+}
+
+impl Into<String> for DimensionValueSource {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DimensionValueSource {
+    fn into(self) -> &'static str {
+        match self {
+            DimensionValueSource::EmailHeader => "emailHeader",
+            DimensionValueSource::LinkTag => "linkTag",
+            DimensionValueSource::MessageTag => "messageTag",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DimensionValueSource {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "emailHeader" => Ok(DimensionValueSource::EmailHeader),
+            "linkTag" => Ok(DimensionValueSource::LinkTag),
+            "messageTag" => Ok(DimensionValueSource::MessageTag),
+            _ => Err(()),
+        }
+    }
+}
+
 struct DimensionValueSourceDeserializer;
 impl DimensionValueSourceDeserializer {
     #[allow(unused_variables)]
@@ -1891,6 +2080,50 @@ impl DkimAttributesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DsnAction {
+    Delayed,
+    Delivered,
+    Expanded,
+    Failed,
+    Relayed,
+}
+
+impl Into<String> for DsnAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DsnAction {
+    fn into(self) -> &'static str {
+        match self {
+            DsnAction::Delayed => "delayed",
+            DsnAction::Delivered => "delivered",
+            DsnAction::Expanded => "expanded",
+            DsnAction::Failed => "failed",
+            DsnAction::Relayed => "relayed",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DsnAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "delayed" => Ok(DsnAction::Delayed),
+            "delivered" => Ok(DsnAction::Delivered),
+            "expanded" => Ok(DsnAction::Expanded),
+            "failed" => Ok(DsnAction::Failed),
+            "relayed" => Ok(DsnAction::Relayed),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EnabledDeserializer;
 impl EnabledDeserializer {
     #[allow(unused_variables)]
@@ -1898,7 +2131,7 @@ impl EnabledDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -2083,6 +2316,56 @@ impl EventDestinationsDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventType {
+    Bounce,
+    Click,
+    Complaint,
+    Delivery,
+    Open,
+    Reject,
+    Send,
+}
+
+impl Into<String> for EventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventType {
+    fn into(self) -> &'static str {
+        match self {
+            EventType::Bounce => "bounce",
+            EventType::Click => "click",
+            EventType::Complaint => "complaint",
+            EventType::Delivery => "delivery",
+            EventType::Open => "open",
+            EventType::Reject => "reject",
+            EventType::Send => "send",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bounce" => Ok(EventType::Bounce),
+            "click" => Ok(EventType::Click),
+            "complaint" => Ok(EventType::Complaint),
+            "delivery" => Ok(EventType::Delivery),
+            "open" => Ok(EventType::Open),
+            "reject" => Ok(EventType::Reject),
+            "send" => Ok(EventType::Send),
+            _ => Err(()),
+        }
+    }
+}
+
 struct EventTypeDeserializer;
 impl EventTypeDeserializer {
     #[allow(unused_variables)]
@@ -2999,6 +3282,41 @@ impl IdentityNotificationAttributesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IdentityType {
+    Domain,
+    EmailAddress,
+}
+
+impl Into<String> for IdentityType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IdentityType {
+    fn into(self) -> &'static str {
+        match self {
+            IdentityType::Domain => "Domain",
+            IdentityType::EmailAddress => "EmailAddress",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IdentityType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Domain" => Ok(IdentityType::Domain),
+            "EmailAddress" => Ok(IdentityType::EmailAddress),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents the verification attributes of a single identity.</p>"]
 #[derive(Default,Debug,Clone)]
 pub struct IdentityVerificationAttributes {
@@ -3056,6 +3374,41 @@ impl IdentityVerificationAttributesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InvocationType {
+    Event,
+    RequestResponse,
+}
+
+impl Into<String> for InvocationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InvocationType {
+    fn into(self) -> &'static str {
+        match self {
+            InvocationType::Event => "Event",
+            InvocationType::RequestResponse => "RequestResponse",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InvocationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Event" => Ok(InvocationType::Event),
+            "RequestResponse" => Ok(InvocationType::RequestResponse),
+            _ => Err(()),
+        }
+    }
+}
+
 struct InvocationTypeDeserializer;
 impl InvocationTypeDeserializer {
     #[allow(unused_variables)]
@@ -3921,6 +4274,44 @@ impl NotificationTopicDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NotificationType {
+    Bounce,
+    Complaint,
+    Delivery,
+}
+
+impl Into<String> for NotificationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NotificationType {
+    fn into(self) -> &'static str {
+        match self {
+            NotificationType::Bounce => "Bounce",
+            NotificationType::Complaint => "Complaint",
+            NotificationType::Delivery => "Delivery",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NotificationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Bounce" => Ok(NotificationType::Bounce),
+            "Complaint" => Ok(NotificationType::Complaint),
+            "Delivery" => Ok(NotificationType::Delivery),
+            _ => Err(()),
+        }
+    }
+}
+
 struct PolicyDeserializer;
 impl PolicyDeserializer {
     #[allow(unused_variables)]
@@ -4423,6 +4814,41 @@ impl ReceiptFilterNameDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReceiptFilterPolicy {
+    Allow,
+    Block,
+}
+
+impl Into<String> for ReceiptFilterPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReceiptFilterPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            ReceiptFilterPolicy::Allow => "Allow",
+            ReceiptFilterPolicy::Block => "Block",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReceiptFilterPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Allow" => Ok(ReceiptFilterPolicy::Allow),
+            "Block" => Ok(ReceiptFilterPolicy::Block),
+            _ => Err(()),
+        }
+    }
+}
+
 struct ReceiptFilterPolicyDeserializer;
 impl ReceiptFilterPolicyDeserializer {
     #[allow(unused_variables)]
@@ -5181,6 +5607,41 @@ impl SNSActionSerializer {
         params.put(&format!("{}{}", prefix, "TopicArn"),
                    &obj.topic_arn.replace("+", "%2B"));
 
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SNSActionEncoding {
+    Base64,
+    Utf8,
+}
+
+impl Into<String> for SNSActionEncoding {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SNSActionEncoding {
+    fn into(self) -> &'static str {
+        match self {
+            SNSActionEncoding::Base64 => "Base64",
+            SNSActionEncoding::Utf8 => "UTF-8",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SNSActionEncoding {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Base64" => Ok(SNSActionEncoding::Base64),
+            "UTF-8" => Ok(SNSActionEncoding::Utf8),
+            _ => Err(()),
+        }
     }
 }
 
@@ -6165,6 +6626,38 @@ impl StopActionSerializer {
     }
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StopScope {
+    RuleSet,
+}
+
+impl Into<String> for StopScope {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StopScope {
+    fn into(self) -> &'static str {
+        match self {
+            StopScope::RuleSet => "RuleSet",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StopScope {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RuleSet" => Ok(StopScope::RuleSet),
+            _ => Err(()),
+        }
+    }
+}
+
 struct StopScopeDeserializer;
 impl StopScopeDeserializer {
     #[allow(unused_variables)]
@@ -6193,6 +6686,41 @@ impl TimestampDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TlsPolicy {
+    Optional,
+    Require,
+}
+
+impl Into<String> for TlsPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TlsPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            TlsPolicy::Optional => "Optional",
+            TlsPolicy::Require => "Require",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TlsPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Optional" => Ok(TlsPolicy::Optional),
+            "Require" => Ok(TlsPolicy::Require),
+            _ => Err(()),
+        }
+    }
+}
+
 struct TlsPolicyDeserializer;
 impl TlsPolicyDeserializer {
     #[allow(unused_variables)]
@@ -6330,6 +6858,50 @@ impl VerificationAttributesDeserializer {
 
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VerificationStatus {
+    Failed,
+    NotStarted,
+    Pending,
+    Success,
+    TemporaryFailure,
+}
+
+impl Into<String> for VerificationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VerificationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            VerificationStatus::Failed => "Failed",
+            VerificationStatus::NotStarted => "NotStarted",
+            VerificationStatus::Pending => "Pending",
+            VerificationStatus::Success => "Success",
+            VerificationStatus::TemporaryFailure => "TemporaryFailure",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VerificationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(VerificationStatus::Failed),
+            "NotStarted" => Ok(VerificationStatus::NotStarted),
+            "Pending" => Ok(VerificationStatus::Pending),
+            "Success" => Ok(VerificationStatus::Success),
+            "TemporaryFailure" => Ok(VerificationStatus::TemporaryFailure),
+            _ => Err(()),
+        }
+    }
+}
+
 struct VerificationStatusDeserializer;
 impl VerificationStatusDeserializer {
     #[allow(unused_variables)]
@@ -10666,7 +11238,7 @@ impl<P, D> Ses for SesClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -10714,7 +11286,7 @@ impl<P, D> Ses for SesClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -10760,7 +11332,7 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -10806,7 +11378,7 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -10853,7 +11425,7 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -10901,7 +11473,7 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -10950,7 +11522,7 @@ fn create_configuration_set_event_destination(&self, input: &CreateConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -10996,7 +11568,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11042,7 +11614,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11090,7 +11662,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11138,7 +11710,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11185,7 +11757,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11233,7 +11805,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11281,7 +11853,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -11311,7 +11883,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11359,7 +11931,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11408,7 +11980,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11456,7 +12028,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11505,7 +12077,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11554,7 +12126,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11602,7 +12174,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11648,7 +12220,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11697,7 +12269,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11741,7 +12313,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11786,7 +12358,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11834,7 +12406,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11882,7 +12454,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11930,7 +12502,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -11978,7 +12550,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12025,7 +12597,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12072,7 +12644,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12119,7 +12691,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12167,7 +12739,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12215,7 +12787,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12260,7 +12832,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12307,7 +12879,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12355,7 +12927,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12405,7 +12977,7 @@ fn delete_configuration_set_event_destination(&self, input: &DeleteConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12451,7 +13023,7 @@ fn set_identity_feedback_forwarding_enabled(&self, input: &SetIdentityFeedbackFo
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12497,7 +13069,7 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12544,7 +13116,7 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12592,7 +13164,7 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12640,7 +13212,7 @@ fn set_identity_headers_in_notifications_enabled(&self, input: &SetIdentityHeade
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12686,7 +13258,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12732,7 +13304,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12779,7 +13351,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12827,7 +13399,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -12875,7 +13447,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -12903,7 +13475,7 @@ fn update_configuration_set_event_destination(&self, input: &UpdateConfiguration
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/shield/src/generated.rs
+++ b/rusoto/services/shield/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -280,6 +276,41 @@ pub struct SubResourceSummary {
     #[serde(rename="Type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SubResourceType {
+    Ip,
+    Url,
+}
+
+impl Into<String> for SubResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SubResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            SubResourceType::Ip => "IP",
+            SubResourceType::Url => "URL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SubResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IP" => Ok(SubResourceType::Ip),
+            "URL" => Ok(SubResourceType::Url),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about the AWS Shield Advanced subscription for an account.</p>"]
@@ -1263,7 +1294,7 @@ impl<P, D> Shield for ShieldClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateProtectionResponse>(String::from_utf8_lossy(&body)
@@ -1292,7 +1323,7 @@ impl<P, D> Shield for ShieldClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateSubscriptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1322,7 +1353,7 @@ impl<P, D> Shield for ShieldClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteProtectionResponse>(String::from_utf8_lossy(&body)
@@ -1351,7 +1382,7 @@ impl<P, D> Shield for ShieldClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteSubscriptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1381,7 +1412,7 @@ impl<P, D> Shield for ShieldClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAttackResponse>(String::from_utf8_lossy(&body)
@@ -1413,7 +1444,7 @@ impl<P, D> Shield for ShieldClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeProtectionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1441,7 +1472,7 @@ impl<P, D> Shield for ShieldClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeSubscriptionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1471,7 +1502,7 @@ impl<P, D> Shield for ShieldClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAttacksResponse>(String::from_utf8_lossy(&body)
@@ -1503,7 +1534,7 @@ impl<P, D> Shield for ShieldClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListProtectionsResponse>(String::from_utf8_lossy(&body)

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -61,6 +57,73 @@ pub struct Connector {
     #[serde(rename="vmManagerType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vm_manager_type: Option<String>,
+}
+
+#[doc="Capabilities for a Connector"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConnectorCapability {
+    Vsphere,
+}
+
+impl Into<String> for ConnectorCapability {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConnectorCapability {
+    fn into(self) -> &'static str {
+        match self {
+            ConnectorCapability::Vsphere => "VSPHERE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConnectorCapability {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "VSPHERE" => Ok(ConnectorCapability::Vsphere),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Status of on-premise Connector"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConnectorStatus {
+    Healthy,
+    Unhealthy,
+}
+
+impl Into<String> for ConnectorStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConnectorStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ConnectorStatus::Healthy => "HEALTHY",
+            ConnectorStatus::Unhealthy => "UNHEALTHY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConnectorStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HEALTHY" => Ok(ConnectorStatus::Healthy),
+            "UNHEALTHY" => Ok(ConnectorStatus::Unhealthy),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -213,6 +276,41 @@ pub struct ImportServerCatalogRequest;
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ImportServerCatalogResponse;
 
+#[doc="The license type to be used for the Amazon Machine Image (AMI) created after a successful ReplicationRun."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LicenseType {
+    Aws,
+    Byol,
+}
+
+impl Into<String> for LicenseType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LicenseType {
+    fn into(self) -> &'static str {
+        match self {
+            LicenseType::Aws => "AWS",
+            LicenseType::Byol => "BYOL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LicenseType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AWS" => Ok(LicenseType::Aws),
+            "BYOL" => Ok(LicenseType::Byol),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="Object representing a Replication Job"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ReplicationJob {
@@ -260,6 +358,50 @@ pub struct ReplicationJob {
     pub vm_server: Option<VmServer>,
 }
 
+#[doc="Current state of Replication Job"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationJobState {
+    Active,
+    Deleted,
+    Deleting,
+    Failed,
+    Pending,
+}
+
+impl Into<String> for ReplicationJobState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationJobState {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationJobState::Active => "ACTIVE",
+            ReplicationJobState::Deleted => "DELETED",
+            ReplicationJobState::Deleting => "DELETING",
+            ReplicationJobState::Failed => "FAILED",
+            ReplicationJobState::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationJobState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(ReplicationJobState::Active),
+            "DELETED" => Ok(ReplicationJobState::Deleted),
+            "DELETING" => Ok(ReplicationJobState::Deleting),
+            "FAILED" => Ok(ReplicationJobState::Failed),
+            "PENDING" => Ok(ReplicationJobState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="Object representing a Replication Run"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ReplicationRun {
@@ -289,6 +431,91 @@ pub struct ReplicationRun {
     pub type_: Option<String>,
 }
 
+#[doc="Current state of Replication Run"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationRunState {
+    Active,
+    Completed,
+    Deleted,
+    Deleting,
+    Failed,
+    Missed,
+    Pending,
+}
+
+impl Into<String> for ReplicationRunState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationRunState {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationRunState::Active => "ACTIVE",
+            ReplicationRunState::Completed => "COMPLETED",
+            ReplicationRunState::Deleted => "DELETED",
+            ReplicationRunState::Deleting => "DELETING",
+            ReplicationRunState::Failed => "FAILED",
+            ReplicationRunState::Missed => "MISSED",
+            ReplicationRunState::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationRunState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(ReplicationRunState::Active),
+            "COMPLETED" => Ok(ReplicationRunState::Completed),
+            "DELETED" => Ok(ReplicationRunState::Deleted),
+            "DELETING" => Ok(ReplicationRunState::Deleting),
+            "FAILED" => Ok(ReplicationRunState::Failed),
+            "MISSED" => Ok(ReplicationRunState::Missed),
+            "PENDING" => Ok(ReplicationRunState::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Type of Replication Run"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ReplicationRunType {
+    Automatic,
+    OnDemand,
+}
+
+impl Into<String> for ReplicationRunType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ReplicationRunType {
+    fn into(self) -> &'static str {
+        match self {
+            ReplicationRunType::Automatic => "AUTOMATIC",
+            ReplicationRunType::OnDemand => "ON_DEMAND",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ReplicationRunType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AUTOMATIC" => Ok(ReplicationRunType::Automatic),
+            "ON_DEMAND" => Ok(ReplicationRunType::OnDemand),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="Object representing a server"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Server {
@@ -307,6 +534,82 @@ pub struct Server {
     #[serde(rename="vmServer")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub vm_server: Option<VmServer>,
+}
+
+#[doc="Status of Server catalog"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ServerCatalogStatus {
+    Available,
+    Deleted,
+    Expired,
+    Importing,
+    NotImported,
+}
+
+impl Into<String> for ServerCatalogStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ServerCatalogStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ServerCatalogStatus::Available => "AVAILABLE",
+            ServerCatalogStatus::Deleted => "DELETED",
+            ServerCatalogStatus::Expired => "EXPIRED",
+            ServerCatalogStatus::Importing => "IMPORTING",
+            ServerCatalogStatus::NotImported => "NOT_IMPORTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ServerCatalogStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(ServerCatalogStatus::Available),
+            "DELETED" => Ok(ServerCatalogStatus::Deleted),
+            "EXPIRED" => Ok(ServerCatalogStatus::Expired),
+            "IMPORTING" => Ok(ServerCatalogStatus::Importing),
+            "NOT_IMPORTED" => Ok(ServerCatalogStatus::NotImported),
+            _ => Err(()),
+        }
+    }
+}
+
+#[doc="Type of server."]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ServerType {
+    VirtualMachine,
+}
+
+impl Into<String> for ServerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ServerType {
+    fn into(self) -> &'static str {
+        match self {
+            ServerType::VirtualMachine => "VIRTUAL_MACHINE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ServerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "VIRTUAL_MACHINE" => Ok(ServerType::VirtualMachine),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -348,6 +651,38 @@ pub struct UpdateReplicationJobRequest {
 
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct UpdateReplicationJobResponse;
+
+#[doc="VM Management Product"]
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum VmManagerType {
+    Vsphere,
+}
+
+impl Into<String> for VmManagerType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for VmManagerType {
+    fn into(self) -> &'static str {
+        match self {
+            VmManagerType::Vsphere => "VSPHERE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for VmManagerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "VSPHERE" => Ok(VmManagerType::Vsphere),
+            _ => Err(()),
+        }
+    }
+}
 
 #[doc="Object representing a VM server"]
 #[derive(Default,Debug,Clone,Deserialize)]
@@ -1536,7 +1871,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateReplicationJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1568,7 +1903,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteReplicationJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1597,7 +1932,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteServerCatalogResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1629,7 +1964,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisassociateConnectorResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1660,7 +1995,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetConnectorsResponse>(String::from_utf8_lossy(&body)
@@ -1693,7 +2028,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetReplicationJobsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1724,7 +2059,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetReplicationRunsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1755,7 +2090,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetServersResponse>(String::from_utf8_lossy(&body)
@@ -1786,7 +2121,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ImportServerCatalogResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1818,7 +2153,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartOnDemandReplicationRunResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -1851,7 +2186,7 @@ impl<P, D> ServerMigrationService for ServerMigrationServiceClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateReplicationJobResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -185,6 +181,50 @@ pub struct ClusterMetadata {
     #[serde(rename="SnowballType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub snowball_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ClusterState {
+    AwaitingQuorum,
+    Cancelled,
+    Complete,
+    InUse,
+    Pending,
+}
+
+impl Into<String> for ClusterState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ClusterState {
+    fn into(self) -> &'static str {
+        match self {
+            ClusterState::AwaitingQuorum => "AwaitingQuorum",
+            ClusterState::Cancelled => "Cancelled",
+            ClusterState::Complete => "Complete",
+            ClusterState::InUse => "InUse",
+            ClusterState::Pending => "Pending",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ClusterState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AwaitingQuorum" => Ok(ClusterState::AwaitingQuorum),
+            "Cancelled" => Ok(ClusterState::Cancelled),
+            "Complete" => Ok(ClusterState::Complete),
+            "InUse" => Ok(ClusterState::InUse),
+            "Pending" => Ok(ClusterState::Pending),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -593,6 +633,109 @@ pub struct JobResource {
     pub s3_resources: Option<Vec<S3Resource>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobState {
+    Cancelled,
+    Complete,
+    InProgress,
+    InTransitToAWS,
+    InTransitToCustomer,
+    Listing,
+    New,
+    Pending,
+    PreparingAppliance,
+    PreparingShipment,
+    WithAWS,
+    WithCustomer,
+}
+
+impl Into<String> for JobState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobState {
+    fn into(self) -> &'static str {
+        match self {
+            JobState::Cancelled => "Cancelled",
+            JobState::Complete => "Complete",
+            JobState::InProgress => "InProgress",
+            JobState::InTransitToAWS => "InTransitToAWS",
+            JobState::InTransitToCustomer => "InTransitToCustomer",
+            JobState::Listing => "Listing",
+            JobState::New => "New",
+            JobState::Pending => "Pending",
+            JobState::PreparingAppliance => "PreparingAppliance",
+            JobState::PreparingShipment => "PreparingShipment",
+            JobState::WithAWS => "WithAWS",
+            JobState::WithCustomer => "WithCustomer",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(JobState::Cancelled),
+            "Complete" => Ok(JobState::Complete),
+            "InProgress" => Ok(JobState::InProgress),
+            "InTransitToAWS" => Ok(JobState::InTransitToAWS),
+            "InTransitToCustomer" => Ok(JobState::InTransitToCustomer),
+            "Listing" => Ok(JobState::Listing),
+            "New" => Ok(JobState::New),
+            "Pending" => Ok(JobState::Pending),
+            "PreparingAppliance" => Ok(JobState::PreparingAppliance),
+            "PreparingShipment" => Ok(JobState::PreparingShipment),
+            "WithAWS" => Ok(JobState::WithAWS),
+            "WithCustomer" => Ok(JobState::WithCustomer),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum JobType {
+    Export,
+    Import,
+    LocalUse,
+}
+
+impl Into<String> for JobType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for JobType {
+    fn into(self) -> &'static str {
+        match self {
+            JobType::Export => "EXPORT",
+            JobType::Import => "IMPORT",
+            JobType::LocalUse => "LOCAL_USE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for JobType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EXPORT" => Ok(JobType::Export),
+            "IMPORT" => Ok(JobType::Import),
+            "LOCAL_USE" => Ok(JobType::LocalUse),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains a key range. For export jobs, a <code>S3Resource</code> object can have an optional <code>KeyRange</code> value. The length of the range is defined at job creation, and has either an inclusive <code>BeginMarker</code>, an inclusive <code>EndMarker</code>, or both. Ranges are UTF-8 binary sorted.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KeyRange {
@@ -752,6 +895,123 @@ pub struct ShippingDetails {
     #[serde(rename="ShippingOption")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub shipping_option: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ShippingOption {
+    Express,
+    NextDay,
+    SecondDay,
+    Standard,
+}
+
+impl Into<String> for ShippingOption {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ShippingOption {
+    fn into(self) -> &'static str {
+        match self {
+            ShippingOption::Express => "EXPRESS",
+            ShippingOption::NextDay => "NEXT_DAY",
+            ShippingOption::SecondDay => "SECOND_DAY",
+            ShippingOption::Standard => "STANDARD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ShippingOption {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EXPRESS" => Ok(ShippingOption::Express),
+            "NEXT_DAY" => Ok(ShippingOption::NextDay),
+            "SECOND_DAY" => Ok(ShippingOption::SecondDay),
+            "STANDARD" => Ok(ShippingOption::Standard),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnowballCapacity {
+    NoPreference,
+    T100,
+    T50,
+    T80,
+}
+
+impl Into<String> for SnowballCapacity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnowballCapacity {
+    fn into(self) -> &'static str {
+        match self {
+            SnowballCapacity::NoPreference => "NoPreference",
+            SnowballCapacity::T100 => "T100",
+            SnowballCapacity::T50 => "T50",
+            SnowballCapacity::T80 => "T80",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnowballCapacity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NoPreference" => Ok(SnowballCapacity::NoPreference),
+            "T100" => Ok(SnowballCapacity::T100),
+            "T50" => Ok(SnowballCapacity::T50),
+            "T80" => Ok(SnowballCapacity::T80),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SnowballType {
+    Edge,
+    Standard,
+}
+
+impl Into<String> for SnowballType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SnowballType {
+    fn into(self) -> &'static str {
+        match self {
+            SnowballType::Edge => "EDGE",
+            SnowballType::Standard => "STANDARD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SnowballType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EDGE" => Ok(SnowballType::Edge),
+            "STANDARD" => Ok(SnowballType::Standard),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -2428,7 +2688,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CancelClusterResult>(String::from_utf8_lossy(&body)
@@ -2459,7 +2719,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CancelJobResult>(String::from_utf8_lossy(&body).as_ref())
@@ -2491,7 +2751,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateAddressResult>(String::from_utf8_lossy(&body)
@@ -2524,7 +2784,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateClusterResult>(String::from_utf8_lossy(&body)
@@ -2555,7 +2815,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateJobResult>(String::from_utf8_lossy(&body).as_ref())
@@ -2587,7 +2847,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAddressResult>(String::from_utf8_lossy(&body)
@@ -2620,7 +2880,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAddressesResult>(String::from_utf8_lossy(&body)
@@ -2653,7 +2913,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeClusterResult>(String::from_utf8_lossy(&body)
@@ -2686,7 +2946,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeJobResult>(String::from_utf8_lossy(&body)
@@ -2719,7 +2979,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetJobManifestResult>(String::from_utf8_lossy(&body)
@@ -2752,7 +3012,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetJobUnlockCodeResult>(String::from_utf8_lossy(&body)
@@ -2782,7 +3042,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetSnowballUsageResult>(String::from_utf8_lossy(&body)
@@ -2815,7 +3075,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListClusterJobsResult>(String::from_utf8_lossy(&body)
@@ -2848,7 +3108,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListClustersResult>(String::from_utf8_lossy(&body)
@@ -2878,7 +3138,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListJobsResult>(String::from_utf8_lossy(&body).as_ref())
@@ -2910,7 +3170,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateClusterResult>(String::from_utf8_lossy(&body)
@@ -2941,7 +3201,7 @@ impl<P, D> Snowball for SnowballClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateJobResult>(String::from_utf8_lossy(&body).as_ref())

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -136,7 +132,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -5444,7 +5440,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -5473,7 +5469,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -5520,7 +5516,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -5568,7 +5564,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -5615,7 +5611,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -5662,7 +5658,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -5707,7 +5703,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -5735,7 +5731,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -5762,7 +5758,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -5791,7 +5787,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -5840,7 +5836,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -5886,7 +5882,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -5934,7 +5930,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -5981,7 +5977,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -6030,7 +6026,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -6077,7 +6073,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -6127,7 +6123,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -6176,7 +6172,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -6224,7 +6220,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -6271,7 +6267,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -6318,7 +6314,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -6363,7 +6359,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -6410,7 +6406,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -6438,7 +6434,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -6466,7 +6462,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -6494,7 +6490,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -6541,7 +6537,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -6570,7 +6566,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -6596,7 +6592,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -6641,7 +6637,7 @@ impl<P, D> Sns for SnsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -279,7 +275,7 @@ impl BooleanDeserializer {
                                        stack: &mut T)
                                        -> Result<bool, XmlParseError> {
         try!(start_element(tag_name, stack));
-        let obj = bool::from_str(try!(characters(stack)).as_ref()).unwrap();
+        let obj = try!(characters(stack)).parse::<bool>().unwrap();
         try!(end_element(tag_name, stack));
 
         Ok(obj)
@@ -1457,6 +1453,60 @@ impl MessageSystemAttributeMapDeserializer {
         Ok(obj)
     }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MessageSystemAttributeName {
+    ApproximateFirstReceiveTimestamp,
+    ApproximateReceiveCount,
+    MessageDeduplicationId,
+    MessageGroupId,
+    SenderId,
+    SentTimestamp,
+    SequenceNumber,
+}
+
+impl Into<String> for MessageSystemAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MessageSystemAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            MessageSystemAttributeName::ApproximateFirstReceiveTimestamp => {
+                "ApproximateFirstReceiveTimestamp"
+            }
+            MessageSystemAttributeName::ApproximateReceiveCount => "ApproximateReceiveCount",
+            MessageSystemAttributeName::MessageDeduplicationId => "MessageDeduplicationId",
+            MessageSystemAttributeName::MessageGroupId => "MessageGroupId",
+            MessageSystemAttributeName::SenderId => "SenderId",
+            MessageSystemAttributeName::SentTimestamp => "SentTimestamp",
+            MessageSystemAttributeName::SequenceNumber => "SequenceNumber",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MessageSystemAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ApproximateFirstReceiveTimestamp" => {
+                Ok(MessageSystemAttributeName::ApproximateFirstReceiveTimestamp)
+            }
+            "ApproximateReceiveCount" => Ok(MessageSystemAttributeName::ApproximateReceiveCount),
+            "MessageDeduplicationId" => Ok(MessageSystemAttributeName::MessageDeduplicationId),
+            "MessageGroupId" => Ok(MessageSystemAttributeName::MessageGroupId),
+            "SenderId" => Ok(MessageSystemAttributeName::SenderId),
+            "SentTimestamp" => Ok(MessageSystemAttributeName::SentTimestamp),
+            "SequenceNumber" => Ok(MessageSystemAttributeName::SequenceNumber),
+            _ => Err(()),
+        }
+    }
+}
+
 struct MessageSystemAttributeNameDeserializer;
 impl MessageSystemAttributeNameDeserializer {
     #[allow(unused_variables)]
@@ -1526,6 +1576,99 @@ impl QueueAttributeMapSerializer {
             let prefix = format!("{}.{}", name, index + 1);
             params.put(&format!("{}.{}", prefix, "Name"), &key);
             params.put(&key, &value);
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum QueueAttributeName {
+    All,
+    ApproximateNumberOfMessages,
+    ApproximateNumberOfMessagesDelayed,
+    ApproximateNumberOfMessagesNotVisible,
+    ContentBasedDeduplication,
+    CreatedTimestamp,
+    DelaySeconds,
+    FifoQueue,
+    KmsDataKeyReusePeriodSeconds,
+    KmsMasterKeyId,
+    LastModifiedTimestamp,
+    MaximumMessageSize,
+    MessageRetentionPeriod,
+    Policy,
+    QueueArn,
+    ReceiveMessageWaitTimeSeconds,
+    RedrivePolicy,
+    VisibilityTimeout,
+}
+
+impl Into<String> for QueueAttributeName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for QueueAttributeName {
+    fn into(self) -> &'static str {
+        match self {
+            QueueAttributeName::All => "All",
+            QueueAttributeName::ApproximateNumberOfMessages => "ApproximateNumberOfMessages",
+            QueueAttributeName::ApproximateNumberOfMessagesDelayed => {
+                "ApproximateNumberOfMessagesDelayed"
+            }
+            QueueAttributeName::ApproximateNumberOfMessagesNotVisible => {
+                "ApproximateNumberOfMessagesNotVisible"
+            }
+            QueueAttributeName::ContentBasedDeduplication => "ContentBasedDeduplication",
+            QueueAttributeName::CreatedTimestamp => "CreatedTimestamp",
+            QueueAttributeName::DelaySeconds => "DelaySeconds",
+            QueueAttributeName::FifoQueue => "FifoQueue",
+            QueueAttributeName::KmsDataKeyReusePeriodSeconds => "KmsDataKeyReusePeriodSeconds",
+            QueueAttributeName::KmsMasterKeyId => "KmsMasterKeyId",
+            QueueAttributeName::LastModifiedTimestamp => "LastModifiedTimestamp",
+            QueueAttributeName::MaximumMessageSize => "MaximumMessageSize",
+            QueueAttributeName::MessageRetentionPeriod => "MessageRetentionPeriod",
+            QueueAttributeName::Policy => "Policy",
+            QueueAttributeName::QueueArn => "QueueArn",
+            QueueAttributeName::ReceiveMessageWaitTimeSeconds => "ReceiveMessageWaitTimeSeconds",
+            QueueAttributeName::RedrivePolicy => "RedrivePolicy",
+            QueueAttributeName::VisibilityTimeout => "VisibilityTimeout",
+        }
+    }
+}
+
+impl ::std::str::FromStr for QueueAttributeName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(QueueAttributeName::All),
+            "ApproximateNumberOfMessages" => Ok(QueueAttributeName::ApproximateNumberOfMessages),
+            "ApproximateNumberOfMessagesDelayed" => {
+                Ok(QueueAttributeName::ApproximateNumberOfMessagesDelayed)
+            }
+            "ApproximateNumberOfMessagesNotVisible" => {
+                Ok(QueueAttributeName::ApproximateNumberOfMessagesNotVisible)
+            }
+            "ContentBasedDeduplication" => Ok(QueueAttributeName::ContentBasedDeduplication),
+            "CreatedTimestamp" => Ok(QueueAttributeName::CreatedTimestamp),
+            "DelaySeconds" => Ok(QueueAttributeName::DelaySeconds),
+            "FifoQueue" => Ok(QueueAttributeName::FifoQueue),
+            "KmsDataKeyReusePeriodSeconds" => Ok(QueueAttributeName::KmsDataKeyReusePeriodSeconds),
+            "KmsMasterKeyId" => Ok(QueueAttributeName::KmsMasterKeyId),
+            "LastModifiedTimestamp" => Ok(QueueAttributeName::LastModifiedTimestamp),
+            "MaximumMessageSize" => Ok(QueueAttributeName::MaximumMessageSize),
+            "MessageRetentionPeriod" => Ok(QueueAttributeName::MessageRetentionPeriod),
+            "Policy" => Ok(QueueAttributeName::Policy),
+            "QueueArn" => Ok(QueueAttributeName::QueueArn),
+            "ReceiveMessageWaitTimeSeconds" => {
+                Ok(QueueAttributeName::ReceiveMessageWaitTimeSeconds)
+            }
+            "RedrivePolicy" => Ok(QueueAttributeName::RedrivePolicy),
+            "VisibilityTimeout" => Ok(QueueAttributeName::VisibilityTimeout),
+            _ => Err(()),
         }
     }
 }
@@ -3610,7 +3753,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3638,7 +3781,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3668,7 +3811,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -3715,7 +3858,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -3760,7 +3903,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3788,7 +3931,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -3833,7 +3976,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -3861,7 +4004,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -3908,7 +4051,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -3956,7 +4099,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4003,7 +4146,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4048,7 +4191,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -4076,7 +4219,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4123,7 +4266,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }
@@ -4151,7 +4294,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4198,7 +4341,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -4245,7 +4388,7 @@ impl<P, D> Sqs for SqsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
                 Ok(result)
             }

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -210,6 +206,56 @@ pub struct AssociationFilter {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssociationFilterKey {
+    AssociationId,
+    AssociationName,
+    AssociationStatusName,
+    InstanceId,
+    LastExecutedAfter,
+    LastExecutedBefore,
+    Name,
+}
+
+impl Into<String> for AssociationFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssociationFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            AssociationFilterKey::AssociationId => "AssociationId",
+            AssociationFilterKey::AssociationName => "AssociationName",
+            AssociationFilterKey::AssociationStatusName => "AssociationStatusName",
+            AssociationFilterKey::InstanceId => "InstanceId",
+            AssociationFilterKey::LastExecutedAfter => "LastExecutedAfter",
+            AssociationFilterKey::LastExecutedBefore => "LastExecutedBefore",
+            AssociationFilterKey::Name => "Name",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssociationFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AssociationId" => Ok(AssociationFilterKey::AssociationId),
+            "AssociationName" => Ok(AssociationFilterKey::AssociationName),
+            "AssociationStatusName" => Ok(AssociationFilterKey::AssociationStatusName),
+            "InstanceId" => Ok(AssociationFilterKey::InstanceId),
+            "LastExecutedAfter" => Ok(AssociationFilterKey::LastExecutedAfter),
+            "LastExecutedBefore" => Ok(AssociationFilterKey::LastExecutedBefore),
+            "Name" => Ok(AssociationFilterKey::Name),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about the association.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AssociationOverview {
@@ -243,6 +289,44 @@ pub struct AssociationStatus {
     #[doc="<p>The status.</p>"]
     #[serde(rename="Name")]
     pub name: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AssociationStatusName {
+    Failed,
+    Pending,
+    Success,
+}
+
+impl Into<String> for AssociationStatusName {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AssociationStatusName {
+    fn into(self) -> &'static str {
+        match self {
+            AssociationStatusName::Failed => "Failed",
+            AssociationStatusName::Pending => "Pending",
+            AssociationStatusName::Success => "Success",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AssociationStatusName {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(AssociationStatusName::Failed),
+            "Pending" => Ok(AssociationStatusName::Pending),
+            "Success" => Ok(AssociationStatusName::Success),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Information about the association version.</p>"]
@@ -346,6 +430,41 @@ pub struct AutomationExecutionFilter {
     pub values: Vec<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutomationExecutionFilterKey {
+    DocumentNamePrefix,
+    ExecutionStatus,
+}
+
+impl Into<String> for AutomationExecutionFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutomationExecutionFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            AutomationExecutionFilterKey::DocumentNamePrefix => "DocumentNamePrefix",
+            AutomationExecutionFilterKey::ExecutionStatus => "ExecutionStatus",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutomationExecutionFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DocumentNamePrefix" => Ok(AutomationExecutionFilterKey::DocumentNamePrefix),
+            "ExecutionStatus" => Ok(AutomationExecutionFilterKey::ExecutionStatus),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Details about a specific Automation execution.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct AutomationExecutionMetadata {
@@ -385,6 +504,56 @@ pub struct AutomationExecutionMetadata {
     #[serde(rename="Outputs")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub outputs: Option<::std::collections::HashMap<String, Vec<String>>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum AutomationExecutionStatus {
+    Cancelled,
+    Failed,
+    InProgress,
+    Pending,
+    Success,
+    TimedOut,
+    Waiting,
+}
+
+impl Into<String> for AutomationExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for AutomationExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            AutomationExecutionStatus::Cancelled => "Cancelled",
+            AutomationExecutionStatus::Failed => "Failed",
+            AutomationExecutionStatus::InProgress => "InProgress",
+            AutomationExecutionStatus::Pending => "Pending",
+            AutomationExecutionStatus::Success => "Success",
+            AutomationExecutionStatus::TimedOut => "TimedOut",
+            AutomationExecutionStatus::Waiting => "Waiting",
+        }
+    }
+}
+
+impl ::std::str::FromStr for AutomationExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(AutomationExecutionStatus::Cancelled),
+            "Failed" => Ok(AutomationExecutionStatus::Failed),
+            "InProgress" => Ok(AutomationExecutionStatus::InProgress),
+            "Pending" => Ok(AutomationExecutionStatus::Pending),
+            "Success" => Ok(AutomationExecutionStatus::Success),
+            "TimedOut" => Ok(AutomationExecutionStatus::TimedOut),
+            "Waiting" => Ok(AutomationExecutionStatus::Waiting),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p/>"]
@@ -499,6 +668,44 @@ pub struct CommandFilter {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CommandFilterKey {
+    InvokedAfter,
+    InvokedBefore,
+    Status,
+}
+
+impl Into<String> for CommandFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CommandFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            CommandFilterKey::InvokedAfter => "InvokedAfter",
+            CommandFilterKey::InvokedBefore => "InvokedBefore",
+            CommandFilterKey::Status => "Status",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CommandFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "InvokedAfter" => Ok(CommandFilterKey::InvokedAfter),
+            "InvokedBefore" => Ok(CommandFilterKey::InvokedBefore),
+            "Status" => Ok(CommandFilterKey::Status),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>An invocation is copy of a command sent to a specific instance. A command can apply to one or more instances. A command invocation applies to one instance. For example, if a user executes SendCommand against three instances, then a command invocation is created for each requested instance ID. A command invocation returns status and detail information about a command you executed. </p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CommandInvocation {
@@ -559,6 +766,59 @@ pub struct CommandInvocation {
     pub trace_output: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CommandInvocationStatus {
+    Cancelled,
+    Cancelling,
+    Delayed,
+    Failed,
+    InProgress,
+    Pending,
+    Success,
+    TimedOut,
+}
+
+impl Into<String> for CommandInvocationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CommandInvocationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CommandInvocationStatus::Cancelled => "Cancelled",
+            CommandInvocationStatus::Cancelling => "Cancelling",
+            CommandInvocationStatus::Delayed => "Delayed",
+            CommandInvocationStatus::Failed => "Failed",
+            CommandInvocationStatus::InProgress => "InProgress",
+            CommandInvocationStatus::Pending => "Pending",
+            CommandInvocationStatus::Success => "Success",
+            CommandInvocationStatus::TimedOut => "TimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CommandInvocationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(CommandInvocationStatus::Cancelled),
+            "Cancelling" => Ok(CommandInvocationStatus::Cancelling),
+            "Delayed" => Ok(CommandInvocationStatus::Delayed),
+            "Failed" => Ok(CommandInvocationStatus::Failed),
+            "InProgress" => Ok(CommandInvocationStatus::InProgress),
+            "Pending" => Ok(CommandInvocationStatus::Pending),
+            "Success" => Ok(CommandInvocationStatus::Success),
+            "TimedOut" => Ok(CommandInvocationStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes plugin details.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CommandPlugin {
@@ -610,6 +870,103 @@ pub struct CommandPlugin {
     #[serde(rename="StatusDetails")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status_details: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CommandPluginStatus {
+    Cancelled,
+    Failed,
+    InProgress,
+    Pending,
+    Success,
+    TimedOut,
+}
+
+impl Into<String> for CommandPluginStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CommandPluginStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CommandPluginStatus::Cancelled => "Cancelled",
+            CommandPluginStatus::Failed => "Failed",
+            CommandPluginStatus::InProgress => "InProgress",
+            CommandPluginStatus::Pending => "Pending",
+            CommandPluginStatus::Success => "Success",
+            CommandPluginStatus::TimedOut => "TimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CommandPluginStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(CommandPluginStatus::Cancelled),
+            "Failed" => Ok(CommandPluginStatus::Failed),
+            "InProgress" => Ok(CommandPluginStatus::InProgress),
+            "Pending" => Ok(CommandPluginStatus::Pending),
+            "Success" => Ok(CommandPluginStatus::Success),
+            "TimedOut" => Ok(CommandPluginStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CommandStatus {
+    Cancelled,
+    Cancelling,
+    Failed,
+    InProgress,
+    Pending,
+    Success,
+    TimedOut,
+}
+
+impl Into<String> for CommandStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CommandStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CommandStatus::Cancelled => "Cancelled",
+            CommandStatus::Cancelling => "Cancelling",
+            CommandStatus::Failed => "Failed",
+            CommandStatus::InProgress => "InProgress",
+            CommandStatus::Pending => "Pending",
+            CommandStatus::Success => "Success",
+            CommandStatus::TimedOut => "TimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CommandStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Cancelled" => Ok(CommandStatus::Cancelled),
+            "Cancelling" => Ok(CommandStatus::Cancelling),
+            "Failed" => Ok(CommandStatus::Failed),
+            "InProgress" => Ok(CommandStatus::InProgress),
+            "Pending" => Ok(CommandStatus::Pending),
+            "Success" => Ok(CommandStatus::Success),
+            "TimedOut" => Ok(CommandStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A summary of the call execution that includes an execution ID, the type of execution (for example, <code>Command</code>), and the date/time of the execution using a datetime object that is saved in the following format: yyyy-MM-dd'T'HH:mm:ss'Z'.</p>"]
@@ -690,6 +1047,132 @@ pub struct ComplianceItemEntry {
     #[serde(rename="Title")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub title: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComplianceQueryOperatorType {
+    BeginWith,
+    Equal,
+    GreaterThan,
+    LessThan,
+    NotEqual,
+}
+
+impl Into<String> for ComplianceQueryOperatorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComplianceQueryOperatorType {
+    fn into(self) -> &'static str {
+        match self {
+            ComplianceQueryOperatorType::BeginWith => "BEGIN_WITH",
+            ComplianceQueryOperatorType::Equal => "EQUAL",
+            ComplianceQueryOperatorType::GreaterThan => "GREATER_THAN",
+            ComplianceQueryOperatorType::LessThan => "LESS_THAN",
+            ComplianceQueryOperatorType::NotEqual => "NOT_EQUAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComplianceQueryOperatorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BEGIN_WITH" => Ok(ComplianceQueryOperatorType::BeginWith),
+            "EQUAL" => Ok(ComplianceQueryOperatorType::Equal),
+            "GREATER_THAN" => Ok(ComplianceQueryOperatorType::GreaterThan),
+            "LESS_THAN" => Ok(ComplianceQueryOperatorType::LessThan),
+            "NOT_EQUAL" => Ok(ComplianceQueryOperatorType::NotEqual),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComplianceSeverity {
+    Critical,
+    High,
+    Informational,
+    Low,
+    Medium,
+    Unspecified,
+}
+
+impl Into<String> for ComplianceSeverity {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComplianceSeverity {
+    fn into(self) -> &'static str {
+        match self {
+            ComplianceSeverity::Critical => "CRITICAL",
+            ComplianceSeverity::High => "HIGH",
+            ComplianceSeverity::Informational => "INFORMATIONAL",
+            ComplianceSeverity::Low => "LOW",
+            ComplianceSeverity::Medium => "MEDIUM",
+            ComplianceSeverity::Unspecified => "UNSPECIFIED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComplianceSeverity {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CRITICAL" => Ok(ComplianceSeverity::Critical),
+            "HIGH" => Ok(ComplianceSeverity::High),
+            "INFORMATIONAL" => Ok(ComplianceSeverity::Informational),
+            "LOW" => Ok(ComplianceSeverity::Low),
+            "MEDIUM" => Ok(ComplianceSeverity::Medium),
+            "UNSPECIFIED" => Ok(ComplianceSeverity::Unspecified),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComplianceStatus {
+    Compliant,
+    NonCompliant,
+}
+
+impl Into<String> for ComplianceStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComplianceStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ComplianceStatus::Compliant => "COMPLIANT",
+            ComplianceStatus::NonCompliant => "NON_COMPLIANT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComplianceStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "COMPLIANT" => Ok(ComplianceStatus::Compliant),
+            "NON_COMPLIANT" => Ok(ComplianceStatus::NonCompliant),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
@@ -1188,6 +1671,44 @@ pub struct DescribeActivationsFilter {
     #[serde(rename="FilterValues")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub filter_values: Option<Vec<String>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DescribeActivationsFilterKeys {
+    ActivationIds,
+    DefaultInstanceName,
+    IamRole,
+}
+
+impl Into<String> for DescribeActivationsFilterKeys {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DescribeActivationsFilterKeys {
+    fn into(self) -> &'static str {
+        match self {
+            DescribeActivationsFilterKeys::ActivationIds => "ActivationIds",
+            DescribeActivationsFilterKeys::DefaultInstanceName => "DefaultInstanceName",
+            DescribeActivationsFilterKeys::IamRole => "IamRole",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DescribeActivationsFilterKeys {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivationIds" => Ok(DescribeActivationsFilterKeys::ActivationIds),
+            "DefaultInstanceName" => Ok(DescribeActivationsFilterKeys::DefaultInstanceName),
+            "IamRole" => Ok(DescribeActivationsFilterKeys::IamRole),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1940,6 +2461,82 @@ pub struct DocumentFilter {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentFilterKey {
+    DocumentType,
+    Name,
+    Owner,
+    PlatformTypes,
+}
+
+impl Into<String> for DocumentFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentFilterKey::DocumentType => "DocumentType",
+            DocumentFilterKey::Name => "Name",
+            DocumentFilterKey::Owner => "Owner",
+            DocumentFilterKey::PlatformTypes => "PlatformTypes",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DocumentType" => Ok(DocumentFilterKey::DocumentType),
+            "Name" => Ok(DocumentFilterKey::Name),
+            "Owner" => Ok(DocumentFilterKey::Owner),
+            "PlatformTypes" => Ok(DocumentFilterKey::PlatformTypes),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentHashType {
+    Sha1,
+    Sha256,
+}
+
+impl Into<String> for DocumentHashType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentHashType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentHashType::Sha1 => "Sha1",
+            DocumentHashType::Sha256 => "Sha256",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentHashType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Sha1" => Ok(DocumentHashType::Sha1),
+            "Sha256" => Ok(DocumentHashType::Sha256),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the name of an SSM document.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DocumentIdentifier {
@@ -1988,6 +2585,152 @@ pub struct DocumentParameter {
     #[serde(rename="Type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentParameterType {
+    String,
+    StringList,
+}
+
+impl Into<String> for DocumentParameterType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentParameterType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentParameterType::String => "String",
+            DocumentParameterType::StringList => "StringList",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentParameterType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "String" => Ok(DocumentParameterType::String),
+            "StringList" => Ok(DocumentParameterType::StringList),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentPermissionType {
+    Share,
+}
+
+impl Into<String> for DocumentPermissionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentPermissionType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentPermissionType::Share => "Share",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentPermissionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Share" => Ok(DocumentPermissionType::Share),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentStatus {
+    Active,
+    Creating,
+    Deleting,
+    Updating,
+}
+
+impl Into<String> for DocumentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentStatus::Active => "Active",
+            DocumentStatus::Creating => "Creating",
+            DocumentStatus::Deleting => "Deleting",
+            DocumentStatus::Updating => "Updating",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Active" => Ok(DocumentStatus::Active),
+            "Creating" => Ok(DocumentStatus::Creating),
+            "Deleting" => Ok(DocumentStatus::Deleting),
+            "Updating" => Ok(DocumentStatus::Updating),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentType {
+    Automation,
+    Command,
+    Policy,
+}
+
+impl Into<String> for DocumentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentType::Automation => "Automation",
+            DocumentType::Command => "Command",
+            DocumentType::Policy => "Policy",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Automation" => Ok(DocumentType::Automation),
+            "Command" => Ok(DocumentType::Command),
+            "Policy" => Ok(DocumentType::Policy),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Version information about the document.</p>"]
@@ -2056,6 +2799,44 @@ pub struct FailureDetails {
     #[serde(rename="FailureType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub failure_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Fault {
+    Client,
+    Server,
+    Unknown,
+}
+
+impl Into<String> for Fault {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Fault {
+    fn into(self) -> &'static str {
+        match self {
+            Fault::Client => "Client",
+            Fault::Server => "Server",
+            Fault::Unknown => "Unknown",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Fault {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Client" => Ok(Fault::Client),
+            "Server" => Ok(Fault::Server),
+            "Unknown" => Ok(Fault::Unknown),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -2982,6 +3763,59 @@ pub struct InstanceInformationFilter {
     pub value_set: Vec<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstanceInformationFilterKey {
+    ActivationIds,
+    AgentVersion,
+    AssociationStatus,
+    IamRole,
+    InstanceIds,
+    PingStatus,
+    PlatformTypes,
+    ResourceType,
+}
+
+impl Into<String> for InstanceInformationFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstanceInformationFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            InstanceInformationFilterKey::ActivationIds => "ActivationIds",
+            InstanceInformationFilterKey::AgentVersion => "AgentVersion",
+            InstanceInformationFilterKey::AssociationStatus => "AssociationStatus",
+            InstanceInformationFilterKey::IamRole => "IamRole",
+            InstanceInformationFilterKey::InstanceIds => "InstanceIds",
+            InstanceInformationFilterKey::PingStatus => "PingStatus",
+            InstanceInformationFilterKey::PlatformTypes => "PlatformTypes",
+            InstanceInformationFilterKey::ResourceType => "ResourceType",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstanceInformationFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivationIds" => Ok(InstanceInformationFilterKey::ActivationIds),
+            "AgentVersion" => Ok(InstanceInformationFilterKey::AgentVersion),
+            "AssociationStatus" => Ok(InstanceInformationFilterKey::AssociationStatus),
+            "IamRole" => Ok(InstanceInformationFilterKey::IamRole),
+            "InstanceIds" => Ok(InstanceInformationFilterKey::InstanceIds),
+            "PingStatus" => Ok(InstanceInformationFilterKey::PingStatus),
+            "PlatformTypes" => Ok(InstanceInformationFilterKey::PlatformTypes),
+            "ResourceType" => Ok(InstanceInformationFilterKey::ResourceType),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The filters to describe or get information about your managed instances.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct InstanceInformationStringFilter {
@@ -3058,6 +3892,82 @@ pub struct InstancePatchStateFilter {
     pub values: Vec<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InstancePatchStateOperatorType {
+    Equal,
+    GreaterThan,
+    LessThan,
+    NotEqual,
+}
+
+impl Into<String> for InstancePatchStateOperatorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InstancePatchStateOperatorType {
+    fn into(self) -> &'static str {
+        match self {
+            InstancePatchStateOperatorType::Equal => "Equal",
+            InstancePatchStateOperatorType::GreaterThan => "GreaterThan",
+            InstancePatchStateOperatorType::LessThan => "LessThan",
+            InstancePatchStateOperatorType::NotEqual => "NotEqual",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InstancePatchStateOperatorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Equal" => Ok(InstancePatchStateOperatorType::Equal),
+            "GreaterThan" => Ok(InstancePatchStateOperatorType::GreaterThan),
+            "LessThan" => Ok(InstancePatchStateOperatorType::LessThan),
+            "NotEqual" => Ok(InstancePatchStateOperatorType::NotEqual),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryAttributeDataType {
+    Number,
+    String,
+}
+
+impl Into<String> for InventoryAttributeDataType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryAttributeDataType {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryAttributeDataType::Number => "number",
+            InventoryAttributeDataType::String => "string",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryAttributeDataType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "number" => Ok(InventoryAttributeDataType::Number),
+            "string" => Ok(InventoryAttributeDataType::String),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct InventoryFilter {
@@ -3125,6 +4035,50 @@ pub struct InventoryItemSchema {
     pub version: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum InventoryQueryOperatorType {
+    BeginWith,
+    Equal,
+    GreaterThan,
+    LessThan,
+    NotEqual,
+}
+
+impl Into<String> for InventoryQueryOperatorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for InventoryQueryOperatorType {
+    fn into(self) -> &'static str {
+        match self {
+            InventoryQueryOperatorType::BeginWith => "BeginWith",
+            InventoryQueryOperatorType::Equal => "Equal",
+            InventoryQueryOperatorType::GreaterThan => "GreaterThan",
+            InventoryQueryOperatorType::LessThan => "LessThan",
+            InventoryQueryOperatorType::NotEqual => "NotEqual",
+        }
+    }
+}
+
+impl ::std::str::FromStr for InventoryQueryOperatorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BeginWith" => Ok(InventoryQueryOperatorType::BeginWith),
+            "Equal" => Ok(InventoryQueryOperatorType::Equal),
+            "GreaterThan" => Ok(InventoryQueryOperatorType::GreaterThan),
+            "LessThan" => Ok(InventoryQueryOperatorType::LessThan),
+            "NotEqual" => Ok(InventoryQueryOperatorType::NotEqual),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Inventory query results.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct InventoryResultEntity {
@@ -3158,6 +4112,44 @@ pub struct InventoryResultItem {
     #[doc="<p>The name of the inventory result item type.</p>"]
     #[serde(rename="TypeName")]
     pub type_name: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LastResourceDataSyncStatus {
+    Failed,
+    InProgress,
+    Successful,
+}
+
+impl Into<String> for LastResourceDataSyncStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LastResourceDataSyncStatus {
+    fn into(self) -> &'static str {
+        match self {
+            LastResourceDataSyncStatus::Failed => "Failed",
+            LastResourceDataSyncStatus::InProgress => "InProgress",
+            LastResourceDataSyncStatus::Successful => "Successful",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LastResourceDataSyncStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Failed" => Ok(LastResourceDataSyncStatus::Failed),
+            "InProgress" => Ok(LastResourceDataSyncStatus::InProgress),
+            "Successful" => Ok(LastResourceDataSyncStatus::Successful),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -3587,6 +4579,59 @@ pub struct MaintenanceWindowExecution {
     pub window_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MaintenanceWindowExecutionStatus {
+    Cancelled,
+    Cancelling,
+    Failed,
+    InProgress,
+    Pending,
+    SkippedOverlapping,
+    Success,
+    TimedOut,
+}
+
+impl Into<String> for MaintenanceWindowExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MaintenanceWindowExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            MaintenanceWindowExecutionStatus::Cancelled => "CANCELLED",
+            MaintenanceWindowExecutionStatus::Cancelling => "CANCELLING",
+            MaintenanceWindowExecutionStatus::Failed => "FAILED",
+            MaintenanceWindowExecutionStatus::InProgress => "IN_PROGRESS",
+            MaintenanceWindowExecutionStatus::Pending => "PENDING",
+            MaintenanceWindowExecutionStatus::SkippedOverlapping => "SKIPPED_OVERLAPPING",
+            MaintenanceWindowExecutionStatus::Success => "SUCCESS",
+            MaintenanceWindowExecutionStatus::TimedOut => "TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MaintenanceWindowExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELLED" => Ok(MaintenanceWindowExecutionStatus::Cancelled),
+            "CANCELLING" => Ok(MaintenanceWindowExecutionStatus::Cancelling),
+            "FAILED" => Ok(MaintenanceWindowExecutionStatus::Failed),
+            "IN_PROGRESS" => Ok(MaintenanceWindowExecutionStatus::InProgress),
+            "PENDING" => Ok(MaintenanceWindowExecutionStatus::Pending),
+            "SKIPPED_OVERLAPPING" => Ok(MaintenanceWindowExecutionStatus::SkippedOverlapping),
+            "SUCCESS" => Ok(MaintenanceWindowExecutionStatus::Success),
+            "TIMED_OUT" => Ok(MaintenanceWindowExecutionStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Information about a task execution performed as part of a Maintenance Window execution.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct MaintenanceWindowExecutionTaskIdentity {
@@ -3738,6 +4783,38 @@ pub struct MaintenanceWindowLambdaParameters {
     #[serde(rename="Qualifier")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub qualifier: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MaintenanceWindowResourceType {
+    Instance,
+}
+
+impl Into<String> for MaintenanceWindowResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MaintenanceWindowResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            MaintenanceWindowResourceType::Instance => "INSTANCE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MaintenanceWindowResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSTANCE" => Ok(MaintenanceWindowResourceType::Instance),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The parameters for a RUN_COMMAND task type.</p>"]
@@ -3915,6 +4992,47 @@ pub struct MaintenanceWindowTaskParameterValueExpression {
     pub values: Option<Vec<String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MaintenanceWindowTaskType {
+    Automation,
+    Lambda,
+    RunCommand,
+    StepFunctions,
+}
+
+impl Into<String> for MaintenanceWindowTaskType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MaintenanceWindowTaskType {
+    fn into(self) -> &'static str {
+        match self {
+            MaintenanceWindowTaskType::Automation => "AUTOMATION",
+            MaintenanceWindowTaskType::Lambda => "LAMBDA",
+            MaintenanceWindowTaskType::RunCommand => "RUN_COMMAND",
+            MaintenanceWindowTaskType::StepFunctions => "STEP_FUNCTIONS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MaintenanceWindowTaskType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AUTOMATION" => Ok(MaintenanceWindowTaskType::Automation),
+            "LAMBDA" => Ok(MaintenanceWindowTaskType::Lambda),
+            "RUN_COMMAND" => Ok(MaintenanceWindowTaskType::RunCommand),
+            "STEP_FUNCTIONS" => Ok(MaintenanceWindowTaskType::StepFunctions),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ModifyDocumentPermissionRequest {
     #[doc="<p>The AWS user accounts that should have access to the document. The account IDs can either be a group of account IDs or <i>All</i>.</p>"]
@@ -3964,6 +5082,129 @@ pub struct NotificationConfig {
     #[serde(rename="NotificationType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub notification_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NotificationEvent {
+    All,
+    Cancelled,
+    Failed,
+    InProgress,
+    Success,
+    TimedOut,
+}
+
+impl Into<String> for NotificationEvent {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NotificationEvent {
+    fn into(self) -> &'static str {
+        match self {
+            NotificationEvent::All => "All",
+            NotificationEvent::Cancelled => "Cancelled",
+            NotificationEvent::Failed => "Failed",
+            NotificationEvent::InProgress => "InProgress",
+            NotificationEvent::Success => "Success",
+            NotificationEvent::TimedOut => "TimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NotificationEvent {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "All" => Ok(NotificationEvent::All),
+            "Cancelled" => Ok(NotificationEvent::Cancelled),
+            "Failed" => Ok(NotificationEvent::Failed),
+            "InProgress" => Ok(NotificationEvent::InProgress),
+            "Success" => Ok(NotificationEvent::Success),
+            "TimedOut" => Ok(NotificationEvent::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum NotificationType {
+    Command,
+    Invocation,
+}
+
+impl Into<String> for NotificationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for NotificationType {
+    fn into(self) -> &'static str {
+        match self {
+            NotificationType::Command => "Command",
+            NotificationType::Invocation => "Invocation",
+        }
+    }
+}
+
+impl ::std::str::FromStr for NotificationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Command" => Ok(NotificationType::Command),
+            "Invocation" => Ok(NotificationType::Invocation),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OperatingSystem {
+    AmazonLinux,
+    RedhatEnterpriseLinux,
+    Ubuntu,
+    Windows,
+}
+
+impl Into<String> for OperatingSystem {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OperatingSystem {
+    fn into(self) -> &'static str {
+        match self {
+            OperatingSystem::AmazonLinux => "AMAZON_LINUX",
+            OperatingSystem::RedhatEnterpriseLinux => "REDHAT_ENTERPRISE_LINUX",
+            OperatingSystem::Ubuntu => "UBUNTU",
+            OperatingSystem::Windows => "WINDOWS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OperatingSystem {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AMAZON_LINUX" => Ok(OperatingSystem::AmazonLinux),
+            "REDHAT_ENTERPRISE_LINUX" => Ok(OperatingSystem::RedhatEnterpriseLinux),
+            "UBUNTU" => Ok(OperatingSystem::Ubuntu),
+            "WINDOWS" => Ok(OperatingSystem::Windows),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>An Amazon EC2 Systems Manager parameter in Parameter Store.</p>"]
@@ -4069,6 +5310,44 @@ pub struct ParameterStringFilter {
     pub values: Option<Vec<String>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterType {
+    SecureString,
+    String,
+    StringList,
+}
+
+impl Into<String> for ParameterType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterType {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterType::SecureString => "SecureString",
+            ParameterType::String => "String",
+            ParameterType::StringList => "StringList",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SecureString" => Ok(ParameterType::SecureString),
+            "String" => Ok(ParameterType::String),
+            "StringList" => Ok(ParameterType::StringList),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ParametersFilter {
@@ -4078,6 +5357,44 @@ pub struct ParametersFilter {
     #[doc="<p>The filter values.</p>"]
     #[serde(rename="Values")]
     pub values: Vec<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParametersFilterKey {
+    KeyId,
+    Name,
+    Type,
+}
+
+impl Into<String> for ParametersFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParametersFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            ParametersFilterKey::KeyId => "KeyId",
+            ParametersFilterKey::Name => "Name",
+            ParametersFilterKey::Type => "Type",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParametersFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "KeyId" => Ok(ParametersFilterKey::KeyId),
+            "Name" => Ok(ParametersFilterKey::Name),
+            "Type" => Ok(ParametersFilterKey::Type),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents metadata about a patch.</p>"]
@@ -4185,6 +5502,138 @@ pub struct PatchComplianceData {
     pub title: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PatchComplianceDataState {
+    Failed,
+    Installed,
+    InstalledOther,
+    Missing,
+    NotApplicable,
+}
+
+impl Into<String> for PatchComplianceDataState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PatchComplianceDataState {
+    fn into(self) -> &'static str {
+        match self {
+            PatchComplianceDataState::Failed => "FAILED",
+            PatchComplianceDataState::Installed => "INSTALLED",
+            PatchComplianceDataState::InstalledOther => "INSTALLED_OTHER",
+            PatchComplianceDataState::Missing => "MISSING",
+            PatchComplianceDataState::NotApplicable => "NOT_APPLICABLE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PatchComplianceDataState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILED" => Ok(PatchComplianceDataState::Failed),
+            "INSTALLED" => Ok(PatchComplianceDataState::Installed),
+            "INSTALLED_OTHER" => Ok(PatchComplianceDataState::InstalledOther),
+            "MISSING" => Ok(PatchComplianceDataState::Missing),
+            "NOT_APPLICABLE" => Ok(PatchComplianceDataState::NotApplicable),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PatchComplianceLevel {
+    Critical,
+    High,
+    Informational,
+    Low,
+    Medium,
+    Unspecified,
+}
+
+impl Into<String> for PatchComplianceLevel {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PatchComplianceLevel {
+    fn into(self) -> &'static str {
+        match self {
+            PatchComplianceLevel::Critical => "CRITICAL",
+            PatchComplianceLevel::High => "HIGH",
+            PatchComplianceLevel::Informational => "INFORMATIONAL",
+            PatchComplianceLevel::Low => "LOW",
+            PatchComplianceLevel::Medium => "MEDIUM",
+            PatchComplianceLevel::Unspecified => "UNSPECIFIED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PatchComplianceLevel {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CRITICAL" => Ok(PatchComplianceLevel::Critical),
+            "HIGH" => Ok(PatchComplianceLevel::High),
+            "INFORMATIONAL" => Ok(PatchComplianceLevel::Informational),
+            "LOW" => Ok(PatchComplianceLevel::Low),
+            "MEDIUM" => Ok(PatchComplianceLevel::Medium),
+            "UNSPECIFIED" => Ok(PatchComplianceLevel::Unspecified),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PatchDeploymentStatus {
+    Approved,
+    ExplicitApproved,
+    ExplicitRejected,
+    PendingApproval,
+}
+
+impl Into<String> for PatchDeploymentStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PatchDeploymentStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PatchDeploymentStatus::Approved => "APPROVED",
+            PatchDeploymentStatus::ExplicitApproved => "EXPLICIT_APPROVED",
+            PatchDeploymentStatus::ExplicitRejected => "EXPLICIT_REJECTED",
+            PatchDeploymentStatus::PendingApproval => "PENDING_APPROVAL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PatchDeploymentStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "APPROVED" => Ok(PatchDeploymentStatus::Approved),
+            "EXPLICIT_APPROVED" => Ok(PatchDeploymentStatus::ExplicitApproved),
+            "EXPLICIT_REJECTED" => Ok(PatchDeploymentStatus::ExplicitRejected),
+            "PENDING_APPROVAL" => Ok(PatchDeploymentStatus::PendingApproval),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Defines a patch filter.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PatchFilter {
@@ -4204,6 +5653,56 @@ pub struct PatchFilterGroup {
     pub patch_filters: Vec<PatchFilter>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PatchFilterKey {
+    Classification,
+    MsrcSeverity,
+    PatchId,
+    Priority,
+    Product,
+    Section,
+    Severity,
+}
+
+impl Into<String> for PatchFilterKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PatchFilterKey {
+    fn into(self) -> &'static str {
+        match self {
+            PatchFilterKey::Classification => "CLASSIFICATION",
+            PatchFilterKey::MsrcSeverity => "MSRC_SEVERITY",
+            PatchFilterKey::PatchId => "PATCH_ID",
+            PatchFilterKey::Priority => "PRIORITY",
+            PatchFilterKey::Product => "PRODUCT",
+            PatchFilterKey::Section => "SECTION",
+            PatchFilterKey::Severity => "SEVERITY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PatchFilterKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLASSIFICATION" => Ok(PatchFilterKey::Classification),
+            "MSRC_SEVERITY" => Ok(PatchFilterKey::MsrcSeverity),
+            "PATCH_ID" => Ok(PatchFilterKey::PatchId),
+            "PRIORITY" => Ok(PatchFilterKey::Priority),
+            "PRODUCT" => Ok(PatchFilterKey::Product),
+            "SECTION" => Ok(PatchFilterKey::Section),
+            "SEVERITY" => Ok(PatchFilterKey::Severity),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The mapping between a patch group and the patch baseline the patch group is registered with.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct PatchGroupPatchBaselineMapping {
@@ -4215,6 +5714,41 @@ pub struct PatchGroupPatchBaselineMapping {
     #[serde(rename="PatchGroup")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub patch_group: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PatchOperationType {
+    Install,
+    Scan,
+}
+
+impl Into<String> for PatchOperationType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PatchOperationType {
+    fn into(self) -> &'static str {
+        match self {
+            PatchOperationType::Install => "Install",
+            PatchOperationType::Scan => "Scan",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PatchOperationType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Install" => Ok(PatchOperationType::Install),
+            "Scan" => Ok(PatchOperationType::Scan),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Defines a filter used in Patch Manager APIs.</p>"]
@@ -4268,6 +5802,79 @@ pub struct PatchStatus {
     #[serde(rename="DeploymentStatus")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub deployment_status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PingStatus {
+    ConnectionLost,
+    Inactive,
+    Online,
+}
+
+impl Into<String> for PingStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PingStatus {
+    fn into(self) -> &'static str {
+        match self {
+            PingStatus::ConnectionLost => "ConnectionLost",
+            PingStatus::Inactive => "Inactive",
+            PingStatus::Online => "Online",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PingStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ConnectionLost" => Ok(PingStatus::ConnectionLost),
+            "Inactive" => Ok(PingStatus::Inactive),
+            "Online" => Ok(PingStatus::Online),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PlatformType {
+    Linux,
+    Windows,
+}
+
+impl Into<String> for PlatformType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PlatformType {
+    fn into(self) -> &'static str {
+        match self {
+            PlatformType::Linux => "Linux",
+            PlatformType::Windows => "Windows",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PlatformType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Linux" => Ok(PlatformType::Linux),
+            "Windows" => Ok(PlatformType::Windows),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -4577,6 +6184,114 @@ pub struct ResourceDataSyncS3Destination {
     pub sync_format: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceDataSyncS3Format {
+    JsonSerDe,
+}
+
+impl Into<String> for ResourceDataSyncS3Format {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceDataSyncS3Format {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceDataSyncS3Format::JsonSerDe => "JsonSerDe",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceDataSyncS3Format {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "JsonSerDe" => Ok(ResourceDataSyncS3Format::JsonSerDe),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceType {
+    Document,
+    Ec2Instance,
+    ManagedInstance,
+}
+
+impl Into<String> for ResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceType::Document => "Document",
+            ResourceType::Ec2Instance => "EC2Instance",
+            ResourceType::ManagedInstance => "ManagedInstance",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Document" => Ok(ResourceType::Document),
+            "EC2Instance" => Ok(ResourceType::Ec2Instance),
+            "ManagedInstance" => Ok(ResourceType::ManagedInstance),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceTypeForTagging {
+    MaintenanceWindow,
+    ManagedInstance,
+    Parameter,
+}
+
+impl Into<String> for ResourceTypeForTagging {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceTypeForTagging {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceTypeForTagging::MaintenanceWindow => "MaintenanceWindow",
+            ResourceTypeForTagging::ManagedInstance => "ManagedInstance",
+            ResourceTypeForTagging::Parameter => "Parameter",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceTypeForTagging {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "MaintenanceWindow" => Ok(ResourceTypeForTagging::MaintenanceWindow),
+            "ManagedInstance" => Ok(ResourceTypeForTagging::ManagedInstance),
+            "Parameter" => Ok(ResourceTypeForTagging::Parameter),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>The inventory item result attribute.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ResultAttribute {
@@ -4726,6 +6441,41 @@ pub struct SeveritySummary {
     #[serde(rename="UnspecifiedCount")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub unspecified_count: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SignalType {
+    Approve,
+    Reject,
+}
+
+impl Into<String> for SignalType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SignalType {
+    fn into(self) -> &'static str {
+        match self {
+            SignalType::Approve => "Approve",
+            SignalType::Reject => "Reject",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SignalType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Approve" => Ok(SignalType::Approve),
+            "Reject" => Ok(SignalType::Reject),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -14883,7 +16633,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddTagsToResourceResult>(String::from_utf8_lossy(&body)
@@ -14915,7 +16665,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CancelCommandResult>(String::from_utf8_lossy(&body)
@@ -14947,7 +16697,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateActivationResult>(String::from_utf8_lossy(&body)
@@ -14979,7 +16729,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateAssociationResult>(String::from_utf8_lossy(&body)
@@ -15012,7 +16762,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateAssociationBatchResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15042,7 +16792,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateDocumentResult>(String::from_utf8_lossy(&body)
@@ -15075,7 +16825,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15106,7 +16856,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreatePatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15137,7 +16887,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateResourceDataSyncResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15167,7 +16917,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteActivationResult>(String::from_utf8_lossy(&body)
@@ -15199,7 +16949,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteAssociationResult>(String::from_utf8_lossy(&body)
@@ -15231,7 +16981,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteDocumentResult>(String::from_utf8_lossy(&body)
@@ -15264,7 +17014,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15295,7 +17045,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteParameterResult>(String::from_utf8_lossy(&body)
@@ -15327,7 +17077,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteParametersResult>(String::from_utf8_lossy(&body)
@@ -15359,7 +17109,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeletePatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15390,7 +17140,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteResourceDataSyncResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15421,7 +17171,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeregisterManagedInstanceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15455,7 +17205,7 @@ impl<P, D> Ssm for SsmClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeregisterPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15484,7 +17234,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeregisterTargetFromMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15517,7 +17267,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeregisterTaskFromMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15547,7 +17297,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeActivationsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15577,7 +17327,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAssociationResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15608,7 +17358,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAutomationExecutionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15640,7 +17390,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAvailablePatchesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15671,7 +17421,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeDocumentResult>(String::from_utf8_lossy(&body)
@@ -15704,7 +17454,7 @@ fn deregister_target_from_maintenance_window(&self, input: &DeregisterTargetFrom
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeDocumentPermissionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15734,7 +17484,7 @@ fn describe_effective_instance_associations(&self, input: &DescribeEffectiveInst
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEffectiveInstanceAssociationsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15763,7 +17513,7 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeEffectivePatchesForPatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15796,7 +17546,7 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeInstanceAssociationsStatusResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15827,7 +17577,7 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeInstanceInformationResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15859,7 +17609,7 @@ fn describe_effective_patches_for_patch_baseline(&self, input: &DescribeEffectiv
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeInstancePatchStatesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15889,7 +17639,7 @@ fn describe_instance_patch_states_for_patch_group(&self, input: &DescribeInstanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeInstancePatchStatesForPatchGroupResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15920,7 +17670,7 @@ fn describe_instance_patch_states_for_patch_group(&self, input: &DescribeInstanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeInstancePatchesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15950,7 +17700,7 @@ fn describe_maintenance_window_execution_task_invocations(&self, input: &Describ
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionTaskInvocationsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -15979,7 +17729,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionTasksResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16012,7 +17762,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMaintenanceWindowExecutionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16043,7 +17793,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMaintenanceWindowTargetsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16074,7 +17824,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMaintenanceWindowTasksResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16106,7 +17856,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMaintenanceWindowsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16137,7 +17887,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeParametersResult>(String::from_utf8_lossy(&body)
@@ -16170,7 +17920,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribePatchBaselinesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16201,7 +17951,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribePatchGroupStateResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16232,7 +17982,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribePatchGroupsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16263,7 +18013,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetAutomationExecutionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16293,7 +18043,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetCommandInvocationResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16324,7 +18074,7 @@ fn describe_maintenance_window_execution_tasks(&self, input: &DescribeMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDefaultPatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16354,7 +18104,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDeployablePatchSnapshotForInstanceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16384,7 +18134,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetDocumentResult>(String::from_utf8_lossy(&body)
@@ -16416,7 +18166,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetInventoryResult>(String::from_utf8_lossy(&body)
@@ -16448,7 +18198,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetInventorySchemaResult>(String::from_utf8_lossy(&body)
@@ -16480,7 +18230,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16511,7 +18261,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetMaintenanceWindowExecutionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16544,7 +18294,7 @@ fn get_deployable_patch_snapshot_for_instance(&self, input: &GetDeployablePatchS
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetMaintenanceWindowExecutionTaskResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16573,7 +18323,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetMaintenanceWindowExecutionTaskInvocationResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16604,7 +18354,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetMaintenanceWindowTaskResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16635,7 +18385,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetParameterResult>(String::from_utf8_lossy(&body)
@@ -16667,7 +18417,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetParameterHistoryResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16697,7 +18447,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetParametersResult>(String::from_utf8_lossy(&body)
@@ -16729,7 +18479,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetParametersByPathResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16759,7 +18509,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetPatchBaselineResult>(String::from_utf8_lossy(&body)
@@ -16792,7 +18542,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16824,7 +18574,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAssociationVersionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16855,7 +18605,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListAssociationsResult>(String::from_utf8_lossy(&body)
@@ -16888,7 +18638,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListCommandInvocationsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16918,7 +18668,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListCommandsResult>(String::from_utf8_lossy(&body)
@@ -16950,7 +18700,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListComplianceItemsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -16981,7 +18731,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListComplianceSummariesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17012,7 +18762,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListDocumentVersionsResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17042,7 +18792,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListDocumentsResult>(String::from_utf8_lossy(&body)
@@ -17074,7 +18824,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListInventoryEntriesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17105,7 +18855,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListResourceComplianceSummariesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17136,7 +18886,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListResourceDataSyncResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17166,7 +18916,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsForResourceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17197,7 +18947,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ModifyDocumentPermissionResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17228,7 +18978,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutComplianceItemsResult>(String::from_utf8_lossy(&body)
@@ -17260,7 +19010,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutInventoryResult>(String::from_utf8_lossy(&body)
@@ -17292,7 +19042,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PutParameterResult>(String::from_utf8_lossy(&body)
@@ -17325,7 +19075,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterDefaultPatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17359,7 +19109,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterPatchBaselineForPatchGroupResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17392,7 +19142,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterTargetWithMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17424,7 +19174,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RegisterTaskWithMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17455,7 +19205,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveTagsFromResourceResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17485,7 +19235,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SendAutomationSignalResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17515,7 +19265,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SendCommandResult>(String::from_utf8_lossy(&body)
@@ -17548,7 +19298,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartAutomationExecutionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17580,7 +19330,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopAutomationExecutionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17611,7 +19361,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateAssociationResult>(String::from_utf8_lossy(&body)
@@ -17644,7 +19394,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateAssociationStatusResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17675,7 +19425,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDocumentResult>(String::from_utf8_lossy(&body)
@@ -17708,7 +19458,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateDocumentDefaultVersionResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17740,7 +19490,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateMaintenanceWindowResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17772,7 +19522,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateMaintenanceWindowTargetResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17804,7 +19554,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateMaintenanceWindowTaskResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17836,7 +19586,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateManagedInstanceRoleResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -17867,7 +19617,7 @@ fn get_maintenance_window_execution_task_invocation(&self, input: &GetMaintenanc
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdatePatchBaselineResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -319,6 +315,50 @@ pub struct ExecutionStartedEventDetails {
     pub role_arn: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExecutionStatus {
+    Aborted,
+    Failed,
+    Running,
+    Succeeded,
+    TimedOut,
+}
+
+impl Into<String> for ExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ExecutionStatus::Aborted => "ABORTED",
+            ExecutionStatus::Failed => "FAILED",
+            ExecutionStatus::Running => "RUNNING",
+            ExecutionStatus::Succeeded => "SUCCEEDED",
+            ExecutionStatus::TimedOut => "TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ABORTED" => Ok(ExecutionStatus::Aborted),
+            "FAILED" => Ok(ExecutionStatus::Failed),
+            "RUNNING" => Ok(ExecutionStatus::Running),
+            "SUCCEEDED" => Ok(ExecutionStatus::Succeeded),
+            "TIMED_OUT" => Ok(ExecutionStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ExecutionSucceededEventDetails {
     #[doc="<p>The JSON data output by the execution.</p>"]
@@ -466,6 +506,128 @@ pub struct HistoryEvent {
     #[doc="<p>The type of the event.</p>"]
     #[serde(rename="type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum HistoryEventType {
+    ActivityFailed,
+    ActivityScheduleFailed,
+    ActivityScheduled,
+    ActivityStarted,
+    ActivitySucceeded,
+    ActivityTimedOut,
+    ChoiceStateEntered,
+    ChoiceStateExited,
+    ExecutionAborted,
+    ExecutionFailed,
+    ExecutionStarted,
+    ExecutionSucceeded,
+    ExecutionTimedOut,
+    FailStateEntered,
+    LambdaFunctionFailed,
+    LambdaFunctionScheduleFailed,
+    LambdaFunctionScheduled,
+    LambdaFunctionStartFailed,
+    LambdaFunctionStarted,
+    LambdaFunctionSucceeded,
+    LambdaFunctionTimedOut,
+    ParallelStateEntered,
+    ParallelStateExited,
+    PassStateEntered,
+    PassStateExited,
+    SucceedStateEntered,
+    SucceedStateExited,
+    TaskStateEntered,
+    TaskStateExited,
+    WaitStateEntered,
+    WaitStateExited,
+}
+
+impl Into<String> for HistoryEventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for HistoryEventType {
+    fn into(self) -> &'static str {
+        match self {
+            HistoryEventType::ActivityFailed => "ActivityFailed",
+            HistoryEventType::ActivityScheduleFailed => "ActivityScheduleFailed",
+            HistoryEventType::ActivityScheduled => "ActivityScheduled",
+            HistoryEventType::ActivityStarted => "ActivityStarted",
+            HistoryEventType::ActivitySucceeded => "ActivitySucceeded",
+            HistoryEventType::ActivityTimedOut => "ActivityTimedOut",
+            HistoryEventType::ChoiceStateEntered => "ChoiceStateEntered",
+            HistoryEventType::ChoiceStateExited => "ChoiceStateExited",
+            HistoryEventType::ExecutionAborted => "ExecutionAborted",
+            HistoryEventType::ExecutionFailed => "ExecutionFailed",
+            HistoryEventType::ExecutionStarted => "ExecutionStarted",
+            HistoryEventType::ExecutionSucceeded => "ExecutionSucceeded",
+            HistoryEventType::ExecutionTimedOut => "ExecutionTimedOut",
+            HistoryEventType::FailStateEntered => "FailStateEntered",
+            HistoryEventType::LambdaFunctionFailed => "LambdaFunctionFailed",
+            HistoryEventType::LambdaFunctionScheduleFailed => "LambdaFunctionScheduleFailed",
+            HistoryEventType::LambdaFunctionScheduled => "LambdaFunctionScheduled",
+            HistoryEventType::LambdaFunctionStartFailed => "LambdaFunctionStartFailed",
+            HistoryEventType::LambdaFunctionStarted => "LambdaFunctionStarted",
+            HistoryEventType::LambdaFunctionSucceeded => "LambdaFunctionSucceeded",
+            HistoryEventType::LambdaFunctionTimedOut => "LambdaFunctionTimedOut",
+            HistoryEventType::ParallelStateEntered => "ParallelStateEntered",
+            HistoryEventType::ParallelStateExited => "ParallelStateExited",
+            HistoryEventType::PassStateEntered => "PassStateEntered",
+            HistoryEventType::PassStateExited => "PassStateExited",
+            HistoryEventType::SucceedStateEntered => "SucceedStateEntered",
+            HistoryEventType::SucceedStateExited => "SucceedStateExited",
+            HistoryEventType::TaskStateEntered => "TaskStateEntered",
+            HistoryEventType::TaskStateExited => "TaskStateExited",
+            HistoryEventType::WaitStateEntered => "WaitStateEntered",
+            HistoryEventType::WaitStateExited => "WaitStateExited",
+        }
+    }
+}
+
+impl ::std::str::FromStr for HistoryEventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivityFailed" => Ok(HistoryEventType::ActivityFailed),
+            "ActivityScheduleFailed" => Ok(HistoryEventType::ActivityScheduleFailed),
+            "ActivityScheduled" => Ok(HistoryEventType::ActivityScheduled),
+            "ActivityStarted" => Ok(HistoryEventType::ActivityStarted),
+            "ActivitySucceeded" => Ok(HistoryEventType::ActivitySucceeded),
+            "ActivityTimedOut" => Ok(HistoryEventType::ActivityTimedOut),
+            "ChoiceStateEntered" => Ok(HistoryEventType::ChoiceStateEntered),
+            "ChoiceStateExited" => Ok(HistoryEventType::ChoiceStateExited),
+            "ExecutionAborted" => Ok(HistoryEventType::ExecutionAborted),
+            "ExecutionFailed" => Ok(HistoryEventType::ExecutionFailed),
+            "ExecutionStarted" => Ok(HistoryEventType::ExecutionStarted),
+            "ExecutionSucceeded" => Ok(HistoryEventType::ExecutionSucceeded),
+            "ExecutionTimedOut" => Ok(HistoryEventType::ExecutionTimedOut),
+            "FailStateEntered" => Ok(HistoryEventType::FailStateEntered),
+            "LambdaFunctionFailed" => Ok(HistoryEventType::LambdaFunctionFailed),
+            "LambdaFunctionScheduleFailed" => Ok(HistoryEventType::LambdaFunctionScheduleFailed),
+            "LambdaFunctionScheduled" => Ok(HistoryEventType::LambdaFunctionScheduled),
+            "LambdaFunctionStartFailed" => Ok(HistoryEventType::LambdaFunctionStartFailed),
+            "LambdaFunctionStarted" => Ok(HistoryEventType::LambdaFunctionStarted),
+            "LambdaFunctionSucceeded" => Ok(HistoryEventType::LambdaFunctionSucceeded),
+            "LambdaFunctionTimedOut" => Ok(HistoryEventType::LambdaFunctionTimedOut),
+            "ParallelStateEntered" => Ok(HistoryEventType::ParallelStateEntered),
+            "ParallelStateExited" => Ok(HistoryEventType::ParallelStateExited),
+            "PassStateEntered" => Ok(HistoryEventType::PassStateEntered),
+            "PassStateExited" => Ok(HistoryEventType::PassStateExited),
+            "SucceedStateEntered" => Ok(HistoryEventType::SucceedStateEntered),
+            "SucceedStateExited" => Ok(HistoryEventType::SucceedStateExited),
+            "TaskStateEntered" => Ok(HistoryEventType::TaskStateEntered),
+            "TaskStateExited" => Ok(HistoryEventType::TaskStateExited),
+            "WaitStateEntered" => Ok(HistoryEventType::WaitStateEntered),
+            "WaitStateExited" => Ok(HistoryEventType::WaitStateExited),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Deserialize)]
@@ -713,6 +875,41 @@ pub struct StateMachineListItem {
     #[doc="<p>The Amazon Resource Name (ARN) that identifies the state machine.</p>"]
     #[serde(rename="stateMachineArn")]
     pub state_machine_arn: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StateMachineStatus {
+    Active,
+    Deleting,
+}
+
+impl Into<String> for StateMachineStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StateMachineStatus {
+    fn into(self) -> &'static str {
+        match self {
+            StateMachineStatus::Active => "ACTIVE",
+            StateMachineStatus::Deleting => "DELETING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StateMachineStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(StateMachineStatus::Active),
+            "DELETING" => Ok(StateMachineStatus::Deleting),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -2388,7 +2585,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateActivityOutput>(String::from_utf8_lossy(&body)
@@ -2420,7 +2617,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateStateMachineOutput>(String::from_utf8_lossy(&body)
@@ -2452,7 +2649,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteActivityOutput>(String::from_utf8_lossy(&body)
@@ -2484,7 +2681,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteStateMachineOutput>(String::from_utf8_lossy(&body)
@@ -2516,7 +2713,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeActivityOutput>(String::from_utf8_lossy(&body)
@@ -2548,7 +2745,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeExecutionOutput>(String::from_utf8_lossy(&body)
@@ -2580,7 +2777,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeStateMachineOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2610,7 +2807,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetActivityTaskOutput>(String::from_utf8_lossy(&body)
@@ -2642,7 +2839,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetExecutionHistoryOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2672,7 +2869,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListActivitiesOutput>(String::from_utf8_lossy(&body)
@@ -2704,7 +2901,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListExecutionsOutput>(String::from_utf8_lossy(&body)
@@ -2736,7 +2933,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListStateMachinesOutput>(String::from_utf8_lossy(&body)
@@ -2768,7 +2965,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SendTaskFailureOutput>(String::from_utf8_lossy(&body)
@@ -2800,7 +2997,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SendTaskHeartbeatOutput>(String::from_utf8_lossy(&body)
@@ -2832,7 +3029,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SendTaskSuccessOutput>(String::from_utf8_lossy(&body)
@@ -2864,7 +3061,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartExecutionOutput>(String::from_utf8_lossy(&body)
@@ -2896,7 +3093,7 @@ impl<P, D> StepFunctions for StepFunctionsClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopExecutionOutput>(String::from_utf8_lossy(&body)

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -1059,6 +1055,218 @@ pub struct Disk {
     #[serde(rename="DiskStatus")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub disk_status: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ErrorCode {
+    ActivationKeyExpired,
+    ActivationKeyInvalid,
+    ActivationKeyNotFound,
+    AuthenticationFailure,
+    BandwidthThrottleScheduleNotFound,
+    Blocked,
+    CannotExportSnapshot,
+    ChapCredentialNotFound,
+    DiskAlreadyAllocated,
+    DiskDoesNotExist,
+    DiskSizeGreaterThanVolumeMaxSize,
+    DiskSizeLessThanVolumeSize,
+    DiskSizeNotGigAligned,
+    DuplicateCertificateInfo,
+    DuplicateSchedule,
+    EndpointNotFound,
+    GatewayInternalError,
+    GatewayNotConnected,
+    GatewayNotFound,
+    GatewayProxyNetworkConnectionBusy,
+    IamnotSupported,
+    InitiatorInvalid,
+    InitiatorNotFound,
+    InternalError,
+    InvalidEndpoint,
+    InvalidGateway,
+    InvalidParameters,
+    InvalidSchedule,
+    LocalStorageLimitExceeded,
+    LunAlreadyAllocated,
+    LunInvalid,
+    MaximumContentLengthExceeded,
+    MaximumTapeCartridgeCountExceeded,
+    MaximumVolumeCountExceeded,
+    NetworkConfigurationChanged,
+    NoDisksAvailable,
+    NotImplemented,
+    NotSupported,
+    OperationAborted,
+    OutdatedGateway,
+    ParametersNotImplemented,
+    RegionInvalid,
+    RequestTimeout,
+    ServiceUnavailable,
+    SnapshotDeleted,
+    SnapshotIdInvalid,
+    SnapshotInProgress,
+    SnapshotNotFound,
+    SnapshotScheduleNotFound,
+    StagingAreaFull,
+    StorageFailure,
+    TapeCartridgeNotFound,
+    TargetAlreadyExists,
+    TargetInvalid,
+    TargetNotFound,
+    UnauthorizedOperation,
+    VolumeAlreadyExists,
+    VolumeIdInvalid,
+    VolumeInUse,
+    VolumeNotFound,
+    VolumeNotReady,
+}
+
+impl Into<String> for ErrorCode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ErrorCode {
+    fn into(self) -> &'static str {
+        match self {
+            ErrorCode::ActivationKeyExpired => "ActivationKeyExpired",
+            ErrorCode::ActivationKeyInvalid => "ActivationKeyInvalid",
+            ErrorCode::ActivationKeyNotFound => "ActivationKeyNotFound",
+            ErrorCode::AuthenticationFailure => "AuthenticationFailure",
+            ErrorCode::BandwidthThrottleScheduleNotFound => "BandwidthThrottleScheduleNotFound",
+            ErrorCode::Blocked => "Blocked",
+            ErrorCode::CannotExportSnapshot => "CannotExportSnapshot",
+            ErrorCode::ChapCredentialNotFound => "ChapCredentialNotFound",
+            ErrorCode::DiskAlreadyAllocated => "DiskAlreadyAllocated",
+            ErrorCode::DiskDoesNotExist => "DiskDoesNotExist",
+            ErrorCode::DiskSizeGreaterThanVolumeMaxSize => "DiskSizeGreaterThanVolumeMaxSize",
+            ErrorCode::DiskSizeLessThanVolumeSize => "DiskSizeLessThanVolumeSize",
+            ErrorCode::DiskSizeNotGigAligned => "DiskSizeNotGigAligned",
+            ErrorCode::DuplicateCertificateInfo => "DuplicateCertificateInfo",
+            ErrorCode::DuplicateSchedule => "DuplicateSchedule",
+            ErrorCode::EndpointNotFound => "EndpointNotFound",
+            ErrorCode::GatewayInternalError => "GatewayInternalError",
+            ErrorCode::GatewayNotConnected => "GatewayNotConnected",
+            ErrorCode::GatewayNotFound => "GatewayNotFound",
+            ErrorCode::GatewayProxyNetworkConnectionBusy => "GatewayProxyNetworkConnectionBusy",
+            ErrorCode::IamnotSupported => "IAMNotSupported",
+            ErrorCode::InitiatorInvalid => "InitiatorInvalid",
+            ErrorCode::InitiatorNotFound => "InitiatorNotFound",
+            ErrorCode::InternalError => "InternalError",
+            ErrorCode::InvalidEndpoint => "InvalidEndpoint",
+            ErrorCode::InvalidGateway => "InvalidGateway",
+            ErrorCode::InvalidParameters => "InvalidParameters",
+            ErrorCode::InvalidSchedule => "InvalidSchedule",
+            ErrorCode::LocalStorageLimitExceeded => "LocalStorageLimitExceeded",
+            ErrorCode::LunAlreadyAllocated => "LunAlreadyAllocated ",
+            ErrorCode::LunInvalid => "LunInvalid",
+            ErrorCode::MaximumContentLengthExceeded => "MaximumContentLengthExceeded",
+            ErrorCode::MaximumTapeCartridgeCountExceeded => "MaximumTapeCartridgeCountExceeded",
+            ErrorCode::MaximumVolumeCountExceeded => "MaximumVolumeCountExceeded",
+            ErrorCode::NetworkConfigurationChanged => "NetworkConfigurationChanged",
+            ErrorCode::NoDisksAvailable => "NoDisksAvailable",
+            ErrorCode::NotImplemented => "NotImplemented",
+            ErrorCode::NotSupported => "NotSupported",
+            ErrorCode::OperationAborted => "OperationAborted",
+            ErrorCode::OutdatedGateway => "OutdatedGateway",
+            ErrorCode::ParametersNotImplemented => "ParametersNotImplemented",
+            ErrorCode::RegionInvalid => "RegionInvalid",
+            ErrorCode::RequestTimeout => "RequestTimeout",
+            ErrorCode::ServiceUnavailable => "ServiceUnavailable",
+            ErrorCode::SnapshotDeleted => "SnapshotDeleted",
+            ErrorCode::SnapshotIdInvalid => "SnapshotIdInvalid",
+            ErrorCode::SnapshotInProgress => "SnapshotInProgress",
+            ErrorCode::SnapshotNotFound => "SnapshotNotFound",
+            ErrorCode::SnapshotScheduleNotFound => "SnapshotScheduleNotFound",
+            ErrorCode::StagingAreaFull => "StagingAreaFull",
+            ErrorCode::StorageFailure => "StorageFailure",
+            ErrorCode::TapeCartridgeNotFound => "TapeCartridgeNotFound",
+            ErrorCode::TargetAlreadyExists => "TargetAlreadyExists",
+            ErrorCode::TargetInvalid => "TargetInvalid",
+            ErrorCode::TargetNotFound => "TargetNotFound",
+            ErrorCode::UnauthorizedOperation => "UnauthorizedOperation",
+            ErrorCode::VolumeAlreadyExists => "VolumeAlreadyExists",
+            ErrorCode::VolumeIdInvalid => "VolumeIdInvalid",
+            ErrorCode::VolumeInUse => "VolumeInUse",
+            ErrorCode::VolumeNotFound => "VolumeNotFound",
+            ErrorCode::VolumeNotReady => "VolumeNotReady",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ErrorCode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivationKeyExpired" => Ok(ErrorCode::ActivationKeyExpired),
+            "ActivationKeyInvalid" => Ok(ErrorCode::ActivationKeyInvalid),
+            "ActivationKeyNotFound" => Ok(ErrorCode::ActivationKeyNotFound),
+            "AuthenticationFailure" => Ok(ErrorCode::AuthenticationFailure),
+            "BandwidthThrottleScheduleNotFound" => Ok(ErrorCode::BandwidthThrottleScheduleNotFound),
+            "Blocked" => Ok(ErrorCode::Blocked),
+            "CannotExportSnapshot" => Ok(ErrorCode::CannotExportSnapshot),
+            "ChapCredentialNotFound" => Ok(ErrorCode::ChapCredentialNotFound),
+            "DiskAlreadyAllocated" => Ok(ErrorCode::DiskAlreadyAllocated),
+            "DiskDoesNotExist" => Ok(ErrorCode::DiskDoesNotExist),
+            "DiskSizeGreaterThanVolumeMaxSize" => Ok(ErrorCode::DiskSizeGreaterThanVolumeMaxSize),
+            "DiskSizeLessThanVolumeSize" => Ok(ErrorCode::DiskSizeLessThanVolumeSize),
+            "DiskSizeNotGigAligned" => Ok(ErrorCode::DiskSizeNotGigAligned),
+            "DuplicateCertificateInfo" => Ok(ErrorCode::DuplicateCertificateInfo),
+            "DuplicateSchedule" => Ok(ErrorCode::DuplicateSchedule),
+            "EndpointNotFound" => Ok(ErrorCode::EndpointNotFound),
+            "GatewayInternalError" => Ok(ErrorCode::GatewayInternalError),
+            "GatewayNotConnected" => Ok(ErrorCode::GatewayNotConnected),
+            "GatewayNotFound" => Ok(ErrorCode::GatewayNotFound),
+            "GatewayProxyNetworkConnectionBusy" => Ok(ErrorCode::GatewayProxyNetworkConnectionBusy),
+            "IAMNotSupported" => Ok(ErrorCode::IamnotSupported),
+            "InitiatorInvalid" => Ok(ErrorCode::InitiatorInvalid),
+            "InitiatorNotFound" => Ok(ErrorCode::InitiatorNotFound),
+            "InternalError" => Ok(ErrorCode::InternalError),
+            "InvalidEndpoint" => Ok(ErrorCode::InvalidEndpoint),
+            "InvalidGateway" => Ok(ErrorCode::InvalidGateway),
+            "InvalidParameters" => Ok(ErrorCode::InvalidParameters),
+            "InvalidSchedule" => Ok(ErrorCode::InvalidSchedule),
+            "LocalStorageLimitExceeded" => Ok(ErrorCode::LocalStorageLimitExceeded),
+            "LunAlreadyAllocated " => Ok(ErrorCode::LunAlreadyAllocated),
+            "LunInvalid" => Ok(ErrorCode::LunInvalid),
+            "MaximumContentLengthExceeded" => Ok(ErrorCode::MaximumContentLengthExceeded),
+            "MaximumTapeCartridgeCountExceeded" => Ok(ErrorCode::MaximumTapeCartridgeCountExceeded),
+            "MaximumVolumeCountExceeded" => Ok(ErrorCode::MaximumVolumeCountExceeded),
+            "NetworkConfigurationChanged" => Ok(ErrorCode::NetworkConfigurationChanged),
+            "NoDisksAvailable" => Ok(ErrorCode::NoDisksAvailable),
+            "NotImplemented" => Ok(ErrorCode::NotImplemented),
+            "NotSupported" => Ok(ErrorCode::NotSupported),
+            "OperationAborted" => Ok(ErrorCode::OperationAborted),
+            "OutdatedGateway" => Ok(ErrorCode::OutdatedGateway),
+            "ParametersNotImplemented" => Ok(ErrorCode::ParametersNotImplemented),
+            "RegionInvalid" => Ok(ErrorCode::RegionInvalid),
+            "RequestTimeout" => Ok(ErrorCode::RequestTimeout),
+            "ServiceUnavailable" => Ok(ErrorCode::ServiceUnavailable),
+            "SnapshotDeleted" => Ok(ErrorCode::SnapshotDeleted),
+            "SnapshotIdInvalid" => Ok(ErrorCode::SnapshotIdInvalid),
+            "SnapshotInProgress" => Ok(ErrorCode::SnapshotInProgress),
+            "SnapshotNotFound" => Ok(ErrorCode::SnapshotNotFound),
+            "SnapshotScheduleNotFound" => Ok(ErrorCode::SnapshotScheduleNotFound),
+            "StagingAreaFull" => Ok(ErrorCode::StagingAreaFull),
+            "StorageFailure" => Ok(ErrorCode::StorageFailure),
+            "TapeCartridgeNotFound" => Ok(ErrorCode::TapeCartridgeNotFound),
+            "TargetAlreadyExists" => Ok(ErrorCode::TargetAlreadyExists),
+            "TargetInvalid" => Ok(ErrorCode::TargetInvalid),
+            "TargetNotFound" => Ok(ErrorCode::TargetNotFound),
+            "UnauthorizedOperation" => Ok(ErrorCode::UnauthorizedOperation),
+            "VolumeAlreadyExists" => Ok(ErrorCode::VolumeAlreadyExists),
+            "VolumeIdInvalid" => Ok(ErrorCode::VolumeIdInvalid),
+            "VolumeInUse" => Ok(ErrorCode::VolumeInUse),
+            "VolumeNotFound" => Ok(ErrorCode::VolumeNotFound),
+            "VolumeNotReady" => Ok(ErrorCode::VolumeNotReady),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a file share.</p>"]
@@ -7677,7 +7885,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ActivateGatewayOutput>(String::from_utf8_lossy(&body)
@@ -7707,7 +7915,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddCacheOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -7738,7 +7946,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddTagsToResourceOutput>(String::from_utf8_lossy(&body)
@@ -7770,7 +7978,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddUploadBufferOutput>(String::from_utf8_lossy(&body)
@@ -7802,7 +8010,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddWorkingStorageOutput>(String::from_utf8_lossy(&body)
@@ -7834,7 +8042,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CancelArchivalOutput>(String::from_utf8_lossy(&body)
@@ -7866,7 +8074,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CancelRetrievalOutput>(String::from_utf8_lossy(&body)
@@ -7900,7 +8108,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateCachediSCSIVolumeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7931,7 +8139,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateNFSFileShareOutput>(String::from_utf8_lossy(&body)
@@ -7963,7 +8171,7 @@ impl<P, D> StorageGateway for StorageGatewayClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateSnapshotOutput>(String::from_utf8_lossy(&body)
@@ -7994,7 +8202,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateSnapshotFromVolumeRecoveryPointOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8026,7 +8234,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateStorediSCSIVolumeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8059,7 +8267,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateTapeWithBarcodeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8089,7 +8297,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateTapesOutput>(String::from_utf8_lossy(&body)
@@ -8123,7 +8331,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteBandwidthRateLimitOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8156,7 +8364,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteChapCredentialsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8186,7 +8394,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteFileShareOutput>(String::from_utf8_lossy(&body)
@@ -8218,7 +8426,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteGatewayOutput>(String::from_utf8_lossy(&body)
@@ -8252,7 +8460,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteSnapshotScheduleOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8280,7 +8488,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteTapeOutput>(String::from_utf8_lossy(&body)
@@ -8312,7 +8520,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteTapeArchiveOutput>(String::from_utf8_lossy(&body)
@@ -8344,7 +8552,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteVolumeOutput>(String::from_utf8_lossy(&body)
@@ -8378,7 +8586,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeBandwidthRateLimitOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8409,7 +8617,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeCacheOutput>(String::from_utf8_lossy(&body)
@@ -8443,7 +8651,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeCachediSCSIVolumesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8476,7 +8684,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeChapCredentialsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8509,7 +8717,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeGatewayInformationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8542,7 +8750,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeMaintenanceStartTimeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8575,7 +8783,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeNFSFileSharesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8607,7 +8815,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeSnapshotScheduleOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8640,7 +8848,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeStorediSCSIVolumesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8672,7 +8880,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTapeArchivesOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8704,7 +8912,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTapeRecoveryPointsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8735,7 +8943,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTapesOutput>(String::from_utf8_lossy(&body)
@@ -8768,7 +8976,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeUploadBufferOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8798,7 +9006,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeVTLDevicesOutput>(String::from_utf8_lossy(&body)
@@ -8832,7 +9040,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeWorkingStorageOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8862,7 +9070,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisableGatewayOutput>(String::from_utf8_lossy(&body)
@@ -8894,7 +9102,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListFileSharesOutput>(String::from_utf8_lossy(&body)
@@ -8926,7 +9134,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListGatewaysOutput>(String::from_utf8_lossy(&body)
@@ -8958,7 +9166,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListLocalDisksOutput>(String::from_utf8_lossy(&body)
@@ -8991,7 +9199,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTagsForResourceOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9019,7 +9227,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListTapesOutput>(String::from_utf8_lossy(&body).as_ref())
@@ -9051,7 +9259,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListVolumeInitiatorsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9083,7 +9291,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListVolumeRecoveryPointsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9114,7 +9322,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListVolumesOutput>(String::from_utf8_lossy(&body)
@@ -9146,7 +9354,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RefreshCacheOutput>(String::from_utf8_lossy(&body)
@@ -9180,7 +9388,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RemoveTagsFromResourceOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9208,7 +9416,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ResetCacheOutput>(String::from_utf8_lossy(&body)
@@ -9241,7 +9449,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RetrieveTapeArchiveOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9273,7 +9481,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RetrieveTapeRecoveryPointOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9306,7 +9514,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<SetLocalConsolePasswordOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9337,7 +9545,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ShutdownGatewayOutput>(String::from_utf8_lossy(&body)
@@ -9369,7 +9577,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartGatewayOutput>(String::from_utf8_lossy(&body)
@@ -9403,7 +9611,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateBandwidthRateLimitOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9436,7 +9644,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateChapCredentialsOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9468,7 +9676,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateGatewayInformationOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9501,7 +9709,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateGatewaySoftwareNowOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9534,7 +9742,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateMaintenanceStartTimeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9565,7 +9773,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateNFSFileShareOutput>(String::from_utf8_lossy(&body)
@@ -9599,7 +9807,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateSnapshotScheduleOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -9630,7 +9838,7 @@ fn create_snapshot_from_volume_recovery_point(&self, input: &CreateSnapshotFromV
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateVTLDeviceTypeOutput>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use std::str::FromStr;
@@ -1845,7 +1841,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -1892,7 +1888,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -1940,7 +1936,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -1988,7 +1984,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -2035,7 +2031,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -2082,7 +2078,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();
@@ -2129,7 +2125,7 @@ impl<P, D> Sts for StsClient<P, D>
         request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
         let mut response = try!(self.dispatcher.dispatch(&request));
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let result;
                 let mut body: Vec<u8> = Vec::new();

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -2009,7 +2005,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddAttachmentsToSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2040,7 +2036,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AddCommunicationToCaseResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2070,7 +2066,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateCaseResponse>(String::from_utf8_lossy(&body)
@@ -2102,7 +2098,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeAttachmentResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2132,7 +2128,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeCasesResponse>(String::from_utf8_lossy(&body)
@@ -2165,7 +2161,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeCommunicationsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2195,7 +2191,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeServicesResponse>(String::from_utf8_lossy(&body)
@@ -2228,7 +2224,7 @@ impl<P, D> AWSSupport for AWSSupportClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeSeverityLevelsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2257,7 +2253,7 @@ fn describe_trusted_advisor_check_refresh_statuses(&self, input: &DescribeTruste
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckRefreshStatusesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2290,7 +2286,7 @@ fn describe_trusted_advisor_check_refresh_statuses(&self, input: &DescribeTruste
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckResultResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2319,7 +2315,7 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTrustedAdvisorCheckSummariesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2351,7 +2347,7 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTrustedAdvisorChecksResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2384,7 +2380,7 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RefreshTrustedAdvisorCheckResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2415,7 +2411,7 @@ fn describe_trusted_advisor_check_summaries(&self, input: &DescribeTrustedAdviso
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ResolveCaseResponse>(String::from_utf8_lossy(&body)

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -199,6 +195,47 @@ pub struct ActivityTaskTimedOutEventAttributes {
     pub timeout_type: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActivityTaskTimeoutType {
+    Heartbeat,
+    ScheduleToClose,
+    ScheduleToStart,
+    StartToClose,
+}
+
+impl Into<String> for ActivityTaskTimeoutType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActivityTaskTimeoutType {
+    fn into(self) -> &'static str {
+        match self {
+            ActivityTaskTimeoutType::Heartbeat => "HEARTBEAT",
+            ActivityTaskTimeoutType::ScheduleToClose => "SCHEDULE_TO_CLOSE",
+            ActivityTaskTimeoutType::ScheduleToStart => "SCHEDULE_TO_START",
+            ActivityTaskTimeoutType::StartToClose => "START_TO_CLOSE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActivityTaskTimeoutType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HEARTBEAT" => Ok(ActivityTaskTimeoutType::Heartbeat),
+            "SCHEDULE_TO_CLOSE" => Ok(ActivityTaskTimeoutType::ScheduleToClose),
+            "SCHEDULE_TO_START" => Ok(ActivityTaskTimeoutType::ScheduleToStart),
+            "START_TO_CLOSE" => Ok(ActivityTaskTimeoutType::StartToClose),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Represents an activity type.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityType {
@@ -292,6 +329,41 @@ pub struct CancelTimerDecisionAttributes {
     pub timer_id: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CancelTimerFailedCause {
+    OperationNotPermitted,
+    TimerIdUnknown,
+}
+
+impl Into<String> for CancelTimerFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CancelTimerFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            CancelTimerFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+            CancelTimerFailedCause::TimerIdUnknown => "TIMER_ID_UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CancelTimerFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => Ok(CancelTimerFailedCause::OperationNotPermitted),
+            "TIMER_ID_UNKNOWN" => Ok(CancelTimerFailedCause::TimerIdUnknown),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides the details of the <code>CancelTimerFailed</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CancelTimerFailedEventAttributes {
@@ -315,6 +387,43 @@ pub struct CancelWorkflowExecutionDecisionAttributes {
     pub details: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CancelWorkflowExecutionFailedCause {
+    OperationNotPermitted,
+    UnhandledDecision,
+}
+
+impl Into<String> for CancelWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CancelWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            CancelWorkflowExecutionFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+            CancelWorkflowExecutionFailedCause::UnhandledDecision => "UNHANDLED_DECISION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CancelWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(CancelWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "UNHANDLED_DECISION" => Ok(CancelWorkflowExecutionFailedCause::UnhandledDecision),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides the details of the <code>CancelWorkflowExecutionFailed</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct CancelWorkflowExecutionFailedEventAttributes {
@@ -324,6 +433,44 @@ pub struct CancelWorkflowExecutionFailedEventAttributes {
     #[doc="<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CancelWorkflowExecution</code> decision for this cancellation request. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="decisionTaskCompletedEventId")]
     pub decision_task_completed_event_id: i64,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChildPolicy {
+    Abandon,
+    RequestCancel,
+    Terminate,
+}
+
+impl Into<String> for ChildPolicy {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChildPolicy {
+    fn into(self) -> &'static str {
+        match self {
+            ChildPolicy::Abandon => "ABANDON",
+            ChildPolicy::RequestCancel => "REQUEST_CANCEL",
+            ChildPolicy::Terminate => "TERMINATE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChildPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ABANDON" => Ok(ChildPolicy::Abandon),
+            "REQUEST_CANCEL" => Ok(ChildPolicy::RequestCancel),
+            "TERMINATE" => Ok(ChildPolicy::Terminate),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provide details of the <code>ChildWorkflowExecutionCanceled</code> event.</p>"]
@@ -444,6 +591,53 @@ pub struct ChildWorkflowExecutionTimedOutEventAttributes {
     pub workflow_type: WorkflowType,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CloseStatus {
+    Canceled,
+    Completed,
+    ContinuedAsNew,
+    Failed,
+    Terminated,
+    TimedOut,
+}
+
+impl Into<String> for CloseStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CloseStatus {
+    fn into(self) -> &'static str {
+        match self {
+            CloseStatus::Canceled => "CANCELED",
+            CloseStatus::Completed => "COMPLETED",
+            CloseStatus::ContinuedAsNew => "CONTINUED_AS_NEW",
+            CloseStatus::Failed => "FAILED",
+            CloseStatus::Terminated => "TERMINATED",
+            CloseStatus::TimedOut => "TIMED_OUT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CloseStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CANCELED" => Ok(CloseStatus::Canceled),
+            "COMPLETED" => Ok(CloseStatus::Completed),
+            "CONTINUED_AS_NEW" => Ok(CloseStatus::ContinuedAsNew),
+            "FAILED" => Ok(CloseStatus::Failed),
+            "TERMINATED" => Ok(CloseStatus::Terminated),
+            "TIMED_OUT" => Ok(CloseStatus::TimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Used to filter the closed workflow executions in visibility APIs by their close status.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct CloseStatusFilter {
@@ -459,6 +653,45 @@ pub struct CompleteWorkflowExecutionDecisionAttributes {
     #[serde(rename="result")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub result: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CompleteWorkflowExecutionFailedCause {
+    OperationNotPermitted,
+    UnhandledDecision,
+}
+
+impl Into<String> for CompleteWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CompleteWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            CompleteWorkflowExecutionFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+            CompleteWorkflowExecutionFailedCause::UnhandledDecision => "UNHANDLED_DECISION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CompleteWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(CompleteWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "UNHANDLED_DECISION" => Ok(CompleteWorkflowExecutionFailedCause::UnhandledDecision),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides the details of the <code>CompleteWorkflowExecutionFailed</code> event.</p>"]
@@ -511,6 +744,86 @@ pub struct ContinueAsNewWorkflowExecutionDecisionAttributes {
     #[serde(rename="workflowTypeVersion")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub workflow_type_version: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ContinueAsNewWorkflowExecutionFailedCause {
+    ContinueAsNewWorkflowExecutionRateExceeded,
+    DefaultChildPolicyUndefined,
+    DefaultExecutionStartToCloseTimeoutUndefined,
+    DefaultTaskListUndefined,
+    DefaultTaskStartToCloseTimeoutUndefined,
+    OperationNotPermitted,
+    UnhandledDecision,
+    WorkflowTypeDeprecated,
+    WorkflowTypeDoesNotExist,
+}
+
+impl Into<String> for ContinueAsNewWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ContinueAsNewWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            ContinueAsNewWorkflowExecutionFailedCause::ContinueAsNewWorkflowExecutionRateExceeded => "CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED",
+            ContinueAsNewWorkflowExecutionFailedCause::DefaultChildPolicyUndefined => {
+                "DEFAULT_CHILD_POLICY_UNDEFINED"
+            }
+            ContinueAsNewWorkflowExecutionFailedCause::DefaultExecutionStartToCloseTimeoutUndefined => "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED",
+            ContinueAsNewWorkflowExecutionFailedCause::DefaultTaskListUndefined => {
+                "DEFAULT_TASK_LIST_UNDEFINED"
+            }
+            ContinueAsNewWorkflowExecutionFailedCause::DefaultTaskStartToCloseTimeoutUndefined => {
+                "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED"
+            }
+            ContinueAsNewWorkflowExecutionFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+            ContinueAsNewWorkflowExecutionFailedCause::UnhandledDecision => "UNHANDLED_DECISION",
+            ContinueAsNewWorkflowExecutionFailedCause::WorkflowTypeDeprecated => {
+                "WORKFLOW_TYPE_DEPRECATED"
+            }
+            ContinueAsNewWorkflowExecutionFailedCause::WorkflowTypeDoesNotExist => {
+                "WORKFLOW_TYPE_DOES_NOT_EXIST"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ContinueAsNewWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED" => Ok(ContinueAsNewWorkflowExecutionFailedCause::ContinueAsNewWorkflowExecutionRateExceeded),
+            "DEFAULT_CHILD_POLICY_UNDEFINED" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::DefaultChildPolicyUndefined)
+            }
+            "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED" => Ok(ContinueAsNewWorkflowExecutionFailedCause::DefaultExecutionStartToCloseTimeoutUndefined),
+            "DEFAULT_TASK_LIST_UNDEFINED" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::DefaultTaskListUndefined)
+            }
+            "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED" => Ok(ContinueAsNewWorkflowExecutionFailedCause::DefaultTaskStartToCloseTimeoutUndefined),
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "UNHANDLED_DECISION" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::UnhandledDecision)
+            }
+            "WORKFLOW_TYPE_DEPRECATED" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::WorkflowTypeDeprecated)
+            }
+            "WORKFLOW_TYPE_DOES_NOT_EXIST" => {
+                Ok(ContinueAsNewWorkflowExecutionFailedCause::WorkflowTypeDoesNotExist)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides the details of the <code>ContinueAsNewWorkflowExecutionFailed</code> event.</p>"]
@@ -752,6 +1065,110 @@ pub struct DecisionTaskTimedOutEventAttributes {
     pub timeout_type: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DecisionTaskTimeoutType {
+    StartToClose,
+}
+
+impl Into<String> for DecisionTaskTimeoutType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DecisionTaskTimeoutType {
+    fn into(self) -> &'static str {
+        match self {
+            DecisionTaskTimeoutType::StartToClose => "START_TO_CLOSE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DecisionTaskTimeoutType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "START_TO_CLOSE" => Ok(DecisionTaskTimeoutType::StartToClose),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DecisionType {
+    CancelTimer,
+    CancelWorkflowExecution,
+    CompleteWorkflowExecution,
+    ContinueAsNewWorkflowExecution,
+    FailWorkflowExecution,
+    RecordMarker,
+    RequestCancelActivityTask,
+    RequestCancelExternalWorkflowExecution,
+    ScheduleActivityTask,
+    ScheduleLambdaFunction,
+    SignalExternalWorkflowExecution,
+    StartChildWorkflowExecution,
+    StartTimer,
+}
+
+impl Into<String> for DecisionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DecisionType {
+    fn into(self) -> &'static str {
+        match self {
+            DecisionType::CancelTimer => "CancelTimer",
+            DecisionType::CancelWorkflowExecution => "CancelWorkflowExecution",
+            DecisionType::CompleteWorkflowExecution => "CompleteWorkflowExecution",
+            DecisionType::ContinueAsNewWorkflowExecution => "ContinueAsNewWorkflowExecution",
+            DecisionType::FailWorkflowExecution => "FailWorkflowExecution",
+            DecisionType::RecordMarker => "RecordMarker",
+            DecisionType::RequestCancelActivityTask => "RequestCancelActivityTask",
+            DecisionType::RequestCancelExternalWorkflowExecution => {
+                "RequestCancelExternalWorkflowExecution"
+            }
+            DecisionType::ScheduleActivityTask => "ScheduleActivityTask",
+            DecisionType::ScheduleLambdaFunction => "ScheduleLambdaFunction",
+            DecisionType::SignalExternalWorkflowExecution => "SignalExternalWorkflowExecution",
+            DecisionType::StartChildWorkflowExecution => "StartChildWorkflowExecution",
+            DecisionType::StartTimer => "StartTimer",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DecisionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CancelTimer" => Ok(DecisionType::CancelTimer),
+            "CancelWorkflowExecution" => Ok(DecisionType::CancelWorkflowExecution),
+            "CompleteWorkflowExecution" => Ok(DecisionType::CompleteWorkflowExecution),
+            "ContinueAsNewWorkflowExecution" => Ok(DecisionType::ContinueAsNewWorkflowExecution),
+            "FailWorkflowExecution" => Ok(DecisionType::FailWorkflowExecution),
+            "RecordMarker" => Ok(DecisionType::RecordMarker),
+            "RequestCancelActivityTask" => Ok(DecisionType::RequestCancelActivityTask),
+            "RequestCancelExternalWorkflowExecution" => {
+                Ok(DecisionType::RequestCancelExternalWorkflowExecution)
+            }
+            "ScheduleActivityTask" => Ok(DecisionType::ScheduleActivityTask),
+            "ScheduleLambdaFunction" => Ok(DecisionType::ScheduleLambdaFunction),
+            "SignalExternalWorkflowExecution" => Ok(DecisionType::SignalExternalWorkflowExecution),
+            "StartChildWorkflowExecution" => Ok(DecisionType::StartChildWorkflowExecution),
+            "StartTimer" => Ok(DecisionType::StartTimer),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct DeprecateActivityTypeInput {
     #[doc="<p>The activity type to deprecate.</p>"]
@@ -862,6 +1279,260 @@ pub struct DomainInfos {
     pub next_page_token: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum EventType {
+    ActivityTaskCancelRequested,
+    ActivityTaskCanceled,
+    ActivityTaskCompleted,
+    ActivityTaskFailed,
+    ActivityTaskScheduled,
+    ActivityTaskStarted,
+    ActivityTaskTimedOut,
+    CancelTimerFailed,
+    CancelWorkflowExecutionFailed,
+    ChildWorkflowExecutionCanceled,
+    ChildWorkflowExecutionCompleted,
+    ChildWorkflowExecutionFailed,
+    ChildWorkflowExecutionStarted,
+    ChildWorkflowExecutionTerminated,
+    ChildWorkflowExecutionTimedOut,
+    CompleteWorkflowExecutionFailed,
+    ContinueAsNewWorkflowExecutionFailed,
+    DecisionTaskCompleted,
+    DecisionTaskScheduled,
+    DecisionTaskStarted,
+    DecisionTaskTimedOut,
+    ExternalWorkflowExecutionCancelRequested,
+    ExternalWorkflowExecutionSignaled,
+    FailWorkflowExecutionFailed,
+    LambdaFunctionCompleted,
+    LambdaFunctionFailed,
+    LambdaFunctionScheduled,
+    LambdaFunctionStarted,
+    LambdaFunctionTimedOut,
+    MarkerRecorded,
+    RecordMarkerFailed,
+    RequestCancelActivityTaskFailed,
+    RequestCancelExternalWorkflowExecutionFailed,
+    RequestCancelExternalWorkflowExecutionInitiated,
+    ScheduleActivityTaskFailed,
+    ScheduleLambdaFunctionFailed,
+    SignalExternalWorkflowExecutionFailed,
+    SignalExternalWorkflowExecutionInitiated,
+    StartChildWorkflowExecutionFailed,
+    StartChildWorkflowExecutionInitiated,
+    StartLambdaFunctionFailed,
+    StartTimerFailed,
+    TimerCanceled,
+    TimerFired,
+    TimerStarted,
+    WorkflowExecutionCancelRequested,
+    WorkflowExecutionCanceled,
+    WorkflowExecutionCompleted,
+    WorkflowExecutionContinuedAsNew,
+    WorkflowExecutionFailed,
+    WorkflowExecutionSignaled,
+    WorkflowExecutionStarted,
+    WorkflowExecutionTerminated,
+    WorkflowExecutionTimedOut,
+}
+
+impl Into<String> for EventType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for EventType {
+    fn into(self) -> &'static str {
+        match self {
+            EventType::ActivityTaskCancelRequested => "ActivityTaskCancelRequested",
+            EventType::ActivityTaskCanceled => "ActivityTaskCanceled",
+            EventType::ActivityTaskCompleted => "ActivityTaskCompleted",
+            EventType::ActivityTaskFailed => "ActivityTaskFailed",
+            EventType::ActivityTaskScheduled => "ActivityTaskScheduled",
+            EventType::ActivityTaskStarted => "ActivityTaskStarted",
+            EventType::ActivityTaskTimedOut => "ActivityTaskTimedOut",
+            EventType::CancelTimerFailed => "CancelTimerFailed",
+            EventType::CancelWorkflowExecutionFailed => "CancelWorkflowExecutionFailed",
+            EventType::ChildWorkflowExecutionCanceled => "ChildWorkflowExecutionCanceled",
+            EventType::ChildWorkflowExecutionCompleted => "ChildWorkflowExecutionCompleted",
+            EventType::ChildWorkflowExecutionFailed => "ChildWorkflowExecutionFailed",
+            EventType::ChildWorkflowExecutionStarted => "ChildWorkflowExecutionStarted",
+            EventType::ChildWorkflowExecutionTerminated => "ChildWorkflowExecutionTerminated",
+            EventType::ChildWorkflowExecutionTimedOut => "ChildWorkflowExecutionTimedOut",
+            EventType::CompleteWorkflowExecutionFailed => "CompleteWorkflowExecutionFailed",
+            EventType::ContinueAsNewWorkflowExecutionFailed => {
+                "ContinueAsNewWorkflowExecutionFailed"
+            }
+            EventType::DecisionTaskCompleted => "DecisionTaskCompleted",
+            EventType::DecisionTaskScheduled => "DecisionTaskScheduled",
+            EventType::DecisionTaskStarted => "DecisionTaskStarted",
+            EventType::DecisionTaskTimedOut => "DecisionTaskTimedOut",
+            EventType::ExternalWorkflowExecutionCancelRequested => {
+                "ExternalWorkflowExecutionCancelRequested"
+            }
+            EventType::ExternalWorkflowExecutionSignaled => "ExternalWorkflowExecutionSignaled",
+            EventType::FailWorkflowExecutionFailed => "FailWorkflowExecutionFailed",
+            EventType::LambdaFunctionCompleted => "LambdaFunctionCompleted",
+            EventType::LambdaFunctionFailed => "LambdaFunctionFailed",
+            EventType::LambdaFunctionScheduled => "LambdaFunctionScheduled",
+            EventType::LambdaFunctionStarted => "LambdaFunctionStarted",
+            EventType::LambdaFunctionTimedOut => "LambdaFunctionTimedOut",
+            EventType::MarkerRecorded => "MarkerRecorded",
+            EventType::RecordMarkerFailed => "RecordMarkerFailed",
+            EventType::RequestCancelActivityTaskFailed => "RequestCancelActivityTaskFailed",
+            EventType::RequestCancelExternalWorkflowExecutionFailed => {
+                "RequestCancelExternalWorkflowExecutionFailed"
+            }
+            EventType::RequestCancelExternalWorkflowExecutionInitiated => {
+                "RequestCancelExternalWorkflowExecutionInitiated"
+            }
+            EventType::ScheduleActivityTaskFailed => "ScheduleActivityTaskFailed",
+            EventType::ScheduleLambdaFunctionFailed => "ScheduleLambdaFunctionFailed",
+            EventType::SignalExternalWorkflowExecutionFailed => {
+                "SignalExternalWorkflowExecutionFailed"
+            }
+            EventType::SignalExternalWorkflowExecutionInitiated => {
+                "SignalExternalWorkflowExecutionInitiated"
+            }
+            EventType::StartChildWorkflowExecutionFailed => "StartChildWorkflowExecutionFailed",
+            EventType::StartChildWorkflowExecutionInitiated => {
+                "StartChildWorkflowExecutionInitiated"
+            }
+            EventType::StartLambdaFunctionFailed => "StartLambdaFunctionFailed",
+            EventType::StartTimerFailed => "StartTimerFailed",
+            EventType::TimerCanceled => "TimerCanceled",
+            EventType::TimerFired => "TimerFired",
+            EventType::TimerStarted => "TimerStarted",
+            EventType::WorkflowExecutionCancelRequested => "WorkflowExecutionCancelRequested",
+            EventType::WorkflowExecutionCanceled => "WorkflowExecutionCanceled",
+            EventType::WorkflowExecutionCompleted => "WorkflowExecutionCompleted",
+            EventType::WorkflowExecutionContinuedAsNew => "WorkflowExecutionContinuedAsNew",
+            EventType::WorkflowExecutionFailed => "WorkflowExecutionFailed",
+            EventType::WorkflowExecutionSignaled => "WorkflowExecutionSignaled",
+            EventType::WorkflowExecutionStarted => "WorkflowExecutionStarted",
+            EventType::WorkflowExecutionTerminated => "WorkflowExecutionTerminated",
+            EventType::WorkflowExecutionTimedOut => "WorkflowExecutionTimedOut",
+        }
+    }
+}
+
+impl ::std::str::FromStr for EventType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ActivityTaskCancelRequested" => Ok(EventType::ActivityTaskCancelRequested),
+            "ActivityTaskCanceled" => Ok(EventType::ActivityTaskCanceled),
+            "ActivityTaskCompleted" => Ok(EventType::ActivityTaskCompleted),
+            "ActivityTaskFailed" => Ok(EventType::ActivityTaskFailed),
+            "ActivityTaskScheduled" => Ok(EventType::ActivityTaskScheduled),
+            "ActivityTaskStarted" => Ok(EventType::ActivityTaskStarted),
+            "ActivityTaskTimedOut" => Ok(EventType::ActivityTaskTimedOut),
+            "CancelTimerFailed" => Ok(EventType::CancelTimerFailed),
+            "CancelWorkflowExecutionFailed" => Ok(EventType::CancelWorkflowExecutionFailed),
+            "ChildWorkflowExecutionCanceled" => Ok(EventType::ChildWorkflowExecutionCanceled),
+            "ChildWorkflowExecutionCompleted" => Ok(EventType::ChildWorkflowExecutionCompleted),
+            "ChildWorkflowExecutionFailed" => Ok(EventType::ChildWorkflowExecutionFailed),
+            "ChildWorkflowExecutionStarted" => Ok(EventType::ChildWorkflowExecutionStarted),
+            "ChildWorkflowExecutionTerminated" => Ok(EventType::ChildWorkflowExecutionTerminated),
+            "ChildWorkflowExecutionTimedOut" => Ok(EventType::ChildWorkflowExecutionTimedOut),
+            "CompleteWorkflowExecutionFailed" => Ok(EventType::CompleteWorkflowExecutionFailed),
+            "ContinueAsNewWorkflowExecutionFailed" => {
+                Ok(EventType::ContinueAsNewWorkflowExecutionFailed)
+            }
+            "DecisionTaskCompleted" => Ok(EventType::DecisionTaskCompleted),
+            "DecisionTaskScheduled" => Ok(EventType::DecisionTaskScheduled),
+            "DecisionTaskStarted" => Ok(EventType::DecisionTaskStarted),
+            "DecisionTaskTimedOut" => Ok(EventType::DecisionTaskTimedOut),
+            "ExternalWorkflowExecutionCancelRequested" => {
+                Ok(EventType::ExternalWorkflowExecutionCancelRequested)
+            }
+            "ExternalWorkflowExecutionSignaled" => Ok(EventType::ExternalWorkflowExecutionSignaled),
+            "FailWorkflowExecutionFailed" => Ok(EventType::FailWorkflowExecutionFailed),
+            "LambdaFunctionCompleted" => Ok(EventType::LambdaFunctionCompleted),
+            "LambdaFunctionFailed" => Ok(EventType::LambdaFunctionFailed),
+            "LambdaFunctionScheduled" => Ok(EventType::LambdaFunctionScheduled),
+            "LambdaFunctionStarted" => Ok(EventType::LambdaFunctionStarted),
+            "LambdaFunctionTimedOut" => Ok(EventType::LambdaFunctionTimedOut),
+            "MarkerRecorded" => Ok(EventType::MarkerRecorded),
+            "RecordMarkerFailed" => Ok(EventType::RecordMarkerFailed),
+            "RequestCancelActivityTaskFailed" => Ok(EventType::RequestCancelActivityTaskFailed),
+            "RequestCancelExternalWorkflowExecutionFailed" => {
+                Ok(EventType::RequestCancelExternalWorkflowExecutionFailed)
+            }
+            "RequestCancelExternalWorkflowExecutionInitiated" => {
+                Ok(EventType::RequestCancelExternalWorkflowExecutionInitiated)
+            }
+            "ScheduleActivityTaskFailed" => Ok(EventType::ScheduleActivityTaskFailed),
+            "ScheduleLambdaFunctionFailed" => Ok(EventType::ScheduleLambdaFunctionFailed),
+            "SignalExternalWorkflowExecutionFailed" => {
+                Ok(EventType::SignalExternalWorkflowExecutionFailed)
+            }
+            "SignalExternalWorkflowExecutionInitiated" => {
+                Ok(EventType::SignalExternalWorkflowExecutionInitiated)
+            }
+            "StartChildWorkflowExecutionFailed" => Ok(EventType::StartChildWorkflowExecutionFailed),
+            "StartChildWorkflowExecutionInitiated" => {
+                Ok(EventType::StartChildWorkflowExecutionInitiated)
+            }
+            "StartLambdaFunctionFailed" => Ok(EventType::StartLambdaFunctionFailed),
+            "StartTimerFailed" => Ok(EventType::StartTimerFailed),
+            "TimerCanceled" => Ok(EventType::TimerCanceled),
+            "TimerFired" => Ok(EventType::TimerFired),
+            "TimerStarted" => Ok(EventType::TimerStarted),
+            "WorkflowExecutionCancelRequested" => Ok(EventType::WorkflowExecutionCancelRequested),
+            "WorkflowExecutionCanceled" => Ok(EventType::WorkflowExecutionCanceled),
+            "WorkflowExecutionCompleted" => Ok(EventType::WorkflowExecutionCompleted),
+            "WorkflowExecutionContinuedAsNew" => Ok(EventType::WorkflowExecutionContinuedAsNew),
+            "WorkflowExecutionFailed" => Ok(EventType::WorkflowExecutionFailed),
+            "WorkflowExecutionSignaled" => Ok(EventType::WorkflowExecutionSignaled),
+            "WorkflowExecutionStarted" => Ok(EventType::WorkflowExecutionStarted),
+            "WorkflowExecutionTerminated" => Ok(EventType::WorkflowExecutionTerminated),
+            "WorkflowExecutionTimedOut" => Ok(EventType::WorkflowExecutionTimedOut),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ExecutionStatus {
+    Closed,
+    Open,
+}
+
+impl Into<String> for ExecutionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ExecutionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ExecutionStatus::Closed => "CLOSED",
+            ExecutionStatus::Open => "OPEN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ExecutionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CLOSED" => Ok(ExecutionStatus::Closed),
+            "OPEN" => Ok(ExecutionStatus::Open),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Used to filter the workflow executions in visibility APIs by various time-based rules. Each parameter, if specified, defines a rule that must be satisfied by each returned query result. The parameter values are in the <a href=\"https://en.wikipedia.org/wiki/Unix_time\">Unix Time format</a>. For example: <code>\"oldestDate\": 1325376070.</code> </p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ExecutionTimeFilter {
@@ -907,6 +1578,43 @@ pub struct FailWorkflowExecutionDecisionAttributes {
     #[serde(rename="reason")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub reason: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FailWorkflowExecutionFailedCause {
+    OperationNotPermitted,
+    UnhandledDecision,
+}
+
+impl Into<String> for FailWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FailWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            FailWorkflowExecutionFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+            FailWorkflowExecutionFailedCause::UnhandledDecision => "UNHANDLED_DECISION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FailWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(FailWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "UNHANDLED_DECISION" => Ok(FailWorkflowExecutionFailedCause::UnhandledDecision),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides the details of the <code>FailWorkflowExecutionFailed</code> event.</p>"]
@@ -1302,6 +2010,38 @@ pub struct LambdaFunctionTimedOutEventAttributes {
     pub timeout_type: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LambdaFunctionTimeoutType {
+    StartToClose,
+}
+
+impl Into<String> for LambdaFunctionTimeoutType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LambdaFunctionTimeoutType {
+    fn into(self) -> &'static str {
+        match self {
+            LambdaFunctionTimeoutType::StartToClose => "START_TO_CLOSE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LambdaFunctionTimeoutType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "START_TO_CLOSE" => Ok(LambdaFunctionTimeoutType::StartToClose),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct ListActivityTypesInput {
     #[doc="<p>The name of the domain in which the activity types have been registered.</p>"]
@@ -1540,6 +2280,38 @@ pub struct RecordMarkerDecisionAttributes {
     pub marker_name: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RecordMarkerFailedCause {
+    OperationNotPermitted,
+}
+
+impl Into<String> for RecordMarkerFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RecordMarkerFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            RecordMarkerFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RecordMarkerFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => Ok(RecordMarkerFailedCause::OperationNotPermitted),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides the details of the <code>RecordMarkerFailed</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct RecordMarkerFailedEventAttributes {
@@ -1650,12 +2422,86 @@ pub struct RegisterWorkflowTypeInput {
     pub version: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RegistrationStatus {
+    Deprecated,
+    Registered,
+}
+
+impl Into<String> for RegistrationStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RegistrationStatus {
+    fn into(self) -> &'static str {
+        match self {
+            RegistrationStatus::Deprecated => "DEPRECATED",
+            RegistrationStatus::Registered => "REGISTERED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RegistrationStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEPRECATED" => Ok(RegistrationStatus::Deprecated),
+            "REGISTERED" => Ok(RegistrationStatus::Registered),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides the details of the <code>RequestCancelActivityTask</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct RequestCancelActivityTaskDecisionAttributes {
     #[doc="<p>The <code>activityId</code> of the activity task to be canceled.</p>"]
     #[serde(rename="activityId")]
     pub activity_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RequestCancelActivityTaskFailedCause {
+    ActivityIdUnknown,
+    OperationNotPermitted,
+}
+
+impl Into<String> for RequestCancelActivityTaskFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RequestCancelActivityTaskFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            RequestCancelActivityTaskFailedCause::ActivityIdUnknown => "ACTIVITY_ID_UNKNOWN",
+            RequestCancelActivityTaskFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for RequestCancelActivityTaskFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVITY_ID_UNKNOWN" => Ok(RequestCancelActivityTaskFailedCause::ActivityIdUnknown),
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(RequestCancelActivityTaskFailedCause::OperationNotPermitted)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides the details of the <code>RequestCancelActivityTaskFailed</code> event.</p>"]
@@ -1686,6 +2532,50 @@ pub struct RequestCancelExternalWorkflowExecutionDecisionAttributes {
     #[doc="<p> The <code>workflowId</code> of the external workflow execution to cancel.</p>"]
     #[serde(rename="workflowId")]
     pub workflow_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RequestCancelExternalWorkflowExecutionFailedCause {
+    OperationNotPermitted,
+    RequestCancelExternalWorkflowExecutionRateExceeded,
+    UnknownExternalWorkflowExecution,
+}
+
+impl Into<String> for RequestCancelExternalWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RequestCancelExternalWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            RequestCancelExternalWorkflowExecutionFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+            RequestCancelExternalWorkflowExecutionFailedCause::RequestCancelExternalWorkflowExecutionRateExceeded => "REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED",
+            RequestCancelExternalWorkflowExecutionFailedCause::UnknownExternalWorkflowExecution => {
+                "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for RequestCancelExternalWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(RequestCancelExternalWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED" => Ok(RequestCancelExternalWorkflowExecutionFailedCause::RequestCancelExternalWorkflowExecutionRateExceeded),
+            "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION" => Ok(RequestCancelExternalWorkflowExecutionFailedCause::UnknownExternalWorkflowExecution),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides the details of the <code>RequestCancelExternalWorkflowExecutionFailed</code> event.</p>"]
@@ -1851,6 +2741,104 @@ pub struct ScheduleActivityTaskDecisionAttributes {
     pub task_priority: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScheduleActivityTaskFailedCause {
+    ActivityCreationRateExceeded,
+    ActivityIdAlreadyInUse,
+    ActivityTypeDeprecated,
+    ActivityTypeDoesNotExist,
+    DefaultHeartbeatTimeoutUndefined,
+    DefaultScheduleToCloseTimeoutUndefined,
+    DefaultScheduleToStartTimeoutUndefined,
+    DefaultStartToCloseTimeoutUndefined,
+    DefaultTaskListUndefined,
+    OpenActivitiesLimitExceeded,
+    OperationNotPermitted,
+}
+
+impl Into<String> for ScheduleActivityTaskFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScheduleActivityTaskFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            ScheduleActivityTaskFailedCause::ActivityCreationRateExceeded => {
+                "ACTIVITY_CREATION_RATE_EXCEEDED"
+            }
+            ScheduleActivityTaskFailedCause::ActivityIdAlreadyInUse => "ACTIVITY_ID_ALREADY_IN_USE",
+            ScheduleActivityTaskFailedCause::ActivityTypeDeprecated => "ACTIVITY_TYPE_DEPRECATED",
+            ScheduleActivityTaskFailedCause::ActivityTypeDoesNotExist => {
+                "ACTIVITY_TYPE_DOES_NOT_EXIST"
+            }
+            ScheduleActivityTaskFailedCause::DefaultHeartbeatTimeoutUndefined => {
+                "DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED"
+            }
+            ScheduleActivityTaskFailedCause::DefaultScheduleToCloseTimeoutUndefined => {
+                "DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED"
+            }
+            ScheduleActivityTaskFailedCause::DefaultScheduleToStartTimeoutUndefined => {
+                "DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED"
+            }
+            ScheduleActivityTaskFailedCause::DefaultStartToCloseTimeoutUndefined => {
+                "DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED"
+            }
+            ScheduleActivityTaskFailedCause::DefaultTaskListUndefined => {
+                "DEFAULT_TASK_LIST_UNDEFINED"
+            }
+            ScheduleActivityTaskFailedCause::OpenActivitiesLimitExceeded => {
+                "OPEN_ACTIVITIES_LIMIT_EXCEEDED"
+            }
+            ScheduleActivityTaskFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScheduleActivityTaskFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVITY_CREATION_RATE_EXCEEDED" => {
+                Ok(ScheduleActivityTaskFailedCause::ActivityCreationRateExceeded)
+            }
+            "ACTIVITY_ID_ALREADY_IN_USE" => {
+                Ok(ScheduleActivityTaskFailedCause::ActivityIdAlreadyInUse)
+            }
+            "ACTIVITY_TYPE_DEPRECATED" => {
+                Ok(ScheduleActivityTaskFailedCause::ActivityTypeDeprecated)
+            }
+            "ACTIVITY_TYPE_DOES_NOT_EXIST" => {
+                Ok(ScheduleActivityTaskFailedCause::ActivityTypeDoesNotExist)
+            }
+            "DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED" => {
+                Ok(ScheduleActivityTaskFailedCause::DefaultHeartbeatTimeoutUndefined)
+            }
+            "DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED" => {
+                Ok(ScheduleActivityTaskFailedCause::DefaultScheduleToCloseTimeoutUndefined)
+            }
+            "DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED" => {
+                Ok(ScheduleActivityTaskFailedCause::DefaultScheduleToStartTimeoutUndefined)
+            }
+            "DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED" => {
+                Ok(ScheduleActivityTaskFailedCause::DefaultStartToCloseTimeoutUndefined)
+            }
+            "DEFAULT_TASK_LIST_UNDEFINED" => {
+                Ok(ScheduleActivityTaskFailedCause::DefaultTaskListUndefined)
+            }
+            "OPEN_ACTIVITIES_LIMIT_EXCEEDED" => {
+                Ok(ScheduleActivityTaskFailedCause::OpenActivitiesLimitExceeded)
+            }
+            "OPERATION_NOT_PERMITTED" => Ok(ScheduleActivityTaskFailedCause::OperationNotPermitted),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides the details of the <code>ScheduleActivityTaskFailed</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ScheduleActivityTaskFailedEventAttributes {
@@ -1891,6 +2879,59 @@ pub struct ScheduleLambdaFunctionDecisionAttributes {
     pub start_to_close_timeout: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ScheduleLambdaFunctionFailedCause {
+    IdAlreadyInUse,
+    LambdaFunctionCreationRateExceeded,
+    LambdaServiceNotAvailableInRegion,
+    OpenLambdaFunctionsLimitExceeded,
+}
+
+impl Into<String> for ScheduleLambdaFunctionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ScheduleLambdaFunctionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            ScheduleLambdaFunctionFailedCause::IdAlreadyInUse => "ID_ALREADY_IN_USE",
+            ScheduleLambdaFunctionFailedCause::LambdaFunctionCreationRateExceeded => {
+                "LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED"
+            }
+            ScheduleLambdaFunctionFailedCause::LambdaServiceNotAvailableInRegion => {
+                "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION"
+            }
+            ScheduleLambdaFunctionFailedCause::OpenLambdaFunctionsLimitExceeded => {
+                "OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for ScheduleLambdaFunctionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ID_ALREADY_IN_USE" => Ok(ScheduleLambdaFunctionFailedCause::IdAlreadyInUse),
+            "LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED" => {
+                Ok(ScheduleLambdaFunctionFailedCause::LambdaFunctionCreationRateExceeded)
+            }
+            "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION" => {
+                Ok(ScheduleLambdaFunctionFailedCause::LambdaServiceNotAvailableInRegion)
+            }
+            "OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED" => {
+                Ok(ScheduleLambdaFunctionFailedCause::OpenLambdaFunctionsLimitExceeded)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides the details of the <code>ScheduleLambdaFunctionFailed</code> event. It isn't set for other event types.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ScheduleLambdaFunctionFailedEventAttributes {
@@ -1929,6 +2970,52 @@ pub struct SignalExternalWorkflowExecutionDecisionAttributes {
     #[doc="<p> The <code>workflowId</code> of the workflow execution to be signaled.</p>"]
     #[serde(rename="workflowId")]
     pub workflow_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SignalExternalWorkflowExecutionFailedCause {
+    OperationNotPermitted,
+    SignalExternalWorkflowExecutionRateExceeded,
+    UnknownExternalWorkflowExecution,
+}
+
+impl Into<String> for SignalExternalWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SignalExternalWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            SignalExternalWorkflowExecutionFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+            SignalExternalWorkflowExecutionFailedCause::SignalExternalWorkflowExecutionRateExceeded => "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED",
+            SignalExternalWorkflowExecutionFailedCause::UnknownExternalWorkflowExecution => {
+                "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for SignalExternalWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(SignalExternalWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED" => Ok(SignalExternalWorkflowExecutionFailedCause::SignalExternalWorkflowExecutionRateExceeded),
+            "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION" => {
+                Ok(SignalExternalWorkflowExecutionFailedCause::UnknownExternalWorkflowExecution)
+            }
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides the details of the <code>SignalExternalWorkflowExecutionFailed</code> event.</p>"]
@@ -2050,6 +3137,108 @@ pub struct StartChildWorkflowExecutionDecisionAttributes {
     pub workflow_type: WorkflowType,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StartChildWorkflowExecutionFailedCause {
+    ChildCreationRateExceeded,
+    DefaultChildPolicyUndefined,
+    DefaultExecutionStartToCloseTimeoutUndefined,
+    DefaultTaskListUndefined,
+    DefaultTaskStartToCloseTimeoutUndefined,
+    OpenChildrenLimitExceeded,
+    OpenWorkflowsLimitExceeded,
+    OperationNotPermitted,
+    WorkflowAlreadyRunning,
+    WorkflowTypeDeprecated,
+    WorkflowTypeDoesNotExist,
+}
+
+impl Into<String> for StartChildWorkflowExecutionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StartChildWorkflowExecutionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            StartChildWorkflowExecutionFailedCause::ChildCreationRateExceeded => {
+                "CHILD_CREATION_RATE_EXCEEDED"
+            }
+            StartChildWorkflowExecutionFailedCause::DefaultChildPolicyUndefined => {
+                "DEFAULT_CHILD_POLICY_UNDEFINED"
+            }
+            StartChildWorkflowExecutionFailedCause::DefaultExecutionStartToCloseTimeoutUndefined => "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED",
+            StartChildWorkflowExecutionFailedCause::DefaultTaskListUndefined => {
+                "DEFAULT_TASK_LIST_UNDEFINED"
+            }
+            StartChildWorkflowExecutionFailedCause::DefaultTaskStartToCloseTimeoutUndefined => {
+                "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED"
+            }
+            StartChildWorkflowExecutionFailedCause::OpenChildrenLimitExceeded => {
+                "OPEN_CHILDREN_LIMIT_EXCEEDED"
+            }
+            StartChildWorkflowExecutionFailedCause::OpenWorkflowsLimitExceeded => {
+                "OPEN_WORKFLOWS_LIMIT_EXCEEDED"
+            }
+            StartChildWorkflowExecutionFailedCause::OperationNotPermitted => {
+                "OPERATION_NOT_PERMITTED"
+            }
+            StartChildWorkflowExecutionFailedCause::WorkflowAlreadyRunning => {
+                "WORKFLOW_ALREADY_RUNNING"
+            }
+            StartChildWorkflowExecutionFailedCause::WorkflowTypeDeprecated => {
+                "WORKFLOW_TYPE_DEPRECATED"
+            }
+            StartChildWorkflowExecutionFailedCause::WorkflowTypeDoesNotExist => {
+                "WORKFLOW_TYPE_DOES_NOT_EXIST"
+            }
+        }
+    }
+}
+
+impl ::std::str::FromStr for StartChildWorkflowExecutionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHILD_CREATION_RATE_EXCEEDED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::ChildCreationRateExceeded)
+            }
+            "DEFAULT_CHILD_POLICY_UNDEFINED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::DefaultChildPolicyUndefined)
+            }
+            "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED" => Ok(StartChildWorkflowExecutionFailedCause::DefaultExecutionStartToCloseTimeoutUndefined),
+            "DEFAULT_TASK_LIST_UNDEFINED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::DefaultTaskListUndefined)
+            }
+            "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::DefaultTaskStartToCloseTimeoutUndefined)
+            }
+            "OPEN_CHILDREN_LIMIT_EXCEEDED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::OpenChildrenLimitExceeded)
+            }
+            "OPEN_WORKFLOWS_LIMIT_EXCEEDED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::OpenWorkflowsLimitExceeded)
+            }
+            "OPERATION_NOT_PERMITTED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::OperationNotPermitted)
+            }
+            "WORKFLOW_ALREADY_RUNNING" => {
+                Ok(StartChildWorkflowExecutionFailedCause::WorkflowAlreadyRunning)
+            }
+            "WORKFLOW_TYPE_DEPRECATED" => {
+                Ok(StartChildWorkflowExecutionFailedCause::WorkflowTypeDeprecated)
+            }
+            "WORKFLOW_TYPE_DOES_NOT_EXIST" => {
+                Ok(StartChildWorkflowExecutionFailedCause::WorkflowTypeDoesNotExist)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides the details of the <code>StartChildWorkflowExecutionFailed</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct StartChildWorkflowExecutionFailedEventAttributes {
@@ -2122,6 +3311,38 @@ pub struct StartChildWorkflowExecutionInitiatedEventAttributes {
     pub workflow_type: WorkflowType,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StartLambdaFunctionFailedCause {
+    AssumeRoleFailed,
+}
+
+impl Into<String> for StartLambdaFunctionFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StartLambdaFunctionFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            StartLambdaFunctionFailedCause::AssumeRoleFailed => "ASSUME_ROLE_FAILED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StartLambdaFunctionFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASSUME_ROLE_FAILED" => Ok(StartLambdaFunctionFailedCause::AssumeRoleFailed),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides the details of the <code>StartLambdaFunctionFailed</code> event. It isn't set for other event types.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct StartLambdaFunctionFailedEventAttributes {
@@ -2152,6 +3373,47 @@ pub struct StartTimerDecisionAttributes {
     #[doc="<p> The unique ID of the timer.</p> <p>The specified string must not start or end with whitespace. It must not contain a <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must not contain the literal string <code>arn</code>.</p>"]
     #[serde(rename="timerId")]
     pub timer_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StartTimerFailedCause {
+    OpenTimersLimitExceeded,
+    OperationNotPermitted,
+    TimerCreationRateExceeded,
+    TimerIdAlreadyInUse,
+}
+
+impl Into<String> for StartTimerFailedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StartTimerFailedCause {
+    fn into(self) -> &'static str {
+        match self {
+            StartTimerFailedCause::OpenTimersLimitExceeded => "OPEN_TIMERS_LIMIT_EXCEEDED",
+            StartTimerFailedCause::OperationNotPermitted => "OPERATION_NOT_PERMITTED",
+            StartTimerFailedCause::TimerCreationRateExceeded => "TIMER_CREATION_RATE_EXCEEDED",
+            StartTimerFailedCause::TimerIdAlreadyInUse => "TIMER_ID_ALREADY_IN_USE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StartTimerFailedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OPEN_TIMERS_LIMIT_EXCEEDED" => Ok(StartTimerFailedCause::OpenTimersLimitExceeded),
+            "OPERATION_NOT_PERMITTED" => Ok(StartTimerFailedCause::OperationNotPermitted),
+            "TIMER_CREATION_RATE_EXCEEDED" => Ok(StartTimerFailedCause::TimerCreationRateExceeded),
+            "TIMER_ID_ALREADY_IN_USE" => Ok(StartTimerFailedCause::TimerIdAlreadyInUse),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides the details of the <code>StartTimerFailed</code> event.</p>"]
@@ -2307,6 +3569,38 @@ pub struct WorkflowExecution {
     #[doc="<p>The user defined identifier associated with the workflow execution.</p>"]
     #[serde(rename="workflowId")]
     pub workflow_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkflowExecutionCancelRequestedCause {
+    ChildPolicyApplied,
+}
+
+impl Into<String> for WorkflowExecutionCancelRequestedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkflowExecutionCancelRequestedCause {
+    fn into(self) -> &'static str {
+        match self {
+            WorkflowExecutionCancelRequestedCause::ChildPolicyApplied => "CHILD_POLICY_APPLIED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkflowExecutionCancelRequestedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHILD_POLICY_APPLIED" => Ok(WorkflowExecutionCancelRequestedCause::ChildPolicyApplied),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Provides the details of the <code>WorkflowExecutionCancelRequested</code> event.</p>"]
@@ -2617,6 +3911,44 @@ pub struct WorkflowExecutionStartedEventAttributes {
     pub workflow_type: WorkflowType,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkflowExecutionTerminatedCause {
+    ChildPolicyApplied,
+    EventLimitExceeded,
+    OperatorInitiated,
+}
+
+impl Into<String> for WorkflowExecutionTerminatedCause {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkflowExecutionTerminatedCause {
+    fn into(self) -> &'static str {
+        match self {
+            WorkflowExecutionTerminatedCause::ChildPolicyApplied => "CHILD_POLICY_APPLIED",
+            WorkflowExecutionTerminatedCause::EventLimitExceeded => "EVENT_LIMIT_EXCEEDED",
+            WorkflowExecutionTerminatedCause::OperatorInitiated => "OPERATOR_INITIATED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkflowExecutionTerminatedCause {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CHILD_POLICY_APPLIED" => Ok(WorkflowExecutionTerminatedCause::ChildPolicyApplied),
+            "EVENT_LIMIT_EXCEEDED" => Ok(WorkflowExecutionTerminatedCause::EventLimitExceeded),
+            "OPERATOR_INITIATED" => Ok(WorkflowExecutionTerminatedCause::OperatorInitiated),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Provides the details of the <code>WorkflowExecutionTerminated</code> event.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct WorkflowExecutionTerminatedEventAttributes {
@@ -2646,6 +3978,38 @@ pub struct WorkflowExecutionTimedOutEventAttributes {
     #[doc="<p>The type of timeout that caused this event.</p>"]
     #[serde(rename="timeoutType")]
     pub timeout_type: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkflowExecutionTimeoutType {
+    StartToClose,
+}
+
+impl Into<String> for WorkflowExecutionTimeoutType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkflowExecutionTimeoutType {
+    fn into(self) -> &'static str {
+        match self {
+            WorkflowExecutionTimeoutType::StartToClose => "START_TO_CLOSE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkflowExecutionTimeoutType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "START_TO_CLOSE" => Ok(WorkflowExecutionTimeoutType::StartToClose),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Represents a workflow type.</p>"]
@@ -5640,7 +7004,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<WorkflowExecutionCount>(String::from_utf8_lossy(&body)
@@ -5675,7 +7039,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<WorkflowExecutionCount>(String::from_utf8_lossy(&body)
@@ -5709,7 +7073,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PendingTaskCount>(String::from_utf8_lossy(&body)
@@ -5743,7 +7107,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<PendingTaskCount>(String::from_utf8_lossy(&body)
@@ -5777,7 +7141,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5801,7 +7165,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5828,7 +7192,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -5854,7 +7218,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ActivityTypeDetail>(String::from_utf8_lossy(&body)
@@ -5886,7 +7250,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DomainDetail>(String::from_utf8_lossy(&body).as_ref())
@@ -5919,7 +7283,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<WorkflowExecutionDetail>(String::from_utf8_lossy(&body)
@@ -5952,7 +7316,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<WorkflowTypeDetail>(String::from_utf8_lossy(&body)
@@ -5985,7 +7349,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<History>(String::from_utf8_lossy(&body).as_ref())
@@ -6017,7 +7381,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ActivityTypeInfos>(String::from_utf8_lossy(&body)
@@ -6051,7 +7415,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<WorkflowExecutionInfos>(String::from_utf8_lossy(&body)
@@ -6082,7 +7446,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DomainInfos>(String::from_utf8_lossy(&body).as_ref())
@@ -6115,7 +7479,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<WorkflowExecutionInfos>(String::from_utf8_lossy(&body)
@@ -6148,7 +7512,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<WorkflowTypeInfos>(String::from_utf8_lossy(&body)
@@ -6180,7 +7544,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ActivityTask>(String::from_utf8_lossy(&body).as_ref())
@@ -6211,7 +7575,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DecisionTask>(String::from_utf8_lossy(&body).as_ref())
@@ -6244,7 +7608,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ActivityTaskStatus>(String::from_utf8_lossy(&body)
@@ -6277,7 +7641,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6301,7 +7665,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6327,7 +7691,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6354,7 +7718,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6382,7 +7746,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6410,7 +7774,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6438,7 +7802,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6466,7 +7830,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6494,7 +7858,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6522,7 +7886,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<Run>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6553,7 +7917,7 @@ impl<P, D> Swf for SwfClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => Ok(()),
+            ::hyper::status::StatusCode::Ok => Ok(()),
             _ => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -116,6 +112,126 @@ pub struct ByteMatchTuple {
     #[doc="<p>Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass AWS WAF. If you specify a transformation, AWS WAF performs the transformation on <code>TargetString</code> before inspecting a request for a match.</p> <p> <b>CMD_LINE</b> </p> <p>When you're concerned that attackers are injecting an operating system commandline command and using unusual formatting to disguise some or all of the command, use this option to perform the following transformations:</p> <ul> <li> <p>Delete the following characters: \\ \" ' ^</p> </li> <li> <p>Delete spaces before the following characters: / (</p> </li> <li> <p>Replace the following characters with a space: , ;</p> </li> <li> <p>Replace multiple spaces with one space</p> </li> <li> <p>Convert uppercase letters (A-Z) to lowercase (a-z)</p> </li> </ul> <p> <b>COMPRESS_WHITE_SPACE</b> </p> <p>Use this option to replace the following characters with a space character (decimal 32):</p> <ul> <li> <p>\\f, formfeed, decimal 12</p> </li> <li> <p>\\t, tab, decimal 9</p> </li> <li> <p>\\n, newline, decimal 10</p> </li> <li> <p>\\r, carriage return, decimal 13</p> </li> <li> <p>\\v, vertical tab, decimal 11</p> </li> <li> <p>non-breaking space, decimal 160</p> </li> </ul> <p> <code>COMPRESS_WHITE_SPACE</code> also replaces multiple spaces with one space.</p> <p> <b>HTML_ENTITY_DECODE</b> </p> <p>Use this option to replace HTML-encoded characters with unencoded characters. <code>HTML_ENTITY_DECODE</code> performs the following operations:</p> <ul> <li> <p>Replaces <code>(ampersand)quot;</code> with <code>\"</code> </p> </li> <li> <p>Replaces <code>(ampersand)nbsp;</code> with a non-breaking space, decimal 160</p> </li> <li> <p>Replaces <code>(ampersand)lt;</code> with a \"less than\" symbol</p> </li> <li> <p>Replaces <code>(ampersand)gt;</code> with <code>&gt;</code> </p> </li> <li> <p>Replaces characters that are represented in hexadecimal format, <code>(ampersand)#xhhhh;</code>, with the corresponding characters</p> </li> <li> <p>Replaces characters that are represented in decimal format, <code>(ampersand)#nnnn;</code>, with the corresponding characters</p> </li> </ul> <p> <b>LOWERCASE</b> </p> <p>Use this option to convert uppercase letters (A-Z) to lowercase (a-z).</p> <p> <b>URL_DECODE</b> </p> <p>Use this option to decode a URL-encoded value.</p> <p> <b>NONE</b> </p> <p>Specify <code>NONE</code> if you don't want to perform any text transformations.</p>"]
     #[serde(rename="TextTransformation")]
     pub text_transformation: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeAction {
+    Delete,
+    Insert,
+}
+
+impl Into<String> for ChangeAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeAction {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeAction::Delete => "DELETE",
+            ChangeAction::Insert => "INSERT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETE" => Ok(ChangeAction::Delete),
+            "INSERT" => Ok(ChangeAction::Insert),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeTokenStatus {
+    Insync,
+    Pending,
+    Provisioned,
+}
+
+impl Into<String> for ChangeTokenStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeTokenStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeTokenStatus::Insync => "INSYNC",
+            ChangeTokenStatus::Pending => "PENDING",
+            ChangeTokenStatus::Provisioned => "PROVISIONED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeTokenStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSYNC" => Ok(ChangeTokenStatus::Insync),
+            "PENDING" => Ok(ChangeTokenStatus::Pending),
+            "PROVISIONED" => Ok(ChangeTokenStatus::Provisioned),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperator {
+    Eq,
+    Ge,
+    Gt,
+    Le,
+    Lt,
+    Ne,
+}
+
+impl Into<String> for ComparisonOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperator::Eq => "EQ",
+            ComparisonOperator::Ge => "GE",
+            ComparisonOperator::Gt => "GT",
+            ComparisonOperator::Le => "LE",
+            ComparisonOperator::Lt => "LT",
+            ComparisonOperator::Ne => "NE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EQ" => Ok(ComparisonOperator::Eq),
+            "GE" => Ok(ComparisonOperator::Ge),
+            "GT" => Ok(ComparisonOperator::Gt),
+            "LE" => Ok(ComparisonOperator::Le),
+            "LT" => Ok(ComparisonOperator::Lt),
+            "NE" => Ok(ComparisonOperator::Ne),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -774,6 +890,41 @@ pub struct IPSetDescriptor {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IPSetDescriptorType {
+    Ipv4,
+    Ipv6,
+}
+
+impl Into<String> for IPSetDescriptorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IPSetDescriptorType {
+    fn into(self) -> &'static str {
+        match self {
+            IPSetDescriptorType::Ipv4 => "IPV4",
+            IPSetDescriptorType::Ipv6 => "IPV6",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IPSetDescriptorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IPV4" => Ok(IPSetDescriptorType::Ipv4),
+            "IPV6" => Ok(IPSetDescriptorType::Ipv6),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the identifier and the name of the <code>IPSet</code>.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct IPSetSummary {
@@ -1007,6 +1158,208 @@ pub struct ListXssMatchSetsResponse {
     pub xss_match_sets: Option<Vec<XssMatchSetSummary>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MatchFieldType {
+    Body,
+    Header,
+    Method,
+    QueryString,
+    Uri,
+}
+
+impl Into<String> for MatchFieldType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MatchFieldType {
+    fn into(self) -> &'static str {
+        match self {
+            MatchFieldType::Body => "BODY",
+            MatchFieldType::Header => "HEADER",
+            MatchFieldType::Method => "METHOD",
+            MatchFieldType::QueryString => "QUERY_STRING",
+            MatchFieldType::Uri => "URI",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MatchFieldType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BODY" => Ok(MatchFieldType::Body),
+            "HEADER" => Ok(MatchFieldType::Header),
+            "METHOD" => Ok(MatchFieldType::Method),
+            "QUERY_STRING" => Ok(MatchFieldType::QueryString),
+            "URI" => Ok(MatchFieldType::Uri),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterExceptionField {
+    ByteMatchFieldType,
+    ByteMatchPositionalConstraint,
+    ByteMatchTextTransformation,
+    ChangeAction,
+    IpsetType,
+    NextMarker,
+    PredicateType,
+    RateKey,
+    RuleType,
+    SizeConstraintComparisonOperator,
+    SqlInjectionMatchFieldType,
+    WafAction,
+}
+
+impl Into<String> for ParameterExceptionField {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterExceptionField {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterExceptionField::ByteMatchFieldType => "BYTE_MATCH_FIELD_TYPE",
+            ParameterExceptionField::ByteMatchPositionalConstraint => {
+                "BYTE_MATCH_POSITIONAL_CONSTRAINT"
+            }
+            ParameterExceptionField::ByteMatchTextTransformation => {
+                "BYTE_MATCH_TEXT_TRANSFORMATION"
+            }
+            ParameterExceptionField::ChangeAction => "CHANGE_ACTION",
+            ParameterExceptionField::IpsetType => "IPSET_TYPE",
+            ParameterExceptionField::NextMarker => "NEXT_MARKER",
+            ParameterExceptionField::PredicateType => "PREDICATE_TYPE",
+            ParameterExceptionField::RateKey => "RATE_KEY",
+            ParameterExceptionField::RuleType => "RULE_TYPE",
+            ParameterExceptionField::SizeConstraintComparisonOperator => {
+                "SIZE_CONSTRAINT_COMPARISON_OPERATOR"
+            }
+            ParameterExceptionField::SqlInjectionMatchFieldType => "SQL_INJECTION_MATCH_FIELD_TYPE",
+            ParameterExceptionField::WafAction => "WAF_ACTION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterExceptionField {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BYTE_MATCH_FIELD_TYPE" => Ok(ParameterExceptionField::ByteMatchFieldType),
+            "BYTE_MATCH_POSITIONAL_CONSTRAINT" => {
+                Ok(ParameterExceptionField::ByteMatchPositionalConstraint)
+            }
+            "BYTE_MATCH_TEXT_TRANSFORMATION" => {
+                Ok(ParameterExceptionField::ByteMatchTextTransformation)
+            }
+            "CHANGE_ACTION" => Ok(ParameterExceptionField::ChangeAction),
+            "IPSET_TYPE" => Ok(ParameterExceptionField::IpsetType),
+            "NEXT_MARKER" => Ok(ParameterExceptionField::NextMarker),
+            "PREDICATE_TYPE" => Ok(ParameterExceptionField::PredicateType),
+            "RATE_KEY" => Ok(ParameterExceptionField::RateKey),
+            "RULE_TYPE" => Ok(ParameterExceptionField::RuleType),
+            "SIZE_CONSTRAINT_COMPARISON_OPERATOR" => {
+                Ok(ParameterExceptionField::SizeConstraintComparisonOperator)
+            }
+            "SQL_INJECTION_MATCH_FIELD_TYPE" => {
+                Ok(ParameterExceptionField::SqlInjectionMatchFieldType)
+            }
+            "WAF_ACTION" => Ok(ParameterExceptionField::WafAction),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterExceptionReason {
+    IllegalCombination,
+    InvalidOption,
+}
+
+impl Into<String> for ParameterExceptionReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterExceptionReason {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterExceptionReason::IllegalCombination => "ILLEGAL_COMBINATION",
+            ParameterExceptionReason::InvalidOption => "INVALID_OPTION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterExceptionReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ILLEGAL_COMBINATION" => Ok(ParameterExceptionReason::IllegalCombination),
+            "INVALID_OPTION" => Ok(ParameterExceptionReason::InvalidOption),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PositionalConstraint {
+    Contains,
+    ContainsWord,
+    EndsWith,
+    Exactly,
+    StartsWith,
+}
+
+impl Into<String> for PositionalConstraint {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PositionalConstraint {
+    fn into(self) -> &'static str {
+        match self {
+            PositionalConstraint::Contains => "CONTAINS",
+            PositionalConstraint::ContainsWord => "CONTAINS_WORD",
+            PositionalConstraint::EndsWith => "ENDS_WITH",
+            PositionalConstraint::Exactly => "EXACTLY",
+            PositionalConstraint::StartsWith => "STARTS_WITH",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PositionalConstraint {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONTAINS" => Ok(PositionalConstraint::Contains),
+            "CONTAINS_WORD" => Ok(PositionalConstraint::ContainsWord),
+            "ENDS_WITH" => Ok(PositionalConstraint::EndsWith),
+            "EXACTLY" => Ok(PositionalConstraint::Exactly),
+            "STARTS_WITH" => Ok(PositionalConstraint::StartsWith),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies the <a>ByteMatchSet</a>, <a>IPSet</a>, <a>SqlInjectionMatchSet</a>, <a>XssMatchSet</a>, and <a>SizeConstraintSet</a> objects that you want to add to a <code>Rule</code> and, for each object, indicates whether you want to negate the settings, for example, requests that do NOT originate from the IP address 192.0.2.44. </p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Predicate {
@@ -1019,6 +1372,50 @@ pub struct Predicate {
     #[doc="<p>The type of predicate in a <code>Rule</code>, such as <code>ByteMatchSet</code> or <code>IPSet</code>.</p>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PredicateType {
+    ByteMatch,
+    Ipmatch,
+    SizeConstraint,
+    SqlInjectionMatch,
+    XssMatch,
+}
+
+impl Into<String> for PredicateType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PredicateType {
+    fn into(self) -> &'static str {
+        match self {
+            PredicateType::ByteMatch => "ByteMatch",
+            PredicateType::Ipmatch => "IPMatch",
+            PredicateType::SizeConstraint => "SizeConstraint",
+            PredicateType::SqlInjectionMatch => "SqlInjectionMatch",
+            PredicateType::XssMatch => "XssMatch",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PredicateType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ByteMatch" => Ok(PredicateType::ByteMatch),
+            "IPMatch" => Ok(PredicateType::Ipmatch),
+            "SizeConstraint" => Ok(PredicateType::SizeConstraint),
+            "SqlInjectionMatch" => Ok(PredicateType::SqlInjectionMatch),
+            "XssMatch" => Ok(PredicateType::XssMatch),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A <code>RateBasedRule</code> is identical to a regular <a>Rule</a>, with one addition: a <code>RateBasedRule</code> counts the number of requests that arrive from a specified IP address every five minutes. For example, based on recent requests that you've seen from an attacker, you might create a <code>RateBasedRule</code> that includes the following conditions: </p> <ul> <li> <p>The requests come from 192.0.2.44.</p> </li> <li> <p>They contain the value <code>BadBot</code> in the <code>User-Agent</code> header.</p> </li> </ul> <p>In the rule, you also define the rate limit as 15,000.</p> <p>Requests that meet both of these conditions and exceed 15,000 requests every five minutes trigger the rule's action (block or count), which is defined in the web ACL.</p>"]
@@ -1044,6 +1441,38 @@ pub struct RateBasedRule {
     #[doc="<p>A unique identifier for a <code>RateBasedRule</code>. You use <code>RuleId</code> to get more information about a <code>RateBasedRule</code> (see <a>GetRateBasedRule</a>), update a <code>RateBasedRule</code> (see <a>UpdateRateBasedRule</a>), insert a <code>RateBasedRule</code> into a <code>WebACL</code> or delete one from a <code>WebACL</code> (see <a>UpdateWebACL</a>), or delete a <code>RateBasedRule</code> from AWS WAF (see <a>DeleteRateBasedRule</a>).</p>"]
     #[serde(rename="RuleId")]
     pub rule_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RateKey {
+    Ip,
+}
+
+impl Into<String> for RateKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RateKey {
+    fn into(self) -> &'static str {
+        match self {
+            RateKey::Ip => "IP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RateKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IP" => Ok(RateKey::Ip),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A combination of <a>ByteMatchSet</a>, <a>IPSet</a>, and/or <a>SqlInjectionMatchSet</a> objects that identify the web requests that you want to allow, block, or count. For example, you might create a <code>Rule</code> that includes the following predicates:</p> <ul> <li> <p>An <code>IPSet</code> that causes AWS WAF to search for web requests that originate from the IP address <code>192.0.2.44</code> </p> </li> <li> <p>A <code>ByteMatchSet</code> that causes AWS WAF to search for web requests for which the value of the <code>User-Agent</code> header is <code>BadBot</code>.</p> </li> </ul> <p>To match the settings in this <code>Rule</code>, a request must originate from <code>192.0.2.44</code> AND include a <code>User-Agent</code> header for which the value is <code>BadBot</code>.</p>"]
@@ -1206,6 +1635,53 @@ pub struct SqlInjectionMatchTuple {
     #[doc="<p>Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass AWS WAF. If you specify a transformation, AWS WAF performs the transformation on <code>FieldToMatch</code> before inspecting a request for a match.</p> <p> <b>CMD_LINE</b> </p> <p>When you're concerned that attackers are injecting an operating system commandline command and using unusual formatting to disguise some or all of the command, use this option to perform the following transformations:</p> <ul> <li> <p>Delete the following characters: \\ \" ' ^</p> </li> <li> <p>Delete spaces before the following characters: / (</p> </li> <li> <p>Replace the following characters with a space: , ;</p> </li> <li> <p>Replace multiple spaces with one space</p> </li> <li> <p>Convert uppercase letters (A-Z) to lowercase (a-z)</p> </li> </ul> <p> <b>COMPRESS_WHITE_SPACE</b> </p> <p>Use this option to replace the following characters with a space character (decimal 32):</p> <ul> <li> <p>\\f, formfeed, decimal 12</p> </li> <li> <p>\\t, tab, decimal 9</p> </li> <li> <p>\\n, newline, decimal 10</p> </li> <li> <p>\\r, carriage return, decimal 13</p> </li> <li> <p>\\v, vertical tab, decimal 11</p> </li> <li> <p>non-breaking space, decimal 160</p> </li> </ul> <p> <code>COMPRESS_WHITE_SPACE</code> also replaces multiple spaces with one space.</p> <p> <b>HTML_ENTITY_DECODE</b> </p> <p>Use this option to replace HTML-encoded characters with unencoded characters. <code>HTML_ENTITY_DECODE</code> performs the following operations:</p> <ul> <li> <p>Replaces <code>(ampersand)quot;</code> with <code>\"</code> </p> </li> <li> <p>Replaces <code>(ampersand)nbsp;</code> with a non-breaking space, decimal 160</p> </li> <li> <p>Replaces <code>(ampersand)lt;</code> with a \"less than\" symbol</p> </li> <li> <p>Replaces <code>(ampersand)gt;</code> with <code>&gt;</code> </p> </li> <li> <p>Replaces characters that are represented in hexadecimal format, <code>(ampersand)#xhhhh;</code>, with the corresponding characters</p> </li> <li> <p>Replaces characters that are represented in decimal format, <code>(ampersand)#nnnn;</code>, with the corresponding characters</p> </li> </ul> <p> <b>LOWERCASE</b> </p> <p>Use this option to convert uppercase letters (A-Z) to lowercase (a-z).</p> <p> <b>URL_DECODE</b> </p> <p>Use this option to decode a URL-encoded value.</p> <p> <b>NONE</b> </p> <p>Specify <code>NONE</code> if you don't want to perform any text transformations.</p>"]
     #[serde(rename="TextTransformation")]
     pub text_transformation: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TextTransformation {
+    CmdLine,
+    CompressWhiteSpace,
+    HtmlEntityDecode,
+    Lowercase,
+    None,
+    UrlDecode,
+}
+
+impl Into<String> for TextTransformation {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TextTransformation {
+    fn into(self) -> &'static str {
+        match self {
+            TextTransformation::CmdLine => "CMD_LINE",
+            TextTransformation::CompressWhiteSpace => "COMPRESS_WHITE_SPACE",
+            TextTransformation::HtmlEntityDecode => "HTML_ENTITY_DECODE",
+            TextTransformation::Lowercase => "LOWERCASE",
+            TextTransformation::None => "NONE",
+            TextTransformation::UrlDecode => "URL_DECODE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TextTransformation {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CMD_LINE" => Ok(TextTransformation::CmdLine),
+            "COMPRESS_WHITE_SPACE" => Ok(TextTransformation::CompressWhiteSpace),
+            "HTML_ENTITY_DECODE" => Ok(TextTransformation::HtmlEntityDecode),
+            "LOWERCASE" => Ok(TextTransformation::Lowercase),
+            "NONE" => Ok(TextTransformation::None),
+            "URL_DECODE" => Ok(TextTransformation::UrlDecode),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>In a <a>GetSampledRequests</a> request, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which you want AWS WAF to return a sample of web requests.</p> <p>In a <a>GetSampledRequests</a> response, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which AWS WAF actually returned a sample of web requests. AWS WAF gets the specified number of requests from among the first 5,000 requests that your AWS resource receives during the specified time period. If your resource receives more than 5,000 requests during that period, AWS WAF stops sampling after the 5,000th request. In that case, <code>EndTime</code> is the time that AWS WAF received the 5,000th request. </p>"]
@@ -1405,6 +1881,79 @@ pub struct WafAction {
     #[doc="<p>Specifies how you want AWS WAF to respond to requests that match the settings in a <code>Rule</code>. Valid settings include the following:</p> <ul> <li> <p> <code>ALLOW</code>: AWS WAF allows requests</p> </li> <li> <p> <code>BLOCK</code>: AWS WAF blocks requests</p> </li> <li> <p> <code>COUNT</code>: AWS WAF increments a counter of the requests that match all of the conditions in the rule. AWS WAF then continues to inspect the web request based on the remaining rules in the web ACL. You can't specify <code>COUNT</code> for the default action for a <code>WebACL</code>.</p> </li> </ul>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WafActionType {
+    Allow,
+    Block,
+    Count,
+}
+
+impl Into<String> for WafActionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WafActionType {
+    fn into(self) -> &'static str {
+        match self {
+            WafActionType::Allow => "ALLOW",
+            WafActionType::Block => "BLOCK",
+            WafActionType::Count => "COUNT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WafActionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALLOW" => Ok(WafActionType::Allow),
+            "BLOCK" => Ok(WafActionType::Block),
+            "COUNT" => Ok(WafActionType::Count),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WafRuleType {
+    RateBased,
+    Regular,
+}
+
+impl Into<String> for WafRuleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WafRuleType {
+    fn into(self) -> &'static str {
+        match self {
+            WafRuleType::RateBased => "RATE_BASED",
+            WafRuleType::Regular => "REGULAR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WafRuleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RATE_BASED" => Ok(WafRuleType::RateBased),
+            "REGULAR" => Ok(WafRuleType::Regular),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains the <code>Rules</code> that identify the requests that you want to allow, block, or count. In a <code>WebACL</code>, you also specify a default action (<code>ALLOW</code> or <code>BLOCK</code>), and the action for each <code>Rule</code> that you add to a <code>WebACL</code>, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the <code>WebACL</code> with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one <code>Rule</code> to a <code>WebACL</code>, a request needs to match only one of the specifications to be allowed, blocked, or counted. For more information, see <a>UpdateWebACL</a>.</p>"]
@@ -6687,7 +7236,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<AssociateWebACLResponse>(String::from_utf8_lossy(&body)
@@ -6720,7 +7269,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6750,7 +7299,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateIPSetResponse>(String::from_utf8_lossy(&body)
@@ -6783,7 +7332,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6813,7 +7362,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateRuleResponse>(String::from_utf8_lossy(&body)
@@ -6847,7 +7396,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6880,7 +7429,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6911,7 +7460,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateWebACLResponse>(String::from_utf8_lossy(&body)
@@ -6943,7 +7492,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6974,7 +7523,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7004,7 +7553,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteIPSetResponse>(String::from_utf8_lossy(&body)
@@ -7037,7 +7586,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7067,7 +7616,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteRuleResponse>(String::from_utf8_lossy(&body)
@@ -7101,7 +7650,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7134,7 +7683,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7165,7 +7714,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteWebACLResponse>(String::from_utf8_lossy(&body)
@@ -7197,7 +7746,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7228,7 +7777,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DisassociateWebACLResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7258,7 +7807,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetByteMatchSetResponse>(String::from_utf8_lossy(&body)
@@ -7287,7 +7836,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetChangeTokenResponse>(String::from_utf8_lossy(&body)
@@ -7321,7 +7870,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetChangeTokenStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7349,7 +7898,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetIPSetResponse>(String::from_utf8_lossy(&body)
@@ -7381,7 +7930,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRateBasedRuleResponse>(String::from_utf8_lossy(&body)
@@ -7415,7 +7964,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRateBasedRuleManagedKeysResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7444,7 +7993,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRuleResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -7476,7 +8025,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetSampledRequestsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7508,7 +8057,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7540,7 +8089,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7569,7 +8118,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetWebACLResponse>(String::from_utf8_lossy(&body)
@@ -7603,7 +8152,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetWebACLForResourceResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7633,7 +8182,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetXssMatchSetResponse>(String::from_utf8_lossy(&body)
@@ -7665,7 +8214,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListByteMatchSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7695,7 +8244,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListIPSetsResponse>(String::from_utf8_lossy(&body)
@@ -7728,7 +8277,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRateBasedRulesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7760,7 +8309,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListResourcesForWebACLResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7788,7 +8337,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&body)
@@ -7822,7 +8371,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListSizeConstraintSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7854,7 +8403,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListSqlInjectionMatchSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7885,7 +8434,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListWebACLsResponse>(String::from_utf8_lossy(&body)
@@ -7917,7 +8466,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListXssMatchSetsResponse>(String::from_utf8_lossy(&body)
@@ -7950,7 +8499,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7980,7 +8529,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateIPSetResponse>(String::from_utf8_lossy(&body)
@@ -8013,7 +8562,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8043,7 +8592,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateRuleResponse>(String::from_utf8_lossy(&body)
@@ -8077,7 +8626,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8110,7 +8659,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -8141,7 +8690,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateWebACLResponse>(String::from_utf8_lossy(&body)
@@ -8173,7 +8722,7 @@ impl<P, D> WAFRegional for WAFRegionalClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -103,6 +99,126 @@ pub struct ByteMatchTuple {
     #[doc="<p>Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass AWS WAF. If you specify a transformation, AWS WAF performs the transformation on <code>TargetString</code> before inspecting a request for a match.</p> <p> <b>CMD_LINE</b> </p> <p>When you're concerned that attackers are injecting an operating system commandline command and using unusual formatting to disguise some or all of the command, use this option to perform the following transformations:</p> <ul> <li> <p>Delete the following characters: \\ \" ' ^</p> </li> <li> <p>Delete spaces before the following characters: / (</p> </li> <li> <p>Replace the following characters with a space: , ;</p> </li> <li> <p>Replace multiple spaces with one space</p> </li> <li> <p>Convert uppercase letters (A-Z) to lowercase (a-z)</p> </li> </ul> <p> <b>COMPRESS_WHITE_SPACE</b> </p> <p>Use this option to replace the following characters with a space character (decimal 32):</p> <ul> <li> <p>\\f, formfeed, decimal 12</p> </li> <li> <p>\\t, tab, decimal 9</p> </li> <li> <p>\\n, newline, decimal 10</p> </li> <li> <p>\\r, carriage return, decimal 13</p> </li> <li> <p>\\v, vertical tab, decimal 11</p> </li> <li> <p>non-breaking space, decimal 160</p> </li> </ul> <p> <code>COMPRESS_WHITE_SPACE</code> also replaces multiple spaces with one space.</p> <p> <b>HTML_ENTITY_DECODE</b> </p> <p>Use this option to replace HTML-encoded characters with unencoded characters. <code>HTML_ENTITY_DECODE</code> performs the following operations:</p> <ul> <li> <p>Replaces <code>(ampersand)quot;</code> with <code>\"</code> </p> </li> <li> <p>Replaces <code>(ampersand)nbsp;</code> with a non-breaking space, decimal 160</p> </li> <li> <p>Replaces <code>(ampersand)lt;</code> with a \"less than\" symbol</p> </li> <li> <p>Replaces <code>(ampersand)gt;</code> with <code>&gt;</code> </p> </li> <li> <p>Replaces characters that are represented in hexadecimal format, <code>(ampersand)#xhhhh;</code>, with the corresponding characters</p> </li> <li> <p>Replaces characters that are represented in decimal format, <code>(ampersand)#nnnn;</code>, with the corresponding characters</p> </li> </ul> <p> <b>LOWERCASE</b> </p> <p>Use this option to convert uppercase letters (A-Z) to lowercase (a-z).</p> <p> <b>URL_DECODE</b> </p> <p>Use this option to decode a URL-encoded value.</p> <p> <b>NONE</b> </p> <p>Specify <code>NONE</code> if you don't want to perform any text transformations.</p>"]
     #[serde(rename="TextTransformation")]
     pub text_transformation: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeAction {
+    Delete,
+    Insert,
+}
+
+impl Into<String> for ChangeAction {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeAction {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeAction::Delete => "DELETE",
+            ChangeAction::Insert => "INSERT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeAction {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETE" => Ok(ChangeAction::Delete),
+            "INSERT" => Ok(ChangeAction::Insert),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ChangeTokenStatus {
+    Insync,
+    Pending,
+    Provisioned,
+}
+
+impl Into<String> for ChangeTokenStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ChangeTokenStatus {
+    fn into(self) -> &'static str {
+        match self {
+            ChangeTokenStatus::Insync => "INSYNC",
+            ChangeTokenStatus::Pending => "PENDING",
+            ChangeTokenStatus::Provisioned => "PROVISIONED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ChangeTokenStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "INSYNC" => Ok(ChangeTokenStatus::Insync),
+            "PENDING" => Ok(ChangeTokenStatus::Pending),
+            "PROVISIONED" => Ok(ChangeTokenStatus::Provisioned),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ComparisonOperator {
+    Eq,
+    Ge,
+    Gt,
+    Le,
+    Lt,
+    Ne,
+}
+
+impl Into<String> for ComparisonOperator {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ComparisonOperator {
+    fn into(self) -> &'static str {
+        match self {
+            ComparisonOperator::Eq => "EQ",
+            ComparisonOperator::Ge => "GE",
+            ComparisonOperator::Gt => "GT",
+            ComparisonOperator::Le => "LE",
+            ComparisonOperator::Lt => "LT",
+            ComparisonOperator::Ne => "NE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ComparisonOperator {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EQ" => Ok(ComparisonOperator::Eq),
+            "GE" => Ok(ComparisonOperator::Ge),
+            "GT" => Ok(ComparisonOperator::Gt),
+            "LE" => Ok(ComparisonOperator::Le),
+            "LT" => Ok(ComparisonOperator::Lt),
+            "NE" => Ok(ComparisonOperator::Ne),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -736,6 +852,41 @@ pub struct IPSetDescriptor {
     pub value: String,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum IPSetDescriptorType {
+    Ipv4,
+    Ipv6,
+}
+
+impl Into<String> for IPSetDescriptorType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for IPSetDescriptorType {
+    fn into(self) -> &'static str {
+        match self {
+            IPSetDescriptorType::Ipv4 => "IPV4",
+            IPSetDescriptorType::Ipv6 => "IPV6",
+        }
+    }
+}
+
+impl ::std::str::FromStr for IPSetDescriptorType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IPV4" => Ok(IPSetDescriptorType::Ipv4),
+            "IPV6" => Ok(IPSetDescriptorType::Ipv6),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains the identifier and the name of the <code>IPSet</code>.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct IPSetSummary {
@@ -954,6 +1105,208 @@ pub struct ListXssMatchSetsResponse {
     pub xss_match_sets: Option<Vec<XssMatchSetSummary>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum MatchFieldType {
+    Body,
+    Header,
+    Method,
+    QueryString,
+    Uri,
+}
+
+impl Into<String> for MatchFieldType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for MatchFieldType {
+    fn into(self) -> &'static str {
+        match self {
+            MatchFieldType::Body => "BODY",
+            MatchFieldType::Header => "HEADER",
+            MatchFieldType::Method => "METHOD",
+            MatchFieldType::QueryString => "QUERY_STRING",
+            MatchFieldType::Uri => "URI",
+        }
+    }
+}
+
+impl ::std::str::FromStr for MatchFieldType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BODY" => Ok(MatchFieldType::Body),
+            "HEADER" => Ok(MatchFieldType::Header),
+            "METHOD" => Ok(MatchFieldType::Method),
+            "QUERY_STRING" => Ok(MatchFieldType::QueryString),
+            "URI" => Ok(MatchFieldType::Uri),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterExceptionField {
+    ByteMatchFieldType,
+    ByteMatchPositionalConstraint,
+    ByteMatchTextTransformation,
+    ChangeAction,
+    IpsetType,
+    NextMarker,
+    PredicateType,
+    RateKey,
+    RuleType,
+    SizeConstraintComparisonOperator,
+    SqlInjectionMatchFieldType,
+    WafAction,
+}
+
+impl Into<String> for ParameterExceptionField {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterExceptionField {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterExceptionField::ByteMatchFieldType => "BYTE_MATCH_FIELD_TYPE",
+            ParameterExceptionField::ByteMatchPositionalConstraint => {
+                "BYTE_MATCH_POSITIONAL_CONSTRAINT"
+            }
+            ParameterExceptionField::ByteMatchTextTransformation => {
+                "BYTE_MATCH_TEXT_TRANSFORMATION"
+            }
+            ParameterExceptionField::ChangeAction => "CHANGE_ACTION",
+            ParameterExceptionField::IpsetType => "IPSET_TYPE",
+            ParameterExceptionField::NextMarker => "NEXT_MARKER",
+            ParameterExceptionField::PredicateType => "PREDICATE_TYPE",
+            ParameterExceptionField::RateKey => "RATE_KEY",
+            ParameterExceptionField::RuleType => "RULE_TYPE",
+            ParameterExceptionField::SizeConstraintComparisonOperator => {
+                "SIZE_CONSTRAINT_COMPARISON_OPERATOR"
+            }
+            ParameterExceptionField::SqlInjectionMatchFieldType => "SQL_INJECTION_MATCH_FIELD_TYPE",
+            ParameterExceptionField::WafAction => "WAF_ACTION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterExceptionField {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BYTE_MATCH_FIELD_TYPE" => Ok(ParameterExceptionField::ByteMatchFieldType),
+            "BYTE_MATCH_POSITIONAL_CONSTRAINT" => {
+                Ok(ParameterExceptionField::ByteMatchPositionalConstraint)
+            }
+            "BYTE_MATCH_TEXT_TRANSFORMATION" => {
+                Ok(ParameterExceptionField::ByteMatchTextTransformation)
+            }
+            "CHANGE_ACTION" => Ok(ParameterExceptionField::ChangeAction),
+            "IPSET_TYPE" => Ok(ParameterExceptionField::IpsetType),
+            "NEXT_MARKER" => Ok(ParameterExceptionField::NextMarker),
+            "PREDICATE_TYPE" => Ok(ParameterExceptionField::PredicateType),
+            "RATE_KEY" => Ok(ParameterExceptionField::RateKey),
+            "RULE_TYPE" => Ok(ParameterExceptionField::RuleType),
+            "SIZE_CONSTRAINT_COMPARISON_OPERATOR" => {
+                Ok(ParameterExceptionField::SizeConstraintComparisonOperator)
+            }
+            "SQL_INJECTION_MATCH_FIELD_TYPE" => {
+                Ok(ParameterExceptionField::SqlInjectionMatchFieldType)
+            }
+            "WAF_ACTION" => Ok(ParameterExceptionField::WafAction),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ParameterExceptionReason {
+    IllegalCombination,
+    InvalidOption,
+}
+
+impl Into<String> for ParameterExceptionReason {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ParameterExceptionReason {
+    fn into(self) -> &'static str {
+        match self {
+            ParameterExceptionReason::IllegalCombination => "ILLEGAL_COMBINATION",
+            ParameterExceptionReason::InvalidOption => "INVALID_OPTION",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ParameterExceptionReason {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ILLEGAL_COMBINATION" => Ok(ParameterExceptionReason::IllegalCombination),
+            "INVALID_OPTION" => Ok(ParameterExceptionReason::InvalidOption),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PositionalConstraint {
+    Contains,
+    ContainsWord,
+    EndsWith,
+    Exactly,
+    StartsWith,
+}
+
+impl Into<String> for PositionalConstraint {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PositionalConstraint {
+    fn into(self) -> &'static str {
+        match self {
+            PositionalConstraint::Contains => "CONTAINS",
+            PositionalConstraint::ContainsWord => "CONTAINS_WORD",
+            PositionalConstraint::EndsWith => "ENDS_WITH",
+            PositionalConstraint::Exactly => "EXACTLY",
+            PositionalConstraint::StartsWith => "STARTS_WITH",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PositionalConstraint {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONTAINS" => Ok(PositionalConstraint::Contains),
+            "CONTAINS_WORD" => Ok(PositionalConstraint::ContainsWord),
+            "ENDS_WITH" => Ok(PositionalConstraint::EndsWith),
+            "EXACTLY" => Ok(PositionalConstraint::Exactly),
+            "STARTS_WITH" => Ok(PositionalConstraint::StartsWith),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Specifies the <a>ByteMatchSet</a>, <a>IPSet</a>, <a>SqlInjectionMatchSet</a>, <a>XssMatchSet</a>, and <a>SizeConstraintSet</a> objects that you want to add to a <code>Rule</code> and, for each object, indicates whether you want to negate the settings, for example, requests that do NOT originate from the IP address 192.0.2.44. </p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Predicate {
@@ -966,6 +1319,50 @@ pub struct Predicate {
     #[doc="<p>The type of predicate in a <code>Rule</code>, such as <code>ByteMatchSet</code> or <code>IPSet</code>.</p>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PredicateType {
+    ByteMatch,
+    Ipmatch,
+    SizeConstraint,
+    SqlInjectionMatch,
+    XssMatch,
+}
+
+impl Into<String> for PredicateType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PredicateType {
+    fn into(self) -> &'static str {
+        match self {
+            PredicateType::ByteMatch => "ByteMatch",
+            PredicateType::Ipmatch => "IPMatch",
+            PredicateType::SizeConstraint => "SizeConstraint",
+            PredicateType::SqlInjectionMatch => "SqlInjectionMatch",
+            PredicateType::XssMatch => "XssMatch",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PredicateType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ByteMatch" => Ok(PredicateType::ByteMatch),
+            "IPMatch" => Ok(PredicateType::Ipmatch),
+            "SizeConstraint" => Ok(PredicateType::SizeConstraint),
+            "SqlInjectionMatch" => Ok(PredicateType::SqlInjectionMatch),
+            "XssMatch" => Ok(PredicateType::XssMatch),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A <code>RateBasedRule</code> is identical to a regular <a>Rule</a>, with one addition: a <code>RateBasedRule</code> counts the number of requests that arrive from a specified IP address every five minutes. For example, based on recent requests that you've seen from an attacker, you might create a <code>RateBasedRule</code> that includes the following conditions: </p> <ul> <li> <p>The requests come from 192.0.2.44.</p> </li> <li> <p>They contain the value <code>BadBot</code> in the <code>User-Agent</code> header.</p> </li> </ul> <p>In the rule, you also define the rate limit as 15,000.</p> <p>Requests that meet both of these conditions and exceed 15,000 requests every five minutes trigger the rule's action (block or count), which is defined in the web ACL.</p>"]
@@ -991,6 +1388,38 @@ pub struct RateBasedRule {
     #[doc="<p>A unique identifier for a <code>RateBasedRule</code>. You use <code>RuleId</code> to get more information about a <code>RateBasedRule</code> (see <a>GetRateBasedRule</a>), update a <code>RateBasedRule</code> (see <a>UpdateRateBasedRule</a>), insert a <code>RateBasedRule</code> into a <code>WebACL</code> or delete one from a <code>WebACL</code> (see <a>UpdateWebACL</a>), or delete a <code>RateBasedRule</code> from AWS WAF (see <a>DeleteRateBasedRule</a>).</p>"]
     #[serde(rename="RuleId")]
     pub rule_id: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RateKey {
+    Ip,
+}
+
+impl Into<String> for RateKey {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RateKey {
+    fn into(self) -> &'static str {
+        match self {
+            RateKey::Ip => "IP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RateKey {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IP" => Ok(RateKey::Ip),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>A combination of <a>ByteMatchSet</a>, <a>IPSet</a>, and/or <a>SqlInjectionMatchSet</a> objects that identify the web requests that you want to allow, block, or count. For example, you might create a <code>Rule</code> that includes the following predicates:</p> <ul> <li> <p>An <code>IPSet</code> that causes AWS WAF to search for web requests that originate from the IP address <code>192.0.2.44</code> </p> </li> <li> <p>A <code>ByteMatchSet</code> that causes AWS WAF to search for web requests for which the value of the <code>User-Agent</code> header is <code>BadBot</code>.</p> </li> </ul> <p>To match the settings in this <code>Rule</code>, a request must originate from <code>192.0.2.44</code> AND include a <code>User-Agent</code> header for which the value is <code>BadBot</code>.</p>"]
@@ -1153,6 +1582,53 @@ pub struct SqlInjectionMatchTuple {
     #[doc="<p>Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass AWS WAF. If you specify a transformation, AWS WAF performs the transformation on <code>FieldToMatch</code> before inspecting a request for a match.</p> <p> <b>CMD_LINE</b> </p> <p>When you're concerned that attackers are injecting an operating system commandline command and using unusual formatting to disguise some or all of the command, use this option to perform the following transformations:</p> <ul> <li> <p>Delete the following characters: \\ \" ' ^</p> </li> <li> <p>Delete spaces before the following characters: / (</p> </li> <li> <p>Replace the following characters with a space: , ;</p> </li> <li> <p>Replace multiple spaces with one space</p> </li> <li> <p>Convert uppercase letters (A-Z) to lowercase (a-z)</p> </li> </ul> <p> <b>COMPRESS_WHITE_SPACE</b> </p> <p>Use this option to replace the following characters with a space character (decimal 32):</p> <ul> <li> <p>\\f, formfeed, decimal 12</p> </li> <li> <p>\\t, tab, decimal 9</p> </li> <li> <p>\\n, newline, decimal 10</p> </li> <li> <p>\\r, carriage return, decimal 13</p> </li> <li> <p>\\v, vertical tab, decimal 11</p> </li> <li> <p>non-breaking space, decimal 160</p> </li> </ul> <p> <code>COMPRESS_WHITE_SPACE</code> also replaces multiple spaces with one space.</p> <p> <b>HTML_ENTITY_DECODE</b> </p> <p>Use this option to replace HTML-encoded characters with unencoded characters. <code>HTML_ENTITY_DECODE</code> performs the following operations:</p> <ul> <li> <p>Replaces <code>(ampersand)quot;</code> with <code>\"</code> </p> </li> <li> <p>Replaces <code>(ampersand)nbsp;</code> with a non-breaking space, decimal 160</p> </li> <li> <p>Replaces <code>(ampersand)lt;</code> with a \"less than\" symbol</p> </li> <li> <p>Replaces <code>(ampersand)gt;</code> with <code>&gt;</code> </p> </li> <li> <p>Replaces characters that are represented in hexadecimal format, <code>(ampersand)#xhhhh;</code>, with the corresponding characters</p> </li> <li> <p>Replaces characters that are represented in decimal format, <code>(ampersand)#nnnn;</code>, with the corresponding characters</p> </li> </ul> <p> <b>LOWERCASE</b> </p> <p>Use this option to convert uppercase letters (A-Z) to lowercase (a-z).</p> <p> <b>URL_DECODE</b> </p> <p>Use this option to decode a URL-encoded value.</p> <p> <b>NONE</b> </p> <p>Specify <code>NONE</code> if you don't want to perform any text transformations.</p>"]
     #[serde(rename="TextTransformation")]
     pub text_transformation: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum TextTransformation {
+    CmdLine,
+    CompressWhiteSpace,
+    HtmlEntityDecode,
+    Lowercase,
+    None,
+    UrlDecode,
+}
+
+impl Into<String> for TextTransformation {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for TextTransformation {
+    fn into(self) -> &'static str {
+        match self {
+            TextTransformation::CmdLine => "CMD_LINE",
+            TextTransformation::CompressWhiteSpace => "COMPRESS_WHITE_SPACE",
+            TextTransformation::HtmlEntityDecode => "HTML_ENTITY_DECODE",
+            TextTransformation::Lowercase => "LOWERCASE",
+            TextTransformation::None => "NONE",
+            TextTransformation::UrlDecode => "URL_DECODE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for TextTransformation {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CMD_LINE" => Ok(TextTransformation::CmdLine),
+            "COMPRESS_WHITE_SPACE" => Ok(TextTransformation::CompressWhiteSpace),
+            "HTML_ENTITY_DECODE" => Ok(TextTransformation::HtmlEntityDecode),
+            "LOWERCASE" => Ok(TextTransformation::Lowercase),
+            "NONE" => Ok(TextTransformation::None),
+            "URL_DECODE" => Ok(TextTransformation::UrlDecode),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>In a <a>GetSampledRequests</a> request, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which you want AWS WAF to return a sample of web requests.</p> <p>In a <a>GetSampledRequests</a> response, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which AWS WAF actually returned a sample of web requests. AWS WAF gets the specified number of requests from among the first 5,000 requests that your AWS resource receives during the specified time period. If your resource receives more than 5,000 requests during that period, AWS WAF stops sampling after the 5,000th request. In that case, <code>EndTime</code> is the time that AWS WAF received the 5,000th request. </p>"]
@@ -1352,6 +1828,79 @@ pub struct WafAction {
     #[doc="<p>Specifies how you want AWS WAF to respond to requests that match the settings in a <code>Rule</code>. Valid settings include the following:</p> <ul> <li> <p> <code>ALLOW</code>: AWS WAF allows requests</p> </li> <li> <p> <code>BLOCK</code>: AWS WAF blocks requests</p> </li> <li> <p> <code>COUNT</code>: AWS WAF increments a counter of the requests that match all of the conditions in the rule. AWS WAF then continues to inspect the web request based on the remaining rules in the web ACL. You can't specify <code>COUNT</code> for the default action for a <code>WebACL</code>.</p> </li> </ul>"]
     #[serde(rename="Type")]
     pub type_: String,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WafActionType {
+    Allow,
+    Block,
+    Count,
+}
+
+impl Into<String> for WafActionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WafActionType {
+    fn into(self) -> &'static str {
+        match self {
+            WafActionType::Allow => "ALLOW",
+            WafActionType::Block => "BLOCK",
+            WafActionType::Count => "COUNT",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WafActionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALLOW" => Ok(WafActionType::Allow),
+            "BLOCK" => Ok(WafActionType::Block),
+            "COUNT" => Ok(WafActionType::Count),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WafRuleType {
+    RateBased,
+    Regular,
+}
+
+impl Into<String> for WafRuleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WafRuleType {
+    fn into(self) -> &'static str {
+        match self {
+            WafRuleType::RateBased => "RATE_BASED",
+            WafRuleType::Regular => "REGULAR",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WafRuleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RATE_BASED" => Ok(WafRuleType::RateBased),
+            "REGULAR" => Ok(WafRuleType::Regular),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Contains the <code>Rules</code> that identify the requests that you want to allow, block, or count. In a <code>WebACL</code>, you also specify a default action (<code>ALLOW</code> or <code>BLOCK</code>), and the action for each <code>Rule</code> that you add to a <code>WebACL</code>, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the <code>WebACL</code> with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one <code>Rule</code> to a <code>WebACL</code>, a request needs to match only one of the specifications to be allowed, blocked, or counted. For more information, see <a>UpdateWebACL</a>.</p>"]
@@ -6208,7 +6757,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6238,7 +6787,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateIPSetResponse>(String::from_utf8_lossy(&body)
@@ -6270,7 +6819,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6300,7 +6849,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateRuleResponse>(String::from_utf8_lossy(&body)
@@ -6333,7 +6882,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6365,7 +6914,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6396,7 +6945,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateWebACLResponse>(String::from_utf8_lossy(&body)
@@ -6428,7 +6977,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6458,7 +7007,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6488,7 +7037,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteIPSetResponse>(String::from_utf8_lossy(&body)
@@ -6520,7 +7069,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6550,7 +7099,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteRuleResponse>(String::from_utf8_lossy(&body)
@@ -6583,7 +7132,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6615,7 +7164,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6646,7 +7195,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteWebACLResponse>(String::from_utf8_lossy(&body)
@@ -6678,7 +7227,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6708,7 +7257,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetByteMatchSetResponse>(String::from_utf8_lossy(&body)
@@ -6737,7 +7286,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetChangeTokenResponse>(String::from_utf8_lossy(&body)
@@ -6770,7 +7319,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetChangeTokenStatusResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6798,7 +7347,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetIPSetResponse>(String::from_utf8_lossy(&body)
@@ -6830,7 +7379,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRateBasedRuleResponse>(String::from_utf8_lossy(&body)
@@ -6864,7 +7413,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRateBasedRuleManagedKeysResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6893,7 +7442,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetRuleResponse>(String::from_utf8_lossy(&body).as_ref())
@@ -6924,7 +7473,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetSampledRequestsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6955,7 +7504,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -6986,7 +7535,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7015,7 +7564,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetWebACLResponse>(String::from_utf8_lossy(&body)
@@ -7047,7 +7596,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<GetXssMatchSetResponse>(String::from_utf8_lossy(&body)
@@ -7079,7 +7628,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListByteMatchSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7109,7 +7658,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListIPSetsResponse>(String::from_utf8_lossy(&body)
@@ -7141,7 +7690,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRateBasedRulesResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7169,7 +7718,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListRulesResponse>(String::from_utf8_lossy(&body)
@@ -7202,7 +7751,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListSizeConstraintSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7233,7 +7782,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListSqlInjectionMatchSetsResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7264,7 +7813,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListWebACLsResponse>(String::from_utf8_lossy(&body)
@@ -7296,7 +7845,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ListXssMatchSetsResponse>(String::from_utf8_lossy(&body)
@@ -7328,7 +7877,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateByteMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7358,7 +7907,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateIPSetResponse>(String::from_utf8_lossy(&body)
@@ -7390,7 +7939,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateRateBasedRuleResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7420,7 +7969,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateRuleResponse>(String::from_utf8_lossy(&body)
@@ -7453,7 +8002,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateSizeConstraintSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7485,7 +8034,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateSqlInjectionMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -7516,7 +8065,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateWebACLResponse>(String::from_utf8_lossy(&body)
@@ -7548,7 +8097,7 @@ impl<P, D> Waf for WafClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<UpdateXssMatchSetResponse>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/workdocs/src/generated.rs
+++ b/rusoto/services/workdocs/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -97,6 +93,136 @@ pub struct Activity {
     #[serde(rename="Type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ActivityType {
+    DocumentAnnotationAdded,
+    DocumentAnnotationDeleted,
+    DocumentCheckedIn,
+    DocumentCheckedOut,
+    DocumentCommentAdded,
+    DocumentCommentDeleted,
+    DocumentMoved,
+    DocumentRecycled,
+    DocumentRenamed,
+    DocumentRestored,
+    DocumentReverted,
+    DocumentShareableLinkCreated,
+    DocumentShareableLinkPermissionChanged,
+    DocumentShareableLinkRemoved,
+    DocumentShared,
+    DocumentSharePermissionChanged,
+    DocumentUnshared,
+    DocumentVersionDeleted,
+    DocumentVersionUploaded,
+    FolderCreated,
+    FolderDeleted,
+    FolderMoved,
+    FolderRecycled,
+    FolderRenamed,
+    FolderRestored,
+    FolderShareableLinkCreated,
+    FolderShareableLinkPermissionChanged,
+    FolderShareableLinkRemoved,
+    FolderShared,
+    FolderSharePermissionChanged,
+    FolderUnshared,
+}
+
+impl Into<String> for ActivityType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ActivityType {
+    fn into(self) -> &'static str {
+        match self {
+            ActivityType::DocumentAnnotationAdded => "DOCUMENT_ANNOTATION_ADDED",
+            ActivityType::DocumentAnnotationDeleted => "DOCUMENT_ANNOTATION_DELETED",
+            ActivityType::DocumentCheckedIn => "DOCUMENT_CHECKED_IN",
+            ActivityType::DocumentCheckedOut => "DOCUMENT_CHECKED_OUT",
+            ActivityType::DocumentCommentAdded => "DOCUMENT_COMMENT_ADDED",
+            ActivityType::DocumentCommentDeleted => "DOCUMENT_COMMENT_DELETED",
+            ActivityType::DocumentMoved => "DOCUMENT_MOVED",
+            ActivityType::DocumentRecycled => "DOCUMENT_RECYCLED",
+            ActivityType::DocumentRenamed => "DOCUMENT_RENAMED",
+            ActivityType::DocumentRestored => "DOCUMENT_RESTORED",
+            ActivityType::DocumentReverted => "DOCUMENT_REVERTED",
+            ActivityType::DocumentShareableLinkCreated => "DOCUMENT_SHAREABLE_LINK_CREATED",
+            ActivityType::DocumentShareableLinkPermissionChanged => {
+                "DOCUMENT_SHAREABLE_LINK_PERMISSION_CHANGED"
+            }
+            ActivityType::DocumentShareableLinkRemoved => "DOCUMENT_SHAREABLE_LINK_REMOVED",
+            ActivityType::DocumentShared => "DOCUMENT_SHARED",
+            ActivityType::DocumentSharePermissionChanged => "DOCUMENT_SHARE_PERMISSION_CHANGED",
+            ActivityType::DocumentUnshared => "DOCUMENT_UNSHARED",
+            ActivityType::DocumentVersionDeleted => "DOCUMENT_VERSION_DELETED",
+            ActivityType::DocumentVersionUploaded => "DOCUMENT_VERSION_UPLOADED",
+            ActivityType::FolderCreated => "FOLDER_CREATED",
+            ActivityType::FolderDeleted => "FOLDER_DELETED",
+            ActivityType::FolderMoved => "FOLDER_MOVED",
+            ActivityType::FolderRecycled => "FOLDER_RECYCLED",
+            ActivityType::FolderRenamed => "FOLDER_RENAMED",
+            ActivityType::FolderRestored => "FOLDER_RESTORED",
+            ActivityType::FolderShareableLinkCreated => "FOLDER_SHAREABLE_LINK_CREATED",
+            ActivityType::FolderShareableLinkPermissionChanged => {
+                "FOLDER_SHAREABLE_LINK_PERMISSION_CHANGED"
+            }
+            ActivityType::FolderShareableLinkRemoved => "FOLDER_SHAREABLE_LINK_REMOVED",
+            ActivityType::FolderShared => "FOLDER_SHARED",
+            ActivityType::FolderSharePermissionChanged => "FOLDER_SHARE_PERMISSION_CHANGED",
+            ActivityType::FolderUnshared => "FOLDER_UNSHARED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ActivityType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DOCUMENT_ANNOTATION_ADDED" => Ok(ActivityType::DocumentAnnotationAdded),
+            "DOCUMENT_ANNOTATION_DELETED" => Ok(ActivityType::DocumentAnnotationDeleted),
+            "DOCUMENT_CHECKED_IN" => Ok(ActivityType::DocumentCheckedIn),
+            "DOCUMENT_CHECKED_OUT" => Ok(ActivityType::DocumentCheckedOut),
+            "DOCUMENT_COMMENT_ADDED" => Ok(ActivityType::DocumentCommentAdded),
+            "DOCUMENT_COMMENT_DELETED" => Ok(ActivityType::DocumentCommentDeleted),
+            "DOCUMENT_MOVED" => Ok(ActivityType::DocumentMoved),
+            "DOCUMENT_RECYCLED" => Ok(ActivityType::DocumentRecycled),
+            "DOCUMENT_RENAMED" => Ok(ActivityType::DocumentRenamed),
+            "DOCUMENT_RESTORED" => Ok(ActivityType::DocumentRestored),
+            "DOCUMENT_REVERTED" => Ok(ActivityType::DocumentReverted),
+            "DOCUMENT_SHAREABLE_LINK_CREATED" => Ok(ActivityType::DocumentShareableLinkCreated),
+            "DOCUMENT_SHAREABLE_LINK_PERMISSION_CHANGED" => {
+                Ok(ActivityType::DocumentShareableLinkPermissionChanged)
+            }
+            "DOCUMENT_SHAREABLE_LINK_REMOVED" => Ok(ActivityType::DocumentShareableLinkRemoved),
+            "DOCUMENT_SHARED" => Ok(ActivityType::DocumentShared),
+            "DOCUMENT_SHARE_PERMISSION_CHANGED" => Ok(ActivityType::DocumentSharePermissionChanged),
+            "DOCUMENT_UNSHARED" => Ok(ActivityType::DocumentUnshared),
+            "DOCUMENT_VERSION_DELETED" => Ok(ActivityType::DocumentVersionDeleted),
+            "DOCUMENT_VERSION_UPLOADED" => Ok(ActivityType::DocumentVersionUploaded),
+            "FOLDER_CREATED" => Ok(ActivityType::FolderCreated),
+            "FOLDER_DELETED" => Ok(ActivityType::FolderDeleted),
+            "FOLDER_MOVED" => Ok(ActivityType::FolderMoved),
+            "FOLDER_RECYCLED" => Ok(ActivityType::FolderRecycled),
+            "FOLDER_RENAMED" => Ok(ActivityType::FolderRenamed),
+            "FOLDER_RESTORED" => Ok(ActivityType::FolderRestored),
+            "FOLDER_SHAREABLE_LINK_CREATED" => Ok(ActivityType::FolderShareableLinkCreated),
+            "FOLDER_SHAREABLE_LINK_PERMISSION_CHANGED" => {
+                Ok(ActivityType::FolderShareableLinkPermissionChanged)
+            }
+            "FOLDER_SHAREABLE_LINK_REMOVED" => Ok(ActivityType::FolderShareableLinkRemoved),
+            "FOLDER_SHARED" => Ok(ActivityType::FolderShared),
+            "FOLDER_SHARE_PERMISSION_CHANGED" => Ok(ActivityType::FolderSharePermissionChanged),
+            "FOLDER_UNSHARED" => Ok(ActivityType::FolderUnshared),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -182,6 +308,79 @@ pub struct CommentMetadata {
     #[serde(rename="RecipientId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub recipient_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CommentStatusType {
+    Deleted,
+    Draft,
+    Published,
+}
+
+impl Into<String> for CommentStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CommentStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            CommentStatusType::Deleted => "DELETED",
+            CommentStatusType::Draft => "DRAFT",
+            CommentStatusType::Published => "PUBLISHED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CommentStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DELETED" => Ok(CommentStatusType::Deleted),
+            "DRAFT" => Ok(CommentStatusType::Draft),
+            "PUBLISHED" => Ok(CommentStatusType::Published),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum CommentVisibilityType {
+    Private,
+    Public,
+}
+
+impl Into<String> for CommentVisibilityType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for CommentVisibilityType {
+    fn into(self) -> &'static str {
+        match self {
+            CommentVisibilityType::Private => "PRIVATE",
+            CommentVisibilityType::Public => "PUBLIC",
+        }
+    }
+}
+
+impl ::std::str::FromStr for CommentVisibilityType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PRIVATE" => Ok(CommentVisibilityType::Private),
+            "PUBLIC" => Ok(CommentVisibilityType::Public),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -834,6 +1033,114 @@ pub struct DocumentMetadata {
     pub resource_state: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentSourceType {
+    Original,
+    WithComments,
+}
+
+impl Into<String> for DocumentSourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentSourceType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentSourceType::Original => "ORIGINAL",
+            DocumentSourceType::WithComments => "WITH_COMMENTS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentSourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ORIGINAL" => Ok(DocumentSourceType::Original),
+            "WITH_COMMENTS" => Ok(DocumentSourceType::WithComments),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentStatusType {
+    Active,
+    Initialized,
+}
+
+impl Into<String> for DocumentStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentStatusType::Active => "ACTIVE",
+            DocumentStatusType::Initialized => "INITIALIZED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(DocumentStatusType::Active),
+            "INITIALIZED" => Ok(DocumentStatusType::Initialized),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentThumbnailType {
+    Large,
+    Small,
+    SmallHq,
+}
+
+impl Into<String> for DocumentThumbnailType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentThumbnailType {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentThumbnailType::Large => "LARGE",
+            DocumentThumbnailType::Small => "SMALL",
+            DocumentThumbnailType::SmallHq => "SMALL_HQ",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentThumbnailType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LARGE" => Ok(DocumentThumbnailType::Large),
+            "SMALL" => Ok(DocumentThumbnailType::Small),
+            "SMALL_HQ" => Ok(DocumentThumbnailType::SmallHq),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes a version of a document.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct DocumentVersionMetadata {
@@ -889,6 +1196,76 @@ pub struct DocumentVersionMetadata {
     #[serde(rename="Thumbnail")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub thumbnail: Option<::std::collections::HashMap<String, String>>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum DocumentVersionStatus {
+    Active,
+}
+
+impl Into<String> for DocumentVersionStatus {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for DocumentVersionStatus {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentVersionStatus::Active => "ACTIVE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for DocumentVersionStatus {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(DocumentVersionStatus::Active),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum FolderContentType {
+    All,
+    Document,
+    Folder,
+}
+
+impl Into<String> for FolderContentType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for FolderContentType {
+    fn into(self) -> &'static str {
+        match self {
+            FolderContentType::All => "ALL",
+            FolderContentType::Document => "DOCUMENT",
+            FolderContentType::Folder => "FOLDER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for FolderContentType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL" => Ok(FolderContentType::All),
+            "DOCUMENT" => Ok(FolderContentType::Document),
+            "FOLDER" => Ok(FolderContentType::Folder),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a folder.</p>"]
@@ -1165,6 +1542,103 @@ pub struct InitiateDocumentVersionUploadResponse {
     pub upload_metadata: Option<UploadMetadata>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum LocaleType {
+    De,
+    Default,
+    En,
+    Es,
+    Fr,
+    Ja,
+    Ko,
+    PtBR,
+    Ru,
+    ZhCN,
+    ZhTW,
+}
+
+impl Into<String> for LocaleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for LocaleType {
+    fn into(self) -> &'static str {
+        match self {
+            LocaleType::De => "de",
+            LocaleType::Default => "default",
+            LocaleType::En => "en",
+            LocaleType::Es => "es",
+            LocaleType::Fr => "fr",
+            LocaleType::Ja => "ja",
+            LocaleType::Ko => "ko",
+            LocaleType::PtBR => "pt_BR",
+            LocaleType::Ru => "ru",
+            LocaleType::ZhCN => "zh_CN",
+            LocaleType::ZhTW => "zh_TW",
+        }
+    }
+}
+
+impl ::std::str::FromStr for LocaleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "de" => Ok(LocaleType::De),
+            "default" => Ok(LocaleType::Default),
+            "en" => Ok(LocaleType::En),
+            "es" => Ok(LocaleType::Es),
+            "fr" => Ok(LocaleType::Fr),
+            "ja" => Ok(LocaleType::Ja),
+            "ko" => Ok(LocaleType::Ko),
+            "pt_BR" => Ok(LocaleType::PtBR),
+            "ru" => Ok(LocaleType::Ru),
+            "zh_CN" => Ok(LocaleType::ZhCN),
+            "zh_TW" => Ok(LocaleType::ZhTW),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum OrderType {
+    Ascending,
+    Descending,
+}
+
+impl Into<String> for OrderType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for OrderType {
+    fn into(self) -> &'static str {
+        match self {
+            OrderType::Ascending => "ASCENDING",
+            OrderType::Descending => "DESCENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for OrderType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ASCENDING" => Ok(OrderType::Ascending),
+            "DESCENDING" => Ok(OrderType::Descending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the users and/or user groups.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct Participants {
@@ -1206,6 +1680,50 @@ pub struct Principal {
     #[serde(rename="Type")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum PrincipalType {
+    Anonymous,
+    Group,
+    Invite,
+    Organization,
+    User,
+}
+
+impl Into<String> for PrincipalType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for PrincipalType {
+    fn into(self) -> &'static str {
+        match self {
+            PrincipalType::Anonymous => "ANONYMOUS",
+            PrincipalType::Group => "GROUP",
+            PrincipalType::Invite => "INVITE",
+            PrincipalType::Organization => "ORGANIZATION",
+            PrincipalType::User => "USER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for PrincipalType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ANONYMOUS" => Ok(PrincipalType::Anonymous),
+            "GROUP" => Ok(PrincipalType::Group),
+            "INVITE" => Ok(PrincipalType::Invite),
+            "ORGANIZATION" => Ok(PrincipalType::Organization),
+            "USER" => Ok(PrincipalType::User),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1292,6 +1810,193 @@ pub struct ResourcePathComponent {
     pub name: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceSortType {
+    Date,
+    Name,
+}
+
+impl Into<String> for ResourceSortType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceSortType {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceSortType::Date => "DATE",
+            ResourceSortType::Name => "NAME",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceSortType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DATE" => Ok(ResourceSortType::Date),
+            "NAME" => Ok(ResourceSortType::Name),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceStateType {
+    Active,
+    Recycled,
+    Recycling,
+    Restoring,
+}
+
+impl Into<String> for ResourceStateType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceStateType {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceStateType::Active => "ACTIVE",
+            ResourceStateType::Recycled => "RECYCLED",
+            ResourceStateType::Recycling => "RECYCLING",
+            ResourceStateType::Restoring => "RESTORING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceStateType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(ResourceStateType::Active),
+            "RECYCLED" => Ok(ResourceStateType::Recycled),
+            "RECYCLING" => Ok(ResourceStateType::Recycling),
+            "RESTORING" => Ok(ResourceStateType::Restoring),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ResourceType {
+    Document,
+    Folder,
+}
+
+impl Into<String> for ResourceType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ResourceType {
+    fn into(self) -> &'static str {
+        match self {
+            ResourceType::Document => "DOCUMENT",
+            ResourceType::Folder => "FOLDER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ResourceType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DOCUMENT" => Ok(ResourceType::Document),
+            "FOLDER" => Ok(ResourceType::Folder),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RolePermissionType {
+    Direct,
+    Inherited,
+}
+
+impl Into<String> for RolePermissionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RolePermissionType {
+    fn into(self) -> &'static str {
+        match self {
+            RolePermissionType::Direct => "DIRECT",
+            RolePermissionType::Inherited => "INHERITED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RolePermissionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DIRECT" => Ok(RolePermissionType::Direct),
+            "INHERITED" => Ok(RolePermissionType::Inherited),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RoleType {
+    Contributor,
+    Coowner,
+    Owner,
+    Viewer,
+}
+
+impl Into<String> for RoleType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RoleType {
+    fn into(self) -> &'static str {
+        match self {
+            RoleType::Contributor => "CONTRIBUTOR",
+            RoleType::Coowner => "COOWNER",
+            RoleType::Owner => "OWNER",
+            RoleType::Viewer => "VIEWER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RoleType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONTRIBUTOR" => Ok(RoleType::Contributor),
+            "COOWNER" => Ok(RoleType::Coowner),
+            "OWNER" => Ok(RoleType::Owner),
+            "VIEWER" => Ok(RoleType::Viewer),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the recipient type and ID, if available.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct SharePrincipal {
@@ -1331,6 +2036,41 @@ pub struct ShareResult {
     pub status_message: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ShareStatusType {
+    Failure,
+    Success,
+}
+
+impl Into<String> for ShareStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ShareStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            ShareStatusType::Failure => "FAILURE",
+            ShareStatusType::Success => "SUCCESS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ShareStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FAILURE" => Ok(ShareStatusType::Failure),
+            "SUCCESS" => Ok(ShareStatusType::Success),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the storage for a user.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StorageRuleType {
@@ -1342,6 +2082,41 @@ pub struct StorageRuleType {
     #[serde(rename="StorageType")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub storage_type: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum StorageType {
+    Quota,
+    Unlimited,
+}
+
+impl Into<String> for StorageType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for StorageType {
+    fn into(self) -> &'static str {
+        match self {
+            StorageType::Quota => "QUOTA",
+            StorageType::Unlimited => "UNLIMITED",
+        }
+    }
+}
+
+impl ::std::str::FromStr for StorageType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "QUOTA" => Ok(StorageType::Quota),
+            "UNLIMITED" => Ok(StorageType::Unlimited),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>Describes a subscription.</p>"]
@@ -1359,6 +2134,70 @@ pub struct Subscription {
     #[serde(rename="SubscriptionId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub subscription_id: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SubscriptionProtocolType {
+    Https,
+}
+
+impl Into<String> for SubscriptionProtocolType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SubscriptionProtocolType {
+    fn into(self) -> &'static str {
+        match self {
+            SubscriptionProtocolType::Https => "HTTPS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SubscriptionProtocolType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HTTPS" => Ok(SubscriptionProtocolType::Https),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum SubscriptionType {
+    All,
+}
+
+impl Into<String> for SubscriptionType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for SubscriptionType {
+    fn into(self) -> &'static str {
+        match self {
+            SubscriptionType::All => "ALL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for SubscriptionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALL" => Ok(SubscriptionType::All),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Default,Debug,Clone,Serialize)]
@@ -1546,6 +2385,41 @@ pub struct User {
     pub username: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UserFilterType {
+    ActivePending,
+    All,
+}
+
+impl Into<String> for UserFilterType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UserFilterType {
+    fn into(self) -> &'static str {
+        match self {
+            UserFilterType::ActivePending => "ACTIVE_PENDING",
+            UserFilterType::All => "ALL",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UserFilterType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE_PENDING" => Ok(UserFilterType::ActivePending),
+            "ALL" => Ok(UserFilterType::All),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the metadata of the user.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct UserMetadata {
@@ -1571,6 +2445,88 @@ pub struct UserMetadata {
     pub username: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UserSortType {
+    FullName,
+    StorageLimit,
+    StorageUsed,
+    UserName,
+    UserStatus,
+}
+
+impl Into<String> for UserSortType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UserSortType {
+    fn into(self) -> &'static str {
+        match self {
+            UserSortType::FullName => "FULL_NAME",
+            UserSortType::StorageLimit => "STORAGE_LIMIT",
+            UserSortType::StorageUsed => "STORAGE_USED",
+            UserSortType::UserName => "USER_NAME",
+            UserSortType::UserStatus => "USER_STATUS",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UserSortType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "FULL_NAME" => Ok(UserSortType::FullName),
+            "STORAGE_LIMIT" => Ok(UserSortType::StorageLimit),
+            "STORAGE_USED" => Ok(UserSortType::StorageUsed),
+            "USER_NAME" => Ok(UserSortType::UserName),
+            "USER_STATUS" => Ok(UserSortType::UserStatus),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UserStatusType {
+    Active,
+    Inactive,
+    Pending,
+}
+
+impl Into<String> for UserStatusType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UserStatusType {
+    fn into(self) -> &'static str {
+        match self {
+            UserStatusType::Active => "ACTIVE",
+            UserStatusType::Inactive => "INACTIVE",
+            UserStatusType::Pending => "PENDING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UserStatusType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ACTIVE" => Ok(UserStatusType::Active),
+            "INACTIVE" => Ok(UserStatusType::Inactive),
+            "PENDING" => Ok(UserStatusType::Pending),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the storage for a user.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct UserStorageMetadata {
@@ -1582,6 +2538,41 @@ pub struct UserStorageMetadata {
     #[serde(rename="StorageUtilizedInBytes")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub storage_utilized_in_bytes: Option<i64>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum UserType {
+    Admin,
+    User,
+}
+
+impl Into<String> for UserType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for UserType {
+    fn into(self) -> &'static str {
+        match self {
+            UserType::Admin => "ADMIN",
+            UserType::User => "USER",
+        }
+    }
+}
+
+impl ::std::str::FromStr for UserType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ADMIN" => Ok(UserType::Admin),
+            "USER" => Ok(UserType::User),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by AbortDocumentVersionUpload
@@ -5995,7 +6986,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -6033,7 +7024,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6083,7 +7074,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6134,7 +7125,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6188,7 +7179,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6236,7 +7227,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6285,7 +7276,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6332,7 +7323,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6383,7 +7374,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6429,7 +7420,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -6466,7 +7457,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -6516,7 +7507,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6562,7 +7553,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -6596,7 +7587,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -6633,7 +7624,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -6679,7 +7670,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6725,7 +7716,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -6760,7 +7751,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -6815,7 +7806,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6871,7 +7862,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -6933,7 +7924,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7003,7 +7994,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7058,7 +8049,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7116,7 +8107,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7169,7 +8160,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7244,7 +8235,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7288,7 +8279,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7340,7 +8331,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7398,7 +8389,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7454,7 +8445,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7503,7 +8494,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7561,7 +8552,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7610,7 +8601,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Created => {
+            ::hyper::status::StatusCode::Created => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -7660,7 +8651,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -7703,7 +8694,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::NoContent => {
+            ::hyper::status::StatusCode::NoContent => {
                 let result = ();
 
 
@@ -7740,7 +8731,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -7779,7 +8770,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -7814,7 +8805,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let result = ();
 
 
@@ -7851,7 +8842,7 @@ impl<P, D> Workdocs for WorkdocsClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -11,23 +11,57 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum Compute {
+    Performance,
+    Standard,
+    Value,
+}
+
+impl Into<String> for Compute {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for Compute {
+    fn into(self) -> &'static str {
+        match self {
+            Compute::Performance => "PERFORMANCE",
+            Compute::Standard => "STANDARD",
+            Compute::Value => "VALUE",
+        }
+    }
+}
+
+impl ::std::str::FromStr for Compute {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PERFORMANCE" => Ok(Compute::Performance),
+            "STANDARD" => Ok(Compute::Standard),
+            "VALUE" => Ok(Compute::Value),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Contains information about the compute type of a WorkSpace bundle.</p>"]
 #[derive(Default,Debug,Clone,Deserialize)]
 pub struct ComputeType {
@@ -35,6 +69,44 @@ pub struct ComputeType {
     #[serde(rename="Name")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum ConnectionState {
+    Connected,
+    Disconnected,
+    Unknown,
+}
+
+impl Into<String> for ConnectionState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for ConnectionState {
+    fn into(self) -> &'static str {
+        match self {
+            ConnectionState::Connected => "CONNECTED",
+            ConnectionState::Disconnected => "DISCONNECTED",
+            ConnectionState::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+impl ::std::str::FromStr for ConnectionState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "CONNECTED" => Ok(ConnectionState::Connected),
+            "DISCONNECTED" => Ok(ConnectionState::Disconnected),
+            "UNKNOWN" => Ok(ConnectionState::Unknown),
+            _ => Err(()),
+        }
+    }
 }
 
 #[doc="<p>The request of the <a>CreateTags</a> operation.</p>"]
@@ -349,6 +421,41 @@ pub struct RebuildWorkspacesResult {
     pub failed_requests: Option<Vec<FailedWorkspaceChangeRequest>>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum RunningMode {
+    AlwaysOn,
+    AutoStop,
+}
+
+impl Into<String> for RunningMode {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for RunningMode {
+    fn into(self) -> &'static str {
+        match self {
+            RunningMode::AlwaysOn => "ALWAYS_ON",
+            RunningMode::AutoStop => "AUTO_STOP",
+        }
+    }
+}
+
+impl ::std::str::FromStr for RunningMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALWAYS_ON" => Ok(RunningMode::AlwaysOn),
+            "AUTO_STOP" => Ok(RunningMode::AutoStop),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the start request.</p>"]
 #[derive(Default,Debug,Clone,Serialize)]
 pub struct StartRequest {
@@ -606,6 +713,85 @@ pub struct WorkspaceDirectory {
     pub workspace_security_group_id: Option<String>,
 }
 
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkspaceDirectoryState {
+    Deregistered,
+    Deregistering,
+    Error,
+    Registered,
+    Registering,
+}
+
+impl Into<String> for WorkspaceDirectoryState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkspaceDirectoryState {
+    fn into(self) -> &'static str {
+        match self {
+            WorkspaceDirectoryState::Deregistered => "DEREGISTERED",
+            WorkspaceDirectoryState::Deregistering => "DEREGISTERING",
+            WorkspaceDirectoryState::Error => "ERROR",
+            WorkspaceDirectoryState::Registered => "REGISTERED",
+            WorkspaceDirectoryState::Registering => "REGISTERING",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkspaceDirectoryState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DEREGISTERED" => Ok(WorkspaceDirectoryState::Deregistered),
+            "DEREGISTERING" => Ok(WorkspaceDirectoryState::Deregistering),
+            "ERROR" => Ok(WorkspaceDirectoryState::Error),
+            "REGISTERED" => Ok(WorkspaceDirectoryState::Registered),
+            "REGISTERING" => Ok(WorkspaceDirectoryState::Registering),
+            _ => Err(()),
+        }
+    }
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkspaceDirectoryType {
+    AdConnector,
+    SimpleAd,
+}
+
+impl Into<String> for WorkspaceDirectoryType {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkspaceDirectoryType {
+    fn into(self) -> &'static str {
+        match self {
+            WorkspaceDirectoryType::AdConnector => "AD_CONNECTOR",
+            WorkspaceDirectoryType::SimpleAd => "SIMPLE_AD",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkspaceDirectoryType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AD_CONNECTOR" => Ok(WorkspaceDirectoryType::AdConnector),
+            "SIMPLE_AD" => Ok(WorkspaceDirectoryType::SimpleAd),
+            _ => Err(()),
+        }
+    }
+}
+
 #[doc="<p>Describes the properties of a WorkSpace.</p>"]
 #[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkspaceProperties {
@@ -650,6 +836,77 @@ pub struct WorkspaceRequest {
     #[serde(rename="WorkspaceProperties")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub workspace_properties: Option<WorkspaceProperties>,
+}
+
+
+#[allow(non_camel_case_types)]
+#[derive(Clone,Debug,Eq,PartialEq)]
+pub enum WorkspaceState {
+    Available,
+    Error,
+    Impaired,
+    Maintenance,
+    Pending,
+    Rebooting,
+    Rebuilding,
+    Starting,
+    Stopped,
+    Stopping,
+    Suspended,
+    Terminated,
+    Terminating,
+    Unhealthy,
+}
+
+impl Into<String> for WorkspaceState {
+    fn into(self) -> String {
+        let s: &'static str = self.into();
+        s.to_owned()
+    }
+}
+
+impl Into<&'static str> for WorkspaceState {
+    fn into(self) -> &'static str {
+        match self {
+            WorkspaceState::Available => "AVAILABLE",
+            WorkspaceState::Error => "ERROR",
+            WorkspaceState::Impaired => "IMPAIRED",
+            WorkspaceState::Maintenance => "MAINTENANCE",
+            WorkspaceState::Pending => "PENDING",
+            WorkspaceState::Rebooting => "REBOOTING",
+            WorkspaceState::Rebuilding => "REBUILDING",
+            WorkspaceState::Starting => "STARTING",
+            WorkspaceState::Stopped => "STOPPED",
+            WorkspaceState::Stopping => "STOPPING",
+            WorkspaceState::Suspended => "SUSPENDED",
+            WorkspaceState::Terminated => "TERMINATED",
+            WorkspaceState::Terminating => "TERMINATING",
+            WorkspaceState::Unhealthy => "UNHEALTHY",
+        }
+    }
+}
+
+impl ::std::str::FromStr for WorkspaceState {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AVAILABLE" => Ok(WorkspaceState::Available),
+            "ERROR" => Ok(WorkspaceState::Error),
+            "IMPAIRED" => Ok(WorkspaceState::Impaired),
+            "MAINTENANCE" => Ok(WorkspaceState::Maintenance),
+            "PENDING" => Ok(WorkspaceState::Pending),
+            "REBOOTING" => Ok(WorkspaceState::Rebooting),
+            "REBUILDING" => Ok(WorkspaceState::Rebuilding),
+            "STARTING" => Ok(WorkspaceState::Starting),
+            "STOPPED" => Ok(WorkspaceState::Stopped),
+            "STOPPING" => Ok(WorkspaceState::Stopping),
+            "SUSPENDED" => Ok(WorkspaceState::Suspended),
+            "TERMINATED" => Ok(WorkspaceState::Terminated),
+            "TERMINATING" => Ok(WorkspaceState::Terminating),
+            "UNHEALTHY" => Ok(WorkspaceState::Unhealthy),
+            _ => Err(()),
+        }
+    }
 }
 
 /// Errors returned by CreateTags
@@ -1914,7 +2171,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateTagsResult>(String::from_utf8_lossy(&body)
@@ -1946,7 +2203,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<CreateWorkspacesResult>(String::from_utf8_lossy(&body)
@@ -1976,7 +2233,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DeleteTagsResult>(String::from_utf8_lossy(&body)
@@ -2008,7 +2265,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeTagsResult>(String::from_utf8_lossy(&body)
@@ -2041,7 +2298,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeWorkspaceBundlesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2074,7 +2331,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeWorkspaceDirectoriesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2105,7 +2362,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeWorkspacesResult>(String::from_utf8_lossy(&body)
@@ -2140,7 +2397,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<DescribeWorkspacesConnectionStatusResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2172,7 +2429,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<ModifyWorkspacePropertiesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())
@@ -2203,7 +2460,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RebootWorkspacesResult>(String::from_utf8_lossy(&body)
@@ -2235,7 +2492,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<RebuildWorkspacesResult>(String::from_utf8_lossy(&body)
@@ -2267,7 +2524,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StartWorkspacesResult>(String::from_utf8_lossy(&body)
@@ -2299,7 +2556,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<StopWorkspacesResult>(String::from_utf8_lossy(&body)
@@ -2331,7 +2588,7 @@ impl<P, D> Workspaces for WorkspacesClient<P, D>
         let mut response = try!(self.dispatcher.dispatch(&request));
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
                 Ok(serde_json::from_str::<TerminateWorkspacesResult>(String::from_utf8_lossy(&body).as_ref()).unwrap())

--- a/rusoto/services/xray/src/generated.rs
+++ b/rusoto/services/xray/src/generated.rs
@@ -11,17 +11,13 @@
 //
 // =================================================================
 
-#[allow(warnings)]
-use hyper::Client;
-use hyper::status::StatusCode;
-use rusoto_core::request::DispatchSignedRequest;
-use rusoto_core::region;
-
 use std::fmt;
 use std::error::Error;
 use std::io;
 use std::io::Read;
-use rusoto_core::request::HttpDispatchError;
+
+use rusoto_core::region;
+use rusoto_core::request::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
@@ -1227,7 +1223,7 @@ impl<P, D> XRay for XRayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1272,7 +1268,7 @@ impl<P, D> XRay for XRayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1317,7 +1313,7 @@ impl<P, D> XRay for XRayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1362,7 +1358,7 @@ impl<P, D> XRay for XRayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1407,7 +1403,7 @@ impl<P, D> XRay for XRayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));
@@ -1452,7 +1448,7 @@ impl<P, D> XRay for XRayClient<P, D>
         let mut response = self.dispatcher.dispatch(&request)?;
 
         match response.status {
-            StatusCode::Ok => {
+            ::hyper::status::StatusCode::Ok => {
 
                 let mut body: Vec<u8> = Vec::new();
                 try!(response.body.read_to_end(&mut body));

--- a/service_crategen/src/commands/generate/codegen/json.rs
+++ b/service_crategen/src/commands/generate/codegen/json.rs
@@ -44,7 +44,7 @@ impl GenerateProtocol for JsonGenerator {
                     let mut response = try!(self.dispatcher.dispatch(&request));
 
                     match response.status {{
-                        StatusCode::Ok => {{
+                        ::hyper::status::StatusCode::Ok => {{
                             {ok_response}
                         }}
                         _ => {{

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{Write, BufWriter};
 
@@ -113,17 +114,13 @@ fn generate<P, E>(writer: &mut FileWriter,
         //
         // =================================================================
 
-        #[allow(warnings)]
-        use hyper::Client;
-        use hyper::status::StatusCode;
-        use rusoto_core::request::DispatchSignedRequest;
-        use rusoto_core::region;
-
         use std::fmt;
         use std::error::Error;
         use std::io;
         use std::io::Read;
-        use rusoto_core::request::HttpDispatchError;
+
+        use rusoto_core::region;
+        use rusoto_core::request::{{DispatchSignedRequest, HttpDispatchError}};
         use rusoto_core::credential::{{CredentialsError, ProvideAwsCredentials}};
     ")?;
 
@@ -290,7 +287,7 @@ fn generate_types<P>(writer: &mut FileWriter, service: &Service, protocol_genera
         let deserialized = deserialized_types.contains(&type_name);
         let serialized = serialized_types.contains(&type_name);
 
-        if shape.shape_type == ShapeType::Structure {
+        if shape.shape_type == ShapeType::Structure || shape.shape_enum.is_some() {
             // If botocore includes documentation, clean it up a bit and use it
             if let Some(ref docs) = shape.documentation {
                 writeln!(writer,
@@ -299,7 +296,7 @@ fn generate_types<P>(writer: &mut FileWriter, service: &Service, protocol_genera
             }
 
             // generate a rust type for the shape
-            if type_name != "String" {
+            if type_name != "String" && shape.shape_type == ShapeType::Structure {
                 let generated = generate_struct(service,
                                                 &type_name,
                                                 shape,
@@ -307,6 +304,13 @@ fn generate_types<P>(writer: &mut FileWriter, service: &Service, protocol_genera
                                                 deserialized,
                                                 protocol_generator);
                 writeln!(writer, "{}", generated)?;
+            }
+
+            if let Some(ref variants) = shape.shape_enum {
+                if variants.len() > 0 {
+                    let generated = generate_enum(&type_name, variants);
+                    writeln!(writer, "{}", generated)?;
+                }
             }
         }
 
@@ -359,6 +363,73 @@ fn generate_types<P>(writer: &mut FileWriter, service: &Service, protocol_genera
         }
     }
     Ok(())
+}
+
+fn get_variant_name(variant: &str) -> String {
+    // There are a few enum types that use numbers. These are not possible to turn into
+    // enums normally due to them not meeting naming conventions, so we replace '.' with
+    // an underscore as well as prepend one to make them valid identifiers.
+    if variant.parse::<f32>().is_ok() || variant.parse::<u32>().is_ok() {
+        format!("_{}", variant.replace(".", "_"))
+    } else {
+        variant.replace(|c| !char::is_alphanumeric(c), "_").to_pascal_case()
+    }
+}
+
+fn generate_enum(name: &str, variants: &Vec<String>) -> String {
+    let variant_names: BTreeMap<String, String> = variants
+        .iter()
+        .map(|v| (v.clone(), get_variant_name(&v)))
+        .collect();
+
+    format!("
+        #[allow(non_camel_case_types)]
+        #[derive(Clone,Debug,Eq,PartialEq)]
+        pub enum {name} {{
+            {variants}
+        }}
+
+        impl Into<String> for {name} {{
+            fn into(self) -> String {{
+                let s: &'static str = self.into();
+                s.to_owned()
+            }}
+        }}
+
+        impl Into<&'static str> for {name} {{
+            fn into(self) -> &'static str {{
+                match self {{
+                    {matches}
+                }}
+            }}
+        }}
+
+        impl ::std::str::FromStr for {name} {{
+            type Err = ();
+            fn from_str(s: &str) -> Result<Self, Self::Err> {{
+                match s {{
+                    {reverse_matches},
+                    _ => Err(())
+                }}
+            }}
+        }}
+        ",
+            name = name,
+            variants = variant_names
+                .values()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(",\n"),
+            matches = variant_names
+                .iter()
+                .map(|(s, v)| format!("{}::{} => \"{}\"", name, v, s))
+                .collect::<Vec<_>>()
+                .join(",\n"),
+            reverse_matches = variant_names
+                .iter()
+                .map(|(s, v)| format!("\"{}\" => Ok({}::{})", s, name, v))
+                .collect::<Vec<_>>()
+                .join(",\n"))
 }
 
 fn generate_struct<P>(service: &Service,

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -41,7 +41,7 @@ impl GenerateProtocol for QueryGenerator {
                     request.sign_with_plus(&try!(self.credentials_provider.credentials()), true);
                     let mut response = try!(self.dispatcher.dispatch(&request));
                     match response.status {{
-                        StatusCode::Ok => {{
+                        ::hyper::status::StatusCode::Ok => {{
                             {parse_payload}
                             Ok(result)
                         }}

--- a/service_crategen/src/commands/generate/codegen/rest_json.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_json.rs
@@ -144,7 +144,7 @@ trait CodegenString {
 }
 impl CodegenString for StatusCode {
     fn enum_as_string(&self) -> String {
-        format!("StatusCode::{:?}", self)
+        format!("::hyper::status::StatusCode::{:?}", self)
     }
 }
 
@@ -153,7 +153,7 @@ fn http_code_to_status_code(code: Option<i32>) -> String {
         Some(actual_code) => StatusCode::from_u16(actual_code as u16).enum_as_string(),
         // Some service definitions such as elastictranscoder don't specify
         // the response code, we'll assume this:
-        None => "StatusCode::Ok".to_string(),
+        None => "::hyper::status::StatusCode::Ok".to_string(),
     }
 }
 
@@ -283,10 +283,10 @@ fn generate_status_code_parser(operation: &Operation, service: &Service) -> Stri
         if let Some(ref location) = member.location {
             if location == "statusCode" {
                 if output_shape.required(member_name) {
-                    status_code_parser += &format!("result.{} = StatusCode::to_u16(&response.status);",
+                    status_code_parser += &format!("result.{} = ::hyper::status::StatusCode::to_u16(&response.status);",
                                                    member_name.to_snake_case());
                 } else {
-                    status_code_parser += &format!("result.{} = Some(StatusCode::to_u16(&response.status) as i64);",
+                    status_code_parser += &format!("result.{} = Some(::hyper::status::StatusCode::to_u16(&response.status) as i64);",
                                                    member_name.to_snake_case());
                 }
             }

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -46,7 +46,7 @@ impl GenerateProtocol for RestXmlGenerator {
                         let mut response = try!(self.dispatcher.dispatch(&request));
 
                         match response.status {{
-                            StatusCode::Ok|StatusCode::NoContent|StatusCode::PartialContent => {{
+                            ::hyper::status::StatusCode::Ok|::hyper::status::StatusCode::NoContent|::hyper::status::StatusCode::PartialContent => {{
                                 {parse_response_body}
                                 {parse_non_payload}
                                 Ok(result)
@@ -88,7 +88,7 @@ impl GenerateProtocol for RestXmlGenerator {
 
     fn generate_prelude(&self, writer: &mut FileWriter, service: &Service) -> IoResult {
         let mut imports = "
-            use std::str::{FromStr};
+            use std::str::FromStr;
             use std::io::Write;
             use xml::reader::ParserConfig;
             use rusoto_core::param::{Params, ServiceParams};

--- a/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
+++ b/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
@@ -302,7 +302,7 @@ fn generate_primitive_deserializer(shape: &Shape) -> String {
         ShapeType::Double => "f64::from_str(try!(characters(stack)).as_ref()).unwrap()",
         ShapeType::Float => "f32::from_str(try!(characters(stack)).as_ref()).unwrap()",
         ShapeType::Blob => "try!(characters(stack)).into_bytes()",
-        ShapeType::Boolean => "bool::from_str(try!(characters(stack)).as_ref()).unwrap()",
+        ShapeType::Boolean => "try!(characters(stack)).parse::<bool>().unwrap()",
         _ => panic!("Unknown primitive shape type"),
     };
 


### PR DESCRIPTION
Merged `master` into https://github.com/rusoto/rusoto/pull/751 .

Still some work to clean up: I think the switch from

`"try!(characters(stack)).parse::<i64>().unwrap()"`

to

`"i64::from_str(try!(characters(stack)).as_ref()).unwrap()"`

is desired: that way we don't have to bring in `from_str` everywhere.  I didn't bring in this change so there are some warnings about services importing `std::str::FromStr` when they don't use them.