### PR TITLE
Remove trailing slash from ECS credential source location.

### DIFF
--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -10,7 +10,7 @@ description = "AWS credential tooling"
 name = "rusoto_credential"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.9.1"
+version = "0.9.2"
 
 [dependencies]
 chrono = "0.4.0"

--- a/rusoto/credential/src/container.rs
+++ b/rusoto/credential/src/container.rs
@@ -43,7 +43,7 @@ fn credentials_from_container(
             }
         };
     let address: String = format!(
-        "http://{}{}/",
+        "http://{}{}",
         AWS_CREDENTIALS_PROVIDER_IP,
         aws_container_credentials_relative_uri
     );


### PR DESCRIPTION
Fixes https://github.com/rusoto/rusoto/issues/870 ! 🎉 

Also preps the credentials crate for a new release.

This was tested to confirm the bug and confirm the fix using a project that overrode the published credential crate, using this Cargo.toml config snippet:

```toml
[dependencies]
rusoto_core = "0.30.0"
rusoto_s3 = "0.30.0"
rusoto_credential = { path = "../rusoto/credential" }

[patch.crates-io]
rusoto_credential = { path = "../rusoto/credential" }
```