### PR TITLE
Fix error when connecting to a `Region::Custom` S3 endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 (Please put an entry here in each PR)
  
+- Allow setting both, Region name and endpoint, via `Region::Custom`
 - Added China-northwest, US-Gov-West & Paris regions
 
 ## [0.30.0] - 2017-12-02

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -194,22 +194,45 @@ mod tests {
 
     #[test]
     fn custom_region_http() {
-        let a_region = Region::Custom("http://localhost".to_owned());
+        let a_region = Region::Custom {
+            endpoint: "http://localhost".to_owned(),
+            name: "eu-west-3".to_owned(),
+        };
         let request = SignedRequest::new("POST", "sqs", &a_region, "/");
+        assert_eq!("http", request.scheme());
         assert_eq!("localhost", request.hostname());
     }
 
     #[test]
     fn custom_region_https() {
-        let a_region = Region::Custom("https://localhost".to_owned());
+        let a_region = Region::Custom {
+            endpoint: "https://localhost".to_owned(),
+            name: "eu-west-3".to_owned(),
+        };
         let request = SignedRequest::new("POST", "sqs", &a_region, "/");
+        assert_eq!("https", request.scheme());
         assert_eq!("localhost", request.hostname());
     }
 
     #[test]
     fn custom_region_with_port() {
-        let a_region = Region::Custom("https://localhost:8000".to_owned());
+        let a_region = Region::Custom {
+            endpoint: "https://localhost:8000".to_owned(),
+            name: "eu-west-3".to_owned(),
+        };
         let request = SignedRequest::new("POST", "sqs", &a_region, "/");
+        assert_eq!("https", request.scheme());
         assert_eq!("localhost:8000", request.hostname());
+    }
+
+    #[test]
+    fn custom_region_no_scheme() {
+        let a_region = Region::Custom {
+            endpoint: "localhost".to_owned(),
+            name: "eu-west-3".to_owned(),
+        };
+        let request = SignedRequest::new("POST", "sqs", &a_region, "/");
+        assert_eq!("https", request.scheme());
+        assert_eq!("localhost", request.hostname());
     }
 }

--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -128,8 +128,8 @@ impl SignedRequest {
             Some(ref p) => p.to_string(),
             None => {
                 match self.region {
-                    Region::Custom(ref hostname) => {
-                        if hostname.starts_with("http://") {
+                    Region::Custom { ref endpoint, .. } => {
+                        if endpoint.starts_with("http://") {
                             "http".to_owned()
                         } else {
                             "https".to_owned()
@@ -268,7 +268,7 @@ impl SignedRequest {
         let signature = sign_string(&string_to_sign,
                                     creds.aws_secret_access_key(),
                                     date,
-                                    &self.region.to_string(),
+                                    &self.region.name(),
                                     &self.service);
 
         // build the actual auth header
@@ -500,30 +500,38 @@ fn build_hostname(service: &str, region: &Region) -> String {
     match service {
         "iam" => {
             match *region {
-                Region::Custom(ref hostname) => remove_scheme_from_custom_hostname(hostname).to_owned(),
-                Region::CnNorth1 => format!("{}.{}.amazonaws.com.cn", service, region),
+                Region::Custom { ref endpoint, .. } => {
+                    remove_scheme_from_custom_hostname(endpoint).to_owned()
+                }
+                Region::CnNorth1 => format!("{}.{}.amazonaws.com.cn", service, region.name()),
                 _ => format!("{}.amazonaws.com", service),
             }
         }
         "s3" => {
             match *region {
-                Region::Custom(ref hostname) => remove_scheme_from_custom_hostname(hostname).to_owned(),
+                Region::Custom { ref endpoint, .. } => {
+                    remove_scheme_from_custom_hostname(endpoint).to_owned()
+                }
                 Region::UsEast1 => "s3.amazonaws.com".to_string(),
-                Region::CnNorth1 => format!("s3.{}.amazonaws.com.cn", region),
-                _ => format!("s3-{}.amazonaws.com", region),
+                Region::CnNorth1 => format!("s3.{}.amazonaws.com.cn", region.name()),
+                _ => format!("s3-{}.amazonaws.com", region.name()),
             }
         }
         "route53" => {
             match *region {
-                Region::Custom(ref hostname) => remove_scheme_from_custom_hostname(hostname).to_owned(),
+                Region::Custom { ref endpoint, .. } => {
+                    remove_scheme_from_custom_hostname(endpoint).to_owned()
+                }
                 _ => "route53.amazonaws.com".to_owned(),
             }
         }
         _ => {
             match *region {
-                Region::Custom(ref hostname) => remove_scheme_from_custom_hostname(hostname).to_owned(),
-                Region::CnNorth1 => format!("{}.{}.amazonaws.com.cn", service, region),
-                _ => format!("{}.{}.amazonaws.com", service, region),
+                Region::Custom { ref endpoint, .. } => {
+                    remove_scheme_from_custom_hostname(endpoint).to_owned()
+                }
+                Region::CnNorth1 => format!("{}.{}.amazonaws.com.cn", service, region.name()),
+                _ => format!("{}.{}.amazonaws.com", service, region.name()),
             }
         }
     }


### PR DESCRIPTION
### Changes (related to #732)

* Allow to specify region name and endpoint hostname:
  * This allows to connect to a custom endpoint that expects
    a region name that differs from the endpoint's hostname.
  * Fixes malformed Authorization Header when a scheme (e.g
    `https://`) is used. Slashes conflict with the encoding
    of the header.
* Implement deserialization of `Region::Custom`.
* Add `Region::name() -> &str` to avoid copying region name
  over and over again.

### Open questions

This pull request includes a non-backwards-compatible change when serializing a `Region`. Not sure how important backwards compatibility is. I guess, alternatively, custom regions could be serialized as `"region/endpoint"`, or similar, and the serialization of Amazon's regions could be retained.