### PR TITLE
Ensure error responses from Ceph are parsed properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 (Please put an entry here in each PR)
 
+- Fix handling of error responses from Ceph (S3)
 - Convert metadata keys to lowercase (only affects third party services, Amazon already converts them)
 - Allow setting both, Region name and endpoint, via `Region::Custom`
 - Added China-northwest, US-Gov-West & Paris regions

--- a/rusoto/core/src/xmlerror.rs
+++ b/rusoto/core/src/xmlerror.rs
@@ -39,7 +39,8 @@ impl XmlErrorDeserializer {
                 "" => {
                     break
                 },
-                _ => {
+                unknown => {
+                    debug!("Ignoring unknown XML element {:?} in error response.", unknown);
                     skip_tree(stack);
                 }
             }

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -8406,8 +8407,7 @@ impl AttachInstancesError {
     pub fn from_body(body: &str) -> AttachInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => AttachInstancesError::ResourceContentionFault(
@@ -8476,8 +8476,7 @@ impl AttachLoadBalancerTargetGroupsError {
     pub fn from_body(body: &str) -> AttachLoadBalancerTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -8550,8 +8549,7 @@ impl AttachLoadBalancersError {
     pub fn from_body(body: &str) -> AttachLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => AttachLoadBalancersError::ResourceContentionFault(
@@ -8622,8 +8620,7 @@ impl CompleteLifecycleActionError {
     pub fn from_body(body: &str) -> CompleteLifecycleActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -8700,8 +8697,7 @@ impl CreateAutoScalingGroupError {
     pub fn from_body(body: &str) -> CreateAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsFault" => CreateAutoScalingGroupError::AlreadyExistsFault(
@@ -8784,8 +8780,7 @@ impl CreateLaunchConfigurationError {
     pub fn from_body(body: &str) -> CreateLaunchConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsFault" => CreateLaunchConfigurationError::AlreadyExistsFault(
@@ -8872,8 +8867,7 @@ impl CreateOrUpdateTagsError {
     pub fn from_body(body: &str) -> CreateOrUpdateTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsFault" => {
@@ -8960,8 +8954,7 @@ impl DeleteAutoScalingGroupError {
     pub fn from_body(body: &str) -> DeleteAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DeleteAutoScalingGroupError::ResourceContentionFault(
@@ -9044,8 +9037,7 @@ impl DeleteLaunchConfigurationError {
     pub fn from_body(body: &str) -> DeleteLaunchConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -9122,8 +9114,7 @@ impl DeleteLifecycleHookError {
     pub fn from_body(body: &str) -> DeleteLifecycleHookError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DeleteLifecycleHookError::ResourceContentionFault(
@@ -9194,8 +9185,7 @@ impl DeleteNotificationConfigurationError {
     pub fn from_body(body: &str) -> DeleteNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -9268,8 +9258,7 @@ impl DeletePolicyError {
     pub fn from_body(body: &str) -> DeletePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -9338,8 +9327,7 @@ impl DeleteScheduledActionError {
     pub fn from_body(body: &str) -> DeleteScheduledActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DeleteScheduledActionError::ResourceContentionFault(
@@ -9412,8 +9400,7 @@ impl DeleteTagsError {
     pub fn from_body(body: &str) -> DeleteTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -9486,8 +9473,7 @@ impl DescribeAccountLimitsError {
     pub fn from_body(body: &str) -> DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DescribeAccountLimitsError::ResourceContentionFault(
@@ -9558,8 +9544,7 @@ impl DescribeAdjustmentTypesError {
     pub fn from_body(body: &str) -> DescribeAdjustmentTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -9634,8 +9619,7 @@ impl DescribeAutoScalingGroupsError {
     pub fn from_body(body: &str) -> DescribeAutoScalingGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeAutoScalingGroupsError::InvalidNextToken(
@@ -9714,8 +9698,7 @@ impl DescribeAutoScalingInstancesError {
     pub fn from_body(body: &str) -> DescribeAutoScalingInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeAutoScalingInstancesError::InvalidNextToken(
@@ -9792,8 +9775,7 @@ impl DescribeAutoScalingNotificationTypesError {
     pub fn from_body(body: &str) -> DescribeAutoScalingNotificationTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -9868,8 +9850,7 @@ impl DescribeLaunchConfigurationsError {
     pub fn from_body(body: &str) -> DescribeLaunchConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeLaunchConfigurationsError::InvalidNextToken(
@@ -9946,8 +9927,7 @@ impl DescribeLifecycleHookTypesError {
     pub fn from_body(body: &str) -> DescribeLifecycleHookTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -10020,8 +10000,7 @@ impl DescribeLifecycleHooksError {
     pub fn from_body(body: &str) -> DescribeLifecycleHooksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DescribeLifecycleHooksError::ResourceContentionFault(
@@ -10092,8 +10071,7 @@ impl DescribeLoadBalancerTargetGroupsError {
     pub fn from_body(body: &str) -> DescribeLoadBalancerTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -10166,8 +10144,7 @@ impl DescribeLoadBalancersError {
     pub fn from_body(body: &str) -> DescribeLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DescribeLoadBalancersError::ResourceContentionFault(
@@ -10238,8 +10215,7 @@ impl DescribeMetricCollectionTypesError {
     pub fn from_body(body: &str) -> DescribeMetricCollectionTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -10314,8 +10290,7 @@ impl DescribeNotificationConfigurationsError {
     pub fn from_body(body: &str) -> DescribeNotificationConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeNotificationConfigurationsError::InvalidNextToken(
@@ -10394,8 +10369,7 @@ impl DescribePoliciesError {
     pub fn from_body(body: &str) -> DescribePoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => {
@@ -10470,8 +10444,7 @@ impl DescribeScalingActivitiesError {
     pub fn from_body(body: &str) -> DescribeScalingActivitiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeScalingActivitiesError::InvalidNextToken(
@@ -10548,8 +10521,7 @@ impl DescribeScalingProcessTypesError {
     pub fn from_body(body: &str) -> DescribeScalingProcessTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -10624,8 +10596,7 @@ impl DescribeScheduledActionsError {
     pub fn from_body(body: &str) -> DescribeScheduledActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeScheduledActionsError::InvalidNextToken(
@@ -10704,8 +10675,7 @@ impl DescribeTagsError {
     pub fn from_body(body: &str) -> DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => {
@@ -10778,8 +10748,7 @@ impl DescribeTerminationPolicyTypesError {
     pub fn from_body(body: &str) -> DescribeTerminationPolicyTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -10852,8 +10821,7 @@ impl DetachInstancesError {
     pub fn from_body(body: &str) -> DetachInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DetachInstancesError::ResourceContentionFault(
@@ -10922,8 +10890,7 @@ impl DetachLoadBalancerTargetGroupsError {
     pub fn from_body(body: &str) -> DetachLoadBalancerTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -10996,8 +10963,7 @@ impl DetachLoadBalancersError {
     pub fn from_body(body: &str) -> DetachLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DetachLoadBalancersError::ResourceContentionFault(
@@ -11068,8 +11034,7 @@ impl DisableMetricsCollectionError {
     pub fn from_body(body: &str) -> DisableMetricsCollectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -11142,8 +11107,7 @@ impl EnableMetricsCollectionError {
     pub fn from_body(body: &str) -> EnableMetricsCollectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -11216,8 +11180,7 @@ impl EnterStandbyError {
     pub fn from_body(body: &str) -> EnterStandbyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -11288,8 +11251,7 @@ impl ExecutePolicyError {
     pub fn from_body(body: &str) -> ExecutePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -11364,8 +11326,7 @@ impl ExitStandbyError {
     pub fn from_body(body: &str) -> ExitStandbyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -11436,8 +11397,7 @@ impl PutLifecycleHookError {
     pub fn from_body(body: &str) -> PutLifecycleHookError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededFault" => {
@@ -11512,8 +11472,7 @@ impl PutNotificationConfigurationError {
     pub fn from_body(body: &str) -> PutNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededFault" => PutNotificationConfigurationError::LimitExceededFault(
@@ -11592,8 +11551,7 @@ impl PutScalingPolicyError {
     pub fn from_body(body: &str) -> PutScalingPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededFault" => {
@@ -11670,8 +11628,7 @@ impl PutScheduledUpdateGroupActionError {
     pub fn from_body(body: &str) -> PutScheduledUpdateGroupActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsFault" => PutScheduledUpdateGroupActionError::AlreadyExistsFault(
@@ -11752,8 +11709,7 @@ impl RecordLifecycleActionHeartbeatError {
     pub fn from_body(body: &str) -> RecordLifecycleActionHeartbeatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -11828,8 +11784,7 @@ impl ResumeProcessesError {
     pub fn from_body(body: &str) -> ResumeProcessesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => ResumeProcessesError::ResourceContentionFault(
@@ -11904,8 +11859,7 @@ impl SetDesiredCapacityError {
     pub fn from_body(body: &str) -> SetDesiredCapacityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => SetDesiredCapacityError::ResourceContentionFault(
@@ -11982,8 +11936,7 @@ impl SetInstanceHealthError {
     pub fn from_body(body: &str) -> SetInstanceHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => SetInstanceHealthError::ResourceContentionFault(
@@ -12056,8 +12009,7 @@ impl SetInstanceProtectionError {
     pub fn from_body(body: &str) -> SetInstanceProtectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededFault" => SetInstanceProtectionError::LimitExceededFault(
@@ -12134,8 +12086,7 @@ impl SuspendProcessesError {
     pub fn from_body(body: &str) -> SuspendProcessesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => SuspendProcessesError::ResourceContentionFault(
@@ -12210,8 +12161,7 @@ impl TerminateInstanceInAutoScalingGroupError {
     pub fn from_body(body: &str) -> TerminateInstanceInAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
@@ -12294,8 +12244,7 @@ impl UpdateAutoScalingGroupError {
     pub fn from_body(body: &str) -> UpdateAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => UpdateAutoScalingGroupError::ResourceContentionFault(

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -8705,8 +8706,7 @@ impl CancelUpdateStackError {
     pub fn from_body(body: &str) -> CancelUpdateStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TokenAlreadyExistsException" => {
@@ -8777,8 +8777,7 @@ impl ContinueUpdateRollbackError {
     pub fn from_body(body: &str) -> ContinueUpdateRollbackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TokenAlreadyExistsException" => ContinueUpdateRollbackError::TokenAlreadyExists(
@@ -8853,8 +8852,7 @@ impl CreateChangeSetError {
     pub fn from_body(body: &str) -> CreateChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
@@ -8939,8 +8937,7 @@ impl CreateStackError {
     pub fn from_body(body: &str) -> CreateStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
@@ -9031,8 +9028,7 @@ impl CreateStackInstancesError {
     pub fn from_body(body: &str) -> CreateStackInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOperationException" => {
@@ -9129,8 +9125,7 @@ impl CreateStackSetError {
     pub fn from_body(body: &str) -> CreateStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CreatedButModifiedException" => {
@@ -9207,8 +9202,7 @@ impl DeleteChangeSetError {
     pub fn from_body(body: &str) -> DeleteChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidChangeSetStatusException" => {
@@ -9277,8 +9271,7 @@ impl DeleteStackError {
     pub fn from_body(body: &str) -> DeleteStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TokenAlreadyExistsException" => {
@@ -9355,8 +9348,7 @@ impl DeleteStackInstancesError {
     pub fn from_body(body: &str) -> DeleteStackInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOperationException" => {
@@ -9447,8 +9439,7 @@ impl DeleteStackSetError {
     pub fn from_body(body: &str) -> DeleteStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationInProgressException" => {
@@ -9519,8 +9510,7 @@ impl DescribeAccountLimitsError {
     pub fn from_body(body: &str) -> DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
@@ -9587,8 +9577,7 @@ impl DescribeChangeSetError {
     pub fn from_body(body: &str) -> DescribeChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ChangeSetNotFoundException" => {
@@ -9657,8 +9646,7 @@ impl DescribeStackEventsError {
     pub fn from_body(body: &str) -> DescribeStackEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStackEventsError::Unknown(String::from(body)),
@@ -9727,8 +9715,7 @@ impl DescribeStackInstanceError {
     pub fn from_body(body: &str) -> DescribeStackInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "StackInstanceNotFoundException" => {
@@ -9803,8 +9790,7 @@ impl DescribeStackResourceError {
     pub fn from_body(body: &str) -> DescribeStackResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStackResourceError::Unknown(String::from(body)),
@@ -9869,8 +9855,7 @@ impl DescribeStackResourcesError {
     pub fn from_body(body: &str) -> DescribeStackResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStackResourcesError::Unknown(String::from(body)),
@@ -9937,8 +9922,7 @@ impl DescribeStackSetError {
     pub fn from_body(body: &str) -> DescribeStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "StackSetNotFoundException" => {
@@ -10009,8 +9993,7 @@ impl DescribeStackSetOperationError {
     pub fn from_body(body: &str) -> DescribeStackSetOperationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationNotFoundException" => DescribeStackSetOperationError::OperationNotFound(
@@ -10083,8 +10066,7 @@ impl DescribeStacksError {
     pub fn from_body(body: &str) -> DescribeStacksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStacksError::Unknown(String::from(body)),
@@ -10147,8 +10129,7 @@ impl EstimateTemplateCostError {
     pub fn from_body(body: &str) -> EstimateTemplateCostError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EstimateTemplateCostError::Unknown(String::from(body)),
@@ -10221,8 +10202,7 @@ impl ExecuteChangeSetError {
     pub fn from_body(body: &str) -> ExecuteChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ChangeSetNotFoundException" => {
@@ -10305,8 +10285,7 @@ impl GetStackPolicyError {
     pub fn from_body(body: &str) -> GetStackPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetStackPolicyError::Unknown(String::from(body)),
@@ -10371,8 +10350,7 @@ impl GetTemplateError {
     pub fn from_body(body: &str) -> GetTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ChangeSetNotFoundException" => {
@@ -10441,8 +10419,7 @@ impl GetTemplateSummaryError {
     pub fn from_body(body: &str) -> GetTemplateSummaryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "StackSetNotFoundException" => {
@@ -10511,8 +10488,7 @@ impl ListChangeSetsError {
     pub fn from_body(body: &str) -> ListChangeSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListChangeSetsError::Unknown(String::from(body)),
@@ -10575,8 +10551,7 @@ impl ListExportsError {
     pub fn from_body(body: &str) -> ListExportsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListExportsError::Unknown(String::from(body)),
@@ -10639,8 +10614,7 @@ impl ListImportsError {
     pub fn from_body(body: &str) -> ListImportsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListImportsError::Unknown(String::from(body)),
@@ -10705,8 +10679,7 @@ impl ListStackInstancesError {
     pub fn from_body(body: &str) -> ListStackInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "StackSetNotFoundException" => {
@@ -10775,8 +10748,7 @@ impl ListStackResourcesError {
     pub fn from_body(body: &str) -> ListStackResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStackResourcesError::Unknown(String::from(body)),
@@ -10845,8 +10817,7 @@ impl ListStackSetOperationResultsError {
     pub fn from_body(body: &str) -> ListStackSetOperationResultsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationNotFoundException" => {
@@ -10925,8 +10896,7 @@ impl ListStackSetOperationsError {
     pub fn from_body(body: &str) -> ListStackSetOperationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "StackSetNotFoundException" => ListStackSetOperationsError::StackSetNotFound(
@@ -10995,8 +10965,7 @@ impl ListStackSetsError {
     pub fn from_body(body: &str) -> ListStackSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStackSetsError::Unknown(String::from(body)),
@@ -11059,8 +11028,7 @@ impl ListStacksError {
     pub fn from_body(body: &str) -> ListStacksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStacksError::Unknown(String::from(body)),
@@ -11123,8 +11091,7 @@ impl SetStackPolicyError {
     pub fn from_body(body: &str) -> SetStackPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetStackPolicyError::Unknown(String::from(body)),
@@ -11187,8 +11154,7 @@ impl SignalResourceError {
     pub fn from_body(body: &str) -> SignalResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SignalResourceError::Unknown(String::from(body)),
@@ -11257,8 +11223,7 @@ impl StopStackSetOperationError {
     pub fn from_body(body: &str) -> StopStackSetOperationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOperationException" => {
@@ -11339,8 +11304,7 @@ impl UpdateStackError {
     pub fn from_body(body: &str) -> UpdateStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientCapabilitiesException" => {
@@ -11421,8 +11385,7 @@ impl UpdateStackSetError {
     pub fn from_body(body: &str) -> UpdateStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOperationException" => {
@@ -11507,8 +11470,7 @@ impl ValidateTemplateError {
     pub fn from_body(body: &str) -> ValidateTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ValidateTemplateError::Unknown(String::from(body)),

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -34,7 +34,8 @@ use xml::EventWriter;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 enum DeserializerNext {
     Close,
     Skip,
@@ -8106,8 +8107,7 @@ impl CreateCloudFrontOriginAccessIdentityError {
     pub fn from_body(body: &str) -> CreateCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
@@ -8257,8 +8257,7 @@ impl CreateDistributionError {
     pub fn from_body(body: &str) -> CreateDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -8589,8 +8588,7 @@ impl CreateDistributionWithTagsError {
     pub fn from_body(body: &str) -> CreateDistributionWithTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => CreateDistributionWithTagsError::AccessDenied(String::from(
@@ -8879,8 +8877,7 @@ impl CreateInvalidationError {
     pub fn from_body(body: &str) -> CreateInvalidationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -8999,8 +8996,7 @@ impl CreateStreamingDistributionError {
     pub fn from_body(body: &str) -> CreateStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => CreateStreamingDistributionError::AccessDenied(String::from(
@@ -9157,8 +9153,7 @@ impl CreateStreamingDistributionWithTagsError {
     pub fn from_body(body: &str) -> CreateStreamingDistributionWithTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => CreateStreamingDistributionWithTagsError::AccessDenied(
@@ -9309,8 +9304,7 @@ impl DeleteCloudFrontOriginAccessIdentityError {
     pub fn from_body(body: &str) -> DeleteCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
@@ -9396,8 +9390,7 @@ impl DeleteDistributionError {
     pub fn from_body(body: &str) -> DeleteDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -9492,8 +9485,7 @@ impl DeleteStreamingDistributionError {
     pub fn from_body(body: &str) -> DeleteStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => DeleteStreamingDistributionError::AccessDenied(String::from(
@@ -9588,8 +9580,7 @@ impl GetCloudFrontOriginAccessIdentityError {
     pub fn from_body(body: &str) -> GetCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => GetCloudFrontOriginAccessIdentityError::AccessDenied(
@@ -9670,8 +9661,7 @@ impl GetCloudFrontOriginAccessIdentityConfigError {
     pub fn from_body(body: &str) -> GetCloudFrontOriginAccessIdentityConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
@@ -9742,8 +9732,7 @@ impl GetDistributionError {
     pub fn from_body(body: &str) -> GetDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -9818,8 +9807,7 @@ impl GetDistributionConfigError {
     pub fn from_body(body: &str) -> GetDistributionConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -9898,8 +9886,7 @@ impl GetInvalidationError {
     pub fn from_body(body: &str) -> GetInvalidationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -9978,8 +9965,7 @@ impl GetStreamingDistributionError {
     pub fn from_body(body: &str) -> GetStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -10058,8 +10044,7 @@ impl GetStreamingDistributionConfigError {
     pub fn from_body(body: &str) -> GetStreamingDistributionConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => GetStreamingDistributionConfigError::AccessDenied(String::from(
@@ -10136,8 +10121,7 @@ impl ListCloudFrontOriginAccessIdentitiesError {
     pub fn from_body(body: &str) -> ListCloudFrontOriginAccessIdentitiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidArgument" => ListCloudFrontOriginAccessIdentitiesError::InvalidArgument(
@@ -10208,8 +10192,7 @@ impl ListDistributionsError {
     pub fn from_body(body: &str) -> ListDistributionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidArgument" => {
@@ -10282,8 +10265,7 @@ impl ListDistributionsByWebACLIdError {
     pub fn from_body(body: &str) -> ListDistributionsByWebACLIdError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidArgument" => ListDistributionsByWebACLIdError::InvalidArgument(
@@ -10362,8 +10344,7 @@ impl ListInvalidationsError {
     pub fn from_body(body: &str) -> ListInvalidationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -10442,8 +10423,7 @@ impl ListStreamingDistributionsError {
     pub fn from_body(body: &str) -> ListStreamingDistributionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidArgument" => ListStreamingDistributionsError::InvalidArgument(
@@ -10520,8 +10500,7 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -10610,8 +10589,7 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -10698,8 +10676,7 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -10794,8 +10771,7 @@ impl UpdateCloudFrontOriginAccessIdentityError {
     pub fn from_body(body: &str) -> UpdateCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
@@ -10952,8 +10928,7 @@ impl UpdateDistributionError {
     pub fn from_body(body: &str) -> UpdateDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
@@ -11228,8 +11203,7 @@ impl UpdateStreamingDistributionError {
     pub fn from_body(body: &str) -> UpdateStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => UpdateStreamingDistributionError::AccessDenied(String::from(

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -5490,8 +5491,7 @@ impl BuildSuggestersError {
     pub fn from_body(body: &str) -> BuildSuggestersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => BuildSuggestersError::Base(String::from(parsed_error.message)),
@@ -5570,8 +5570,7 @@ impl CreateDomainError {
     pub fn from_body(body: &str) -> CreateDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => CreateDomainError::Base(String::from(parsed_error.message)),
@@ -5654,8 +5653,7 @@ impl DefineAnalysisSchemeError {
     pub fn from_body(body: &str) -> DefineAnalysisSchemeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
@@ -5750,8 +5748,7 @@ impl DefineExpressionError {
     pub fn from_body(body: &str) -> DefineExpressionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DefineExpressionError::Base(String::from(parsed_error.message)),
@@ -5842,8 +5839,7 @@ impl DefineIndexFieldError {
     pub fn from_body(body: &str) -> DefineIndexFieldError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DefineIndexFieldError::Base(String::from(parsed_error.message)),
@@ -5934,8 +5930,7 @@ impl DefineSuggesterError {
     pub fn from_body(body: &str) -> DefineSuggesterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DefineSuggesterError::Base(String::from(parsed_error.message)),
@@ -6024,8 +6019,7 @@ impl DeleteAnalysisSchemeError {
     pub fn from_body(body: &str) -> DeleteAnalysisSchemeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
@@ -6110,8 +6104,7 @@ impl DeleteDomainError {
     pub fn from_body(body: &str) -> DeleteDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DeleteDomainError::Base(String::from(parsed_error.message)),
@@ -6188,8 +6181,7 @@ impl DeleteExpressionError {
     pub fn from_body(body: &str) -> DeleteExpressionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DeleteExpressionError::Base(String::from(parsed_error.message)),
@@ -6274,8 +6266,7 @@ impl DeleteIndexFieldError {
     pub fn from_body(body: &str) -> DeleteIndexFieldError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DeleteIndexFieldError::Base(String::from(parsed_error.message)),
@@ -6360,8 +6351,7 @@ impl DeleteSuggesterError {
     pub fn from_body(body: &str) -> DeleteSuggesterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DeleteSuggesterError::Base(String::from(parsed_error.message)),
@@ -6444,8 +6434,7 @@ impl DescribeAnalysisSchemesError {
     pub fn from_body(body: &str) -> DescribeAnalysisSchemesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
@@ -6534,8 +6523,7 @@ impl DescribeAvailabilityOptionsError {
     pub fn from_body(body: &str) -> DescribeAvailabilityOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
@@ -6630,8 +6618,7 @@ impl DescribeDomainsError {
     pub fn from_body(body: &str) -> DescribeDomainsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DescribeDomainsError::Base(String::from(parsed_error.message)),
@@ -6706,8 +6693,7 @@ impl DescribeExpressionsError {
     pub fn from_body(body: &str) -> DescribeExpressionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
@@ -6790,8 +6776,7 @@ impl DescribeIndexFieldsError {
     pub fn from_body(body: &str) -> DescribeIndexFieldsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
@@ -6874,8 +6859,7 @@ impl DescribeScalingParametersError {
     pub fn from_body(body: &str) -> DescribeScalingParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
@@ -6958,8 +6942,7 @@ impl DescribeServiceAccessPoliciesError {
     pub fn from_body(body: &str) -> DescribeServiceAccessPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
@@ -7044,8 +7027,7 @@ impl DescribeSuggestersError {
     pub fn from_body(body: &str) -> DescribeSuggestersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
@@ -7128,8 +7110,7 @@ impl IndexDocumentsError {
     pub fn from_body(body: &str) -> IndexDocumentsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => IndexDocumentsError::Base(String::from(parsed_error.message)),
@@ -7204,8 +7185,7 @@ impl ListDomainNamesError {
     pub fn from_body(body: &str) -> ListDomainNamesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => ListDomainNamesError::Base(String::from(parsed_error.message)),
@@ -7282,8 +7262,7 @@ impl UpdateAvailabilityOptionsError {
     pub fn from_body(body: &str) -> UpdateAvailabilityOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
@@ -7382,8 +7361,7 @@ impl UpdateScalingParametersError {
     pub fn from_body(body: &str) -> UpdateScalingParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
@@ -7478,8 +7456,7 @@ impl UpdateServiceAccessPoliciesError {
     pub fn from_body(body: &str) -> UpdateServiceAccessPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -2959,8 +2960,7 @@ impl DeleteAlarmsError {
     pub fn from_body(body: &str) -> DeleteAlarmsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceNotFound" => {
@@ -3033,8 +3033,7 @@ impl DeleteDashboardsError {
     pub fn from_body(body: &str) -> DeleteDashboardsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DashboardNotFoundError" => DeleteDashboardsError::DashboardNotFoundError(
@@ -3111,8 +3110,7 @@ impl DescribeAlarmHistoryError {
     pub fn from_body(body: &str) -> DescribeAlarmHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => {
@@ -3183,8 +3181,7 @@ impl DescribeAlarmsError {
     pub fn from_body(body: &str) -> DescribeAlarmsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => {
@@ -3251,8 +3248,7 @@ impl DescribeAlarmsForMetricError {
     pub fn from_body(body: &str) -> DescribeAlarmsForMetricError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAlarmsForMetricError::Unknown(String::from(body)),
@@ -3317,8 +3313,7 @@ impl DisableAlarmActionsError {
     pub fn from_body(body: &str) -> DisableAlarmActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableAlarmActionsError::Unknown(String::from(body)),
@@ -3383,8 +3378,7 @@ impl EnableAlarmActionsError {
     pub fn from_body(body: &str) -> EnableAlarmActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableAlarmActionsError::Unknown(String::from(body)),
@@ -3455,8 +3449,7 @@ impl GetDashboardError {
     pub fn from_body(body: &str) -> GetDashboardError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DashboardNotFoundError" => {
@@ -3539,8 +3532,7 @@ impl GetMetricStatisticsError {
     pub fn from_body(body: &str) -> GetMetricStatisticsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InternalServiceFault" => GetMetricStatisticsError::InternalServiceFault(
@@ -3631,8 +3623,7 @@ impl ListDashboardsError {
     pub fn from_body(body: &str) -> ListDashboardsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InternalServiceFault" => {
@@ -3707,8 +3698,7 @@ impl ListMetricsError {
     pub fn from_body(body: &str) -> ListMetricsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InternalServiceFault" => {
@@ -3783,8 +3773,7 @@ impl PutDashboardError {
     pub fn from_body(body: &str) -> PutDashboardError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DashboardInvalidInputError" => PutDashboardError::DashboardInvalidInputError(
@@ -3857,8 +3846,7 @@ impl PutMetricAlarmError {
     pub fn from_body(body: &str) -> PutMetricAlarmError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededFault" => {
@@ -3933,8 +3921,7 @@ impl PutMetricDataError {
     pub fn from_body(body: &str) -> PutMetricDataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InternalServiceFault" => {
@@ -4019,8 +4006,7 @@ impl SetAlarmStateError {
     pub fn from_body(body: &str) -> SetAlarmStateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidFormatFault" => {

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -45075,8 +45076,7 @@ impl AcceptReservedInstancesExchangeQuoteError {
     pub fn from_body(body: &str) -> AcceptReservedInstancesExchangeQuoteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AcceptReservedInstancesExchangeQuoteError::Unknown(String::from(body)),
@@ -45141,8 +45141,7 @@ impl AcceptVpcPeeringConnectionError {
     pub fn from_body(body: &str) -> AcceptVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AcceptVpcPeeringConnectionError::Unknown(String::from(body)),
@@ -45207,8 +45206,7 @@ impl AllocateAddressError {
     pub fn from_body(body: &str) -> AllocateAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AllocateAddressError::Unknown(String::from(body)),
@@ -45271,8 +45269,7 @@ impl AllocateHostsError {
     pub fn from_body(body: &str) -> AllocateHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AllocateHostsError::Unknown(String::from(body)),
@@ -45335,8 +45332,7 @@ impl AssignIpv6AddressesError {
     pub fn from_body(body: &str) -> AssignIpv6AddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssignIpv6AddressesError::Unknown(String::from(body)),
@@ -45401,8 +45397,7 @@ impl AssignPrivateIpAddressesError {
     pub fn from_body(body: &str) -> AssignPrivateIpAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssignPrivateIpAddressesError::Unknown(String::from(body)),
@@ -45467,8 +45462,7 @@ impl AssociateAddressError {
     pub fn from_body(body: &str) -> AssociateAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateAddressError::Unknown(String::from(body)),
@@ -45531,8 +45525,7 @@ impl AssociateDhcpOptionsError {
     pub fn from_body(body: &str) -> AssociateDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateDhcpOptionsError::Unknown(String::from(body)),
@@ -45597,8 +45590,7 @@ impl AssociateIamInstanceProfileError {
     pub fn from_body(body: &str) -> AssociateIamInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateIamInstanceProfileError::Unknown(String::from(body)),
@@ -45663,8 +45655,7 @@ impl AssociateRouteTableError {
     pub fn from_body(body: &str) -> AssociateRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateRouteTableError::Unknown(String::from(body)),
@@ -45729,8 +45720,7 @@ impl AssociateSubnetCidrBlockError {
     pub fn from_body(body: &str) -> AssociateSubnetCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateSubnetCidrBlockError::Unknown(String::from(body)),
@@ -45795,8 +45785,7 @@ impl AssociateVpcCidrBlockError {
     pub fn from_body(body: &str) -> AssociateVpcCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateVpcCidrBlockError::Unknown(String::from(body)),
@@ -45861,8 +45850,7 @@ impl AttachClassicLinkVpcError {
     pub fn from_body(body: &str) -> AttachClassicLinkVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachClassicLinkVpcError::Unknown(String::from(body)),
@@ -45927,8 +45915,7 @@ impl AttachInternetGatewayError {
     pub fn from_body(body: &str) -> AttachInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachInternetGatewayError::Unknown(String::from(body)),
@@ -45993,8 +45980,7 @@ impl AttachNetworkInterfaceError {
     pub fn from_body(body: &str) -> AttachNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachNetworkInterfaceError::Unknown(String::from(body)),
@@ -46059,8 +46045,7 @@ impl AttachVolumeError {
     pub fn from_body(body: &str) -> AttachVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachVolumeError::Unknown(String::from(body)),
@@ -46123,8 +46108,7 @@ impl AttachVpnGatewayError {
     pub fn from_body(body: &str) -> AttachVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachVpnGatewayError::Unknown(String::from(body)),
@@ -46187,8 +46171,7 @@ impl AuthorizeSecurityGroupEgressError {
     pub fn from_body(body: &str) -> AuthorizeSecurityGroupEgressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AuthorizeSecurityGroupEgressError::Unknown(String::from(body)),
@@ -46253,8 +46236,7 @@ impl AuthorizeSecurityGroupIngressError {
     pub fn from_body(body: &str) -> AuthorizeSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AuthorizeSecurityGroupIngressError::Unknown(String::from(body)),
@@ -46319,8 +46301,7 @@ impl BundleInstanceError {
     pub fn from_body(body: &str) -> BundleInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => BundleInstanceError::Unknown(String::from(body)),
@@ -46383,8 +46364,7 @@ impl CancelBundleTaskError {
     pub fn from_body(body: &str) -> CancelBundleTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelBundleTaskError::Unknown(String::from(body)),
@@ -46447,8 +46427,7 @@ impl CancelConversionTaskError {
     pub fn from_body(body: &str) -> CancelConversionTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelConversionTaskError::Unknown(String::from(body)),
@@ -46513,8 +46492,7 @@ impl CancelExportTaskError {
     pub fn from_body(body: &str) -> CancelExportTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelExportTaskError::Unknown(String::from(body)),
@@ -46577,8 +46555,7 @@ impl CancelImportTaskError {
     pub fn from_body(body: &str) -> CancelImportTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelImportTaskError::Unknown(String::from(body)),
@@ -46641,8 +46618,7 @@ impl CancelReservedInstancesListingError {
     pub fn from_body(body: &str) -> CancelReservedInstancesListingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelReservedInstancesListingError::Unknown(String::from(body)),
@@ -46707,8 +46683,7 @@ impl EC2CancelSpotFleetRequestsError {
     pub fn from_body(body: &str) -> EC2CancelSpotFleetRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EC2CancelSpotFleetRequestsError::Unknown(String::from(body)),
@@ -46773,8 +46748,7 @@ impl CancelSpotInstanceRequestsError {
     pub fn from_body(body: &str) -> CancelSpotInstanceRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelSpotInstanceRequestsError::Unknown(String::from(body)),
@@ -46839,8 +46813,7 @@ impl ConfirmProductInstanceError {
     pub fn from_body(body: &str) -> ConfirmProductInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ConfirmProductInstanceError::Unknown(String::from(body)),
@@ -46905,8 +46878,7 @@ impl CopyImageError {
     pub fn from_body(body: &str) -> CopyImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CopyImageError::Unknown(String::from(body)),
@@ -46969,8 +46941,7 @@ impl CopySnapshotError {
     pub fn from_body(body: &str) -> CopySnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CopySnapshotError::Unknown(String::from(body)),
@@ -47033,8 +47004,7 @@ impl CreateCustomerGatewayError {
     pub fn from_body(body: &str) -> CreateCustomerGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateCustomerGatewayError::Unknown(String::from(body)),
@@ -47099,8 +47069,7 @@ impl CreateDefaultVpcError {
     pub fn from_body(body: &str) -> CreateDefaultVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateDefaultVpcError::Unknown(String::from(body)),
@@ -47163,8 +47132,7 @@ impl CreateDhcpOptionsError {
     pub fn from_body(body: &str) -> CreateDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateDhcpOptionsError::Unknown(String::from(body)),
@@ -47229,8 +47197,7 @@ impl CreateEgressOnlyInternetGatewayError {
     pub fn from_body(body: &str) -> CreateEgressOnlyInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateEgressOnlyInternetGatewayError::Unknown(String::from(body)),
@@ -47295,8 +47262,7 @@ impl CreateFlowLogsError {
     pub fn from_body(body: &str) -> CreateFlowLogsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateFlowLogsError::Unknown(String::from(body)),
@@ -47359,8 +47325,7 @@ impl CreateFpgaImageError {
     pub fn from_body(body: &str) -> CreateFpgaImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateFpgaImageError::Unknown(String::from(body)),
@@ -47423,8 +47388,7 @@ impl CreateImageError {
     pub fn from_body(body: &str) -> CreateImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateImageError::Unknown(String::from(body)),
@@ -47487,8 +47451,7 @@ impl CreateInstanceExportTaskError {
     pub fn from_body(body: &str) -> CreateInstanceExportTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateInstanceExportTaskError::Unknown(String::from(body)),
@@ -47553,8 +47516,7 @@ impl CreateInternetGatewayError {
     pub fn from_body(body: &str) -> CreateInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateInternetGatewayError::Unknown(String::from(body)),
@@ -47619,8 +47581,7 @@ impl CreateKeyPairError {
     pub fn from_body(body: &str) -> CreateKeyPairError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateKeyPairError::Unknown(String::from(body)),
@@ -47683,8 +47644,7 @@ impl CreateNatGatewayError {
     pub fn from_body(body: &str) -> CreateNatGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNatGatewayError::Unknown(String::from(body)),
@@ -47747,8 +47707,7 @@ impl CreateNetworkAclError {
     pub fn from_body(body: &str) -> CreateNetworkAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkAclError::Unknown(String::from(body)),
@@ -47811,8 +47770,7 @@ impl CreateNetworkAclEntryError {
     pub fn from_body(body: &str) -> CreateNetworkAclEntryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkAclEntryError::Unknown(String::from(body)),
@@ -47877,8 +47835,7 @@ impl CreateNetworkInterfaceError {
     pub fn from_body(body: &str) -> CreateNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkInterfaceError::Unknown(String::from(body)),
@@ -47943,8 +47900,7 @@ impl CreateNetworkInterfacePermissionError {
     pub fn from_body(body: &str) -> CreateNetworkInterfacePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkInterfacePermissionError::Unknown(String::from(body)),
@@ -48009,8 +47965,7 @@ impl CreatePlacementGroupError {
     pub fn from_body(body: &str) -> CreatePlacementGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreatePlacementGroupError::Unknown(String::from(body)),
@@ -48075,8 +48030,7 @@ impl CreateReservedInstancesListingError {
     pub fn from_body(body: &str) -> CreateReservedInstancesListingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateReservedInstancesListingError::Unknown(String::from(body)),
@@ -48141,8 +48095,7 @@ impl CreateRouteError {
     pub fn from_body(body: &str) -> CreateRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateRouteError::Unknown(String::from(body)),
@@ -48205,8 +48158,7 @@ impl CreateRouteTableError {
     pub fn from_body(body: &str) -> CreateRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateRouteTableError::Unknown(String::from(body)),
@@ -48269,8 +48221,7 @@ impl CreateSecurityGroupError {
     pub fn from_body(body: &str) -> CreateSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSecurityGroupError::Unknown(String::from(body)),
@@ -48335,8 +48286,7 @@ impl CreateSnapshotError {
     pub fn from_body(body: &str) -> CreateSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSnapshotError::Unknown(String::from(body)),
@@ -48399,8 +48349,7 @@ impl CreateSpotDatafeedSubscriptionError {
     pub fn from_body(body: &str) -> CreateSpotDatafeedSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSpotDatafeedSubscriptionError::Unknown(String::from(body)),
@@ -48465,8 +48414,7 @@ impl CreateSubnetError {
     pub fn from_body(body: &str) -> CreateSubnetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSubnetError::Unknown(String::from(body)),
@@ -48529,8 +48477,7 @@ impl CreateTagsError {
     pub fn from_body(body: &str) -> CreateTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateTagsError::Unknown(String::from(body)),
@@ -48593,8 +48540,7 @@ impl CreateVolumeError {
     pub fn from_body(body: &str) -> CreateVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVolumeError::Unknown(String::from(body)),
@@ -48657,8 +48603,7 @@ impl CreateVpcError {
     pub fn from_body(body: &str) -> CreateVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcError::Unknown(String::from(body)),
@@ -48721,8 +48666,7 @@ impl CreateVpcEndpointError {
     pub fn from_body(body: &str) -> CreateVpcEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcEndpointError::Unknown(String::from(body)),
@@ -48787,8 +48731,7 @@ impl CreateVpcPeeringConnectionError {
     pub fn from_body(body: &str) -> CreateVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcPeeringConnectionError::Unknown(String::from(body)),
@@ -48853,8 +48796,7 @@ impl CreateVpnConnectionError {
     pub fn from_body(body: &str) -> CreateVpnConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpnConnectionError::Unknown(String::from(body)),
@@ -48919,8 +48861,7 @@ impl CreateVpnConnectionRouteError {
     pub fn from_body(body: &str) -> CreateVpnConnectionRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpnConnectionRouteError::Unknown(String::from(body)),
@@ -48985,8 +48926,7 @@ impl CreateVpnGatewayError {
     pub fn from_body(body: &str) -> CreateVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpnGatewayError::Unknown(String::from(body)),
@@ -49049,8 +48989,7 @@ impl DeleteCustomerGatewayError {
     pub fn from_body(body: &str) -> DeleteCustomerGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteCustomerGatewayError::Unknown(String::from(body)),
@@ -49115,8 +49054,7 @@ impl DeleteDhcpOptionsError {
     pub fn from_body(body: &str) -> DeleteDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteDhcpOptionsError::Unknown(String::from(body)),
@@ -49181,8 +49119,7 @@ impl DeleteEgressOnlyInternetGatewayError {
     pub fn from_body(body: &str) -> DeleteEgressOnlyInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteEgressOnlyInternetGatewayError::Unknown(String::from(body)),
@@ -49247,8 +49184,7 @@ impl DeleteFlowLogsError {
     pub fn from_body(body: &str) -> DeleteFlowLogsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteFlowLogsError::Unknown(String::from(body)),
@@ -49311,8 +49247,7 @@ impl DeleteInternetGatewayError {
     pub fn from_body(body: &str) -> DeleteInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteInternetGatewayError::Unknown(String::from(body)),
@@ -49377,8 +49312,7 @@ impl DeleteKeyPairError {
     pub fn from_body(body: &str) -> DeleteKeyPairError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteKeyPairError::Unknown(String::from(body)),
@@ -49441,8 +49375,7 @@ impl DeleteNatGatewayError {
     pub fn from_body(body: &str) -> DeleteNatGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNatGatewayError::Unknown(String::from(body)),
@@ -49505,8 +49438,7 @@ impl DeleteNetworkAclError {
     pub fn from_body(body: &str) -> DeleteNetworkAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkAclError::Unknown(String::from(body)),
@@ -49569,8 +49501,7 @@ impl DeleteNetworkAclEntryError {
     pub fn from_body(body: &str) -> DeleteNetworkAclEntryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkAclEntryError::Unknown(String::from(body)),
@@ -49635,8 +49566,7 @@ impl DeleteNetworkInterfaceError {
     pub fn from_body(body: &str) -> DeleteNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkInterfaceError::Unknown(String::from(body)),
@@ -49701,8 +49631,7 @@ impl DeleteNetworkInterfacePermissionError {
     pub fn from_body(body: &str) -> DeleteNetworkInterfacePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkInterfacePermissionError::Unknown(String::from(body)),
@@ -49767,8 +49696,7 @@ impl DeletePlacementGroupError {
     pub fn from_body(body: &str) -> DeletePlacementGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeletePlacementGroupError::Unknown(String::from(body)),
@@ -49833,8 +49761,7 @@ impl DeleteRouteError {
     pub fn from_body(body: &str) -> DeleteRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteRouteError::Unknown(String::from(body)),
@@ -49897,8 +49824,7 @@ impl DeleteRouteTableError {
     pub fn from_body(body: &str) -> DeleteRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteRouteTableError::Unknown(String::from(body)),
@@ -49961,8 +49887,7 @@ impl DeleteSecurityGroupError {
     pub fn from_body(body: &str) -> DeleteSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSecurityGroupError::Unknown(String::from(body)),
@@ -50027,8 +49952,7 @@ impl DeleteSnapshotError {
     pub fn from_body(body: &str) -> DeleteSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSnapshotError::Unknown(String::from(body)),
@@ -50091,8 +50015,7 @@ impl DeleteSpotDatafeedSubscriptionError {
     pub fn from_body(body: &str) -> DeleteSpotDatafeedSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSpotDatafeedSubscriptionError::Unknown(String::from(body)),
@@ -50157,8 +50080,7 @@ impl DeleteSubnetError {
     pub fn from_body(body: &str) -> DeleteSubnetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSubnetError::Unknown(String::from(body)),
@@ -50221,8 +50143,7 @@ impl DeleteTagsError {
     pub fn from_body(body: &str) -> DeleteTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteTagsError::Unknown(String::from(body)),
@@ -50285,8 +50206,7 @@ impl DeleteVolumeError {
     pub fn from_body(body: &str) -> DeleteVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVolumeError::Unknown(String::from(body)),
@@ -50349,8 +50269,7 @@ impl DeleteVpcError {
     pub fn from_body(body: &str) -> DeleteVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcError::Unknown(String::from(body)),
@@ -50413,8 +50332,7 @@ impl DeleteVpcEndpointsError {
     pub fn from_body(body: &str) -> DeleteVpcEndpointsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcEndpointsError::Unknown(String::from(body)),
@@ -50479,8 +50397,7 @@ impl DeleteVpcPeeringConnectionError {
     pub fn from_body(body: &str) -> DeleteVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcPeeringConnectionError::Unknown(String::from(body)),
@@ -50545,8 +50462,7 @@ impl DeleteVpnConnectionError {
     pub fn from_body(body: &str) -> DeleteVpnConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpnConnectionError::Unknown(String::from(body)),
@@ -50611,8 +50527,7 @@ impl DeleteVpnConnectionRouteError {
     pub fn from_body(body: &str) -> DeleteVpnConnectionRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpnConnectionRouteError::Unknown(String::from(body)),
@@ -50677,8 +50592,7 @@ impl DeleteVpnGatewayError {
     pub fn from_body(body: &str) -> DeleteVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpnGatewayError::Unknown(String::from(body)),
@@ -50741,8 +50655,7 @@ impl DeregisterImageError {
     pub fn from_body(body: &str) -> DeregisterImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeregisterImageError::Unknown(String::from(body)),
@@ -50805,8 +50718,7 @@ impl DescribeAccountAttributesError {
     pub fn from_body(body: &str) -> DescribeAccountAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountAttributesError::Unknown(String::from(body)),
@@ -50871,8 +50783,7 @@ impl DescribeAddressesError {
     pub fn from_body(body: &str) -> DescribeAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAddressesError::Unknown(String::from(body)),
@@ -50937,8 +50848,7 @@ impl DescribeAvailabilityZonesError {
     pub fn from_body(body: &str) -> DescribeAvailabilityZonesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAvailabilityZonesError::Unknown(String::from(body)),
@@ -51003,8 +50913,7 @@ impl DescribeBundleTasksError {
     pub fn from_body(body: &str) -> DescribeBundleTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeBundleTasksError::Unknown(String::from(body)),
@@ -51069,8 +50978,7 @@ impl DescribeClassicLinkInstancesError {
     pub fn from_body(body: &str) -> DescribeClassicLinkInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeClassicLinkInstancesError::Unknown(String::from(body)),
@@ -51135,8 +51043,7 @@ impl DescribeConversionTasksError {
     pub fn from_body(body: &str) -> DescribeConversionTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeConversionTasksError::Unknown(String::from(body)),
@@ -51201,8 +51108,7 @@ impl DescribeCustomerGatewaysError {
     pub fn from_body(body: &str) -> DescribeCustomerGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeCustomerGatewaysError::Unknown(String::from(body)),
@@ -51267,8 +51173,7 @@ impl DescribeDhcpOptionsError {
     pub fn from_body(body: &str) -> DescribeDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDhcpOptionsError::Unknown(String::from(body)),
@@ -51333,8 +51238,7 @@ impl DescribeEgressOnlyInternetGatewaysError {
     pub fn from_body(body: &str) -> DescribeEgressOnlyInternetGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEgressOnlyInternetGatewaysError::Unknown(String::from(body)),
@@ -51399,8 +51303,7 @@ impl DescribeElasticGpusError {
     pub fn from_body(body: &str) -> DescribeElasticGpusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeElasticGpusError::Unknown(String::from(body)),
@@ -51465,8 +51368,7 @@ impl DescribeExportTasksError {
     pub fn from_body(body: &str) -> DescribeExportTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeExportTasksError::Unknown(String::from(body)),
@@ -51531,8 +51433,7 @@ impl DescribeFlowLogsError {
     pub fn from_body(body: &str) -> DescribeFlowLogsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFlowLogsError::Unknown(String::from(body)),
@@ -51595,8 +51496,7 @@ impl DescribeFpgaImagesError {
     pub fn from_body(body: &str) -> DescribeFpgaImagesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFpgaImagesError::Unknown(String::from(body)),
@@ -51661,8 +51561,7 @@ impl DescribeHostReservationOfferingsError {
     pub fn from_body(body: &str) -> DescribeHostReservationOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeHostReservationOfferingsError::Unknown(String::from(body)),
@@ -51727,8 +51626,7 @@ impl DescribeHostReservationsError {
     pub fn from_body(body: &str) -> DescribeHostReservationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeHostReservationsError::Unknown(String::from(body)),
@@ -51793,8 +51691,7 @@ impl DescribeHostsError {
     pub fn from_body(body: &str) -> DescribeHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeHostsError::Unknown(String::from(body)),
@@ -51857,8 +51754,7 @@ impl DescribeIamInstanceProfileAssociationsError {
     pub fn from_body(body: &str) -> DescribeIamInstanceProfileAssociationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeIamInstanceProfileAssociationsError::Unknown(String::from(body)),
@@ -51923,8 +51819,7 @@ impl DescribeIdFormatError {
     pub fn from_body(body: &str) -> DescribeIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeIdFormatError::Unknown(String::from(body)),
@@ -51987,8 +51882,7 @@ impl DescribeIdentityIdFormatError {
     pub fn from_body(body: &str) -> DescribeIdentityIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeIdentityIdFormatError::Unknown(String::from(body)),
@@ -52053,8 +51947,7 @@ impl DescribeImageAttributeError {
     pub fn from_body(body: &str) -> DescribeImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImageAttributeError::Unknown(String::from(body)),
@@ -52119,8 +52012,7 @@ impl DescribeImagesError {
     pub fn from_body(body: &str) -> DescribeImagesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImagesError::Unknown(String::from(body)),
@@ -52183,8 +52075,7 @@ impl DescribeImportImageTasksError {
     pub fn from_body(body: &str) -> DescribeImportImageTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImportImageTasksError::Unknown(String::from(body)),
@@ -52249,8 +52140,7 @@ impl DescribeImportSnapshotTasksError {
     pub fn from_body(body: &str) -> DescribeImportSnapshotTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImportSnapshotTasksError::Unknown(String::from(body)),
@@ -52315,8 +52205,7 @@ impl DescribeInstanceAttributeError {
     pub fn from_body(body: &str) -> DescribeInstanceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstanceAttributeError::Unknown(String::from(body)),
@@ -52381,8 +52270,7 @@ impl DescribeInstanceStatusError {
     pub fn from_body(body: &str) -> DescribeInstanceStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstanceStatusError::Unknown(String::from(body)),
@@ -52447,8 +52335,7 @@ impl DescribeInstancesError {
     pub fn from_body(body: &str) -> DescribeInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstancesError::Unknown(String::from(body)),
@@ -52513,8 +52400,7 @@ impl DescribeInternetGatewaysError {
     pub fn from_body(body: &str) -> DescribeInternetGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInternetGatewaysError::Unknown(String::from(body)),
@@ -52579,8 +52465,7 @@ impl DescribeKeyPairsError {
     pub fn from_body(body: &str) -> DescribeKeyPairsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeKeyPairsError::Unknown(String::from(body)),
@@ -52643,8 +52528,7 @@ impl DescribeMovingAddressesError {
     pub fn from_body(body: &str) -> DescribeMovingAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeMovingAddressesError::Unknown(String::from(body)),
@@ -52709,8 +52593,7 @@ impl DescribeNatGatewaysError {
     pub fn from_body(body: &str) -> DescribeNatGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNatGatewaysError::Unknown(String::from(body)),
@@ -52775,8 +52658,7 @@ impl DescribeNetworkAclsError {
     pub fn from_body(body: &str) -> DescribeNetworkAclsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkAclsError::Unknown(String::from(body)),
@@ -52841,8 +52723,7 @@ impl DescribeNetworkInterfaceAttributeError {
     pub fn from_body(body: &str) -> DescribeNetworkInterfaceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkInterfaceAttributeError::Unknown(String::from(body)),
@@ -52907,8 +52788,7 @@ impl DescribeNetworkInterfacePermissionsError {
     pub fn from_body(body: &str) -> DescribeNetworkInterfacePermissionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkInterfacePermissionsError::Unknown(String::from(body)),
@@ -52973,8 +52853,7 @@ impl DescribeNetworkInterfacesError {
     pub fn from_body(body: &str) -> DescribeNetworkInterfacesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkInterfacesError::Unknown(String::from(body)),
@@ -53039,8 +52918,7 @@ impl DescribePlacementGroupsError {
     pub fn from_body(body: &str) -> DescribePlacementGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribePlacementGroupsError::Unknown(String::from(body)),
@@ -53105,8 +52983,7 @@ impl DescribePrefixListsError {
     pub fn from_body(body: &str) -> DescribePrefixListsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribePrefixListsError::Unknown(String::from(body)),
@@ -53171,8 +53048,7 @@ impl DescribeRegionsError {
     pub fn from_body(body: &str) -> DescribeRegionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeRegionsError::Unknown(String::from(body)),
@@ -53235,8 +53111,7 @@ impl DescribeReservedInstancesError {
     pub fn from_body(body: &str) -> DescribeReservedInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesError::Unknown(String::from(body)),
@@ -53301,8 +53176,7 @@ impl DescribeReservedInstancesListingsError {
     pub fn from_body(body: &str) -> DescribeReservedInstancesListingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesListingsError::Unknown(String::from(body)),
@@ -53367,8 +53241,7 @@ impl DescribeReservedInstancesModificationsError {
     pub fn from_body(body: &str) -> DescribeReservedInstancesModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesModificationsError::Unknown(String::from(body)),
@@ -53433,8 +53306,7 @@ impl DescribeReservedInstancesOfferingsError {
     pub fn from_body(body: &str) -> DescribeReservedInstancesOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesOfferingsError::Unknown(String::from(body)),
@@ -53499,8 +53371,7 @@ impl DescribeRouteTablesError {
     pub fn from_body(body: &str) -> DescribeRouteTablesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeRouteTablesError::Unknown(String::from(body)),
@@ -53565,8 +53436,7 @@ impl DescribeScheduledInstanceAvailabilityError {
     pub fn from_body(body: &str) -> DescribeScheduledInstanceAvailabilityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeScheduledInstanceAvailabilityError::Unknown(String::from(body)),
@@ -53631,8 +53501,7 @@ impl DescribeScheduledInstancesError {
     pub fn from_body(body: &str) -> DescribeScheduledInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeScheduledInstancesError::Unknown(String::from(body)),
@@ -53697,8 +53566,7 @@ impl DescribeSecurityGroupReferencesError {
     pub fn from_body(body: &str) -> DescribeSecurityGroupReferencesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSecurityGroupReferencesError::Unknown(String::from(body)),
@@ -53763,8 +53631,7 @@ impl DescribeSecurityGroupsError {
     pub fn from_body(body: &str) -> DescribeSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSecurityGroupsError::Unknown(String::from(body)),
@@ -53829,8 +53696,7 @@ impl DescribeSnapshotAttributeError {
     pub fn from_body(body: &str) -> DescribeSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSnapshotAttributeError::Unknown(String::from(body)),
@@ -53895,8 +53761,7 @@ impl DescribeSnapshotsError {
     pub fn from_body(body: &str) -> DescribeSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSnapshotsError::Unknown(String::from(body)),
@@ -53961,8 +53826,7 @@ impl DescribeSpotDatafeedSubscriptionError {
     pub fn from_body(body: &str) -> DescribeSpotDatafeedSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotDatafeedSubscriptionError::Unknown(String::from(body)),
@@ -54027,8 +53891,7 @@ impl DescribeSpotFleetInstancesError {
     pub fn from_body(body: &str) -> DescribeSpotFleetInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotFleetInstancesError::Unknown(String::from(body)),
@@ -54093,8 +53956,7 @@ impl DescribeSpotFleetRequestHistoryError {
     pub fn from_body(body: &str) -> DescribeSpotFleetRequestHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotFleetRequestHistoryError::Unknown(String::from(body)),
@@ -54159,8 +54021,7 @@ impl DescribeSpotFleetRequestsError {
     pub fn from_body(body: &str) -> DescribeSpotFleetRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotFleetRequestsError::Unknown(String::from(body)),
@@ -54225,8 +54086,7 @@ impl DescribeSpotInstanceRequestsError {
     pub fn from_body(body: &str) -> DescribeSpotInstanceRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotInstanceRequestsError::Unknown(String::from(body)),
@@ -54291,8 +54151,7 @@ impl DescribeSpotPriceHistoryError {
     pub fn from_body(body: &str) -> DescribeSpotPriceHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotPriceHistoryError::Unknown(String::from(body)),
@@ -54357,8 +54216,7 @@ impl DescribeStaleSecurityGroupsError {
     pub fn from_body(body: &str) -> DescribeStaleSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStaleSecurityGroupsError::Unknown(String::from(body)),
@@ -54423,8 +54281,7 @@ impl DescribeSubnetsError {
     pub fn from_body(body: &str) -> DescribeSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSubnetsError::Unknown(String::from(body)),
@@ -54487,8 +54344,7 @@ impl DescribeTagsError {
     pub fn from_body(body: &str) -> DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeTagsError::Unknown(String::from(body)),
@@ -54551,8 +54407,7 @@ impl DescribeVolumeAttributeError {
     pub fn from_body(body: &str) -> DescribeVolumeAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumeAttributeError::Unknown(String::from(body)),
@@ -54617,8 +54472,7 @@ impl DescribeVolumeStatusError {
     pub fn from_body(body: &str) -> DescribeVolumeStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumeStatusError::Unknown(String::from(body)),
@@ -54683,8 +54537,7 @@ impl DescribeVolumesError {
     pub fn from_body(body: &str) -> DescribeVolumesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumesError::Unknown(String::from(body)),
@@ -54747,8 +54600,7 @@ impl DescribeVolumesModificationsError {
     pub fn from_body(body: &str) -> DescribeVolumesModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumesModificationsError::Unknown(String::from(body)),
@@ -54813,8 +54665,7 @@ impl DescribeVpcAttributeError {
     pub fn from_body(body: &str) -> DescribeVpcAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcAttributeError::Unknown(String::from(body)),
@@ -54879,8 +54730,7 @@ impl DescribeVpcClassicLinkError {
     pub fn from_body(body: &str) -> DescribeVpcClassicLinkError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcClassicLinkError::Unknown(String::from(body)),
@@ -54945,8 +54795,7 @@ impl DescribeVpcClassicLinkDnsSupportError {
     pub fn from_body(body: &str) -> DescribeVpcClassicLinkDnsSupportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
@@ -55011,8 +54860,7 @@ impl DescribeVpcEndpointServicesError {
     pub fn from_body(body: &str) -> DescribeVpcEndpointServicesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointServicesError::Unknown(String::from(body)),
@@ -55077,8 +54925,7 @@ impl DescribeVpcEndpointsError {
     pub fn from_body(body: &str) -> DescribeVpcEndpointsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointsError::Unknown(String::from(body)),
@@ -55143,8 +54990,7 @@ impl DescribeVpcPeeringConnectionsError {
     pub fn from_body(body: &str) -> DescribeVpcPeeringConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcPeeringConnectionsError::Unknown(String::from(body)),
@@ -55209,8 +55055,7 @@ impl DescribeVpcsError {
     pub fn from_body(body: &str) -> DescribeVpcsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcsError::Unknown(String::from(body)),
@@ -55273,8 +55118,7 @@ impl DescribeVpnConnectionsError {
     pub fn from_body(body: &str) -> DescribeVpnConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpnConnectionsError::Unknown(String::from(body)),
@@ -55339,8 +55183,7 @@ impl DescribeVpnGatewaysError {
     pub fn from_body(body: &str) -> DescribeVpnGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpnGatewaysError::Unknown(String::from(body)),
@@ -55405,8 +55248,7 @@ impl DetachClassicLinkVpcError {
     pub fn from_body(body: &str) -> DetachClassicLinkVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachClassicLinkVpcError::Unknown(String::from(body)),
@@ -55471,8 +55313,7 @@ impl DetachInternetGatewayError {
     pub fn from_body(body: &str) -> DetachInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachInternetGatewayError::Unknown(String::from(body)),
@@ -55537,8 +55378,7 @@ impl DetachNetworkInterfaceError {
     pub fn from_body(body: &str) -> DetachNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachNetworkInterfaceError::Unknown(String::from(body)),
@@ -55603,8 +55443,7 @@ impl DetachVolumeError {
     pub fn from_body(body: &str) -> DetachVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachVolumeError::Unknown(String::from(body)),
@@ -55667,8 +55506,7 @@ impl DetachVpnGatewayError {
     pub fn from_body(body: &str) -> DetachVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachVpnGatewayError::Unknown(String::from(body)),
@@ -55731,8 +55569,7 @@ impl DisableVgwRoutePropagationError {
     pub fn from_body(body: &str) -> DisableVgwRoutePropagationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableVgwRoutePropagationError::Unknown(String::from(body)),
@@ -55797,8 +55634,7 @@ impl DisableVpcClassicLinkError {
     pub fn from_body(body: &str) -> DisableVpcClassicLinkError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableVpcClassicLinkError::Unknown(String::from(body)),
@@ -55863,8 +55699,7 @@ impl DisableVpcClassicLinkDnsSupportError {
     pub fn from_body(body: &str) -> DisableVpcClassicLinkDnsSupportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
@@ -55929,8 +55764,7 @@ impl DisassociateAddressError {
     pub fn from_body(body: &str) -> DisassociateAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateAddressError::Unknown(String::from(body)),
@@ -55995,8 +55829,7 @@ impl DisassociateIamInstanceProfileError {
     pub fn from_body(body: &str) -> DisassociateIamInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateIamInstanceProfileError::Unknown(String::from(body)),
@@ -56061,8 +55894,7 @@ impl DisassociateRouteTableError {
     pub fn from_body(body: &str) -> DisassociateRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateRouteTableError::Unknown(String::from(body)),
@@ -56127,8 +55959,7 @@ impl DisassociateSubnetCidrBlockError {
     pub fn from_body(body: &str) -> DisassociateSubnetCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateSubnetCidrBlockError::Unknown(String::from(body)),
@@ -56193,8 +56024,7 @@ impl DisassociateVpcCidrBlockError {
     pub fn from_body(body: &str) -> DisassociateVpcCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateVpcCidrBlockError::Unknown(String::from(body)),
@@ -56259,8 +56089,7 @@ impl EnableVgwRoutePropagationError {
     pub fn from_body(body: &str) -> EnableVgwRoutePropagationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVgwRoutePropagationError::Unknown(String::from(body)),
@@ -56325,8 +56154,7 @@ impl EnableVolumeIOError {
     pub fn from_body(body: &str) -> EnableVolumeIOError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVolumeIOError::Unknown(String::from(body)),
@@ -56389,8 +56217,7 @@ impl EnableVpcClassicLinkError {
     pub fn from_body(body: &str) -> EnableVpcClassicLinkError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVpcClassicLinkError::Unknown(String::from(body)),
@@ -56455,8 +56282,7 @@ impl EnableVpcClassicLinkDnsSupportError {
     pub fn from_body(body: &str) -> EnableVpcClassicLinkDnsSupportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
@@ -56521,8 +56347,7 @@ impl GetConsoleOutputError {
     pub fn from_body(body: &str) -> GetConsoleOutputError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetConsoleOutputError::Unknown(String::from(body)),
@@ -56585,8 +56410,7 @@ impl GetConsoleScreenshotError {
     pub fn from_body(body: &str) -> GetConsoleScreenshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetConsoleScreenshotError::Unknown(String::from(body)),
@@ -56651,8 +56475,7 @@ impl GetHostReservationPurchasePreviewError {
     pub fn from_body(body: &str) -> GetHostReservationPurchasePreviewError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetHostReservationPurchasePreviewError::Unknown(String::from(body)),
@@ -56717,8 +56540,7 @@ impl GetPasswordDataError {
     pub fn from_body(body: &str) -> GetPasswordDataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetPasswordDataError::Unknown(String::from(body)),
@@ -56781,8 +56603,7 @@ impl GetReservedInstancesExchangeQuoteError {
     pub fn from_body(body: &str) -> GetReservedInstancesExchangeQuoteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetReservedInstancesExchangeQuoteError::Unknown(String::from(body)),
@@ -56847,8 +56668,7 @@ impl ImportImageError {
     pub fn from_body(body: &str) -> ImportImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportImageError::Unknown(String::from(body)),
@@ -56911,8 +56731,7 @@ impl ImportInstanceError {
     pub fn from_body(body: &str) -> ImportInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportInstanceError::Unknown(String::from(body)),
@@ -56975,8 +56794,7 @@ impl ImportKeyPairError {
     pub fn from_body(body: &str) -> ImportKeyPairError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportKeyPairError::Unknown(String::from(body)),
@@ -57039,8 +56857,7 @@ impl ImportSnapshotError {
     pub fn from_body(body: &str) -> ImportSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportSnapshotError::Unknown(String::from(body)),
@@ -57103,8 +56920,7 @@ impl ImportVolumeError {
     pub fn from_body(body: &str) -> ImportVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportVolumeError::Unknown(String::from(body)),
@@ -57167,8 +56983,7 @@ impl ModifyHostsError {
     pub fn from_body(body: &str) -> ModifyHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyHostsError::Unknown(String::from(body)),
@@ -57231,8 +57046,7 @@ impl ModifyIdFormatError {
     pub fn from_body(body: &str) -> ModifyIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyIdFormatError::Unknown(String::from(body)),
@@ -57295,8 +57109,7 @@ impl ModifyIdentityIdFormatError {
     pub fn from_body(body: &str) -> ModifyIdentityIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyIdentityIdFormatError::Unknown(String::from(body)),
@@ -57361,8 +57174,7 @@ impl ModifyImageAttributeError {
     pub fn from_body(body: &str) -> ModifyImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyImageAttributeError::Unknown(String::from(body)),
@@ -57427,8 +57239,7 @@ impl ModifyInstanceAttributeError {
     pub fn from_body(body: &str) -> ModifyInstanceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyInstanceAttributeError::Unknown(String::from(body)),
@@ -57493,8 +57304,7 @@ impl ModifyInstancePlacementError {
     pub fn from_body(body: &str) -> ModifyInstancePlacementError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyInstancePlacementError::Unknown(String::from(body)),
@@ -57559,8 +57369,7 @@ impl ModifyNetworkInterfaceAttributeError {
     pub fn from_body(body: &str) -> ModifyNetworkInterfaceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyNetworkInterfaceAttributeError::Unknown(String::from(body)),
@@ -57625,8 +57434,7 @@ impl ModifyReservedInstancesError {
     pub fn from_body(body: &str) -> ModifyReservedInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyReservedInstancesError::Unknown(String::from(body)),
@@ -57691,8 +57499,7 @@ impl ModifySnapshotAttributeError {
     pub fn from_body(body: &str) -> ModifySnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifySnapshotAttributeError::Unknown(String::from(body)),
@@ -57757,8 +57564,7 @@ impl ModifySpotFleetRequestError {
     pub fn from_body(body: &str) -> ModifySpotFleetRequestError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifySpotFleetRequestError::Unknown(String::from(body)),
@@ -57823,8 +57629,7 @@ impl ModifySubnetAttributeError {
     pub fn from_body(body: &str) -> ModifySubnetAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifySubnetAttributeError::Unknown(String::from(body)),
@@ -57889,8 +57694,7 @@ impl ModifyVolumeError {
     pub fn from_body(body: &str) -> ModifyVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVolumeError::Unknown(String::from(body)),
@@ -57953,8 +57757,7 @@ impl ModifyVolumeAttributeError {
     pub fn from_body(body: &str) -> ModifyVolumeAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVolumeAttributeError::Unknown(String::from(body)),
@@ -58019,8 +57822,7 @@ impl ModifyVpcAttributeError {
     pub fn from_body(body: &str) -> ModifyVpcAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcAttributeError::Unknown(String::from(body)),
@@ -58085,8 +57887,7 @@ impl ModifyVpcEndpointError {
     pub fn from_body(body: &str) -> ModifyVpcEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointError::Unknown(String::from(body)),
@@ -58151,8 +57952,7 @@ impl ModifyVpcPeeringConnectionOptionsError {
     pub fn from_body(body: &str) -> ModifyVpcPeeringConnectionOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcPeeringConnectionOptionsError::Unknown(String::from(body)),
@@ -58217,8 +58017,7 @@ impl MonitorInstancesError {
     pub fn from_body(body: &str) -> MonitorInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => MonitorInstancesError::Unknown(String::from(body)),
@@ -58281,8 +58080,7 @@ impl MoveAddressToVpcError {
     pub fn from_body(body: &str) -> MoveAddressToVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => MoveAddressToVpcError::Unknown(String::from(body)),
@@ -58345,8 +58143,7 @@ impl PurchaseHostReservationError {
     pub fn from_body(body: &str) -> PurchaseHostReservationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PurchaseHostReservationError::Unknown(String::from(body)),
@@ -58411,8 +58208,7 @@ impl PurchaseReservedInstancesOfferingError {
     pub fn from_body(body: &str) -> PurchaseReservedInstancesOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PurchaseReservedInstancesOfferingError::Unknown(String::from(body)),
@@ -58477,8 +58273,7 @@ impl PurchaseScheduledInstancesError {
     pub fn from_body(body: &str) -> PurchaseScheduledInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PurchaseScheduledInstancesError::Unknown(String::from(body)),
@@ -58543,8 +58338,7 @@ impl RebootInstancesError {
     pub fn from_body(body: &str) -> RebootInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RebootInstancesError::Unknown(String::from(body)),
@@ -58607,8 +58401,7 @@ impl RegisterImageError {
     pub fn from_body(body: &str) -> RegisterImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RegisterImageError::Unknown(String::from(body)),
@@ -58671,8 +58464,7 @@ impl RejectVpcPeeringConnectionError {
     pub fn from_body(body: &str) -> RejectVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RejectVpcPeeringConnectionError::Unknown(String::from(body)),
@@ -58737,8 +58529,7 @@ impl ReleaseAddressError {
     pub fn from_body(body: &str) -> ReleaseAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReleaseAddressError::Unknown(String::from(body)),
@@ -58801,8 +58592,7 @@ impl ReleaseHostsError {
     pub fn from_body(body: &str) -> ReleaseHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReleaseHostsError::Unknown(String::from(body)),
@@ -58865,8 +58655,7 @@ impl ReplaceIamInstanceProfileAssociationError {
     pub fn from_body(body: &str) -> ReplaceIamInstanceProfileAssociationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceIamInstanceProfileAssociationError::Unknown(String::from(body)),
@@ -58931,8 +58720,7 @@ impl ReplaceNetworkAclAssociationError {
     pub fn from_body(body: &str) -> ReplaceNetworkAclAssociationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceNetworkAclAssociationError::Unknown(String::from(body)),
@@ -58997,8 +58785,7 @@ impl ReplaceNetworkAclEntryError {
     pub fn from_body(body: &str) -> ReplaceNetworkAclEntryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceNetworkAclEntryError::Unknown(String::from(body)),
@@ -59063,8 +58850,7 @@ impl ReplaceRouteError {
     pub fn from_body(body: &str) -> ReplaceRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceRouteError::Unknown(String::from(body)),
@@ -59127,8 +58913,7 @@ impl ReplaceRouteTableAssociationError {
     pub fn from_body(body: &str) -> ReplaceRouteTableAssociationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceRouteTableAssociationError::Unknown(String::from(body)),
@@ -59193,8 +58978,7 @@ impl ReportInstanceStatusError {
     pub fn from_body(body: &str) -> ReportInstanceStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReportInstanceStatusError::Unknown(String::from(body)),
@@ -59259,8 +59043,7 @@ impl RequestSpotFleetError {
     pub fn from_body(body: &str) -> RequestSpotFleetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RequestSpotFleetError::Unknown(String::from(body)),
@@ -59323,8 +59106,7 @@ impl RequestSpotInstancesError {
     pub fn from_body(body: &str) -> RequestSpotInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RequestSpotInstancesError::Unknown(String::from(body)),
@@ -59389,8 +59171,7 @@ impl ResetImageAttributeError {
     pub fn from_body(body: &str) -> ResetImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetImageAttributeError::Unknown(String::from(body)),
@@ -59455,8 +59236,7 @@ impl ResetInstanceAttributeError {
     pub fn from_body(body: &str) -> ResetInstanceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetInstanceAttributeError::Unknown(String::from(body)),
@@ -59521,8 +59301,7 @@ impl ResetNetworkInterfaceAttributeError {
     pub fn from_body(body: &str) -> ResetNetworkInterfaceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetNetworkInterfaceAttributeError::Unknown(String::from(body)),
@@ -59587,8 +59366,7 @@ impl ResetSnapshotAttributeError {
     pub fn from_body(body: &str) -> ResetSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetSnapshotAttributeError::Unknown(String::from(body)),
@@ -59653,8 +59431,7 @@ impl RestoreAddressToClassicError {
     pub fn from_body(body: &str) -> RestoreAddressToClassicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RestoreAddressToClassicError::Unknown(String::from(body)),
@@ -59719,8 +59496,7 @@ impl RevokeSecurityGroupEgressError {
     pub fn from_body(body: &str) -> RevokeSecurityGroupEgressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RevokeSecurityGroupEgressError::Unknown(String::from(body)),
@@ -59785,8 +59561,7 @@ impl RevokeSecurityGroupIngressError {
     pub fn from_body(body: &str) -> RevokeSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RevokeSecurityGroupIngressError::Unknown(String::from(body)),
@@ -59851,8 +59626,7 @@ impl RunInstancesError {
     pub fn from_body(body: &str) -> RunInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RunInstancesError::Unknown(String::from(body)),
@@ -59915,8 +59689,7 @@ impl RunScheduledInstancesError {
     pub fn from_body(body: &str) -> RunScheduledInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RunScheduledInstancesError::Unknown(String::from(body)),
@@ -59981,8 +59754,7 @@ impl StartInstancesError {
     pub fn from_body(body: &str) -> StartInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => StartInstancesError::Unknown(String::from(body)),
@@ -60045,8 +59817,7 @@ impl StopInstancesError {
     pub fn from_body(body: &str) -> StopInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => StopInstancesError::Unknown(String::from(body)),
@@ -60109,8 +59880,7 @@ impl TerminateInstancesError {
     pub fn from_body(body: &str) -> TerminateInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => TerminateInstancesError::Unknown(String::from(body)),
@@ -60175,8 +59945,7 @@ impl UnassignIpv6AddressesError {
     pub fn from_body(body: &str) -> UnassignIpv6AddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UnassignIpv6AddressesError::Unknown(String::from(body)),
@@ -60241,8 +60010,7 @@ impl UnassignPrivateIpAddressesError {
     pub fn from_body(body: &str) -> UnassignPrivateIpAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UnassignPrivateIpAddressesError::Unknown(String::from(body)),
@@ -60307,8 +60075,7 @@ impl UnmonitorInstancesError {
     pub fn from_body(body: &str) -> UnmonitorInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UnmonitorInstancesError::Unknown(String::from(body)),

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -7894,8 +7895,7 @@ impl AddTagsToResourceError {
     pub fn from_body(body: &str) -> AddTagsToResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => AddTagsToResourceError::CacheClusterNotFoundFault(
@@ -7988,8 +7988,7 @@ impl AuthorizeCacheSecurityGroupIngressError {
     pub fn from_body(body: &str) -> AuthorizeCacheSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationAlreadyExistsFault" => {
@@ -8104,8 +8103,7 @@ impl CopySnapshotError {
     pub fn from_body(body: &str) -> CopySnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
@@ -8222,8 +8220,7 @@ impl CreateCacheClusterError {
     pub fn from_body(body: &str) -> CreateCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterAlreadyExistsFault" => {
@@ -8382,8 +8379,7 @@ impl CreateCacheParameterGroupError {
     pub fn from_body(body: &str) -> CreateCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupAlreadyExistsFault" => {
@@ -8492,8 +8488,7 @@ impl CreateCacheSecurityGroupError {
     pub fn from_body(body: &str) -> CreateCacheSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSecurityGroupAlreadyExistsFault" => {
@@ -8590,8 +8585,7 @@ impl CreateCacheSubnetGroupError {
     pub fn from_body(body: &str) -> CreateCacheSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSubnetGroupAlreadyExistsFault" => {
@@ -8708,8 +8702,7 @@ impl CreateReplicationGroupError {
     pub fn from_body(body: &str) -> CreateReplicationGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
@@ -8884,8 +8877,7 @@ impl CreateSnapshotError {
     pub fn from_body(body: &str) -> CreateSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => CreateSnapshotError::CacheClusterNotFoundFault(
@@ -9008,8 +9000,7 @@ impl DeleteCacheClusterError {
     pub fn from_body(body: &str) -> DeleteCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => DeleteCacheClusterError::CacheClusterNotFoundFault(
@@ -9122,8 +9113,7 @@ impl DeleteCacheParameterGroupError {
     pub fn from_body(body: &str) -> DeleteCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupNotFoundFault" => {
@@ -9222,8 +9212,7 @@ impl DeleteCacheSecurityGroupError {
     pub fn from_body(body: &str) -> DeleteCacheSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSecurityGroupNotFoundFault" => {
@@ -9316,8 +9305,7 @@ impl DeleteCacheSubnetGroupError {
     pub fn from_body(body: &str) -> DeleteCacheSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSubnetGroupInUse" => DeleteCacheSubnetGroupError::CacheSubnetGroupInUse(
@@ -9406,8 +9394,7 @@ impl DeleteReplicationGroupError {
     pub fn from_body(body: &str) -> DeleteReplicationGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
@@ -9522,8 +9509,7 @@ impl DeleteSnapshotError {
     pub fn from_body(body: &str) -> DeleteSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
@@ -9610,8 +9596,7 @@ impl DescribeCacheClustersError {
     pub fn from_body(body: &str) -> DescribeCacheClustersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
@@ -9694,8 +9679,7 @@ impl DescribeCacheEngineVersionsError {
     pub fn from_body(body: &str) -> DescribeCacheEngineVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeCacheEngineVersionsError::Unknown(String::from(body)),
@@ -9766,8 +9750,7 @@ impl DescribeCacheParameterGroupsError {
     pub fn from_body(body: &str) -> DescribeCacheParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupNotFoundFault" => {
@@ -9856,8 +9839,7 @@ impl DescribeCacheParametersError {
     pub fn from_body(body: &str) -> DescribeCacheParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupNotFoundFault" => {
@@ -9946,8 +9928,7 @@ impl DescribeCacheSecurityGroupsError {
     pub fn from_body(body: &str) -> DescribeCacheSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSecurityGroupNotFoundFault" => {
@@ -10032,8 +10013,7 @@ impl DescribeCacheSubnetGroupsError {
     pub fn from_body(body: &str) -> DescribeCacheSubnetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSubnetGroupNotFoundFault" => {
@@ -10108,8 +10088,7 @@ impl DescribeEngineDefaultParametersError {
     pub fn from_body(body: &str) -> DescribeEngineDefaultParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
@@ -10190,8 +10169,7 @@ impl DescribeEventsError {
     pub fn from_body(body: &str) -> DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
@@ -10270,8 +10248,7 @@ impl DescribeReplicationGroupsError {
     pub fn from_body(body: &str) -> DescribeReplicationGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
@@ -10360,8 +10337,7 @@ impl DescribeReservedCacheNodesError {
     pub fn from_body(body: &str) -> DescribeReservedCacheNodesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
@@ -10450,8 +10426,7 @@ impl DescribeReservedCacheNodesOfferingsError {
     pub fn from_body(body: &str) -> DescribeReservedCacheNodesOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
@@ -10533,8 +10508,7 @@ impl DescribeSnapshotsError {
     pub fn from_body(body: &str) -> DescribeSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => DescribeSnapshotsError::CacheClusterNotFoundFault(
@@ -10625,8 +10599,7 @@ impl ListAllowedNodeTypeModificationsError {
     pub fn from_body(body: &str) -> ListAllowedNodeTypeModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
@@ -10723,8 +10696,7 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
@@ -10825,8 +10797,7 @@ impl ModifyCacheClusterError {
     pub fn from_body(body: &str) -> ModifyCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => ModifyCacheClusterError::CacheClusterNotFoundFault(
@@ -10963,8 +10934,7 @@ impl ModifyCacheParameterGroupError {
     pub fn from_body(body: &str) -> ModifyCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupNotFoundFault" => {
@@ -11063,8 +11033,7 @@ impl ModifyCacheSubnetGroupError {
     pub fn from_body(body: &str) -> ModifyCacheSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSubnetGroupNotFoundFault" => {
@@ -11175,8 +11144,7 @@ impl ModifyReplicationGroupError {
     pub fn from_body(body: &str) -> ModifyReplicationGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
@@ -11329,8 +11297,7 @@ impl PurchaseReservedCacheNodesOfferingError {
     pub fn from_body(body: &str) -> PurchaseReservedCacheNodesOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
@@ -11414,8 +11381,7 @@ impl RebootCacheClusterError {
     pub fn from_body(body: &str) -> RebootCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => RebootCacheClusterError::CacheClusterNotFoundFault(
@@ -11498,8 +11464,7 @@ impl RemoveTagsFromResourceError {
     pub fn from_body(body: &str) -> RemoveTagsFromResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
@@ -11590,8 +11555,7 @@ impl ResetCacheParameterGroupError {
     pub fn from_body(body: &str) -> ResetCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupNotFoundFault" => {
@@ -11690,8 +11654,7 @@ impl RevokeCacheSecurityGroupIngressError {
     pub fn from_body(body: &str) -> RevokeCacheSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => {
@@ -11806,8 +11769,7 @@ impl TestFailoverError {
     pub fn from_body(body: &str) -> TestFailoverError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "APICallRateForCustomerExceededFault" => {

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -9903,8 +9904,7 @@ impl AbortEnvironmentUpdateError {
     pub fn from_body(body: &str) -> AbortEnvironmentUpdateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -9979,8 +9979,7 @@ impl ApplyEnvironmentManagedActionError {
     pub fn from_body(body: &str) -> ApplyEnvironmentManagedActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
@@ -10057,8 +10056,7 @@ impl CheckDNSAvailabilityError {
     pub fn from_body(body: &str) -> CheckDNSAvailabilityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CheckDNSAvailabilityError::Unknown(String::from(body)),
@@ -10127,8 +10125,7 @@ impl ComposeEnvironmentsError {
     pub fn from_body(body: &str) -> ComposeEnvironmentsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -10205,8 +10202,7 @@ impl CreateApplicationError {
     pub fn from_body(body: &str) -> CreateApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TooManyApplicationsException" => {
@@ -10285,8 +10281,7 @@ impl CreateApplicationVersionError {
     pub fn from_body(body: &str) -> CreateApplicationVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CodeBuildNotInServiceRegionException" => {
@@ -10387,8 +10382,7 @@ impl CreateConfigurationTemplateError {
     pub fn from_body(body: &str) -> CreateConfigurationTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -10473,8 +10467,7 @@ impl CreateEnvironmentError {
     pub fn from_body(body: &str) -> CreateEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -10555,8 +10548,7 @@ impl CreatePlatformVersionError {
     pub fn from_body(body: &str) -> CreatePlatformVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
@@ -10643,8 +10635,7 @@ impl CreateStorageLocationError {
     pub fn from_body(body: &str) -> CreateStorageLocationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -10727,8 +10718,7 @@ impl DeleteApplicationError {
     pub fn from_body(body: &str) -> DeleteApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationInProgressException" => {
@@ -10805,8 +10795,7 @@ impl DeleteApplicationVersionError {
     pub fn from_body(body: &str) -> DeleteApplicationVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -10897,8 +10886,7 @@ impl DeleteConfigurationTemplateError {
     pub fn from_body(body: &str) -> DeleteConfigurationTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationInProgressException" => {
@@ -10969,8 +10957,7 @@ impl DeleteEnvironmentConfigurationError {
     pub fn from_body(body: &str) -> DeleteEnvironmentConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteEnvironmentConfigurationError::Unknown(String::from(body)),
@@ -11043,8 +11030,7 @@ impl DeletePlatformVersionError {
     pub fn from_body(body: &str) -> DeletePlatformVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
@@ -11131,8 +11117,7 @@ impl DescribeApplicationVersionsError {
     pub fn from_body(body: &str) -> DescribeApplicationVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeApplicationVersionsError::Unknown(String::from(body)),
@@ -11197,8 +11182,7 @@ impl DescribeApplicationsError {
     pub fn from_body(body: &str) -> DescribeApplicationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeApplicationsError::Unknown(String::from(body)),
@@ -11265,8 +11249,7 @@ impl DescribeConfigurationOptionsError {
     pub fn from_body(body: &str) -> DescribeConfigurationOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TooManyBucketsException" => DescribeConfigurationOptionsError::TooManyBuckets(
@@ -11337,8 +11320,7 @@ impl DescribeConfigurationSettingsError {
     pub fn from_body(body: &str) -> DescribeConfigurationSettingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TooManyBucketsException" => DescribeConfigurationSettingsError::TooManyBuckets(
@@ -11411,8 +11393,7 @@ impl DescribeEnvironmentHealthError {
     pub fn from_body(body: &str) -> DescribeEnvironmentHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
@@ -11489,8 +11470,7 @@ impl DescribeEnvironmentManagedActionHistoryError {
     pub fn from_body(body: &str) -> DescribeEnvironmentManagedActionHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
@@ -11565,8 +11545,7 @@ impl DescribeEnvironmentManagedActionsError {
     pub fn from_body(body: &str) -> DescribeEnvironmentManagedActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
@@ -11639,8 +11618,7 @@ impl DescribeEnvironmentResourcesError {
     pub fn from_body(body: &str) -> DescribeEnvironmentResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -11711,8 +11689,7 @@ impl DescribeEnvironmentsError {
     pub fn from_body(body: &str) -> DescribeEnvironmentsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEnvironmentsError::Unknown(String::from(body)),
@@ -11777,8 +11754,7 @@ impl DescribeEventsError {
     pub fn from_body(body: &str) -> DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
@@ -11845,8 +11821,7 @@ impl DescribeInstancesHealthError {
     pub fn from_body(body: &str) -> DescribeInstancesHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
@@ -11925,8 +11900,7 @@ impl DescribePlatformVersionError {
     pub fn from_body(body: &str) -> DescribePlatformVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
@@ -12003,8 +11977,7 @@ impl ListAvailableSolutionStacksError {
     pub fn from_body(body: &str) -> ListAvailableSolutionStacksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListAvailableSolutionStacksError::Unknown(String::from(body)),
@@ -12073,8 +12046,7 @@ impl ListPlatformVersionsError {
     pub fn from_body(body: &str) -> ListPlatformVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
@@ -12153,8 +12125,7 @@ impl RebuildEnvironmentError {
     pub fn from_body(body: &str) -> RebuildEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -12225,8 +12196,7 @@ impl RequestEnvironmentInfoError {
     pub fn from_body(body: &str) -> RequestEnvironmentInfoError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RequestEnvironmentInfoError::Unknown(String::from(body)),
@@ -12291,8 +12261,7 @@ impl RestartAppServerError {
     pub fn from_body(body: &str) -> RestartAppServerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RestartAppServerError::Unknown(String::from(body)),
@@ -12355,8 +12324,7 @@ impl RetrieveEnvironmentInfoError {
     pub fn from_body(body: &str) -> RetrieveEnvironmentInfoError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RetrieveEnvironmentInfoError::Unknown(String::from(body)),
@@ -12421,8 +12389,7 @@ impl SwapEnvironmentCNAMEsError {
     pub fn from_body(body: &str) -> SwapEnvironmentCNAMEsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SwapEnvironmentCNAMEsError::Unknown(String::from(body)),
@@ -12489,8 +12456,7 @@ impl TerminateEnvironmentError {
     pub fn from_body(body: &str) -> TerminateEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -12561,8 +12527,7 @@ impl UpdateApplicationError {
     pub fn from_body(body: &str) -> UpdateApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateApplicationError::Unknown(String::from(body)),
@@ -12629,8 +12594,7 @@ impl UpdateApplicationResourceLifecycleError {
     pub fn from_body(body: &str) -> UpdateApplicationResourceLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -12701,8 +12665,7 @@ impl UpdateApplicationVersionError {
     pub fn from_body(body: &str) -> UpdateApplicationVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateApplicationVersionError::Unknown(String::from(body)),
@@ -12771,8 +12734,7 @@ impl UpdateConfigurationTemplateError {
     pub fn from_body(body: &str) -> UpdateConfigurationTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -12851,8 +12813,7 @@ impl UpdateEnvironmentError {
     pub fn from_body(body: &str) -> UpdateEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
@@ -12931,8 +12892,7 @@ impl ValidateConfigurationSettingsError {
     pub fn from_body(body: &str) -> ValidateConfigurationSettingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -5609,8 +5610,7 @@ impl AddTagsError {
     pub fn from_body(body: &str) -> AddTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -5691,8 +5691,7 @@ impl ApplySecurityGroupsToLoadBalancerError {
     pub fn from_body(body: &str) -> ApplySecurityGroupsToLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -5783,8 +5782,7 @@ impl AttachLoadBalancerToSubnetsError {
     pub fn from_body(body: &str) -> AttachLoadBalancerToSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -5871,8 +5869,7 @@ impl ConfigureHealthCheckError {
     pub fn from_body(body: &str) -> ConfigureHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => ConfigureHealthCheckError::AccessPointNotFound(
@@ -5949,8 +5946,7 @@ impl CreateAppCookieStickinessPolicyError {
     pub fn from_body(body: &str) -> CreateAppCookieStickinessPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -6047,8 +6043,7 @@ impl CreateLBCookieStickinessPolicyError {
     pub fn from_body(body: &str) -> CreateLBCookieStickinessPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -6159,8 +6154,7 @@ impl CreateLoadBalancerError {
     pub fn from_body(body: &str) -> CreateLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CertificateNotFoundException" => {
@@ -6283,8 +6277,7 @@ impl CreateLoadBalancerListenersError {
     pub fn from_body(body: &str) -> CreateLoadBalancerListenersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -6389,8 +6382,7 @@ impl CreateLoadBalancerPolicyError {
     pub fn from_body(body: &str) -> CreateLoadBalancerPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -6483,8 +6475,7 @@ impl DeleteLoadBalancerError {
     pub fn from_body(body: &str) -> DeleteLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteLoadBalancerError::Unknown(String::from(body)),
@@ -6551,8 +6542,7 @@ impl DeleteLoadBalancerListenersError {
     pub fn from_body(body: &str) -> DeleteLoadBalancerListenersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -6627,8 +6617,7 @@ impl DeleteLoadBalancerPolicyError {
     pub fn from_body(body: &str) -> DeleteLoadBalancerPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -6709,8 +6698,7 @@ impl DeregisterInstancesFromLoadBalancerError {
     pub fn from_body(body: &str) -> DeregisterInstancesFromLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -6787,8 +6775,7 @@ impl DescribeAccountLimitsError {
     pub fn from_body(body: &str) -> DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
@@ -6857,8 +6844,7 @@ impl DescribeInstanceHealthError {
     pub fn from_body(body: &str) -> DescribeInstanceHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -6937,8 +6923,7 @@ impl DescribeLoadBalancerAttributesError {
     pub fn from_body(body: &str) -> DescribeLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -7019,8 +7004,7 @@ impl DescribeLoadBalancerPoliciesError {
     pub fn from_body(body: &str) -> DescribeLoadBalancerPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -7097,8 +7081,7 @@ impl DescribeLoadBalancerPolicyTypesError {
     pub fn from_body(body: &str) -> DescribeLoadBalancerPolicyTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "PolicyTypeNotFoundException" => {
@@ -7173,8 +7156,7 @@ impl DescribeLoadBalancersError {
     pub fn from_body(body: &str) -> DescribeLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => DescribeLoadBalancersError::AccessPointNotFound(
@@ -7249,8 +7231,7 @@ impl DescribeTagsError {
     pub fn from_body(body: &str) -> DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -7321,8 +7302,7 @@ impl DetachLoadBalancerFromSubnetsError {
     pub fn from_body(body: &str) -> DetachLoadBalancerFromSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -7403,8 +7383,7 @@ impl DisableAvailabilityZonesForLoadBalancerError {
     pub fn from_body(body: &str) -> DisableAvailabilityZonesForLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -7485,8 +7464,7 @@ impl EnableAvailabilityZonesForLoadBalancerError {
     pub fn from_body(body: &str) -> EnableAvailabilityZonesForLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -7563,8 +7541,7 @@ impl ModifyLoadBalancerAttributesError {
     pub fn from_body(body: &str) -> ModifyLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -7651,8 +7628,7 @@ impl RegisterInstancesWithLoadBalancerError {
     pub fn from_body(body: &str) -> RegisterInstancesWithLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -7731,8 +7707,7 @@ impl RemoveTagsError {
     pub fn from_body(body: &str) -> RemoveTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -7809,8 +7784,7 @@ impl SetLoadBalancerListenerSSLCertificateError {
     pub fn from_body(body: &str) -> SetLoadBalancerListenerSSLCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -7913,8 +7887,7 @@ impl SetLoadBalancerPoliciesForBackendServerError {
     pub fn from_body(body: &str) -> SetLoadBalancerPoliciesForBackendServerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
@@ -8007,8 +7980,7 @@ impl SetLoadBalancerPoliciesOfListenerError {
     pub fn from_body(body: &str) -> SetLoadBalancerPoliciesOfListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -5787,8 +5788,7 @@ impl AddTagsError {
     pub fn from_body(body: &str) -> AddTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DuplicateTagKeysException" => {
@@ -5891,8 +5891,7 @@ impl CreateListenerError {
     pub fn from_body(body: &str) -> CreateListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CertificateNotFoundException" => {
@@ -6027,8 +6026,7 @@ impl CreateLoadBalancerError {
     pub fn from_body(body: &str) -> CreateLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DuplicateLoadBalancerNameException" => {
@@ -6149,8 +6147,7 @@ impl CreateRuleError {
     pub fn from_body(body: &str) -> CreateRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidConfigurationRequestException" => {
@@ -6251,8 +6248,7 @@ impl CreateTargetGroupError {
     pub fn from_body(body: &str) -> CreateTargetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DuplicateTargetGroupNameException" => {
@@ -6329,8 +6325,7 @@ impl DeleteListenerError {
     pub fn from_body(body: &str) -> DeleteListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => {
@@ -6401,8 +6396,7 @@ impl DeleteLoadBalancerError {
     pub fn from_body(body: &str) -> DeleteLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LoadBalancerNotFoundException" => DeleteLoadBalancerError::LoadBalancerNotFound(
@@ -6481,8 +6475,7 @@ impl DeleteRuleError {
     pub fn from_body(body: &str) -> DeleteRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationNotPermittedException" => {
@@ -6555,8 +6548,7 @@ impl DeleteTargetGroupError {
     pub fn from_body(body: &str) -> DeleteTargetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceInUseException" => {
@@ -6629,8 +6621,7 @@ impl DeregisterTargetsError {
     pub fn from_body(body: &str) -> DeregisterTargetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTargetException" => {
@@ -6703,8 +6694,7 @@ impl DescribeAccountLimitsError {
     pub fn from_body(body: &str) -> DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
@@ -6773,8 +6763,7 @@ impl DescribeListenersError {
     pub fn from_body(body: &str) -> DescribeListenersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => {
@@ -6849,8 +6838,7 @@ impl DescribeLoadBalancerAttributesError {
     pub fn from_body(body: &str) -> DescribeLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LoadBalancerNotFoundException" => {
@@ -6923,8 +6911,7 @@ impl DescribeLoadBalancersError {
     pub fn from_body(body: &str) -> DescribeLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LoadBalancerNotFoundException" => {
@@ -6999,8 +6986,7 @@ impl DescribeRulesError {
     pub fn from_body(body: &str) -> DescribeRulesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => {
@@ -7073,8 +7059,7 @@ impl DescribeSSLPoliciesError {
     pub fn from_body(body: &str) -> DescribeSSLPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "SSLPolicyNotFoundException" => {
@@ -7151,8 +7136,7 @@ impl DescribeTagsError {
     pub fn from_body(body: &str) -> DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => {
@@ -7233,8 +7217,7 @@ impl DescribeTargetGroupAttributesError {
     pub fn from_body(body: &str) -> DescribeTargetGroupAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TargetGroupNotFoundException" => {
@@ -7309,8 +7292,7 @@ impl DescribeTargetGroupsError {
     pub fn from_body(body: &str) -> DescribeTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LoadBalancerNotFoundException" => {
@@ -7391,8 +7373,7 @@ impl DescribeTargetHealthError {
     pub fn from_body(body: &str) -> DescribeTargetHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HealthUnavailableException" => {
@@ -7493,8 +7474,7 @@ impl ModifyListenerError {
     pub fn from_body(body: &str) -> ModifyListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CertificateNotFoundException" => {
@@ -7615,8 +7595,7 @@ impl ModifyLoadBalancerAttributesError {
     pub fn from_body(body: &str) -> ModifyLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidConfigurationRequestException" => {
@@ -7705,8 +7684,7 @@ impl ModifyRuleError {
     pub fn from_body(body: &str) -> ModifyRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationNotPermittedException" => {
@@ -7797,8 +7775,7 @@ impl ModifyTargetGroupError {
     pub fn from_body(body: &str) -> ModifyTargetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TargetGroupNotFoundException" => {
@@ -7869,8 +7846,7 @@ impl ModifyTargetGroupAttributesError {
     pub fn from_body(body: &str) -> ModifyTargetGroupAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TargetGroupNotFoundException" => {
@@ -7949,8 +7925,7 @@ impl RegisterTargetsError {
     pub fn from_body(body: &str) -> RegisterTargetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTargetException" => {
@@ -8041,8 +8016,7 @@ impl RemoveTagsError {
     pub fn from_body(body: &str) -> RemoveTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => {
@@ -8131,8 +8105,7 @@ impl SetIpAddressTypeError {
     pub fn from_body(body: &str) -> SetIpAddressTypeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidConfigurationRequestException" => {
@@ -8215,8 +8188,7 @@ impl SetRulePrioritiesError {
     pub fn from_body(body: &str) -> SetRulePrioritiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationNotPermittedException" => SetRulePrioritiesError::OperationNotPermitted(
@@ -8299,8 +8271,7 @@ impl SetSecurityGroupsError {
     pub fn from_body(body: &str) -> SetSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidConfigurationRequestException" => {
@@ -8387,8 +8358,7 @@ impl SetSubnetsError {
     pub fn from_body(body: &str) -> SetSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidConfigurationRequestException" => {

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -12648,8 +12649,7 @@ impl AddClientIDToOpenIDConnectProviderError {
     pub fn from_body(body: &str) -> AddClientIDToOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => AddClientIDToOpenIDConnectProviderError::InvalidInput(
@@ -12744,8 +12744,7 @@ impl AddRoleToInstanceProfileError {
     pub fn from_body(body: &str) -> AddRoleToInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -12840,8 +12839,7 @@ impl AddUserToGroupError {
     pub fn from_body(body: &str) -> AddUserToGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -12924,8 +12922,7 @@ impl AttachGroupPolicyError {
     pub fn from_body(body: &str) -> AttachGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -13016,8 +13013,7 @@ impl AttachRolePolicyError {
     pub fn from_body(body: &str) -> AttachRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -13108,8 +13104,7 @@ impl AttachUserPolicyError {
     pub fn from_body(body: &str) -> AttachUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -13200,8 +13195,7 @@ impl ChangePasswordError {
     pub fn from_body(body: &str) -> ChangePasswordError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityTemporarilyUnmodifiableException" => {
@@ -13296,8 +13290,7 @@ impl CreateAccessKeyError {
     pub fn from_body(body: &str) -> CreateAccessKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -13378,8 +13371,7 @@ impl CreateAccountAliasError {
     pub fn from_body(body: &str) -> CreateAccountAliasError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -13464,8 +13456,7 @@ impl CreateGroupError {
     pub fn from_body(body: &str) -> CreateGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -13550,8 +13541,7 @@ impl CreateInstanceProfileError {
     pub fn from_body(body: &str) -> CreateInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => CreateInstanceProfileError::EntityAlreadyExists(
@@ -13638,8 +13628,7 @@ impl CreateLoginProfileError {
     pub fn from_body(body: &str) -> CreateLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -13734,8 +13723,7 @@ impl CreateOpenIDConnectProviderError {
     pub fn from_body(body: &str) -> CreateOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -13828,8 +13816,7 @@ impl CreatePolicyError {
     pub fn from_body(body: &str) -> CreatePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -13922,8 +13909,7 @@ impl CreatePolicyVersionError {
     pub fn from_body(body: &str) -> CreatePolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -14020,8 +14006,7 @@ impl CreateRoleError {
     pub fn from_body(body: &str) -> CreateRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -14112,8 +14097,7 @@ impl CreateSAMLProviderError {
     pub fn from_body(body: &str) -> CreateSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -14202,8 +14186,7 @@ impl CreateServiceLinkedRoleError {
     pub fn from_body(body: &str) -> CreateServiceLinkedRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -14290,8 +14273,7 @@ impl CreateServiceSpecificCredentialError {
     pub fn from_body(body: &str) -> CreateServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => CreateServiceSpecificCredentialError::LimitExceeded(
@@ -14378,8 +14360,7 @@ impl CreateUserError {
     pub fn from_body(body: &str) -> CreateUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -14464,8 +14445,7 @@ impl CreateVirtualMFADeviceError {
     pub fn from_body(body: &str) -> CreateVirtualMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -14552,8 +14532,7 @@ impl DeactivateMFADeviceError {
     pub fn from_body(body: &str) -> DeactivateMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityTemporarilyUnmodifiableException" => {
@@ -14642,8 +14621,7 @@ impl DeleteAccessKeyError {
     pub fn from_body(body: &str) -> DeleteAccessKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -14724,8 +14702,7 @@ impl DeleteAccountAliasError {
     pub fn from_body(body: &str) -> DeleteAccountAliasError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -14808,8 +14785,7 @@ impl DeleteAccountPasswordPolicyError {
     pub fn from_body(body: &str) -> DeleteAccountPasswordPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => DeleteAccountPasswordPolicyError::LimitExceeded(
@@ -14894,8 +14870,7 @@ impl DeleteGroupError {
     pub fn from_body(body: &str) -> DeleteGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
@@ -14980,8 +14955,7 @@ impl DeleteGroupPolicyError {
     pub fn from_body(body: &str) -> DeleteGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -15066,8 +15040,7 @@ impl DeleteInstanceProfileError {
     pub fn from_body(body: &str) -> DeleteInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
@@ -15156,8 +15129,7 @@ impl DeleteLoginProfileError {
     pub fn from_body(body: &str) -> DeleteLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityTemporarilyUnmodifiableException" => {
@@ -15246,8 +15218,7 @@ impl DeleteOpenIDConnectProviderError {
     pub fn from_body(body: &str) -> DeleteOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => DeleteOpenIDConnectProviderError::InvalidInput(
@@ -15334,8 +15305,7 @@ impl DeletePolicyError {
     pub fn from_body(body: &str) -> DeletePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
@@ -15428,8 +15398,7 @@ impl DeletePolicyVersionError {
     pub fn from_body(body: &str) -> DeletePolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
@@ -15524,8 +15493,7 @@ impl DeleteRoleError {
     pub fn from_body(body: &str) -> DeleteRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
@@ -15616,8 +15584,7 @@ impl DeleteRolePolicyError {
     pub fn from_body(body: &str) -> DeleteRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -15704,8 +15671,7 @@ impl DeleteSAMLProviderError {
     pub fn from_body(body: &str) -> DeleteSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -15788,8 +15754,7 @@ impl DeleteSSHPublicKeyError {
     pub fn from_body(body: &str) -> DeleteSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -15866,8 +15831,7 @@ impl DeleteServerCertificateError {
     pub fn from_body(body: &str) -> DeleteServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
@@ -15950,8 +15914,7 @@ impl DeleteServiceSpecificCredentialError {
     pub fn from_body(body: &str) -> DeleteServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => DeleteServiceSpecificCredentialError::NoSuchEntity(
@@ -16026,8 +15989,7 @@ impl DeleteSigningCertificateError {
     pub fn from_body(body: &str) -> DeleteSigningCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -16112,8 +16074,7 @@ impl DeleteUserError {
     pub fn from_body(body: &str) -> DeleteUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
@@ -16198,8 +16159,7 @@ impl DeleteUserPolicyError {
     pub fn from_body(body: &str) -> DeleteUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -16282,8 +16242,7 @@ impl DeleteVirtualMFADeviceError {
     pub fn from_body(body: &str) -> DeleteVirtualMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
@@ -16372,8 +16331,7 @@ impl DetachGroupPolicyError {
     pub fn from_body(body: &str) -> DetachGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -16464,8 +16422,7 @@ impl DetachRolePolicyError {
     pub fn from_body(body: &str) -> DetachRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -16556,8 +16513,7 @@ impl DetachUserPolicyError {
     pub fn from_body(body: &str) -> DetachUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -16648,8 +16604,7 @@ impl EnableMFADeviceError {
     pub fn from_body(body: &str) -> EnableMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -16744,8 +16699,7 @@ impl GenerateCredentialReportError {
     pub fn from_body(body: &str) -> GenerateCredentialReportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -16820,8 +16774,7 @@ impl GetAccessKeyLastUsedError {
     pub fn from_body(body: &str) -> GetAccessKeyLastUsedError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -16892,8 +16845,7 @@ impl GetAccountAuthorizationDetailsError {
     pub fn from_body(body: &str) -> GetAccountAuthorizationDetailsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => GetAccountAuthorizationDetailsError::ServiceFailure(
@@ -16966,8 +16918,7 @@ impl GetAccountPasswordPolicyError {
     pub fn from_body(body: &str) -> GetAccountPasswordPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -17042,8 +16993,7 @@ impl GetAccountSummaryError {
     pub fn from_body(body: &str) -> GetAccountSummaryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
@@ -17114,8 +17064,7 @@ impl GetContextKeysForCustomPolicyError {
     pub fn from_body(body: &str) -> GetContextKeysForCustomPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => GetContextKeysForCustomPolicyError::InvalidInput(
@@ -17188,8 +17137,7 @@ impl GetContextKeysForPrincipalPolicyError {
     pub fn from_body(body: &str) -> GetContextKeysForPrincipalPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => GetContextKeysForPrincipalPolicyError::InvalidInput(
@@ -17270,8 +17218,7 @@ impl GetCredentialReportError {
     pub fn from_body(body: &str) -> GetCredentialReportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CredentialReportExpiredException" => {
@@ -17362,8 +17309,7 @@ impl GetGroupError {
     pub fn from_body(body: &str) -> GetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -17438,8 +17384,7 @@ impl GetGroupPolicyError {
     pub fn from_body(body: &str) -> GetGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -17514,8 +17459,7 @@ impl GetInstanceProfileError {
     pub fn from_body(body: &str) -> GetInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -17592,8 +17536,7 @@ impl GetLoginProfileError {
     pub fn from_body(body: &str) -> GetLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -17670,8 +17613,7 @@ impl GetOpenIDConnectProviderError {
     pub fn from_body(body: &str) -> GetOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -17754,8 +17696,7 @@ impl GetPolicyError {
     pub fn from_body(body: &str) -> GetPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -17836,8 +17777,7 @@ impl GetPolicyVersionError {
     pub fn from_body(body: &str) -> GetPolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -17916,8 +17856,7 @@ impl GetRoleError {
     pub fn from_body(body: &str) -> GetRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -17992,8 +17931,7 @@ impl GetRolePolicyError {
     pub fn from_body(body: &str) -> GetRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -18070,8 +18008,7 @@ impl GetSAMLProviderError {
     pub fn from_body(body: &str) -> GetSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -18150,8 +18087,7 @@ impl GetSSHPublicKeyError {
     pub fn from_body(body: &str) -> GetSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -18228,8 +18164,7 @@ impl GetServerCertificateError {
     pub fn from_body(body: &str) -> GetServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -18306,8 +18241,7 @@ impl GetUserError {
     pub fn from_body(body: &str) -> GetUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -18382,8 +18316,7 @@ impl GetUserPolicyError {
     pub fn from_body(body: &str) -> GetUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -18458,8 +18391,7 @@ impl ListAccessKeysError {
     pub fn from_body(body: &str) -> ListAccessKeysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -18532,8 +18464,7 @@ impl ListAccountAliasesError {
     pub fn from_body(body: &str) -> ListAccountAliasesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
@@ -18608,8 +18539,7 @@ impl ListAttachedGroupPoliciesError {
     pub fn from_body(body: &str) -> ListAttachedGroupPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -18692,8 +18622,7 @@ impl ListAttachedRolePoliciesError {
     pub fn from_body(body: &str) -> ListAttachedRolePoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -18776,8 +18705,7 @@ impl ListAttachedUserPoliciesError {
     pub fn from_body(body: &str) -> ListAttachedUserPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -18860,8 +18788,7 @@ impl ListEntitiesForPolicyError {
     pub fn from_body(body: &str) -> ListEntitiesForPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -18942,8 +18869,7 @@ impl ListGroupPoliciesError {
     pub fn from_body(body: &str) -> ListGroupPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -19018,8 +18944,7 @@ impl ListGroupsError {
     pub fn from_body(body: &str) -> ListGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
@@ -19090,8 +19015,7 @@ impl ListGroupsForUserError {
     pub fn from_body(body: &str) -> ListGroupsForUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -19166,8 +19090,7 @@ impl ListInstanceProfilesError {
     pub fn from_body(body: &str) -> ListInstanceProfilesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
@@ -19240,8 +19163,7 @@ impl ListInstanceProfilesForRoleError {
     pub fn from_body(body: &str) -> ListInstanceProfilesForRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => ListInstanceProfilesForRoleError::NoSuchEntity(
@@ -19318,8 +19240,7 @@ impl ListMFADevicesError {
     pub fn from_body(body: &str) -> ListMFADevicesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -19392,8 +19313,7 @@ impl ListOpenIDConnectProvidersError {
     pub fn from_body(body: &str) -> ListOpenIDConnectProvidersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => ListOpenIDConnectProvidersError::ServiceFailure(
@@ -19464,8 +19384,7 @@ impl ListPoliciesError {
     pub fn from_body(body: &str) -> ListPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
@@ -19538,8 +19457,7 @@ impl ListPolicyVersionsError {
     pub fn from_body(body: &str) -> ListPolicyVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -19620,8 +19538,7 @@ impl ListRolePoliciesError {
     pub fn from_body(body: &str) -> ListRolePoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -19694,8 +19611,7 @@ impl ListRolesError {
     pub fn from_body(body: &str) -> ListRolesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
@@ -19764,8 +19680,7 @@ impl ListSAMLProvidersError {
     pub fn from_body(body: &str) -> ListSAMLProvidersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
@@ -19836,8 +19751,7 @@ impl ListSSHPublicKeysError {
     pub fn from_body(body: &str) -> ListSSHPublicKeysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -19908,8 +19822,7 @@ impl ListServerCertificatesError {
     pub fn from_body(body: &str) -> ListServerCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
@@ -19982,8 +19895,7 @@ impl ListServiceSpecificCredentialsError {
     pub fn from_body(body: &str) -> ListServiceSpecificCredentialsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => ListServiceSpecificCredentialsError::NoSuchEntity(
@@ -20062,8 +19974,7 @@ impl ListSigningCertificatesError {
     pub fn from_body(body: &str) -> ListSigningCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -20140,8 +20051,7 @@ impl ListUserPoliciesError {
     pub fn from_body(body: &str) -> ListUserPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -20214,8 +20124,7 @@ impl ListUsersError {
     pub fn from_body(body: &str) -> ListUsersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
@@ -20282,8 +20191,7 @@ impl ListVirtualMFADevicesError {
     pub fn from_body(body: &str) -> ListVirtualMFADevicesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListVirtualMFADevicesError::Unknown(String::from(body)),
@@ -20356,8 +20264,7 @@ impl PutGroupPolicyError {
     pub fn from_body(body: &str) -> PutGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -20446,8 +20353,7 @@ impl PutRolePolicyError {
     pub fn from_body(body: &str) -> PutRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -20538,8 +20444,7 @@ impl PutUserPolicyError {
     pub fn from_body(body: &str) -> PutUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -20624,8 +20529,7 @@ impl RemoveClientIDFromOpenIDConnectProviderError {
     pub fn from_body(body: &str) -> RemoveClientIDFromOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -20716,8 +20620,7 @@ impl RemoveRoleFromInstanceProfileError {
     pub fn from_body(body: &str) -> RemoveRoleFromInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => RemoveRoleFromInstanceProfileError::LimitExceeded(
@@ -20806,8 +20709,7 @@ impl RemoveUserFromGroupError {
     pub fn from_body(body: &str) -> RemoveUserFromGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -20886,8 +20788,7 @@ impl ResetServiceSpecificCredentialError {
     pub fn from_body(body: &str) -> ResetServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => ResetServiceSpecificCredentialError::NoSuchEntity(
@@ -20964,8 +20865,7 @@ impl ResyncMFADeviceError {
     pub fn from_body(body: &str) -> ResyncMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidAuthenticationCodeException" => {
@@ -21054,8 +20954,7 @@ impl SetDefaultPolicyVersionError {
     pub fn from_body(body: &str) -> SetDefaultPolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -21140,8 +21039,7 @@ impl SimulateCustomPolicyError {
     pub fn from_body(body: &str) -> SimulateCustomPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -21220,8 +21118,7 @@ impl SimulatePrincipalPolicyError {
     pub fn from_body(body: &str) -> SimulatePrincipalPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -21304,8 +21201,7 @@ impl UpdateAccessKeyError {
     pub fn from_body(body: &str) -> UpdateAccessKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -21388,8 +21284,7 @@ impl UpdateAccountPasswordPolicyError {
     pub fn from_body(body: &str) -> UpdateAccountPasswordPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => UpdateAccountPasswordPolicyError::LimitExceeded(
@@ -21482,8 +21377,7 @@ impl UpdateAssumeRolePolicyError {
     pub fn from_body(body: &str) -> UpdateAssumeRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -21578,8 +21472,7 @@ impl UpdateGroupError {
     pub fn from_body(body: &str) -> UpdateGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -21668,8 +21561,7 @@ impl UpdateLoginProfileError {
     pub fn from_body(body: &str) -> UpdateLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityTemporarilyUnmodifiableException" => {
@@ -21764,8 +21656,7 @@ impl UpdateOpenIDConnectProviderThumbprintError {
     pub fn from_body(body: &str) -> UpdateOpenIDConnectProviderThumbprintError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -21854,8 +21745,7 @@ impl UpdateRoleDescriptionError {
     pub fn from_body(body: &str) -> UpdateRoleDescriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -21940,8 +21830,7 @@ impl UpdateSAMLProviderError {
     pub fn from_body(body: &str) -> UpdateSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
@@ -22024,8 +21913,7 @@ impl UpdateSSHPublicKeyError {
     pub fn from_body(body: &str) -> UpdateSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
@@ -22102,8 +21990,7 @@ impl UpdateServerCertificateError {
     pub fn from_body(body: &str) -> UpdateServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -22188,8 +22075,7 @@ impl UpdateServiceSpecificCredentialError {
     pub fn from_body(body: &str) -> UpdateServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => UpdateServiceSpecificCredentialError::NoSuchEntity(
@@ -22264,8 +22150,7 @@ impl UpdateSigningCertificateError {
     pub fn from_body(body: &str) -> UpdateSigningCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
@@ -22352,8 +22237,7 @@ impl UpdateUserError {
     pub fn from_body(body: &str) -> UpdateUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -22448,8 +22332,7 @@ impl UploadSSHPublicKeyError {
     pub fn from_body(body: &str) -> UploadSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DuplicateSSHPublicKeyException" => {
@@ -22548,8 +22431,7 @@ impl UploadServerCertificateError {
     pub fn from_body(body: &str) -> UploadServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
@@ -22652,8 +22534,7 @@ impl UploadSigningCertificateError {
     pub fn from_body(body: &str) -> UploadSigningCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DuplicateCertificateException" => {

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -1287,8 +1288,7 @@ impl CancelJobError {
     pub fn from_body(body: &str) -> CancelJobError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "UnableToCancelJobIdException" => {
@@ -1407,8 +1407,7 @@ impl CreateJobError {
     pub fn from_body(body: &str) -> CreateJobError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CreateJobQuotaExceededException" => {
@@ -1549,8 +1548,7 @@ impl GetShippingLabelError {
     pub fn from_body(body: &str) -> GetShippingLabelError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ExpiredJobIdException" => {
@@ -1651,8 +1649,7 @@ impl GetStatusError {
     pub fn from_body(body: &str) -> GetStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ExpiredJobIdException" => {
@@ -1741,8 +1738,7 @@ impl ListJobsError {
     pub fn from_body(body: &str) -> ListJobsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterException" => {
@@ -1853,8 +1849,7 @@ impl UpdateJobError {
     pub fn from_body(body: &str) -> UpdateJobError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "UnableToUpdateJobIdException" => {

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -17039,8 +17040,7 @@ impl AddRoleToDBClusterError {
     pub fn from_body(body: &str) -> AddRoleToDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => AddRoleToDBClusterError::DBClusterNotFoundFault(
@@ -17131,8 +17131,7 @@ impl AddSourceIdentifierToSubscriptionError {
     pub fn from_body(body: &str) -> AddSourceIdentifierToSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "SourceNotFoundFault" => {
@@ -17215,8 +17214,7 @@ impl AddTagsToResourceError {
     pub fn from_body(body: &str) -> AddTagsToResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => AddTagsToResourceError::DBClusterNotFoundFault(
@@ -17295,8 +17293,7 @@ impl ApplyPendingMaintenanceActionError {
     pub fn from_body(body: &str) -> ApplyPendingMaintenanceActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceNotFoundFault" => {
@@ -17375,8 +17372,7 @@ impl AuthorizeDBSecurityGroupIngressError {
     pub fn from_body(body: &str) -> AuthorizeDBSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationAlreadyExistsFault" => {
@@ -17477,8 +17473,7 @@ impl CopyDBClusterParameterGroupError {
     pub fn from_body(body: &str) -> CopyDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupAlreadyExistsFault" => {
@@ -17577,8 +17572,7 @@ impl CopyDBClusterSnapshotError {
     pub fn from_body(body: &str) -> CopyDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterSnapshotAlreadyExistsFault" => {
@@ -17685,8 +17679,7 @@ impl CopyDBParameterGroupError {
     pub fn from_body(body: &str) -> CopyDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupAlreadyExistsFault" => {
@@ -17779,8 +17772,7 @@ impl CopyDBSnapshotError {
     pub fn from_body(body: &str) -> CopyDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotAlreadyExistsFault" => {
@@ -17871,8 +17863,7 @@ impl CopyOptionGroupError {
     pub fn from_body(body: &str) -> CopyOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OptionGroupAlreadyExistsFault" => {
@@ -17981,8 +17972,7 @@ impl CreateDBClusterError {
     pub fn from_body(body: &str) -> CreateDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterAlreadyExistsFault" => {
@@ -18125,8 +18115,7 @@ impl CreateDBClusterParameterGroupError {
     pub fn from_body(body: &str) -> CreateDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupAlreadyExistsFault" => {
@@ -18217,8 +18206,7 @@ impl CreateDBClusterSnapshotError {
     pub fn from_body(body: &str) -> CreateDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => CreateDBClusterSnapshotError::DBClusterNotFoundFault(
@@ -18347,8 +18335,7 @@ impl CreateDBInstanceError {
     pub fn from_body(body: &str) -> CreateDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => CreateDBInstanceError::AuthorizationNotFoundFault(
@@ -18535,8 +18522,7 @@ impl CreateDBInstanceReadReplicaError {
     pub fn from_body(body: &str) -> CreateDBInstanceReadReplicaError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceAlreadyExistsFault" => {
@@ -18717,8 +18703,7 @@ impl CreateDBParameterGroupError {
     pub fn from_body(body: &str) -> CreateDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupAlreadyExistsFault" => {
@@ -18801,8 +18786,7 @@ impl CreateDBSecurityGroupError {
     pub fn from_body(body: &str) -> CreateDBSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSecurityGroupAlreadyExistsFault" => {
@@ -18893,8 +18877,7 @@ impl CreateDBSnapshotError {
     pub fn from_body(body: &str) -> CreateDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => CreateDBSnapshotError::DBInstanceNotFoundFault(
@@ -18987,8 +18970,7 @@ impl CreateDBSubnetGroupError {
     pub fn from_body(body: &str) -> CreateDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSubnetGroupAlreadyExistsFault" => {
@@ -19095,8 +19077,7 @@ impl CreateEventSubscriptionError {
     pub fn from_body(body: &str) -> CreateEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EventSubscriptionQuotaExceededFault" => {
@@ -19203,8 +19184,7 @@ impl CreateOptionGroupError {
     pub fn from_body(body: &str) -> CreateOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OptionGroupAlreadyExistsFault" => {
@@ -19291,8 +19271,7 @@ impl DeleteDBClusterError {
     pub fn from_body(body: &str) -> DeleteDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => {
@@ -19383,8 +19362,7 @@ impl DeleteDBClusterParameterGroupError {
     pub fn from_body(body: &str) -> DeleteDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
@@ -19467,8 +19445,7 @@ impl DeleteDBClusterSnapshotError {
     pub fn from_body(body: &str) -> DeleteDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterSnapshotNotFoundFault" => {
@@ -19555,8 +19532,7 @@ impl DeleteDBInstanceError {
     pub fn from_body(body: &str) -> DeleteDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => DeleteDBInstanceError::DBInstanceNotFoundFault(
@@ -19647,8 +19623,7 @@ impl DeleteDBParameterGroupError {
     pub fn from_body(body: &str) -> DeleteDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
@@ -19729,8 +19704,7 @@ impl DeleteDBSecurityGroupError {
     pub fn from_body(body: &str) -> DeleteDBSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSecurityGroupNotFoundFault" => {
@@ -19811,8 +19785,7 @@ impl DeleteDBSnapshotError {
     pub fn from_body(body: &str) -> DeleteDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotNotFoundFault" => DeleteDBSnapshotError::DBSnapshotNotFoundFault(
@@ -19891,8 +19864,7 @@ impl DeleteDBSubnetGroupError {
     pub fn from_body(body: &str) -> DeleteDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSubnetGroupNotFoundFault" => {
@@ -19979,8 +19951,7 @@ impl DeleteEventSubscriptionError {
     pub fn from_body(body: &str) -> DeleteEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidEventSubscriptionStateFault" => {
@@ -20061,8 +20032,7 @@ impl DeleteOptionGroupError {
     pub fn from_body(body: &str) -> DeleteOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOptionGroupStateFault" => {
@@ -20137,8 +20107,7 @@ impl DescribeAccountAttributesError {
     pub fn from_body(body: &str) -> DescribeAccountAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountAttributesError::Unknown(String::from(body)),
@@ -20205,8 +20174,7 @@ impl DescribeCertificatesError {
     pub fn from_body(body: &str) -> DescribeCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CertificateNotFoundFault" => DescribeCertificatesError::CertificateNotFoundFault(
@@ -20277,8 +20245,7 @@ impl DescribeDBClusterParameterGroupsError {
     pub fn from_body(body: &str) -> DescribeDBClusterParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
@@ -20353,8 +20320,7 @@ impl DescribeDBClusterParametersError {
     pub fn from_body(body: &str) -> DescribeDBClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
@@ -20427,8 +20393,7 @@ impl DescribeDBClusterSnapshotAttributesError {
     pub fn from_body(body: &str) -> DescribeDBClusterSnapshotAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterSnapshotNotFoundFault" => {
@@ -20503,8 +20468,7 @@ impl DescribeDBClusterSnapshotsError {
     pub fn from_body(body: &str) -> DescribeDBClusterSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterSnapshotNotFoundFault" => {
@@ -20577,8 +20541,7 @@ impl DescribeDBClustersError {
     pub fn from_body(body: &str) -> DescribeDBClustersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => DescribeDBClustersError::DBClusterNotFoundFault(
@@ -20647,8 +20610,7 @@ impl DescribeDBEngineVersionsError {
     pub fn from_body(body: &str) -> DescribeDBEngineVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDBEngineVersionsError::Unknown(String::from(body)),
@@ -20715,8 +20677,7 @@ impl DescribeDBInstancesError {
     pub fn from_body(body: &str) -> DescribeDBInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => DescribeDBInstancesError::DBInstanceNotFoundFault(
@@ -20787,8 +20748,7 @@ impl DescribeDBLogFilesError {
     pub fn from_body(body: &str) -> DescribeDBLogFilesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => DescribeDBLogFilesError::DBInstanceNotFoundFault(
@@ -20859,8 +20819,7 @@ impl DescribeDBParameterGroupsError {
     pub fn from_body(body: &str) -> DescribeDBParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
@@ -20933,8 +20892,7 @@ impl DescribeDBParametersError {
     pub fn from_body(body: &str) -> DescribeDBParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
@@ -21007,8 +20965,7 @@ impl DescribeDBSecurityGroupsError {
     pub fn from_body(body: &str) -> DescribeDBSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSecurityGroupNotFoundFault" => {
@@ -21081,8 +21038,7 @@ impl DescribeDBSnapshotAttributesError {
     pub fn from_body(body: &str) -> DescribeDBSnapshotAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotNotFoundFault" => {
@@ -21155,8 +21111,7 @@ impl DescribeDBSnapshotsError {
     pub fn from_body(body: &str) -> DescribeDBSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotNotFoundFault" => DescribeDBSnapshotsError::DBSnapshotNotFoundFault(
@@ -21227,8 +21182,7 @@ impl DescribeDBSubnetGroupsError {
     pub fn from_body(body: &str) -> DescribeDBSubnetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSubnetGroupNotFoundFault" => {
@@ -21299,8 +21253,7 @@ impl DescribeEngineDefaultClusterParametersError {
     pub fn from_body(body: &str) -> DescribeEngineDefaultClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultClusterParametersError::Unknown(String::from(body)),
@@ -21365,8 +21318,7 @@ impl DescribeEngineDefaultParametersError {
     pub fn from_body(body: &str) -> DescribeEngineDefaultParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultParametersError::Unknown(String::from(body)),
@@ -21431,8 +21383,7 @@ impl DescribeEventCategoriesError {
     pub fn from_body(body: &str) -> DescribeEventCategoriesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventCategoriesError::Unknown(String::from(body)),
@@ -21499,8 +21450,7 @@ impl DescribeEventSubscriptionsError {
     pub fn from_body(body: &str) -> DescribeEventSubscriptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "SubscriptionNotFoundFault" => {
@@ -21571,8 +21521,7 @@ impl DescribeEventsError {
     pub fn from_body(body: &str) -> DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
@@ -21635,8 +21584,7 @@ impl DescribeOptionGroupOptionsError {
     pub fn from_body(body: &str) -> DescribeOptionGroupOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOptionGroupOptionsError::Unknown(String::from(body)),
@@ -21703,8 +21651,7 @@ impl DescribeOptionGroupsError {
     pub fn from_body(body: &str) -> DescribeOptionGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OptionGroupNotFoundFault" => DescribeOptionGroupsError::OptionGroupNotFoundFault(
@@ -21773,8 +21720,7 @@ impl DescribeOrderableDBInstanceOptionsError {
     pub fn from_body(body: &str) -> DescribeOrderableDBInstanceOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOrderableDBInstanceOptionsError::Unknown(String::from(body)),
@@ -21841,8 +21787,7 @@ impl DescribePendingMaintenanceActionsError {
     pub fn from_body(body: &str) -> DescribePendingMaintenanceActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceNotFoundFault" => {
@@ -21915,8 +21860,7 @@ impl DescribeReservedDBInstancesError {
     pub fn from_body(body: &str) -> DescribeReservedDBInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ReservedDBInstanceNotFoundFault" => {
@@ -21989,8 +21933,7 @@ impl DescribeReservedDBInstancesOfferingsError {
     pub fn from_body(body: &str) -> DescribeReservedDBInstancesOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
@@ -22056,8 +21999,7 @@ impl DescribeSourceRegionsError {
     pub fn from_body(body: &str) -> DescribeSourceRegionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSourceRegionsError::Unknown(String::from(body)),
@@ -22126,8 +22068,7 @@ impl DownloadDBLogFilePortionError {
     pub fn from_body(body: &str) -> DownloadDBLogFilePortionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => {
@@ -22208,8 +22149,7 @@ impl FailoverDBClusterError {
     pub fn from_body(body: &str) -> FailoverDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => FailoverDBClusterError::DBClusterNotFoundFault(
@@ -22296,8 +22236,7 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => ListTagsForResourceError::DBClusterNotFoundFault(
@@ -22396,8 +22335,7 @@ impl ModifyDBClusterError {
     pub fn from_body(body: &str) -> ModifyDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterAlreadyExistsFault" => {
@@ -22520,8 +22458,7 @@ impl ModifyDBClusterParameterGroupError {
     pub fn from_body(body: &str) -> ModifyDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
@@ -22606,8 +22543,7 @@ impl ModifyDBClusterSnapshotAttributeError {
     pub fn from_body(body: &str) -> ModifyDBClusterSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterSnapshotNotFoundFault" => {
@@ -22728,8 +22664,7 @@ impl ModifyDBInstanceError {
     pub fn from_body(body: &str) -> ModifyDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => ModifyDBInstanceError::AuthorizationNotFoundFault(
@@ -22880,8 +22815,7 @@ impl ModifyDBParameterGroupError {
     pub fn from_body(body: &str) -> ModifyDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
@@ -22960,8 +22894,7 @@ impl ModifyDBSnapshotError {
     pub fn from_body(body: &str) -> ModifyDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotNotFoundFault" => ModifyDBSnapshotError::DBSnapshotNotFoundFault(
@@ -23034,8 +22967,7 @@ impl ModifyDBSnapshotAttributeError {
     pub fn from_body(body: &str) -> ModifyDBSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotNotFoundFault" => {
@@ -23128,8 +23060,7 @@ impl ModifyDBSubnetGroupError {
     pub fn from_body(body: &str) -> ModifyDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSubnetGroupDoesNotCoverEnoughAZs" => {
@@ -23232,8 +23163,7 @@ impl ModifyEventSubscriptionError {
     pub fn from_body(body: &str) -> ModifyEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EventSubscriptionQuotaExceededFault" => {
@@ -23336,8 +23266,7 @@ impl ModifyOptionGroupError {
     pub fn from_body(body: &str) -> ModifyOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOptionGroupStateFault" => {
@@ -23416,8 +23345,7 @@ impl PromoteReadReplicaError {
     pub fn from_body(body: &str) -> PromoteReadReplicaError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => PromoteReadReplicaError::DBInstanceNotFoundFault(
@@ -23496,8 +23424,7 @@ impl PromoteReadReplicaDBClusterError {
     pub fn from_body(body: &str) -> PromoteReadReplicaDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => {
@@ -23580,8 +23507,7 @@ impl PurchaseReservedDBInstancesOfferingError {
     pub fn from_body(body: &str) -> PurchaseReservedDBInstancesOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
@@ -23653,8 +23579,7 @@ impl RebootDBInstanceError {
     pub fn from_body(body: &str) -> RebootDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => RebootDBInstanceError::DBInstanceNotFoundFault(
@@ -23733,8 +23658,7 @@ impl RemoveRoleFromDBClusterError {
     pub fn from_body(body: &str) -> RemoveRoleFromDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => RemoveRoleFromDBClusterError::DBClusterNotFoundFault(
@@ -23819,8 +23743,7 @@ impl RemoveSourceIdentifierFromSubscriptionError {
     pub fn from_body(body: &str) -> RemoveSourceIdentifierFromSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "SourceNotFoundFault" => {
@@ -23905,8 +23828,7 @@ impl RemoveTagsFromResourceError {
     pub fn from_body(body: &str) -> RemoveTagsFromResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => RemoveTagsFromResourceError::DBClusterNotFoundFault(
@@ -23987,8 +23909,7 @@ impl ResetDBClusterParameterGroupError {
     pub fn from_body(body: &str) -> ResetDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
@@ -24071,8 +23992,7 @@ impl ResetDBParameterGroupError {
     pub fn from_body(body: &str) -> ResetDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
@@ -24175,8 +24095,7 @@ impl RestoreDBClusterFromS3Error {
     pub fn from_body(body: &str) -> RestoreDBClusterFromS3Error {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterAlreadyExistsFault" => {
@@ -24345,8 +24264,7 @@ impl RestoreDBClusterFromSnapshotError {
     pub fn from_body(body: &str) -> RestoreDBClusterFromSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterAlreadyExistsFault" => {
@@ -24535,8 +24453,7 @@ impl RestoreDBClusterToPointInTimeError {
     pub fn from_body(body: &str) -> RestoreDBClusterToPointInTimeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterAlreadyExistsFault" => {
@@ -24735,8 +24652,7 @@ impl RestoreDBInstanceFromDBSnapshotError {
     pub fn from_body(body: &str) -> RestoreDBInstanceFromDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => {
@@ -24951,8 +24867,7 @@ impl RestoreDBInstanceToPointInTimeError {
     pub fn from_body(body: &str) -> RestoreDBInstanceToPointInTimeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => {
@@ -25139,8 +25054,7 @@ impl RevokeDBSecurityGroupIngressError {
     pub fn from_body(body: &str) -> RevokeDBSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => {
@@ -25245,8 +25159,7 @@ impl StartDBInstanceError {
     pub fn from_body(body: &str) -> StartDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => StartDBInstanceError::AuthorizationNotFoundFault(
@@ -25371,8 +25284,7 @@ impl StopDBInstanceError {
     pub fn from_body(body: &str) -> StopDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => {

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -10963,8 +10964,7 @@ impl AuthorizeClusterSecurityGroupIngressError {
     pub fn from_body(body: &str) -> AuthorizeClusterSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
@@ -11055,8 +11055,7 @@ impl AuthorizeSnapshotAccessError {
     pub fn from_body(body: &str) -> AuthorizeSnapshotAccessError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationAlreadyExistsFault" => {
@@ -11165,8 +11164,7 @@ impl CopyClusterSnapshotError {
     pub fn from_body(body: &str) -> CopyClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSnapshotAlreadyExistsFault" => {
@@ -11293,8 +11291,7 @@ impl CreateClusterError {
     pub fn from_body(body: &str) -> CreateClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterAlreadyExistsFault" => CreateClusterError::ClusterAlreadyExistsFault(
@@ -11461,8 +11458,7 @@ impl CreateClusterParameterGroupError {
     pub fn from_body(body: &str) -> CreateClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupAlreadyExistsFault" => {
@@ -11561,8 +11557,7 @@ impl CreateClusterSecurityGroupError {
     pub fn from_body(body: &str) -> CreateClusterSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSecurityGroupAlreadyExistsFault" => {
@@ -11663,8 +11658,7 @@ impl CreateClusterSnapshotError {
     pub fn from_body(body: &str) -> CreateClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => CreateClusterSnapshotError::ClusterNotFoundFault(
@@ -11775,8 +11769,7 @@ impl CreateClusterSubnetGroupError {
     pub fn from_body(body: &str) -> CreateClusterSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSubnetGroupAlreadyExistsFault" => {
@@ -11905,8 +11898,7 @@ impl CreateEventSubscriptionError {
     pub fn from_body(body: &str) -> CreateEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EventSubscriptionQuotaExceededFault" => {
@@ -12037,8 +12029,7 @@ impl CreateHsmClientCertificateError {
     pub fn from_body(body: &str) -> CreateHsmClientCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmClientCertificateAlreadyExistsFault" => {
@@ -12135,8 +12126,7 @@ impl CreateHsmConfigurationError {
     pub fn from_body(body: &str) -> CreateHsmConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmConfigurationAlreadyExistsFault" => {
@@ -12233,8 +12223,7 @@ impl CreateSnapshotCopyGrantError {
     pub fn from_body(body: &str) -> CreateSnapshotCopyGrantError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DependentServiceRequestThrottlingFault" => {
@@ -12337,8 +12326,7 @@ impl CreateTagsError {
     pub fn from_body(body: &str) -> CreateTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTagFault" => {
@@ -12421,8 +12409,7 @@ impl DeleteClusterError {
     pub fn from_body(body: &str) -> DeleteClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
@@ -12509,8 +12496,7 @@ impl DeleteClusterParameterGroupError {
     pub fn from_body(body: &str) -> DeleteClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupNotFoundFault" => {
@@ -12595,8 +12581,7 @@ impl DeleteClusterSecurityGroupError {
     pub fn from_body(body: &str) -> DeleteClusterSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSecurityGroupNotFoundFault" => {
@@ -12679,8 +12664,7 @@ impl DeleteClusterSnapshotError {
     pub fn from_body(body: &str) -> DeleteClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSnapshotNotFoundFault" => {
@@ -12763,8 +12747,7 @@ impl DeleteClusterSubnetGroupError {
     pub fn from_body(body: &str) -> DeleteClusterSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSubnetGroupNotFoundFault" => {
@@ -12851,8 +12834,7 @@ impl DeleteEventSubscriptionError {
     pub fn from_body(body: &str) -> DeleteEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidSubscriptionStateFault" => {
@@ -12933,8 +12915,7 @@ impl DeleteHsmClientCertificateError {
     pub fn from_body(body: &str) -> DeleteHsmClientCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmClientCertificateNotFoundFault" => {
@@ -13017,8 +12998,7 @@ impl DeleteHsmConfigurationError {
     pub fn from_body(body: &str) -> DeleteHsmConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmConfigurationNotFoundFault" => {
@@ -13099,8 +13079,7 @@ impl DeleteSnapshotCopyGrantError {
     pub fn from_body(body: &str) -> DeleteSnapshotCopyGrantError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidSnapshotCopyGrantStateFault" => {
@@ -13181,8 +13160,7 @@ impl DeleteTagsError {
     pub fn from_body(body: &str) -> DeleteTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTagFault" => {
@@ -13257,8 +13235,7 @@ impl DescribeClusterParameterGroupsError {
     pub fn from_body(body: &str) -> DescribeClusterParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupNotFoundFault" => {
@@ -13337,8 +13314,7 @@ impl DescribeClusterParametersError {
     pub fn from_body(body: &str) -> DescribeClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupNotFoundFault" => {
@@ -13413,8 +13389,7 @@ impl DescribeClusterSecurityGroupsError {
     pub fn from_body(body: &str) -> DescribeClusterSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSecurityGroupNotFoundFault" => {
@@ -13495,8 +13470,7 @@ impl DescribeClusterSnapshotsError {
     pub fn from_body(body: &str) -> DescribeClusterSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSnapshotNotFoundFault" => {
@@ -13575,8 +13549,7 @@ impl DescribeClusterSubnetGroupsError {
     pub fn from_body(body: &str) -> DescribeClusterSubnetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSubnetGroupNotFoundFault" => {
@@ -13651,8 +13624,7 @@ impl DescribeClusterVersionsError {
     pub fn from_body(body: &str) -> DescribeClusterVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeClusterVersionsError::Unknown(String::from(body)),
@@ -13721,8 +13693,7 @@ impl DescribeClustersError {
     pub fn from_body(body: &str) -> DescribeClustersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
@@ -13793,8 +13764,7 @@ impl DescribeDefaultClusterParametersError {
     pub fn from_body(body: &str) -> DescribeDefaultClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDefaultClusterParametersError::Unknown(String::from(body)),
@@ -13859,8 +13829,7 @@ impl DescribeEventCategoriesError {
     pub fn from_body(body: &str) -> DescribeEventCategoriesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventCategoriesError::Unknown(String::from(body)),
@@ -13927,8 +13896,7 @@ impl DescribeEventSubscriptionsError {
     pub fn from_body(body: &str) -> DescribeEventSubscriptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "SubscriptionNotFoundFault" => {
@@ -13999,8 +13967,7 @@ impl DescribeEventsError {
     pub fn from_body(body: &str) -> DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
@@ -14067,8 +14034,7 @@ impl DescribeHsmClientCertificatesError {
     pub fn from_body(body: &str) -> DescribeHsmClientCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmClientCertificateNotFoundFault" => {
@@ -14149,8 +14115,7 @@ impl DescribeHsmConfigurationsError {
     pub fn from_body(body: &str) -> DescribeHsmConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmConfigurationNotFoundFault" => {
@@ -14227,8 +14192,7 @@ impl DescribeLoggingStatusError {
     pub fn from_body(body: &str) -> DescribeLoggingStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => DescribeLoggingStatusError::ClusterNotFoundFault(
@@ -14297,8 +14261,7 @@ impl DescribeOrderableClusterOptionsError {
     pub fn from_body(body: &str) -> DescribeOrderableClusterOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOrderableClusterOptionsError::Unknown(String::from(body)),
@@ -14369,8 +14332,7 @@ impl DescribeReservedNodeOfferingsError {
     pub fn from_body(body: &str) -> DescribeReservedNodeOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DependentServiceUnavailableFault" => {
@@ -14461,8 +14423,7 @@ impl DescribeReservedNodesError {
     pub fn from_body(body: &str) -> DescribeReservedNodesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DependentServiceUnavailableFault" => {
@@ -14543,8 +14504,7 @@ impl DescribeResizeError {
     pub fn from_body(body: &str) -> DescribeResizeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
@@ -14619,8 +14579,7 @@ impl DescribeSnapshotCopyGrantsError {
     pub fn from_body(body: &str) -> DescribeSnapshotCopyGrantsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTagFault" => DescribeSnapshotCopyGrantsError::InvalidTagFault(
@@ -14699,8 +14658,7 @@ impl DescribeTableRestoreStatusError {
     pub fn from_body(body: &str) -> DescribeTableRestoreStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => DescribeTableRestoreStatusError::ClusterNotFoundFault(
@@ -14779,8 +14737,7 @@ impl DescribeTagsError {
     pub fn from_body(body: &str) -> DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTagFault" => {
@@ -14853,8 +14810,7 @@ impl DisableLoggingError {
     pub fn from_body(body: &str) -> DisableLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
@@ -14929,8 +14885,7 @@ impl DisableSnapshotCopyError {
     pub fn from_body(body: &str) -> DisableSnapshotCopyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => DisableSnapshotCopyError::ClusterNotFoundFault(
@@ -15023,8 +14978,7 @@ impl EnableLoggingError {
     pub fn from_body(body: &str) -> EnableLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BucketNotFoundFault" => {
@@ -15129,8 +15083,7 @@ impl EnableSnapshotCopyError {
     pub fn from_body(body: &str) -> EnableSnapshotCopyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => EnableSnapshotCopyError::ClusterNotFoundFault(
@@ -15249,8 +15202,7 @@ impl GetClusterCredentialsError {
     pub fn from_body(body: &str) -> GetClusterCredentialsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => GetClusterCredentialsError::ClusterNotFoundFault(
@@ -15357,8 +15309,7 @@ impl ModifyClusterError {
     pub fn from_body(body: &str) -> ModifyClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterAlreadyExistsFault" => ModifyClusterError::ClusterAlreadyExistsFault(
@@ -15507,8 +15458,7 @@ impl ModifyClusterIamRolesError {
     pub fn from_body(body: &str) -> ModifyClusterIamRolesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => ModifyClusterIamRolesError::ClusterNotFoundFault(
@@ -15587,8 +15537,7 @@ impl ModifyClusterParameterGroupError {
     pub fn from_body(body: &str) -> ModifyClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupNotFoundFault" => {
@@ -15681,8 +15630,7 @@ impl ModifyClusterSubnetGroupError {
     pub fn from_body(body: &str) -> ModifyClusterSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSubnetGroupNotFoundFault" => {
@@ -15797,8 +15745,7 @@ impl ModifyEventSubscriptionError {
     pub fn from_body(body: &str) -> ModifyEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidSubscriptionStateFault" => {
@@ -15921,8 +15868,7 @@ impl ModifySnapshotCopyRetentionPeriodError {
     pub fn from_body(body: &str) -> ModifySnapshotCopyRetentionPeriodError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
@@ -16019,8 +15965,7 @@ impl PurchaseReservedNodeOfferingError {
     pub fn from_body(body: &str) -> PurchaseReservedNodeOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ReservedNodeAlreadyExistsFault" => {
@@ -16115,8 +16060,7 @@ impl RebootClusterError {
     pub fn from_body(body: &str) -> RebootClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
@@ -16191,8 +16135,7 @@ impl ResetClusterParameterGroupError {
     pub fn from_body(body: &str) -> ResetClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupNotFoundFault" => {
@@ -16313,8 +16256,7 @@ impl RestoreFromClusterSnapshotError {
     pub fn from_body(body: &str) -> RestoreFromClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessToSnapshotDeniedFault" => {
@@ -16515,8 +16457,7 @@ impl RestoreTableFromClusterSnapshotError {
     pub fn from_body(body: &str) -> RestoreTableFromClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
@@ -16635,8 +16576,7 @@ impl RevokeClusterSecurityGroupIngressError {
     pub fn from_body(body: &str) -> RevokeClusterSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => {
@@ -16729,8 +16669,7 @@ impl RevokeSnapshotAccessError {
     pub fn from_body(body: &str) -> RevokeSnapshotAccessError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessToSnapshotDeniedFault" => {
@@ -16819,8 +16758,7 @@ impl RotateEncryptionKeyError {
     pub fn from_body(body: &str) -> RotateEncryptionKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => RotateEncryptionKeyError::ClusterNotFoundFault(

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -34,7 +34,8 @@ use xml::EventWriter;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 enum DeserializerNext {
     Close,
     Skip,
@@ -8998,8 +8999,7 @@ impl AssociateVPCWithHostedZoneError {
     pub fn from_body(body: &str) -> AssociateVPCWithHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConflictingDomainExists" => {
@@ -9106,8 +9106,7 @@ impl ChangeResourceRecordSetsError {
     pub fn from_body(body: &str) -> ChangeResourceRecordSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidChangeBatch" => ChangeResourceRecordSetsError::InvalidChangeBatch(
@@ -9204,8 +9203,7 @@ impl ChangeTagsForResourceError {
     pub fn from_body(body: &str) -> ChangeTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -9296,8 +9294,7 @@ impl CreateHealthCheckError {
     pub fn from_body(body: &str) -> CreateHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HealthCheckAlreadyExists" => CreateHealthCheckError::HealthCheckAlreadyExists(
@@ -9392,8 +9389,7 @@ impl CreateHostedZoneError {
     pub fn from_body(body: &str) -> CreateHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConflictingDomainExists" => CreateHostedZoneError::ConflictingDomainExists(
@@ -9506,8 +9502,7 @@ impl CreateReusableDelegationSetError {
     pub fn from_body(body: &str) -> CreateReusableDelegationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DelegationSetAlreadyCreated" => {
@@ -9614,8 +9609,7 @@ impl CreateTrafficPolicyError {
     pub fn from_body(body: &str) -> CreateTrafficPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -9710,8 +9704,7 @@ impl CreateTrafficPolicyInstanceError {
     pub fn from_body(body: &str) -> CreateTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => CreateTrafficPolicyInstanceError::InvalidInput(String::from(
@@ -9810,8 +9803,7 @@ impl CreateTrafficPolicyVersionError {
     pub fn from_body(body: &str) -> CreateTrafficPolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => {
@@ -9906,8 +9898,7 @@ impl CreateVPCAssociationAuthorizationError {
     pub fn from_body(body: &str) -> CreateVPCAssociationAuthorizationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => {
@@ -10004,8 +9995,7 @@ impl DeleteHealthCheckError {
     pub fn from_body(body: &str) -> DeleteHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HealthCheckInUse" => {
@@ -10092,8 +10082,7 @@ impl DeleteHostedZoneError {
     pub fn from_body(body: &str) -> DeleteHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HostedZoneNotEmpty" => {
@@ -10184,8 +10173,7 @@ impl DeleteReusableDelegationSetError {
     pub fn from_body(body: &str) -> DeleteReusableDelegationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DelegationSetInUse" => DeleteReusableDelegationSetError::DelegationSetInUse(
@@ -10276,8 +10264,7 @@ impl DeleteTrafficPolicyError {
     pub fn from_body(body: &str) -> DeleteTrafficPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => DeleteTrafficPolicyError::ConcurrentModification(
@@ -10364,8 +10351,7 @@ impl DeleteTrafficPolicyInstanceError {
     pub fn from_body(body: &str) -> DeleteTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => DeleteTrafficPolicyInstanceError::InvalidInput(String::from(
@@ -10456,8 +10442,7 @@ impl DeleteVPCAssociationAuthorizationError {
     pub fn from_body(body: &str) -> DeleteVPCAssociationAuthorizationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => {
@@ -10558,8 +10543,7 @@ impl DisassociateVPCFromHostedZoneError {
     pub fn from_body(body: &str) -> DisassociateVPCFromHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => DisassociateVPCFromHostedZoneError::InvalidInput(String::from(
@@ -10650,8 +10634,7 @@ impl GetChangeError {
     pub fn from_body(body: &str) -> GetChangeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => GetChangeError::InvalidInput(String::from(parsed_error.message)),
@@ -10718,8 +10701,7 @@ impl GetCheckerIpRangesError {
     pub fn from_body(body: &str) -> GetCheckerIpRangesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetCheckerIpRangesError::Unknown(String::from(body)),
@@ -10788,8 +10770,7 @@ impl GetGeoLocationError {
     pub fn from_body(body: &str) -> GetGeoLocationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -10866,8 +10847,7 @@ impl GetHealthCheckError {
     pub fn from_body(body: &str) -> GetHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "IncompatibleVersion" => {
@@ -10942,8 +10922,7 @@ impl GetHealthCheckCountError {
     pub fn from_body(body: &str) -> GetHealthCheckCountError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetHealthCheckCountError::Unknown(String::from(body)),
@@ -11012,8 +10991,7 @@ impl GetHealthCheckLastFailureReasonError {
     pub fn from_body(body: &str) -> GetHealthCheckLastFailureReasonError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => GetHealthCheckLastFailureReasonError::InvalidInput(
@@ -11090,8 +11068,7 @@ impl GetHealthCheckStatusError {
     pub fn from_body(body: &str) -> GetHealthCheckStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -11168,8 +11145,7 @@ impl GetHostedZoneError {
     pub fn from_body(body: &str) -> GetHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -11242,8 +11218,7 @@ impl GetHostedZoneCountError {
     pub fn from_body(body: &str) -> GetHostedZoneCountError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -11318,8 +11293,7 @@ impl GetReusableDelegationSetError {
     pub fn from_body(body: &str) -> GetReusableDelegationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DelegationSetNotReusable" => {
@@ -11402,8 +11376,7 @@ impl GetTrafficPolicyError {
     pub fn from_body(body: &str) -> GetTrafficPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -11478,8 +11451,7 @@ impl GetTrafficPolicyInstanceError {
     pub fn from_body(body: &str) -> GetTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -11554,8 +11526,7 @@ impl GetTrafficPolicyInstanceCountError {
     pub fn from_body(body: &str) -> GetTrafficPolicyInstanceCountError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetTrafficPolicyInstanceCountError::Unknown(String::from(body)),
@@ -11622,8 +11593,7 @@ impl ListGeoLocationsError {
     pub fn from_body(body: &str) -> ListGeoLocationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -11694,8 +11664,7 @@ impl ListHealthChecksError {
     pub fn from_body(body: &str) -> ListHealthChecksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "IncompatibleVersion" => {
@@ -11772,8 +11741,7 @@ impl ListHostedZonesError {
     pub fn from_body(body: &str) -> ListHostedZonesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DelegationSetNotReusable" => ListHostedZonesError::DelegationSetNotReusable(
@@ -11852,8 +11820,7 @@ impl ListHostedZonesByNameError {
     pub fn from_body(body: &str) -> ListHostedZonesByNameError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidDomainName" => ListHostedZonesByNameError::InvalidDomainName(
@@ -11930,8 +11897,7 @@ impl ListResourceRecordSetsError {
     pub fn from_body(body: &str) -> ListResourceRecordSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -12006,8 +11972,7 @@ impl ListReusableDelegationSetsError {
     pub fn from_body(body: &str) -> ListReusableDelegationSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => ListReusableDelegationSetsError::InvalidInput(String::from(
@@ -12086,8 +12051,7 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -12182,8 +12146,7 @@ impl ListTagsForResourcesError {
     pub fn from_body(body: &str) -> ListTagsForResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -12270,8 +12233,7 @@ impl ListTrafficPoliciesError {
     pub fn from_body(body: &str) -> ListTrafficPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -12344,8 +12306,7 @@ impl ListTrafficPolicyInstancesError {
     pub fn from_body(body: &str) -> ListTrafficPolicyInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => ListTrafficPolicyInstancesError::InvalidInput(String::from(
@@ -12426,8 +12387,7 @@ impl ListTrafficPolicyInstancesByHostedZoneError {
     pub fn from_body(body: &str) -> ListTrafficPolicyInstancesByHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => ListTrafficPolicyInstancesByHostedZoneError::InvalidInput(
@@ -12516,8 +12476,7 @@ impl ListTrafficPolicyInstancesByPolicyError {
     pub fn from_body(body: &str) -> ListTrafficPolicyInstancesByPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => ListTrafficPolicyInstancesByPolicyError::InvalidInput(
@@ -12604,8 +12563,7 @@ impl ListTrafficPolicyVersionsError {
     pub fn from_body(body: &str) -> ListTrafficPolicyVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -12684,8 +12642,7 @@ impl ListVPCAssociationAuthorizationsError {
     pub fn from_body(body: &str) -> ListVPCAssociationAuthorizationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => ListVPCAssociationAuthorizationsError::InvalidInput(
@@ -12768,8 +12725,7 @@ impl TestDNSAnswerError {
     pub fn from_body(body: &str) -> TestDNSAnswerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -12846,8 +12802,7 @@ impl UpdateHealthCheckError {
     pub fn from_body(body: &str) -> UpdateHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HealthCheckVersionMismatch" => {
@@ -12930,8 +12885,7 @@ impl UpdateHostedZoneCommentError {
     pub fn from_body(body: &str) -> UpdateHostedZoneCommentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
@@ -13010,8 +12964,7 @@ impl UpdateTrafficPolicyCommentError {
     pub fn from_body(body: &str) -> UpdateTrafficPolicyCommentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => {
@@ -13100,8 +13053,7 @@ impl UpdateTrafficPolicyInstanceError {
     pub fn from_body(body: &str) -> UpdateTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConflictingTypes" => UpdateTrafficPolicyInstanceError::ConflictingTypes(

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -34,7 +34,8 @@ use xml::EventWriter;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 enum DeserializerNext {
     Close,
     Skip,
@@ -13671,8 +13672,7 @@ impl AbortMultipartUploadError {
     pub fn from_body(body: &str) -> AbortMultipartUploadError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchUpload" => {
@@ -13741,8 +13741,7 @@ impl CompleteMultipartUploadError {
     pub fn from_body(body: &str) -> CompleteMultipartUploadError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CompleteMultipartUploadError::Unknown(String::from(body)),
@@ -13809,8 +13808,7 @@ impl CopyObjectError {
     pub fn from_body(body: &str) -> CopyObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ObjectNotInActiveTierError" => {
@@ -13881,8 +13879,7 @@ impl CreateBucketError {
     pub fn from_body(body: &str) -> CreateBucketError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BucketAlreadyExists" => {
@@ -13953,8 +13950,7 @@ impl CreateMultipartUploadError {
     pub fn from_body(body: &str) -> CreateMultipartUploadError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateMultipartUploadError::Unknown(String::from(body)),
@@ -14019,8 +14015,7 @@ impl DeleteBucketError {
     pub fn from_body(body: &str) -> DeleteBucketError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketError::Unknown(String::from(body)),
@@ -14083,8 +14078,7 @@ impl DeleteBucketAnalyticsConfigurationError {
     pub fn from_body(body: &str) -> DeleteBucketAnalyticsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketAnalyticsConfigurationError::Unknown(String::from(body)),
@@ -14149,8 +14143,7 @@ impl DeleteBucketCorsError {
     pub fn from_body(body: &str) -> DeleteBucketCorsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketCorsError::Unknown(String::from(body)),
@@ -14213,8 +14206,7 @@ impl DeleteBucketInventoryConfigurationError {
     pub fn from_body(body: &str) -> DeleteBucketInventoryConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketInventoryConfigurationError::Unknown(String::from(body)),
@@ -14279,8 +14271,7 @@ impl DeleteBucketLifecycleError {
     pub fn from_body(body: &str) -> DeleteBucketLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketLifecycleError::Unknown(String::from(body)),
@@ -14345,8 +14336,7 @@ impl DeleteBucketMetricsConfigurationError {
     pub fn from_body(body: &str) -> DeleteBucketMetricsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketMetricsConfigurationError::Unknown(String::from(body)),
@@ -14411,8 +14401,7 @@ impl DeleteBucketPolicyError {
     pub fn from_body(body: &str) -> DeleteBucketPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketPolicyError::Unknown(String::from(body)),
@@ -14477,8 +14466,7 @@ impl DeleteBucketReplicationError {
     pub fn from_body(body: &str) -> DeleteBucketReplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketReplicationError::Unknown(String::from(body)),
@@ -14543,8 +14531,7 @@ impl DeleteBucketTaggingError {
     pub fn from_body(body: &str) -> DeleteBucketTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketTaggingError::Unknown(String::from(body)),
@@ -14609,8 +14596,7 @@ impl DeleteBucketWebsiteError {
     pub fn from_body(body: &str) -> DeleteBucketWebsiteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketWebsiteError::Unknown(String::from(body)),
@@ -14675,8 +14661,7 @@ impl DeleteObjectError {
     pub fn from_body(body: &str) -> DeleteObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectError::Unknown(String::from(body)),
@@ -14739,8 +14724,7 @@ impl DeleteObjectTaggingError {
     pub fn from_body(body: &str) -> DeleteObjectTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectTaggingError::Unknown(String::from(body)),
@@ -14805,8 +14789,7 @@ impl DeleteObjectsError {
     pub fn from_body(body: &str) -> DeleteObjectsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectsError::Unknown(String::from(body)),
@@ -14869,8 +14852,7 @@ impl GetBucketAccelerateConfigurationError {
     pub fn from_body(body: &str) -> GetBucketAccelerateConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAccelerateConfigurationError::Unknown(String::from(body)),
@@ -14935,8 +14917,7 @@ impl GetBucketAclError {
     pub fn from_body(body: &str) -> GetBucketAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAclError::Unknown(String::from(body)),
@@ -14999,8 +14980,7 @@ impl GetBucketAnalyticsConfigurationError {
     pub fn from_body(body: &str) -> GetBucketAnalyticsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAnalyticsConfigurationError::Unknown(String::from(body)),
@@ -15065,8 +15045,7 @@ impl GetBucketCorsError {
     pub fn from_body(body: &str) -> GetBucketCorsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketCorsError::Unknown(String::from(body)),
@@ -15129,8 +15108,7 @@ impl GetBucketInventoryConfigurationError {
     pub fn from_body(body: &str) -> GetBucketInventoryConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketInventoryConfigurationError::Unknown(String::from(body)),
@@ -15195,8 +15173,7 @@ impl GetBucketLifecycleError {
     pub fn from_body(body: &str) -> GetBucketLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLifecycleError::Unknown(String::from(body)),
@@ -15261,8 +15238,7 @@ impl GetBucketLifecycleConfigurationError {
     pub fn from_body(body: &str) -> GetBucketLifecycleConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLifecycleConfigurationError::Unknown(String::from(body)),
@@ -15327,8 +15303,7 @@ impl GetBucketLocationError {
     pub fn from_body(body: &str) -> GetBucketLocationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLocationError::Unknown(String::from(body)),
@@ -15393,8 +15368,7 @@ impl GetBucketLoggingError {
     pub fn from_body(body: &str) -> GetBucketLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLoggingError::Unknown(String::from(body)),
@@ -15457,8 +15431,7 @@ impl GetBucketMetricsConfigurationError {
     pub fn from_body(body: &str) -> GetBucketMetricsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketMetricsConfigurationError::Unknown(String::from(body)),
@@ -15523,8 +15496,7 @@ impl GetBucketNotificationError {
     pub fn from_body(body: &str) -> GetBucketNotificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketNotificationError::Unknown(String::from(body)),
@@ -15589,8 +15561,7 @@ impl GetBucketNotificationConfigurationError {
     pub fn from_body(body: &str) -> GetBucketNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketNotificationConfigurationError::Unknown(String::from(body)),
@@ -15655,8 +15626,7 @@ impl GetBucketPolicyError {
     pub fn from_body(body: &str) -> GetBucketPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketPolicyError::Unknown(String::from(body)),
@@ -15719,8 +15689,7 @@ impl GetBucketReplicationError {
     pub fn from_body(body: &str) -> GetBucketReplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketReplicationError::Unknown(String::from(body)),
@@ -15785,8 +15754,7 @@ impl GetBucketRequestPaymentError {
     pub fn from_body(body: &str) -> GetBucketRequestPaymentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketRequestPaymentError::Unknown(String::from(body)),
@@ -15851,8 +15819,7 @@ impl GetBucketTaggingError {
     pub fn from_body(body: &str) -> GetBucketTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketTaggingError::Unknown(String::from(body)),
@@ -15915,8 +15882,7 @@ impl GetBucketVersioningError {
     pub fn from_body(body: &str) -> GetBucketVersioningError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketVersioningError::Unknown(String::from(body)),
@@ -15981,8 +15947,7 @@ impl GetBucketWebsiteError {
     pub fn from_body(body: &str) -> GetBucketWebsiteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketWebsiteError::Unknown(String::from(body)),
@@ -16047,8 +16012,7 @@ impl GetObjectError {
     pub fn from_body(body: &str) -> GetObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchKey" => GetObjectError::NoSuchKey(String::from(parsed_error.message)),
@@ -16115,8 +16079,7 @@ impl GetObjectAclError {
     pub fn from_body(body: &str) -> GetObjectAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchKey" => GetObjectAclError::NoSuchKey(String::from(parsed_error.message)),
@@ -16181,8 +16144,7 @@ impl GetObjectTaggingError {
     pub fn from_body(body: &str) -> GetObjectTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetObjectTaggingError::Unknown(String::from(body)),
@@ -16245,8 +16207,7 @@ impl GetObjectTorrentError {
     pub fn from_body(body: &str) -> GetObjectTorrentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetObjectTorrentError::Unknown(String::from(body)),
@@ -16311,8 +16272,7 @@ impl HeadBucketError {
     pub fn from_body(body: &str) -> HeadBucketError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchBucket" => HeadBucketError::NoSuchBucket(String::from(parsed_error.message)),
@@ -16379,8 +16339,7 @@ impl HeadObjectError {
     pub fn from_body(body: &str) -> HeadObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchKey" => HeadObjectError::NoSuchKey(String::from(parsed_error.message)),
@@ -16445,8 +16404,7 @@ impl ListBucketAnalyticsConfigurationsError {
     pub fn from_body(body: &str) -> ListBucketAnalyticsConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketAnalyticsConfigurationsError::Unknown(String::from(body)),
@@ -16511,8 +16469,7 @@ impl ListBucketInventoryConfigurationsError {
     pub fn from_body(body: &str) -> ListBucketInventoryConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketInventoryConfigurationsError::Unknown(String::from(body)),
@@ -16577,8 +16534,7 @@ impl ListBucketMetricsConfigurationsError {
     pub fn from_body(body: &str) -> ListBucketMetricsConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketMetricsConfigurationsError::Unknown(String::from(body)),
@@ -16643,8 +16599,7 @@ impl ListBucketsError {
     pub fn from_body(body: &str) -> ListBucketsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketsError::Unknown(String::from(body)),
@@ -16707,8 +16662,7 @@ impl ListMultipartUploadsError {
     pub fn from_body(body: &str) -> ListMultipartUploadsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListMultipartUploadsError::Unknown(String::from(body)),
@@ -16773,8 +16727,7 @@ impl ListObjectVersionsError {
     pub fn from_body(body: &str) -> ListObjectVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListObjectVersionsError::Unknown(String::from(body)),
@@ -16841,8 +16794,7 @@ impl ListObjectsError {
     pub fn from_body(body: &str) -> ListObjectsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchBucket" => {
@@ -16911,8 +16863,7 @@ impl ListObjectsV2Error {
     pub fn from_body(body: &str) -> ListObjectsV2Error {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchBucket" => {
@@ -16979,8 +16930,7 @@ impl ListPartsError {
     pub fn from_body(body: &str) -> ListPartsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListPartsError::Unknown(String::from(body)),
@@ -17043,8 +16993,7 @@ impl PutBucketAccelerateConfigurationError {
     pub fn from_body(body: &str) -> PutBucketAccelerateConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAccelerateConfigurationError::Unknown(String::from(body)),
@@ -17109,8 +17058,7 @@ impl PutBucketAclError {
     pub fn from_body(body: &str) -> PutBucketAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAclError::Unknown(String::from(body)),
@@ -17173,8 +17121,7 @@ impl PutBucketAnalyticsConfigurationError {
     pub fn from_body(body: &str) -> PutBucketAnalyticsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAnalyticsConfigurationError::Unknown(String::from(body)),
@@ -17239,8 +17186,7 @@ impl PutBucketCorsError {
     pub fn from_body(body: &str) -> PutBucketCorsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketCorsError::Unknown(String::from(body)),
@@ -17303,8 +17249,7 @@ impl PutBucketInventoryConfigurationError {
     pub fn from_body(body: &str) -> PutBucketInventoryConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketInventoryConfigurationError::Unknown(String::from(body)),
@@ -17369,8 +17314,7 @@ impl PutBucketLifecycleError {
     pub fn from_body(body: &str) -> PutBucketLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLifecycleError::Unknown(String::from(body)),
@@ -17435,8 +17379,7 @@ impl PutBucketLifecycleConfigurationError {
     pub fn from_body(body: &str) -> PutBucketLifecycleConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLifecycleConfigurationError::Unknown(String::from(body)),
@@ -17501,8 +17444,7 @@ impl PutBucketLoggingError {
     pub fn from_body(body: &str) -> PutBucketLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLoggingError::Unknown(String::from(body)),
@@ -17565,8 +17507,7 @@ impl PutBucketMetricsConfigurationError {
     pub fn from_body(body: &str) -> PutBucketMetricsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketMetricsConfigurationError::Unknown(String::from(body)),
@@ -17631,8 +17572,7 @@ impl PutBucketNotificationError {
     pub fn from_body(body: &str) -> PutBucketNotificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketNotificationError::Unknown(String::from(body)),
@@ -17697,8 +17637,7 @@ impl PutBucketNotificationConfigurationError {
     pub fn from_body(body: &str) -> PutBucketNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketNotificationConfigurationError::Unknown(String::from(body)),
@@ -17763,8 +17702,7 @@ impl PutBucketPolicyError {
     pub fn from_body(body: &str) -> PutBucketPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketPolicyError::Unknown(String::from(body)),
@@ -17827,8 +17765,7 @@ impl PutBucketReplicationError {
     pub fn from_body(body: &str) -> PutBucketReplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketReplicationError::Unknown(String::from(body)),
@@ -17893,8 +17830,7 @@ impl PutBucketRequestPaymentError {
     pub fn from_body(body: &str) -> PutBucketRequestPaymentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketRequestPaymentError::Unknown(String::from(body)),
@@ -17959,8 +17895,7 @@ impl PutBucketTaggingError {
     pub fn from_body(body: &str) -> PutBucketTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketTaggingError::Unknown(String::from(body)),
@@ -18023,8 +17958,7 @@ impl PutBucketVersioningError {
     pub fn from_body(body: &str) -> PutBucketVersioningError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketVersioningError::Unknown(String::from(body)),
@@ -18089,8 +18023,7 @@ impl PutBucketWebsiteError {
     pub fn from_body(body: &str) -> PutBucketWebsiteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketWebsiteError::Unknown(String::from(body)),
@@ -18153,8 +18086,7 @@ impl PutObjectError {
     pub fn from_body(body: &str) -> PutObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutObjectError::Unknown(String::from(body)),
@@ -18219,8 +18151,7 @@ impl PutObjectAclError {
     pub fn from_body(body: &str) -> PutObjectAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchKey" => PutObjectAclError::NoSuchKey(String::from(parsed_error.message)),
@@ -18285,8 +18216,7 @@ impl PutObjectTaggingError {
     pub fn from_body(body: &str) -> PutObjectTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutObjectTaggingError::Unknown(String::from(body)),
@@ -18351,8 +18281,7 @@ impl RestoreObjectError {
     pub fn from_body(body: &str) -> RestoreObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ObjectAlreadyInActiveTierError" => {
@@ -18421,8 +18350,7 @@ impl UploadPartError {
     pub fn from_body(body: &str) -> UploadPartError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UploadPartError::Unknown(String::from(body)),
@@ -18485,8 +18413,7 @@ impl UploadPartCopyError {
     pub fn from_body(body: &str) -> UploadPartCopyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UploadPartCopyError::Unknown(String::from(body)),

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -1096,8 +1097,7 @@ impl BatchDeleteAttributesError {
     pub fn from_body(body: &str) -> BatchDeleteAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => BatchDeleteAttributesError::Unknown(String::from(body)),
@@ -1180,8 +1180,7 @@ impl BatchPutAttributesError {
     pub fn from_body(body: &str) -> BatchPutAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DuplicateItemName" => {
@@ -1296,8 +1295,7 @@ impl CreateDomainError {
     pub fn from_body(body: &str) -> CreateDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
@@ -1380,8 +1378,7 @@ impl DeleteAttributesError {
     pub fn from_body(body: &str) -> DeleteAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
@@ -1462,8 +1459,7 @@ impl DeleteDomainError {
     pub fn from_body(body: &str) -> DeleteDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
@@ -1534,8 +1530,7 @@ impl DomainMetadataError {
     pub fn from_body(body: &str) -> DomainMetadataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
@@ -1612,8 +1607,7 @@ impl GetAttributesError {
     pub fn from_body(body: &str) -> GetAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
@@ -1692,8 +1686,7 @@ impl ListDomainsError {
     pub fn from_body(body: &str) -> ListDomainsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => {
@@ -1778,8 +1771,7 @@ impl PutAttributesError {
     pub fn from_body(body: &str) -> PutAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
@@ -1892,8 +1884,7 @@ impl SelectError {
     pub fn from_body(body: &str) -> SelectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RequestTimeout" => SelectError::RequestTimeout(String::from(parsed_error.message)),

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -6882,8 +6883,7 @@ impl CloneReceiptRuleSetError {
     pub fn from_body(body: &str) -> CloneReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
@@ -6966,8 +6966,7 @@ impl CreateConfigurationSetError {
     pub fn from_body(body: &str) -> CreateConfigurationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetAlreadyExistsException" => {
@@ -7060,8 +7059,7 @@ impl CreateConfigurationSetEventDestinationError {
     pub fn from_body(body: &str) -> CreateConfigurationSetEventDestinationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
@@ -7174,8 +7172,7 @@ impl CreateReceiptFilterError {
     pub fn from_body(body: &str) -> CreateReceiptFilterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
@@ -7262,8 +7259,7 @@ impl CreateReceiptRuleError {
     pub fn from_body(body: &str) -> CreateReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
@@ -7362,8 +7358,7 @@ impl CreateReceiptRuleSetError {
     pub fn from_body(body: &str) -> CreateReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
@@ -7438,8 +7433,7 @@ impl DeleteConfigurationSetError {
     pub fn from_body(body: &str) -> DeleteConfigurationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
@@ -7514,8 +7508,7 @@ impl DeleteConfigurationSetEventDestinationError {
     pub fn from_body(body: &str) -> DeleteConfigurationSetEventDestinationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
@@ -7596,8 +7589,7 @@ impl DeleteIdentityError {
     pub fn from_body(body: &str) -> DeleteIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteIdentityError::Unknown(String::from(body)),
@@ -7660,8 +7652,7 @@ impl DeleteIdentityPolicyError {
     pub fn from_body(body: &str) -> DeleteIdentityPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteIdentityPolicyError::Unknown(String::from(body)),
@@ -7726,8 +7717,7 @@ impl DeleteReceiptFilterError {
     pub fn from_body(body: &str) -> DeleteReceiptFilterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteReceiptFilterError::Unknown(String::from(body)),
@@ -7794,8 +7784,7 @@ impl DeleteReceiptRuleError {
     pub fn from_body(body: &str) -> DeleteReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleSetDoesNotExistException" => {
@@ -7866,8 +7855,7 @@ impl DeleteReceiptRuleSetError {
     pub fn from_body(body: &str) -> DeleteReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CannotDeleteException" => {
@@ -7936,8 +7924,7 @@ impl DeleteVerifiedEmailAddressError {
     pub fn from_body(body: &str) -> DeleteVerifiedEmailAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVerifiedEmailAddressError::Unknown(String::from(body)),
@@ -8002,8 +7989,7 @@ impl DescribeActiveReceiptRuleSetError {
     pub fn from_body(body: &str) -> DescribeActiveReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeActiveReceiptRuleSetError::Unknown(String::from(body)),
@@ -8070,8 +8056,7 @@ impl DescribeConfigurationSetError {
     pub fn from_body(body: &str) -> DescribeConfigurationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
@@ -8146,8 +8131,7 @@ impl DescribeReceiptRuleError {
     pub fn from_body(body: &str) -> DescribeReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleDoesNotExistException" => {
@@ -8222,8 +8206,7 @@ impl DescribeReceiptRuleSetError {
     pub fn from_body(body: &str) -> DescribeReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleSetDoesNotExistException" => {
@@ -8294,8 +8277,7 @@ impl GetIdentityDkimAttributesError {
     pub fn from_body(body: &str) -> GetIdentityDkimAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityDkimAttributesError::Unknown(String::from(body)),
@@ -8360,8 +8342,7 @@ impl GetIdentityMailFromDomainAttributesError {
     pub fn from_body(body: &str) -> GetIdentityMailFromDomainAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityMailFromDomainAttributesError::Unknown(String::from(body)),
@@ -8426,8 +8407,7 @@ impl GetIdentityNotificationAttributesError {
     pub fn from_body(body: &str) -> GetIdentityNotificationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityNotificationAttributesError::Unknown(String::from(body)),
@@ -8492,8 +8472,7 @@ impl GetIdentityPoliciesError {
     pub fn from_body(body: &str) -> GetIdentityPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityPoliciesError::Unknown(String::from(body)),
@@ -8558,8 +8537,7 @@ impl GetIdentityVerificationAttributesError {
     pub fn from_body(body: &str) -> GetIdentityVerificationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityVerificationAttributesError::Unknown(String::from(body)),
@@ -8624,8 +8602,7 @@ impl GetSendQuotaError {
     pub fn from_body(body: &str) -> GetSendQuotaError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetSendQuotaError::Unknown(String::from(body)),
@@ -8688,8 +8665,7 @@ impl GetSendStatisticsError {
     pub fn from_body(body: &str) -> GetSendStatisticsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetSendStatisticsError::Unknown(String::from(body)),
@@ -8754,8 +8730,7 @@ impl ListConfigurationSetsError {
     pub fn from_body(body: &str) -> ListConfigurationSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListConfigurationSetsError::Unknown(String::from(body)),
@@ -8820,8 +8795,7 @@ impl ListIdentitiesError {
     pub fn from_body(body: &str) -> ListIdentitiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListIdentitiesError::Unknown(String::from(body)),
@@ -8884,8 +8858,7 @@ impl ListIdentityPoliciesError {
     pub fn from_body(body: &str) -> ListIdentityPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListIdentityPoliciesError::Unknown(String::from(body)),
@@ -8950,8 +8923,7 @@ impl ListReceiptFiltersError {
     pub fn from_body(body: &str) -> ListReceiptFiltersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListReceiptFiltersError::Unknown(String::from(body)),
@@ -9016,8 +8988,7 @@ impl ListReceiptRuleSetsError {
     pub fn from_body(body: &str) -> ListReceiptRuleSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListReceiptRuleSetsError::Unknown(String::from(body)),
@@ -9082,8 +9053,7 @@ impl ListVerifiedEmailAddressesError {
     pub fn from_body(body: &str) -> ListVerifiedEmailAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListVerifiedEmailAddressesError::Unknown(String::from(body)),
@@ -9150,8 +9120,7 @@ impl PutIdentityPolicyError {
     pub fn from_body(body: &str) -> PutIdentityPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidPolicyException" => {
@@ -9224,8 +9193,7 @@ impl ReorderReceiptRuleSetError {
     pub fn from_body(body: &str) -> ReorderReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleDoesNotExistException" => {
@@ -9300,8 +9268,7 @@ impl SendBounceError {
     pub fn from_body(body: &str) -> SendBounceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MessageRejected" => {
@@ -9374,8 +9341,7 @@ impl SendEmailError {
     pub fn from_body(body: &str) -> SendEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
@@ -9456,8 +9422,7 @@ impl SendRawEmailError {
     pub fn from_body(body: &str) -> SendRawEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
@@ -9536,8 +9501,7 @@ impl SetActiveReceiptRuleSetError {
     pub fn from_body(body: &str) -> SetActiveReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleSetDoesNotExistException" => {
@@ -9608,8 +9572,7 @@ impl SetIdentityDkimEnabledError {
     pub fn from_body(body: &str) -> SetIdentityDkimEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityDkimEnabledError::Unknown(String::from(body)),
@@ -9674,8 +9637,7 @@ impl SetIdentityFeedbackForwardingEnabledError {
     pub fn from_body(body: &str) -> SetIdentityFeedbackForwardingEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityFeedbackForwardingEnabledError::Unknown(String::from(body)),
@@ -9740,8 +9702,7 @@ impl SetIdentityHeadersInNotificationsEnabledError {
     pub fn from_body(body: &str) -> SetIdentityHeadersInNotificationsEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityHeadersInNotificationsEnabledError::Unknown(String::from(body)),
@@ -9808,8 +9769,7 @@ impl SetIdentityMailFromDomainError {
     pub fn from_body(body: &str) -> SetIdentityMailFromDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityMailFromDomainError::Unknown(String::from(body)),
@@ -9874,8 +9834,7 @@ impl SetIdentityNotificationTopicError {
     pub fn from_body(body: &str) -> SetIdentityNotificationTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityNotificationTopicError::Unknown(String::from(body)),
@@ -9944,8 +9903,7 @@ impl SetReceiptRulePositionError {
     pub fn from_body(body: &str) -> SetReceiptRulePositionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleDoesNotExistException" => SetReceiptRulePositionError::RuleDoesNotExist(
@@ -10030,8 +9988,7 @@ impl UpdateConfigurationSetEventDestinationError {
     pub fn from_body(body: &str) -> UpdateConfigurationSetEventDestinationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
@@ -10146,8 +10103,7 @@ impl UpdateReceiptRuleError {
     pub fn from_body(body: &str) -> UpdateReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidLambdaFunctionException" => UpdateReceiptRuleError::InvalidLambdaFunction(
@@ -10238,8 +10194,7 @@ impl VerifyDomainDkimError {
     pub fn from_body(body: &str) -> VerifyDomainDkimError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyDomainDkimError::Unknown(String::from(body)),
@@ -10302,8 +10257,7 @@ impl VerifyDomainIdentityError {
     pub fn from_body(body: &str) -> VerifyDomainIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyDomainIdentityError::Unknown(String::from(body)),
@@ -10368,8 +10322,7 @@ impl VerifyEmailAddressError {
     pub fn from_body(body: &str) -> VerifyEmailAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyEmailAddressError::Unknown(String::from(body)),
@@ -10434,8 +10387,7 @@ impl VerifyEmailIdentityError {
     pub fn from_body(body: &str) -> VerifyEmailIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyEmailIdentityError::Unknown(String::from(body)),

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -2630,8 +2631,7 @@ impl AddPermissionError {
     pub fn from_body(body: &str) -> AddPermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -2718,8 +2718,7 @@ impl CheckIfPhoneNumberIsOptedOutError {
     pub fn from_body(body: &str) -> CheckIfPhoneNumberIsOptedOutError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -2814,8 +2813,7 @@ impl ConfirmSubscriptionError {
     pub fn from_body(body: &str) -> ConfirmSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -2908,8 +2906,7 @@ impl CreatePlatformApplicationError {
     pub fn from_body(body: &str) -> CreatePlatformApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -2996,8 +2993,7 @@ impl CreatePlatformEndpointError {
     pub fn from_body(body: &str) -> CreatePlatformEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => CreatePlatformEndpointError::AuthorizationError(
@@ -3086,8 +3082,7 @@ impl CreateTopicError {
     pub fn from_body(body: &str) -> CreateTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -3172,8 +3167,7 @@ impl DeleteEndpointError {
     pub fn from_body(body: &str) -> DeleteEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -3254,8 +3248,7 @@ impl DeletePlatformApplicationError {
     pub fn from_body(body: &str) -> DeletePlatformApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -3342,8 +3335,7 @@ impl DeleteTopicError {
     pub fn from_body(body: &str) -> DeleteTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -3430,8 +3422,7 @@ impl GetEndpointAttributesError {
     pub fn from_body(body: &str) -> GetEndpointAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => GetEndpointAttributesError::AuthorizationError(
@@ -3520,8 +3511,7 @@ impl GetPlatformApplicationAttributesError {
     pub fn from_body(body: &str) -> GetPlatformApplicationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -3614,8 +3604,7 @@ impl GetSMSAttributesError {
     pub fn from_body(body: &str) -> GetSMSAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -3702,8 +3691,7 @@ impl GetSubscriptionAttributesError {
     pub fn from_body(body: &str) -> GetSubscriptionAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -3794,8 +3782,7 @@ impl GetTopicAttributesError {
     pub fn from_body(body: &str) -> GetTopicAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -3884,8 +3871,7 @@ impl ListEndpointsByPlatformApplicationError {
     pub fn from_body(body: &str) -> ListEndpointsByPlatformApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -3980,8 +3966,7 @@ impl ListPhoneNumbersOptedOutError {
     pub fn from_body(body: &str) -> ListPhoneNumbersOptedOutError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -4070,8 +4055,7 @@ impl ListPlatformApplicationsError {
     pub fn from_body(body: &str) -> ListPlatformApplicationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -4156,8 +4140,7 @@ impl ListSubscriptionsError {
     pub fn from_body(body: &str) -> ListSubscriptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -4242,8 +4225,7 @@ impl ListSubscriptionsByTopicError {
     pub fn from_body(body: &str) -> ListSubscriptionsByTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -4332,8 +4314,7 @@ impl ListTopicsError {
     pub fn from_body(body: &str) -> ListTopicsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -4416,8 +4397,7 @@ impl OptInPhoneNumberError {
     pub fn from_body(body: &str) -> OptInPhoneNumberError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -4510,8 +4490,7 @@ impl PublishError {
     pub fn from_body(body: &str) -> PublishError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -4608,8 +4587,7 @@ impl RemovePermissionError {
     pub fn from_body(body: &str) -> RemovePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -4696,8 +4674,7 @@ impl SetEndpointAttributesError {
     pub fn from_body(body: &str) -> SetEndpointAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => SetEndpointAttributesError::AuthorizationError(
@@ -4786,8 +4763,7 @@ impl SetPlatformApplicationAttributesError {
     pub fn from_body(body: &str) -> SetPlatformApplicationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -4880,8 +4856,7 @@ impl SetSMSAttributesError {
     pub fn from_body(body: &str) -> SetSMSAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -4968,8 +4943,7 @@ impl SetSubscriptionAttributesError {
     pub fn from_body(body: &str) -> SetSubscriptionAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -5060,8 +5034,7 @@ impl SetTopicAttributesError {
     pub fn from_body(body: &str) -> SetTopicAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -5152,8 +5125,7 @@ impl SubscribeError {
     pub fn from_body(body: &str) -> SubscribeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
@@ -5242,8 +5214,7 @@ impl UnsubscribeError {
     pub fn from_body(body: &str) -> UnsubscribeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -2247,8 +2248,7 @@ impl AddPermissionError {
     pub fn from_body(body: &str) -> AddPermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OverLimit" => AddPermissionError::OverLimit(String::from(parsed_error.message)),
@@ -2317,8 +2317,7 @@ impl ChangeMessageVisibilityError {
     pub fn from_body(body: &str) -> ChangeMessageVisibilityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MessageNotInflight" => ChangeMessageVisibilityError::MessageNotInflight(
@@ -2399,8 +2398,7 @@ impl ChangeMessageVisibilityBatchError {
     pub fn from_body(body: &str) -> ChangeMessageVisibilityBatchError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BatchEntryIdsNotDistinct" => {
@@ -2489,8 +2487,7 @@ impl CreateQueueError {
     pub fn from_body(body: &str) -> CreateQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "QueueDeletedRecently" => {
@@ -2565,8 +2562,7 @@ impl DeleteMessageError {
     pub fn from_body(body: &str) -> DeleteMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidIdFormat" => {
@@ -2645,8 +2641,7 @@ impl DeleteMessageBatchError {
     pub fn from_body(body: &str) -> DeleteMessageBatchError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BatchEntryIdsNotDistinct" => DeleteMessageBatchError::BatchEntryIdsNotDistinct(
@@ -2729,8 +2724,7 @@ impl DeleteQueueError {
     pub fn from_body(body: &str) -> DeleteQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteQueueError::Unknown(String::from(body)),
@@ -2795,8 +2789,7 @@ impl GetQueueAttributesError {
     pub fn from_body(body: &str) -> GetQueueAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidAttributeName" => GetQueueAttributesError::InvalidAttributeName(
@@ -2867,8 +2860,7 @@ impl GetQueueUrlError {
     pub fn from_body(body: &str) -> GetQueueUrlError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "QueueDoesNotExist" => {
@@ -2937,8 +2929,7 @@ impl ListDeadLetterSourceQueuesError {
     pub fn from_body(body: &str) -> ListDeadLetterSourceQueuesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "QueueDoesNotExist" => ListDeadLetterSourceQueuesError::QueueDoesNotExist(
@@ -3007,8 +2998,7 @@ impl ListQueuesError {
     pub fn from_body(body: &str) -> ListQueuesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListQueuesError::Unknown(String::from(body)),
@@ -3075,8 +3065,7 @@ impl PurgeQueueError {
     pub fn from_body(body: &str) -> PurgeQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "PurgeQueueInProgress" => {
@@ -3149,8 +3138,7 @@ impl ReceiveMessageError {
     pub fn from_body(body: &str) -> ReceiveMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OverLimit" => ReceiveMessageError::OverLimit(String::from(parsed_error.message)),
@@ -3215,8 +3203,7 @@ impl RemovePermissionError {
     pub fn from_body(body: &str) -> RemovePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RemovePermissionError::Unknown(String::from(body)),
@@ -3283,8 +3270,7 @@ impl SendMessageError {
     pub fn from_body(body: &str) -> SendMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidMessageContents" => {
@@ -3367,8 +3353,7 @@ impl SendMessageBatchError {
     pub fn from_body(body: &str) -> SendMessageBatchError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BatchEntryIdsNotDistinct" => SendMessageBatchError::BatchEntryIdsNotDistinct(
@@ -3459,8 +3444,7 @@ impl SetQueueAttributesError {
     pub fn from_body(body: &str) -> SetQueueAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidAttributeName" => SetQueueAttributesError::InvalidAttributeName(

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -30,7 +30,8 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use xml::reader::XmlEvent;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-use rusoto_core::xmlutil::{characters, end_element, peek_at_name, skip_tree, start_element};
+use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
+                           start_element};
 use rusoto_core::xmlerror::*;
 
 enum DeserializerNext {
@@ -1235,8 +1236,7 @@ impl AssumeRoleError {
     pub fn from_body(body: &str) -> AssumeRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MalformedPolicyDocumentException" => {
@@ -1323,8 +1323,7 @@ impl AssumeRoleWithSAMLError {
     pub fn from_body(body: &str) -> AssumeRoleWithSAMLError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ExpiredTokenException" => {
@@ -1429,8 +1428,7 @@ impl AssumeRoleWithWebIdentityError {
     pub fn from_body(body: &str) -> AssumeRoleWithWebIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ExpiredTokenException" => {
@@ -1533,8 +1531,7 @@ impl DecodeAuthorizationMessageError {
     pub fn from_body(body: &str) -> DecodeAuthorizationMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidAuthorizationMessageException" => {
@@ -1605,8 +1602,7 @@ impl GetCallerIdentityError {
     pub fn from_body(body: &str) -> GetCallerIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetCallerIdentityError::Unknown(String::from(body)),
@@ -1677,8 +1673,7 @@ impl GetFederationTokenError {
     pub fn from_body(body: &str) -> GetFederationTokenError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MalformedPolicyDocumentException" => {
@@ -1759,8 +1754,7 @@ impl GetSessionTokenError {
     pub fn from_body(body: &str) -> GetSessionTokenError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-        let _start_document = stack.next();
-        let _response_envelope = stack.next();
+        find_start_element(&mut stack);
         match XmlErrorDeserializer::deserialize("Error", &mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RegionDisabledException" => {

--- a/service_crategen/src/commands/generate/codegen/error_types.rs
+++ b/service_crategen/src/commands/generate/codegen/error_types.rs
@@ -156,8 +156,7 @@ impl GenerateErrorTypes for XmlErrorTypes {
                     pub fn from_body(body: &str) -> {type_name} {{
                         let reader = EventReader::new(body.as_bytes());
                         let mut stack = XmlResponse::new(reader.into_iter().peekable());
-                        let _start_document = stack.next();
-                        let _response_envelope = stack.next();
+                        find_start_element(&mut stack);
                         match XmlErrorDeserializer::deserialize(\"Error\", &mut stack) {{
                             Ok(parsed_error) => {{
                                 match &parsed_error.code[..] {{

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -77,7 +77,7 @@ impl GenerateProtocol for QueryGenerator {
             use rusoto_core::signature::SignedRequest;
             use xml::reader::XmlEvent;
             use rusoto_core::xmlutil::{{Next, Peek, XmlParseError, XmlResponse}};
-            use rusoto_core::xmlutil::{{characters, end_element, start_element, skip_tree, peek_at_name}};
+            use rusoto_core::xmlutil::{{characters, end_element, find_start_element, start_element, skip_tree, peek_at_name}};
             use rusoto_core::xmlerror::*;
 
             enum DeserializerNext {{

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -99,7 +99,7 @@ impl GenerateProtocol for RestXmlGenerator {
             use xml::reader::XmlEvent;
             use rusoto_core::xmlerror::*;
             use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-            use rusoto_core::xmlutil::{peek_at_name, characters, end_element, start_element, skip_tree};
+            use rusoto_core::xmlutil::{peek_at_name, characters, end_element, find_start_element, start_element, skip_tree};
             enum DeserializerNext {
                 Close,
                 Skip,


### PR DESCRIPTION
In XML error responses:
  * Don't skip the first two elements unconditionally. Instead,
    skip everything until we find a start element. (Skipped one
    too many in case of Ceph.)
  * Don't abort parsing if an unknown element is encountered, skip
    it instead.

Note: `xmlutil::peek_at_name` should probably be made to return `None` or `Error` instead of `""` when no element is remaining. But I believe it is be better to do that in a separate pull request.

related to #732