### PR TITLE
Make all caller-facing types SerDe

### DIFF
--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToCertificateRequest {
     #[doc="<p>String that contains the ARN of the ACM Certificate to which the tag is to be applied. This must be of the form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>"]
     #[serde(rename="CertificateArn")]
@@ -39,7 +39,7 @@ pub struct AddTagsToCertificateRequest {
 }
 
 #[doc="<p>Contains metadata about an ACM certificate. This structure is returned in the response to a <a>DescribeCertificate</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CertificateDetail {
     #[doc="<p>The Amazon Resource Name (ARN) of the certificate. For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
     #[serde(rename="CertificateArn")]
@@ -128,7 +128,7 @@ pub struct CertificateDetail {
 }
 
 #[doc="<p>This structure is returned in the response object of <a>ListCertificates</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CertificateSummary {
     #[doc="<p>Amazon Resource Name (ARN) of the certificate. This is of the form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>"]
     #[serde(rename="CertificateArn")]
@@ -140,21 +140,21 @@ pub struct CertificateSummary {
     pub domain_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCertificateRequest {
     #[doc="<p>String that contains the ARN of the ACM Certificate to be deleted. This must be of the form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>"]
     #[serde(rename="CertificateArn")]
     pub certificate_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCertificateRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the ACM Certificate. The ARN must have the following form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>"]
     #[serde(rename="CertificateArn")]
     pub certificate_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCertificateResponse {
     #[doc="<p>Metadata about an ACM certificate.</p>"]
     #[serde(rename="Certificate")]
@@ -163,7 +163,7 @@ pub struct DescribeCertificateResponse {
 }
 
 #[doc="<p>Contains information about the validation of each domain name in the certificate.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainValidation {
     #[doc="<p>A fully qualified domain name (FQDN) in the certificate. For example, <code>www.example.com</code> or <code>example.com</code>.</p>"]
     #[serde(rename="DomainName")]
@@ -183,7 +183,7 @@ pub struct DomainValidation {
 }
 
 #[doc="<p>Contains information about the domain names that you want ACM to use to send you emails to validate your ownership of the domain.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainValidationOption {
     #[doc="<p>A fully qualified domain name (FQDN) in the certificate request.</p>"]
     #[serde(rename="DomainName")]
@@ -193,14 +193,14 @@ pub struct DomainValidationOption {
     pub validation_domain: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCertificateRequest {
     #[doc="<p>String that contains a certificate ARN in the following format:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>"]
     #[serde(rename="CertificateArn")]
     pub certificate_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCertificateResponse {
     #[doc="<p>String that contains the ACM Certificate represented by the ARN specified at input.</p>"]
     #[serde(rename="Certificate")]
@@ -212,7 +212,7 @@ pub struct GetCertificateResponse {
     pub certificate_chain: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportCertificateRequest {
     #[doc="<p>The certificate to import. It must meet the following requirements:</p> <ul> <li> <p>Must be PEM-encoded.</p> </li> <li> <p>Must contain a 1024-bit or 2048-bit RSA public key.</p> </li> <li> <p>Must be valid at the time of import. You cannot import a certificate before its validity period begins (the certificate's <code>NotBefore</code> date) or after it expires (the certificate's <code>NotAfter</code> date).</p> </li> </ul>"]
     #[serde(rename="Certificate")]
@@ -244,7 +244,7 @@ pub struct ImportCertificateRequest {
     pub private_key: Vec<u8>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportCertificateResponse {
     #[doc="<p>The <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Name (ARN)</a> of the imported certificate.</p>"]
     #[serde(rename="CertificateArn")]
@@ -252,7 +252,7 @@ pub struct ImportCertificateResponse {
     pub certificate_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCertificatesRequest {
     #[doc="<p>The status or statuses on which to filter the list of ACM Certificates.</p>"]
     #[serde(rename="CertificateStatuses")]
@@ -268,7 +268,7 @@ pub struct ListCertificatesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCertificatesResponse {
     #[doc="<p>A list of ACM Certificates.</p>"]
     #[serde(rename="CertificateSummaryList")]
@@ -280,14 +280,14 @@ pub struct ListCertificatesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForCertificateRequest {
     #[doc="<p>String that contains the ARN of the ACM Certificate for which you want to list the tags. This has the following form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>"]
     #[serde(rename="CertificateArn")]
     pub certificate_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForCertificateResponse {
     #[doc="<p>The key-value pairs that define the applied tags.</p>"]
     #[serde(rename="Tags")]
@@ -295,7 +295,7 @@ pub struct ListTagsForCertificateResponse {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromCertificateRequest {
     #[doc="<p>String that contains the ARN of the ACM Certificate with one or more tags that you want to remove. This must be of the form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>"]
     #[serde(rename="CertificateArn")]
@@ -306,7 +306,7 @@ pub struct RemoveTagsFromCertificateRequest {
 }
 
 #[doc="<p>Contains information about the status of ACM's <a href=\"http://docs.aws.amazon.com/acm/latest/userguide/acm-renewal.html\">managed renewal</a> for the certificate. This structure exists only when the certificate type is <code>AMAZON_ISSUED</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RenewalSummary {
     #[doc="<p>Contains information about the validation of each domain name in the certificate, as it pertains to ACM's <a href=\"http://docs.aws.amazon.com/acm/latest/userguide/acm-renewal.html\">managed renewal</a>. This is different from the initial validation that occurs as a result of the <a>RequestCertificate</a> request. This field exists only when the certificate type is <code>AMAZON_ISSUED</code>.</p>"]
     #[serde(rename="DomainValidationOptions")]
@@ -316,7 +316,7 @@ pub struct RenewalSummary {
     pub renewal_status: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestCertificateRequest {
     #[doc="<p> Fully qualified domain name (FQDN), such as www.example.com, of the site that you want to secure with an ACM Certificate. Use an asterisk (*) to create a wildcard certificate that protects several sites in the same domain. For example, *.example.com protects www.example.com, site.example.com, and images.example.com. </p> <p> The maximum length of a DNS name is 253 octets. The name is made up of multiple labels separated by periods. No label can be longer than 63 octets. Consider the following examples: </p> <p> <code>(63 octets).(63 octets).(63 octets).(61 octets)</code> is legal because the total length is 253 octets (63+1+63+1+63+1+61) and no label exceeds 63 octets. </p> <p> <code>(64 octets).(63 octets).(63 octets).(61 octets)</code> is not legal because the total length exceeds 253 octets (64+1+63+1+63+1+61) and the first label exceeds 63 octets. </p> <p> <code>(63 octets).(63 octets).(63 octets).(62 octets)</code> is not legal because the total length of the DNS name (63+1+63+1+63+1+62) exceeds 253 octets. </p>"]
     #[serde(rename="DomainName")]
@@ -335,7 +335,7 @@ pub struct RequestCertificateRequest {
     pub subject_alternative_names: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestCertificateResponse {
     #[doc="<p>String that contains the ARN of the issued certificate. This must be of the form:</p> <p> <code>arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p>"]
     #[serde(rename="CertificateArn")]
@@ -343,7 +343,7 @@ pub struct RequestCertificateResponse {
     pub certificate_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResendValidationEmailRequest {
     #[doc="<p>String that contains the ARN of the requested certificate. The certificate ARN is generated and returned by the <a>RequestCertificate</a> action as soon as the request is made. By default, using this parameter causes email to be sent to all top-level domains you specified in the certificate request.</p> <p>The ARN must be of the form:</p> <p> <code>arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p>"]
     #[serde(rename="CertificateArn")]

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 #[doc="<p>Represents an AWS account that is associated with Amazon API Gateway.</p> <div class=\"remarks\"> <p>To view the account info, call <code>GET</code> on this resource.</p> <h4>Error Codes</h4> <p>The following exception may be thrown when the request fails.</p> <ul> <li>UnauthorizedException</li> <li>NotFoundException</li> <li>TooManyRequestsException</li> </ul> <p>For detailed error code information, including the corresponding HTTP Status Codes, see <a href=\"http://docs.aws.amazon.com/apigateway/api-reference/handling-errors/#api-error-codes\">API Gateway Error Codes</a></p> <h4>Example: Get the information about an account.</h4> <h5>Request</h5> <pre><code>GET /account HTTP/1.1 Content-Type: application/json Host: apigateway.us-east-1.amazonaws.com X-Amz-Date: 20160531T184618Z Authorization: AWS4-HMAC-SHA256 Credential={access_key_ID}/us-east-1/apigateway/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature={sig4_hash} </code></pre> <h5>Response</h5> <p>The successful response returns a <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ \"_links\": { \"curies\": { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/account-apigateway-{rel}.html\", \"name\": \"account\", \"templated\": true }, \"self\": { \"href\": \"/account\" }, \"account:update\": { \"href\": \"/account\" } }, \"cloudwatchRoleArn\": \"arn:aws:iam::123456789012:role/apigAwsProxyRole\", \"throttleSettings\": { \"rateLimit\": 500, \"burstLimit\": 1000 } } </code></pre> <p>In addition to making the REST API call directly, you can use the AWS CLI and an AWS SDK to access this resource.</p> </div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-limits.html\">API Gateway Limits</a> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html\">Developer Guide</a>, <a href=\"http://docs.aws.amazon.com/cli/latest/reference/apigateway/get-account.html\">AWS CLI</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Account {
     #[doc="<p>The version of the API keys used for the account.</p>"]
     #[serde(rename="apiKeyVersion")]
@@ -51,7 +51,7 @@ pub struct Account {
 }
 
 #[doc="<p>A resource that can be distributed to callers for executing <a>Method</a> resources that require an API key. API keys can be mapped to any <a>Stage</a> on any <a>RestApi</a>, which indicates that the callers with the API key can make requests to that stage.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html\">Use API Keys</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApiKey {
     #[doc="<p>The timestamp when the API Key was created.</p>"]
     #[serde(rename="createdDate")]
@@ -92,7 +92,7 @@ pub struct ApiKey {
 }
 
 #[doc="<p>The identifier of an <a>ApiKey</a> used in a <a>UsagePlan</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApiKeyIds {
     #[doc="<p>A list of all the <a>ApiKey</a> identifiers.</p>"]
     #[serde(rename="ids")]
@@ -105,7 +105,7 @@ pub struct ApiKeyIds {
 }
 
 #[doc="<p>Represents a collection of API keys as represented by an <a>ApiKeys</a> resource.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html\">Use API Keys</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApiKeys {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -134,7 +134,7 @@ pub struct ApiStage {
 }
 
 #[doc="<p>Represents an authorization layer for methods. If enabled on a method, API Gateway will activate the authorizer when a client calls the method.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html\">Enable custom authorization</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Authorizer {
     #[doc="<p>Optional customer-defined field, used in Swagger imports/exports. Has no functional impact.</p>"]
     #[serde(rename="authType")]
@@ -179,7 +179,7 @@ pub struct Authorizer {
 }
 
 #[doc="<p>Represents a collection of <a>Authorizer</a> resources.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html\">Enable custom authorization</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Authorizers {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -191,7 +191,7 @@ pub struct Authorizers {
 }
 
 #[doc="<p>Represents the base path that callers of the API must provide as part of the URL after the domain name.</p> <div class=\"remarks\">A custom domain name plus a <code>BasePathMapping</code> specification identifies a deployed <a>RestApi</a> in a given stage of the owner <a>Account</a>.</div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html\">Use Custom Domain Names</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BasePathMapping {
     #[doc="<p>The base path name that callers of the API must provide as part of the URL after the domain name.</p>"]
     #[serde(rename="basePath")]
@@ -208,7 +208,7 @@ pub struct BasePathMapping {
 }
 
 #[doc="<p>Represents a collection of <a>BasePathMapping</a> resources.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html\">Use Custom Domain Names</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BasePathMappings {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -220,7 +220,7 @@ pub struct BasePathMappings {
 }
 
 #[doc="<p>Represents a client certificate used to configure client-side SSL authentication while sending requests to the integration endpoint.</p> <div class=\"remarks\">Client certificates are used authenticate an API by the back-end server. To authenticate an API client (or user), use a custom <a>Authorizer</a>.</div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html\">Use Client-Side Certificate</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClientCertificate {
     #[doc="<p>The identifier of the client certificate.</p>"]
     #[serde(rename="clientCertificateId")]
@@ -245,7 +245,7 @@ pub struct ClientCertificate {
 }
 
 #[doc="<p>Represents a collection of <a>ClientCertificate</a> resources.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html\">Use Client-Side Certificate</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClientCertificates {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -257,7 +257,7 @@ pub struct ClientCertificates {
 }
 
 #[doc="<p>Request to create an <a>ApiKey</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateApiKeyRequest {
     #[doc="<p>An AWS Marketplace customer identifier , when integrating with the AWS SaaS Marketplace.</p>"]
     #[serde(rename="customerId")]
@@ -290,7 +290,7 @@ pub struct CreateApiKeyRequest {
 }
 
 #[doc="<p>Request to add a new <a>Authorizer</a> to an existing <a>RestApi</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAuthorizerRequest {
     #[doc="<p>Optional customer-defined field, used in Swagger imports/exports. Has no functional impact.</p>"]
     #[serde(rename="authType")]
@@ -331,7 +331,7 @@ pub struct CreateAuthorizerRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to create a new <a>BasePathMapping</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBasePathMappingRequest {
     #[doc="<p>The base path name that callers of the API must provide as part of the URL after the domain name. This value must be unique for all of the mappings across a single API. Leave this blank if you do not want callers to specify a base path name after the domain name.</p>"]
     #[serde(rename="basePath")]
@@ -350,7 +350,7 @@ pub struct CreateBasePathMappingRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to create a <a>Deployment</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeploymentRequest {
     #[doc="<p>Enables a cache cluster for the <a>Stage</a> resource specified in the input.</p>"]
     #[serde(rename="cacheClusterEnabled")]
@@ -382,7 +382,7 @@ pub struct CreateDeploymentRequest {
 }
 
 #[doc="<p>Creates a new documentation part of a given API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDocumentationPartRequest {
     #[doc="<p>[Required] The location of the targeted API entity of the to-be-created documentation part.</p>"]
     #[serde(rename="location")]
@@ -396,7 +396,7 @@ pub struct CreateDocumentationPartRequest {
 }
 
 #[doc="<p>Creates a new documentation version of a given API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDocumentationVersionRequest {
     #[doc="<p>A description about the new documentation snapshot.</p>"]
     #[serde(rename="description")]
@@ -415,7 +415,7 @@ pub struct CreateDocumentationVersionRequest {
 }
 
 #[doc="<p>A request to create a new domain name.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDomainNameRequest {
     #[doc="<p>The reference to an AWS-managed certificate. AWS Certificate Manager is the only supported source.</p>"]
     #[serde(rename="certificateArn")]
@@ -443,7 +443,7 @@ pub struct CreateDomainNameRequest {
 }
 
 #[doc="<p>Request to add a new <a>Model</a> to an existing <a>RestApi</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateModelRequest {
     #[doc="<p>The content-type for the model.</p>"]
     #[serde(rename="contentType")]
@@ -465,7 +465,7 @@ pub struct CreateModelRequest {
 }
 
 #[doc="<p>Creates a <a>RequestValidator</a> of a given <a>RestApi</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRequestValidatorRequest {
     #[doc="<p>The name of the to-be-created <a>RequestValidator</a>.</p>"]
     #[serde(rename="name")]
@@ -485,7 +485,7 @@ pub struct CreateRequestValidatorRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to create a <a>Resource</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateResourceRequest {
     #[doc="<p>The parent resource's identifier.</p>"]
     #[serde(rename="parentId")]
@@ -499,7 +499,7 @@ pub struct CreateResourceRequest {
 }
 
 #[doc="<p>The POST Request to add a new <a>RestApi</a> resource to your collection.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRestApiRequest {
     #[doc="<p>The list of binary media types supported by the <a>RestApi</a>. By default, the <a>RestApi</a> supports only UTF-8-encoded text payloads.</p>"]
     #[serde(rename="binaryMediaTypes")]
@@ -523,7 +523,7 @@ pub struct CreateRestApiRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to create a <a>Stage</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStageRequest {
     #[doc="<p>Whether cache clustering is enabled for the stage.</p>"]
     #[serde(rename="cacheClusterEnabled")]
@@ -557,7 +557,7 @@ pub struct CreateStageRequest {
 }
 
 #[doc="<p>The POST request to create a usage plan key for adding an existing API key to a usage plan.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUsagePlanKeyRequest {
     #[doc="<p>The identifier of a <a>UsagePlanKey</a> resource for a plan customer.</p>"]
     #[serde(rename="keyId")]
@@ -571,7 +571,7 @@ pub struct CreateUsagePlanKeyRequest {
 }
 
 #[doc="<p>The POST request to create a usage plan with the name, description, throttle limits and quota limits, as well as the associated API stages, specified in the payload.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUsagePlanRequest {
     #[doc="<p>The associated API stages of the usage plan.</p>"]
     #[serde(rename="apiStages")]
@@ -595,7 +595,7 @@ pub struct CreateUsagePlanRequest {
 }
 
 #[doc="<p>A request to delete the <a>ApiKey</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApiKeyRequest {
     #[doc="<p>The identifier of the <a>ApiKey</a> resource to be deleted.</p>"]
     #[serde(rename="apiKey")]
@@ -603,7 +603,7 @@ pub struct DeleteApiKeyRequest {
 }
 
 #[doc="<p>Request to delete an existing <a>Authorizer</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAuthorizerRequest {
     #[doc="<p>The identifier of the <a>Authorizer</a> resource.</p>"]
     #[serde(rename="authorizerId")]
@@ -614,7 +614,7 @@ pub struct DeleteAuthorizerRequest {
 }
 
 #[doc="<p>A request to delete the <a>BasePathMapping</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBasePathMappingRequest {
     #[doc="<p>The base path name of the <a>BasePathMapping</a> resource to delete.</p>"]
     #[serde(rename="basePath")]
@@ -625,7 +625,7 @@ pub struct DeleteBasePathMappingRequest {
 }
 
 #[doc="<p>A request to delete the <a>ClientCertificate</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClientCertificateRequest {
     #[doc="<p>The identifier of the <a>ClientCertificate</a> resource to be deleted.</p>"]
     #[serde(rename="clientCertificateId")]
@@ -633,7 +633,7 @@ pub struct DeleteClientCertificateRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to delete a <a>Deployment</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDeploymentRequest {
     #[doc="<p>The identifier of the <a>Deployment</a> resource to delete.</p>"]
     #[serde(rename="deploymentId")]
@@ -644,7 +644,7 @@ pub struct DeleteDeploymentRequest {
 }
 
 #[doc="<p>Deletes an existing documentation part of an API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDocumentationPartRequest {
     #[doc="<p>[Required] The identifier of the to-be-deleted documentation part.</p>"]
     #[serde(rename="documentationPartId")]
@@ -655,7 +655,7 @@ pub struct DeleteDocumentationPartRequest {
 }
 
 #[doc="<p>Deletes an existing documentation version of an API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDocumentationVersionRequest {
     #[doc="<p>[Required] The version identifier of a to-be-deleted documentation snapshot.</p>"]
     #[serde(rename="documentationVersion")]
@@ -666,7 +666,7 @@ pub struct DeleteDocumentationVersionRequest {
 }
 
 #[doc="<p>A request to delete the <a>DomainName</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDomainNameRequest {
     #[doc="<p>The name of the <a>DomainName</a> resource to be deleted.</p>"]
     #[serde(rename="domainName")]
@@ -674,7 +674,7 @@ pub struct DeleteDomainNameRequest {
 }
 
 #[doc="<p>Clears any customization of a <a>GatewayResponse</a> of a specified response type on the given <a>RestApi</a> and resets it with the default settings.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteGatewayResponseRequest {
     #[doc="<p><p>The response type of the associated <a>GatewayResponse</a>. Valid values are <ul><li>ACCESS_DENIED</li><li>API_CONFIGURATION_ERROR</li><li>AUTHORIZER_FAILURE</li><li> AUTHORIZER_CONFIGURATION_ERROR</li><li>BAD_REQUEST_PARAMETERS</li><li>BAD_REQUEST_BODY</li><li>DEFAULT_4XX</li><li>DEFAULT_5XX</li><li>EXPIRED_TOKEN</li><li>INVALID_SIGNATURE</li><li>INTEGRATION_FAILURE</li><li>INTEGRATION_TIMEOUT</li><li>INVALID_API_KEY</li><li>MISSING_AUTHENTICATION_TOKEN</li><li> QUOTA_EXCEEDED</li><li>REQUEST_TOO_LARGE</li><li>RESOURCE_NOT_FOUND</li><li>THROTTLED</li><li>UNAUTHORIZED</li><li>UNSUPPORTED_MEDIA_TYPES</li></ul> </p></p>"]
     #[serde(rename="responseType")]
@@ -685,7 +685,7 @@ pub struct DeleteGatewayResponseRequest {
 }
 
 #[doc="<p>Represents a delete integration request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIntegrationRequest {
     #[doc="<p>Specifies a delete integration request's HTTP method.</p>"]
     #[serde(rename="httpMethod")]
@@ -699,7 +699,7 @@ pub struct DeleteIntegrationRequest {
 }
 
 #[doc="<p>Represents a delete integration response request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIntegrationResponseRequest {
     #[doc="<p>Specifies a delete integration response request's HTTP method.</p>"]
     #[serde(rename="httpMethod")]
@@ -716,7 +716,7 @@ pub struct DeleteIntegrationResponseRequest {
 }
 
 #[doc="<p>Request to delete an existing <a>Method</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMethodRequest {
     #[doc="<p>The HTTP verb of the <a>Method</a> resource.</p>"]
     #[serde(rename="httpMethod")]
@@ -730,7 +730,7 @@ pub struct DeleteMethodRequest {
 }
 
 #[doc="<p>A request to delete an existing <a>MethodResponse</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMethodResponseRequest {
     #[doc="<p>The HTTP verb of the <a>Method</a> resource.</p>"]
     #[serde(rename="httpMethod")]
@@ -747,7 +747,7 @@ pub struct DeleteMethodResponseRequest {
 }
 
 #[doc="<p>Request to delete an existing model in an existing <a>RestApi</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteModelRequest {
     #[doc="<p>The name of the model to delete.</p>"]
     #[serde(rename="modelName")]
@@ -758,7 +758,7 @@ pub struct DeleteModelRequest {
 }
 
 #[doc="<p>Deletes a specified <a>RequestValidator</a> of a given <a>RestApi</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRequestValidatorRequest {
     #[doc="<p>[Required] The identifier of the <a>RequestValidator</a> to be deleted.</p>"]
     #[serde(rename="requestValidatorId")]
@@ -769,7 +769,7 @@ pub struct DeleteRequestValidatorRequest {
 }
 
 #[doc="<p>Request to delete a <a>Resource</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteResourceRequest {
     #[doc="<p>The identifier of the <a>Resource</a> resource.</p>"]
     #[serde(rename="resourceId")]
@@ -780,7 +780,7 @@ pub struct DeleteResourceRequest {
 }
 
 #[doc="<p>Request to delete the specified API from your collection.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRestApiRequest {
     #[doc="<p>The string identifier of the associated <a>RestApi</a>.</p>"]
     #[serde(rename="restApiId")]
@@ -788,7 +788,7 @@ pub struct DeleteRestApiRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to delete a <a>Stage</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStageRequest {
     #[doc="<p>The string identifier of the associated <a>RestApi</a>.</p>"]
     #[serde(rename="restApiId")]
@@ -799,7 +799,7 @@ pub struct DeleteStageRequest {
 }
 
 #[doc="<p>The DELETE request to delete a usage plan key and remove the underlying API key from the associated usage plan.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUsagePlanKeyRequest {
     #[doc="<p>The Id of the <a>UsagePlanKey</a> resource to be deleted.</p>"]
     #[serde(rename="keyId")]
@@ -810,7 +810,7 @@ pub struct DeleteUsagePlanKeyRequest {
 }
 
 #[doc="<p>The DELETE request to delete a usage plan of a given plan Id.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUsagePlanRequest {
     #[doc="<p>The Id of the to-be-deleted usage plan.</p>"]
     #[serde(rename="usagePlanId")]
@@ -818,7 +818,7 @@ pub struct DeleteUsagePlanRequest {
 }
 
 #[doc="<p>An immutable representation of a <a>RestApi</a> resource that can be called by users using <a>Stages</a>. A deployment must be associated with a <a>Stage</a> for it to be callable over the Internet.</p> <div class=\"remarks\">To create a deployment, call <code>POST</code> on the <a>Deployments</a> resource of a <a>RestApi</a>. To view, update, or delete a deployment, call <code>GET</code>, <code>PATCH</code>, or <code>DELETE</code> on the specified deployment resource (<code>/restapis/{restapi_id}/deployments/{deployment_id}</code>).</div> <div class=\"seeAlso\"><a>RestApi</a>, <a>Deployments</a>, <a>Stage</a>, <a href=\"http://docs.aws.amazon.com/cli/latest/reference/apigateway/get-deployment.html\">AWS CLI</a>, <a href=\"https://aws.amazon.com/tools/\">AWS SDKs</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Deployment {
     #[doc="<p>A summary of the <a>RestApi</a> at the date and time that the deployment resource was created.</p>"]
     #[serde(rename="apiSummary")]
@@ -841,7 +841,7 @@ pub struct Deployment {
 }
 
 #[doc="<p>Represents a collection resource that contains zero or more references to your existing deployments, and links that guide you on how to interact with your collection. The collection offers a paginated view of the contained deployments.</p> <div class=\"remarks\">To create a new deployment of a <a>RestApi</a>, make a <code>POST</code> request against this resource. To view, update, or delete an existing deployment, make a <code>GET</code>, <code>PATCH</code>, or <code>DELETE</code> request, respectively, on a specified <a>Deployment</a> resource.</div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html\">Deploying an API</a>, <a href=\"http://docs.aws.amazon.com/cli/latest/reference/apigateway/get-deployment.html\">AWS CLI</a>, <a href=\"https://aws.amazon.com/tools/\">AWS SDKs</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Deployments {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -853,7 +853,7 @@ pub struct Deployments {
 }
 
 #[doc="<p>A documentation part for a targeted API entity.</p> <div class=\"remarks\"> <p>A documentation part consists of a content map (<code>properties</code>) and a target (<code>location</code>). The target specifies an API entity to which the documentation content applies. The supported API entity types are <code>API</code>, <code>AUTHORIZER</code>, <code>MODEL</code>, <code>RESOURCE</code>, <code>METHOD</code>, <code>PATH_PARAMETER</code>, <code>QUERY_PARAMETER</code>, <code>REQUEST_HEADER</code>, <code>REQUEST_BODY</code>, <code>RESPONSE</code>, <code>RESPONSE_HEADER</code>, and <code>RESPONSE_BODY</code>. Valid <code>location</code> fields depend on the API entity type. All valid fields are not required.</p> <p>The content map is a JSON string of API-specific key-value pairs. Although an API can use any shape for the content map, only the Swagger-compliant documentation fields will be injected into the associated API entity definition in the exported Swagger definition file.</p></div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html\">Documenting an API</a>, <a>DocumentationParts</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentationPart {
     #[doc="<p>The <a>DocumentationPart</a> identifier, generated by Amazon API Gateway when the <code>DocumentationPart</code> is created.</p>"]
     #[serde(rename="id")]
@@ -870,7 +870,7 @@ pub struct DocumentationPart {
 }
 
 #[doc="<p>A collection of the imported <a>DocumentationPart</a> identifiers.</p> <div class=\"remarks\">This is used to return the result when documentation parts in an external (e.g., Swagger) file are imported into Amazon API Gateway</div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html\">Documenting an API</a>, <a href=\"http://docs.aws.amazon.com/apigateway/api-reference/link-relation/documentationpart-import/\">documentationpart:import</a>, <a>DocumentationPart</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentationPartIds {
     #[doc="<p>A list of the returned documentation part identifiers.</p>"]
     #[serde(rename="ids")]
@@ -907,7 +907,7 @@ pub struct DocumentationPartLocation {
 }
 
 #[doc="<p>The collection of documentation parts of an API.</p> <div class=\"remarks\"/> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html\">Documenting an API</a>, <a>DocumentationPart</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentationParts {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -919,7 +919,7 @@ pub struct DocumentationParts {
 }
 
 #[doc="<p>A snapshot of the documentation of an API.</p> <div class=\"remarks\"><p>Publishing API documentation involves creating a documentation version associated with an API stage and exporting the versioned documentation to an external (e.g., Swagger) file.</p></div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html\">Documenting an API</a>, <a>DocumentationPart</a>, <a>DocumentationVersions</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentationVersion {
     #[doc="<p>The date when the API documentation snapshot is created.</p>"]
     #[serde(rename="createdDate")]
@@ -936,7 +936,7 @@ pub struct DocumentationVersion {
 }
 
 #[doc="<p>The collection of documentation snapshots of an API. </p> <div class=\"remarks\"><p>Use the <a>DocumentationVersions</a> to manage documentation snapshots associated with various API stages.</p></div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html\">Documenting an API</a>, <a>DocumentationPart</a>, <a>DocumentationVersion</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentationVersions {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -948,7 +948,7 @@ pub struct DocumentationVersions {
 }
 
 #[doc="<p>Represents a domain name that is contained in a simpler, more intuitive URL that can be called.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html\">Use Client-Side Certificate</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainName {
     #[doc="<p>The reference to an AWS-managed certificate. AWS Certificate Manager is the only supported source.</p>"]
     #[serde(rename="certificateArn")]
@@ -973,7 +973,7 @@ pub struct DomainName {
 }
 
 #[doc="<p>Represents a collection of <a>DomainName</a> resources.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html\">Use Client-Side Certificate</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainNames {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -985,18 +985,28 @@ pub struct DomainNames {
 }
 
 #[doc="<p>The binary blob response to <a>GetExport</a>, which contains the generated SDK.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExportResponse {
     #[doc="<p>The binary blob response to <a>GetExport</a>, which contains the export.</p>"]
+    #[serde(rename="body")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub body: Option<Vec<u8>>,
     #[doc="<p>The content-disposition header value in the HTTP response.</p>"]
+    #[serde(rename="contentDisposition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_disposition: Option<String>,
     #[doc="<p>The content-type header value in the HTTP response. This will correspond to a valid 'accept' type in the request.</p>"]
+    #[serde(rename="contentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_type: Option<String>,
 }
 
 #[doc="<p>Request to flush authorizer cache entries on a specified stage.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FlushStageAuthorizersCacheRequest {
     #[doc="<p>The string identifier of the associated <a>RestApi</a>.</p>"]
     #[serde(rename="restApiId")]
@@ -1007,7 +1017,7 @@ pub struct FlushStageAuthorizersCacheRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to flush a stage's cache.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FlushStageCacheRequest {
     #[doc="<p>The string identifier of the associated <a>RestApi</a>.</p>"]
     #[serde(rename="restApiId")]
@@ -1018,7 +1028,7 @@ pub struct FlushStageCacheRequest {
 }
 
 #[doc="<p>A gateway response of a given response type and status code, with optional response parameters and mapping templates.</p> <div class=\"remarks\"> For more information about valid gateway response types, see <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/supported-gateway-response-types.html\">Gateway Response Types Supported by Amazon API Gateway</a> <div class=\"example\"> <h4>Example: Get a Gateway Response of a given response type</h4> <h5>Request</h5> <p>This example shows how to get a gateway response of the <code>MISSING_AUTHNETICATION_TOKEN</code> type.</p> <pre><code>GET /restapis/o81lxisefl/gatewayresponses/MISSING_AUTHENTICATION_TOKEN HTTP/1.1 Host: beta-apigateway.us-east-1.amazonaws.com Content-Type: application/json X-Amz-Date: 20170503T202516Z Authorization: AWS4-HMAC-SHA256 Credential={access-key-id}/20170503/us-east-1/apigateway/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=1b52460e3159c1a26cff29093855d50ea141c1c5b937528fecaf60f51129697a Cache-Control: no-cache Postman-Token: 3b2a1ce9-c848-2e26-2e2f-9c2caefbed45 </code></pre> <p>The response type is specified as a URL path.</p> <h5>Response</h5> <p>The successful operation returns the <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ \"_links\": { \"curies\": { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-gatewayresponse-{rel}.html\", \"name\": \"gatewayresponse\", \"templated\": true }, \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/MISSING_AUTHENTICATION_TOKEN\" }, \"gatewayresponse:delete\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/MISSING_AUTHENTICATION_TOKEN\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/MISSING_AUTHENTICATION_TOKEN\" } }, \"defaultResponse\": false, \"responseParameters\": { \"gatewayresponse.header.x-request-path\": \"method.request.path.petId\", \"gatewayresponse.header.Access-Control-Allow-Origin\": \"&apos;a.b.c&apos;\", \"gatewayresponse.header.x-request-query\": \"method.request.querystring.q\", \"gatewayresponse.header.x-request-header\": \"method.request.header.Accept\" }, \"responseTemplates\": { \"application/json\": \"{\\n \\\"message\\\": $context.error.messageString,\\n \\\"type\\\": \\\"$context.error.responseType\\\",\\n \\\"stage\\\": \\\"$context.stage\\\",\\n \\\"resourcePath\\\": \\\"$context.resourcePath\\\",\\n \\\"stageVariables.a\\\": \\\"$stageVariables.a\\\",\\n \\\"statusCode\\\": \\\"&apos;404&apos;\\\"\\n}\" }, \"responseType\": \"MISSING_AUTHENTICATION_TOKEN\", \"statusCode\": \"404\" }</code></pre> <p></p> </div> </div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/customize-gateway-responses.html\">Customize Gateway Responses</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GatewayResponse {
     #[doc="<p>A Boolean flag to indicate whether this <a>GatewayResponse</a> is the default gateway response (<code>true</code>) or not (<code>false</code>). A default gateway response is one generated by Amazon API Gateway without any customization by an API developer. </p>"]
     #[serde(rename="defaultResponse")]
@@ -1043,7 +1053,7 @@ pub struct GatewayResponse {
 }
 
 #[doc="<p>The collection of the <a>GatewayResponse</a> instances of a <a>RestApi</a> as a <code>responseType</code>-to-<a>GatewayResponse</a> object map of key-value pairs. As such, pagination is not supported for querying this collection.</p> <div class=\"remarks\"> For more information about valid gateway response types, see <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/supported-gateway-response-types.html\">Gateway Response Types Supported by Amazon API Gateway</a> <div class=\"example\"> <h4>Example: Get the collection of gateway responses of an API</h4> <h5>Request</h5> <p>This example request shows how to retrieve the <a>GatewayResponses</a> collection from an API.</p> <pre><code>GET /restapis/o81lxisefl/gatewayresponses HTTP/1.1 Host: beta-apigateway.us-east-1.amazonaws.com Content-Type: application/json X-Amz-Date: 20170503T220604Z Authorization: AWS4-HMAC-SHA256 Credential={access-key-id}/20170503/us-east-1/apigateway/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=59b42fe54a76a5de8adf2c67baa6d39206f8e9ad49a1d77ccc6a5da3103a398a Cache-Control: no-cache Postman-Token: 5637af27-dc29-fc5c-9dfe-0645d52cb515 </code></pre> <p></p> <h5>Response</h5> <p>The successful operation returns the <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ \"_links\": { \"curies\": { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-gatewayresponse-{rel}.html\", \"name\": \"gatewayresponse\", \"templated\": true }, \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses\" }, \"first\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses\" }, \"gatewayresponse:by-type\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"item\": [ { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_FAILURE\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/RESOURCE_NOT_FOUND\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/REQUEST_TOO_LARGE\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/THROTTLED\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED_MEDIA_TYPE\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_CONFIGURATION_ERROR\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_5XX\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_4XX\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_PARAMETERS\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_BODY\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/EXPIRED_TOKEN\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/ACCESS_DENIED\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_API_KEY\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/API_CONFIGURATION_ERROR\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/QUOTA_EXCEEDED\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_TIMEOUT\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/MISSING_AUTHENTICATION_TOKEN\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_SIGNATURE\" }, { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_FAILURE\" } ] }, \"_embedded\": { \"item\": [ { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_FAILURE\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_FAILURE\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"INTEGRATION_FAILURE\", \"statusCode\": \"504\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/RESOURCE_NOT_FOUND\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/RESOURCE_NOT_FOUND\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"RESOURCE_NOT_FOUND\", \"statusCode\": \"404\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/REQUEST_TOO_LARGE\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/REQUEST_TOO_LARGE\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"REQUEST_TOO_LARGE\", \"statusCode\": \"413\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/THROTTLED\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/THROTTLED\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"THROTTLED\", \"statusCode\": \"429\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED_MEDIA_TYPE\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED_MEDIA_TYPE\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"UNSUPPORTED_MEDIA_TYPE\", \"statusCode\": \"415\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_CONFIGURATION_ERROR\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_CONFIGURATION_ERROR\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"AUTHORIZER_CONFIGURATION_ERROR\", \"statusCode\": \"500\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_5XX\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_5XX\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"DEFAULT_5XX\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_4XX\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/DEFAULT_4XX\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"DEFAULT_4XX\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_PARAMETERS\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_PARAMETERS\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"BAD_REQUEST_PARAMETERS\", \"statusCode\": \"400\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_BODY\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/BAD_REQUEST_BODY\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"BAD_REQUEST_BODY\", \"statusCode\": \"400\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/EXPIRED_TOKEN\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/EXPIRED_TOKEN\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"EXPIRED_TOKEN\", \"statusCode\": \"403\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/ACCESS_DENIED\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/ACCESS_DENIED\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"ACCESS_DENIED\", \"statusCode\": \"403\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_API_KEY\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_API_KEY\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"INVALID_API_KEY\", \"statusCode\": \"403\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"UNAUTHORIZED\", \"statusCode\": \"401\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/API_CONFIGURATION_ERROR\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/API_CONFIGURATION_ERROR\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"API_CONFIGURATION_ERROR\", \"statusCode\": \"500\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/QUOTA_EXCEEDED\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/QUOTA_EXCEEDED\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"QUOTA_EXCEEDED\", \"statusCode\": \"429\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_TIMEOUT\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INTEGRATION_TIMEOUT\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"INTEGRATION_TIMEOUT\", \"statusCode\": \"504\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/MISSING_AUTHENTICATION_TOKEN\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/MISSING_AUTHENTICATION_TOKEN\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"MISSING_AUTHENTICATION_TOKEN\", \"statusCode\": \"403\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_SIGNATURE\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/INVALID_SIGNATURE\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"INVALID_SIGNATURE\", \"statusCode\": \"403\" }, { \"_links\": { \"self\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_FAILURE\" }, \"gatewayresponse:put\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/{response_type}\", \"templated\": true }, \"gatewayresponse:update\": { \"href\": \"/restapis/o81lxisefl/gatewayresponses/AUTHORIZER_FAILURE\" } }, \"defaultResponse\": true, \"responseParameters\": {}, \"responseTemplates\": { \"application/json\": \"{\\\"message\\\":$context.error.messageString}\" }, \"responseType\": \"AUTHORIZER_FAILURE\", \"statusCode\": \"500\" } ] } }</code></pre> <p></p> </div> </div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/customize-gateway-responses.html\">Customize Gateway Responses</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GatewayResponses {
     #[doc="<p>Returns the entire collection, because of no pagination support.</p>"]
     #[serde(rename="items")]
@@ -1055,7 +1065,7 @@ pub struct GatewayResponses {
 }
 
 #[doc="<p>A request to generate a <a>ClientCertificate</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenerateClientCertificateRequest {
     #[doc="<p>The description of the <a>ClientCertificate</a>.</p>"]
     #[serde(rename="description")]
@@ -1064,11 +1074,11 @@ pub struct GenerateClientCertificateRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to get information about the current <a>Account</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccountRequest;
 
 #[doc="<p>A request to get information about the current <a>ApiKey</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetApiKeyRequest {
     #[doc="<p>The identifier of the <a>ApiKey</a> resource.</p>"]
     #[serde(rename="apiKey")]
@@ -1080,7 +1090,7 @@ pub struct GetApiKeyRequest {
 }
 
 #[doc="<p>A request to get information about the current <a>ApiKeys</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetApiKeysRequest {
     #[doc="<p>The identifier of a customer in AWS Marketplace or an external system, such as a developer portal.</p>"]
     #[serde(rename="customerId")]
@@ -1105,7 +1115,7 @@ pub struct GetApiKeysRequest {
 }
 
 #[doc="<p>Request to describe an existing <a>Authorizer</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAuthorizerRequest {
     #[doc="<p>The identifier of the <a>Authorizer</a> resource.</p>"]
     #[serde(rename="authorizerId")]
@@ -1116,7 +1126,7 @@ pub struct GetAuthorizerRequest {
 }
 
 #[doc="<p>Request to describe an existing <a>Authorizers</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAuthorizersRequest {
     #[doc="<p>The maximum number of returned results per page.</p>"]
     #[serde(rename="limit")]
@@ -1132,7 +1142,7 @@ pub struct GetAuthorizersRequest {
 }
 
 #[doc="<p>Request to describe a <a>BasePathMapping</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBasePathMappingRequest {
     #[doc="<p>The base path name that callers of the API must provide as part of the URL after the domain name. This value must be unique for all of the mappings across a single API. Leave this blank if you do not want callers to specify any base path name after the domain name.</p>"]
     #[serde(rename="basePath")]
@@ -1143,7 +1153,7 @@ pub struct GetBasePathMappingRequest {
 }
 
 #[doc="<p>A request to get information about a collection of <a>BasePathMapping</a> resources.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBasePathMappingsRequest {
     #[doc="<p>The domain name of a <a>BasePathMapping</a> resource.</p>"]
     #[serde(rename="domainName")]
@@ -1159,7 +1169,7 @@ pub struct GetBasePathMappingsRequest {
 }
 
 #[doc="<p>A request to get information about the current <a>ClientCertificate</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetClientCertificateRequest {
     #[doc="<p>The identifier of the <a>ClientCertificate</a> resource to be described.</p>"]
     #[serde(rename="clientCertificateId")]
@@ -1167,7 +1177,7 @@ pub struct GetClientCertificateRequest {
 }
 
 #[doc="<p>A request to get information about a collection of <a>ClientCertificate</a> resources.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetClientCertificatesRequest {
     #[doc="<p>The maximum number of returned results per page. The value is 25 by default and could be between 1 - 500.</p>"]
     #[serde(rename="limit")]
@@ -1180,7 +1190,7 @@ pub struct GetClientCertificatesRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to get information about a <a>Deployment</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentRequest {
     #[doc="<p>The identifier of the <a>Deployment</a> resource to get information about.</p>"]
     #[serde(rename="deploymentId")]
@@ -1195,7 +1205,7 @@ pub struct GetDeploymentRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to get information about a <a>Deployments</a> collection.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentsRequest {
     #[doc="<p>The maximum number of returned results per page. The value is 25 by default and could be between 1 - 500.</p>"]
     #[serde(rename="limit")]
@@ -1211,7 +1221,7 @@ pub struct GetDeploymentsRequest {
 }
 
 #[doc="<p>Gets a specified documentation part of a given API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentationPartRequest {
     #[doc="<p>[Required] The string identifier of the associated <a>RestApi</a>.</p>"]
     #[serde(rename="documentationPartId")]
@@ -1222,7 +1232,7 @@ pub struct GetDocumentationPartRequest {
 }
 
 #[doc="<p>Gets the documentation parts of an API. The result may be filtered by the type, name, or path of API entities (targets).</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentationPartsRequest {
     #[doc="<p>The maximum number of returned results per page.</p>"]
     #[serde(rename="limit")]
@@ -1250,7 +1260,7 @@ pub struct GetDocumentationPartsRequest {
 }
 
 #[doc="<p>Gets a documentation snapshot of an API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentationVersionRequest {
     #[doc="<p>[Required] The version identifier of the to-be-retrieved documentation snapshot.</p>"]
     #[serde(rename="documentationVersion")]
@@ -1261,7 +1271,7 @@ pub struct GetDocumentationVersionRequest {
 }
 
 #[doc="<p>Gets the documentation versions of an API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentationVersionsRequest {
     #[doc="<p>The maximum number of returned results per page.</p>"]
     #[serde(rename="limit")]
@@ -1277,7 +1287,7 @@ pub struct GetDocumentationVersionsRequest {
 }
 
 #[doc="<p>Request to get the name of a <a>DomainName</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDomainNameRequest {
     #[doc="<p>The name of the <a>DomainName</a> resource.</p>"]
     #[serde(rename="domainName")]
@@ -1285,7 +1295,7 @@ pub struct GetDomainNameRequest {
 }
 
 #[doc="<p>Request to describe a collection of <a>DomainName</a> resources.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDomainNamesRequest {
     #[doc="<p>The maximum number of returned results per page. The value is 25 by default and could be between 1 - 500.</p>"]
     #[serde(rename="limit")]
@@ -1298,7 +1308,7 @@ pub struct GetDomainNamesRequest {
 }
 
 #[doc="<p>Request a new export of a <a>RestApi</a> for a particular <a>Stage</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetExportRequest {
     #[doc="<p>The content-type of the export, for example <code>application/json</code>. Currently <code>application/json</code> and <code>application/yaml</code> are supported for <code>exportType</code> of <code>swagger</code>. This should be specified in the <code>Accept</code> header for direct API requests.</p>"]
     #[serde(rename="accepts")]
@@ -1320,7 +1330,7 @@ pub struct GetExportRequest {
 }
 
 #[doc="<p>Gets a <a>GatewayResponse</a> of a specified response type on the given <a>RestApi</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGatewayResponseRequest {
     #[doc="<p><p>The response type of the associated <a>GatewayResponse</a>. Valid values are <ul><li>ACCESS_DENIED</li><li>API_CONFIGURATION_ERROR</li><li>AUTHORIZER_FAILURE</li><li> AUTHORIZER_CONFIGURATION_ERROR</li><li>BAD_REQUEST_PARAMETERS</li><li>BAD_REQUEST_BODY</li><li>DEFAULT_4XX</li><li>DEFAULT_5XX</li><li>EXPIRED_TOKEN</li><li>INVALID_SIGNATURE</li><li>INTEGRATION_FAILURE</li><li>INTEGRATION_TIMEOUT</li><li>INVALID_API_KEY</li><li>MISSING_AUTHENTICATION_TOKEN</li><li> QUOTA_EXCEEDED</li><li>REQUEST_TOO_LARGE</li><li>RESOURCE_NOT_FOUND</li><li>THROTTLED</li><li>UNAUTHORIZED</li><li>UNSUPPORTED_MEDIA_TYPES</li></ul> </p></p>"]
     #[serde(rename="responseType")]
@@ -1331,7 +1341,7 @@ pub struct GetGatewayResponseRequest {
 }
 
 #[doc="<p>Gets the <a>GatewayResponses</a> collection on the given <a>RestApi</a>. If an API developer has not added any definitions for gateway responses, the result will be the Amazon API Gateway-generated default <a>GatewayResponses</a> collection for the supported response types.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGatewayResponsesRequest {
     #[doc="<p>The maximum number of returned results per page. The <a>GatewayResponses</a> collection does not support pagination and the limit does not apply here.</p>"]
     #[serde(rename="limit")]
@@ -1347,7 +1357,7 @@ pub struct GetGatewayResponsesRequest {
 }
 
 #[doc="<p>Represents a get integration request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIntegrationRequest {
     #[doc="<p>Specifies a get integration request's HTTP method.</p>"]
     #[serde(rename="httpMethod")]
@@ -1361,7 +1371,7 @@ pub struct GetIntegrationRequest {
 }
 
 #[doc="<p>Represents a get integration response request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIntegrationResponseRequest {
     #[doc="<p>Specifies a get integration response request's HTTP method.</p>"]
     #[serde(rename="httpMethod")]
@@ -1378,7 +1388,7 @@ pub struct GetIntegrationResponseRequest {
 }
 
 #[doc="<p>Request to describe an existing <a>Method</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMethodRequest {
     #[doc="<p>Specifies the method request's HTTP method type.</p>"]
     #[serde(rename="httpMethod")]
@@ -1392,7 +1402,7 @@ pub struct GetMethodRequest {
 }
 
 #[doc="<p>Request to describe a <a>MethodResponse</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMethodResponseRequest {
     #[doc="<p>The HTTP verb of the <a>Method</a> resource.</p>"]
     #[serde(rename="httpMethod")]
@@ -1409,7 +1419,7 @@ pub struct GetMethodResponseRequest {
 }
 
 #[doc="<p>Request to list information about a model in an existing <a>RestApi</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetModelRequest {
     #[doc="<p>A query parameter of a Boolean value to resolve (<code>true</code>) all external model references and returns a flattened model schema or not (<code>false</code>) The default is <code>false</code>.</p>"]
     #[serde(rename="flatten")]
@@ -1424,7 +1434,7 @@ pub struct GetModelRequest {
 }
 
 #[doc="<p>Request to generate a sample mapping template used to transform the payload.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetModelTemplateRequest {
     #[doc="<p>The name of the model for which to generate a template.</p>"]
     #[serde(rename="modelName")]
@@ -1435,7 +1445,7 @@ pub struct GetModelTemplateRequest {
 }
 
 #[doc="<p>Request to list existing <a>Models</a> defined for a <a>RestApi</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetModelsRequest {
     #[doc="<p>The maximum number of returned results per page. The value is 25 by default and could be between 1 - 500.</p>"]
     #[serde(rename="limit")]
@@ -1451,7 +1461,7 @@ pub struct GetModelsRequest {
 }
 
 #[doc="<p>Gets a <a>RequestValidator</a> of a given <a>RestApi</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRequestValidatorRequest {
     #[doc="<p>[Required] The identifier of the <a>RequestValidator</a> to be retrieved.</p>"]
     #[serde(rename="requestValidatorId")]
@@ -1462,7 +1472,7 @@ pub struct GetRequestValidatorRequest {
 }
 
 #[doc="<p>Gets the <a>RequestValidators</a> collection of a given <a>RestApi</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRequestValidatorsRequest {
     #[doc="<p>The maximum number of returned results per page.</p>"]
     #[serde(rename="limit")]
@@ -1478,7 +1488,7 @@ pub struct GetRequestValidatorsRequest {
 }
 
 #[doc="<p>Request to list information about a resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetResourceRequest {
     #[doc="<p>A query parameter to retrieve the specified resources embedded in the returned <a>Resource</a> representation in the response. This <code>embed</code> parameter value is a list of comma-separated strings. Currently, the request supports only retrieval of the embedded <a>Method</a> resources this way. The query parameter value must be a single-valued list and contain the <code>\"methods\"</code> string. For example, <code>GET /restapis/{restapi_id}/resources/{resource_id}?embed=methods</code>.</p>"]
     #[serde(rename="embed")]
@@ -1493,7 +1503,7 @@ pub struct GetResourceRequest {
 }
 
 #[doc="<p>Request to list information about a collection of resources.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetResourcesRequest {
     #[doc="<p>A query parameter used to retrieve the specified resources embedded in the returned <a>Resources</a> resource in the response. This <code>embed</code> parameter value is a list of comma-separated strings. Currently, the request supports only retrieval of the embedded <a>Method</a> resources this way. The query parameter value must be a single-valued list and contain the <code>\"methods\"</code> string. For example, <code>GET /restapis/{restapi_id}/resources?embed=methods</code>.</p>"]
     #[serde(rename="embed")]
@@ -1513,7 +1523,7 @@ pub struct GetResourcesRequest {
 }
 
 #[doc="<p>The GET request to list an existing <a>RestApi</a> defined for your collection. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRestApiRequest {
     #[doc="<p>The identifier of the <a>RestApi</a> resource.</p>"]
     #[serde(rename="restApiId")]
@@ -1521,7 +1531,7 @@ pub struct GetRestApiRequest {
 }
 
 #[doc="<p>The GET request to list existing <a>RestApis</a> defined for your collection.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRestApisRequest {
     #[doc="<p>The maximum number of returned results per page. The value is 25 by default and could be between 1 - 500.</p>"]
     #[serde(rename="limit")]
@@ -1534,7 +1544,7 @@ pub struct GetRestApisRequest {
 }
 
 #[doc="<p>Request a new generated client SDK for a <a>RestApi</a> and <a>Stage</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSdkRequest {
     #[doc="<p>A key-value map of query string parameters that specify properties of the SDK, depending on the requested <code>sdkType</code>. For <code>sdkType</code> of <code>objectivec</code>, a parameter named <code>classPrefix</code> is required. For <code>sdkType</code> of <code>android</code>, parameters named <code>groupId</code>, <code>artifactId</code>, <code>artifactVersion</code>, and <code>invokerPackage</code> are required.</p>"]
     #[serde(rename="parameters")]
@@ -1552,7 +1562,7 @@ pub struct GetSdkRequest {
 }
 
 #[doc="<p>Get an <a>SdkType</a> instance.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSdkTypeRequest {
     #[doc="<p>The identifier of the queried <a>SdkType</a> instance.</p>"]
     #[serde(rename="id")]
@@ -1560,7 +1570,7 @@ pub struct GetSdkTypeRequest {
 }
 
 #[doc="<p>Get the <a>SdkTypes</a> collection.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSdkTypesRequest {
     #[doc="<p>The maximum number of returned results per page.</p>"]
     #[serde(rename="limit")]
@@ -1573,7 +1583,7 @@ pub struct GetSdkTypesRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to get information about a <a>Stage</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetStageRequest {
     #[doc="<p>The string identifier of the associated <a>RestApi</a>.</p>"]
     #[serde(rename="restApiId")]
@@ -1584,7 +1594,7 @@ pub struct GetStageRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to get information about one or more <a>Stage</a> resources.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetStagesRequest {
     #[doc="<p>The stages' deployment identifiers.</p>"]
     #[serde(rename="deploymentId")]
@@ -1596,7 +1606,7 @@ pub struct GetStagesRequest {
 }
 
 #[doc="<p>The GET request to get a usage plan key of a given key identifier.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUsagePlanKeyRequest {
     #[doc="<p>The key Id of the to-be-retrieved <a>UsagePlanKey</a> resource representing a plan customer.</p>"]
     #[serde(rename="keyId")]
@@ -1607,7 +1617,7 @@ pub struct GetUsagePlanKeyRequest {
 }
 
 #[doc="<p>The GET request to get all the usage plan keys representing the API keys added to a specified usage plan.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUsagePlanKeysRequest {
     #[doc="<p>The maximum number of returned results per page.</p>"]
     #[serde(rename="limit")]
@@ -1627,7 +1637,7 @@ pub struct GetUsagePlanKeysRequest {
 }
 
 #[doc="<p>The GET request to get a usage plan of a given plan identifier.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUsagePlanRequest {
     #[doc="<p>The identifier of the <a>UsagePlan</a> resource to be retrieved.</p>"]
     #[serde(rename="usagePlanId")]
@@ -1635,7 +1645,7 @@ pub struct GetUsagePlanRequest {
 }
 
 #[doc="<p>The GET request to get all the usage plans of the caller's account.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUsagePlansRequest {
     #[doc="<p>The identifier of the API key associated with the usage plans.</p>"]
     #[serde(rename="keyId")]
@@ -1652,7 +1662,7 @@ pub struct GetUsagePlansRequest {
 }
 
 #[doc="<p>The GET request to get the usage data of a usage plan in a specified time interval.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUsageRequest {
     #[doc="<p>The ending date (e.g., 2016-12-31) of the usage data.</p>"]
     #[serde(rename="endDate")]
@@ -1678,7 +1688,7 @@ pub struct GetUsageRequest {
 }
 
 #[doc="<p>The POST request to import API keys from an external source, such as a CSV-formatted file.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportApiKeysRequest {
     #[doc="<p>The payload of the POST request to import API keys. For the payload format, see <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-key-file-format.html\">API Key File Format</a>.</p>"]
     #[serde(rename="body")]
@@ -1698,7 +1708,7 @@ pub struct ImportApiKeysRequest {
 }
 
 #[doc="<p>Import documentation parts from an external (e.g., Swagger) definition file. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportDocumentationPartsRequest {
     #[doc="<p>[Required] Raw byte array representing the to-be-imported documentation parts. To import from a Swagger file, this is a JSON object.</p>"]
     #[serde(rename="body")]
@@ -1722,7 +1732,7 @@ pub struct ImportDocumentationPartsRequest {
 }
 
 #[doc="<p>A POST request to import an API to Amazon API Gateway using an input of an API definition file.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportRestApiRequest {
     #[doc="<p>The POST request body containing external API definitions. Currently, only Swagger definition JSON files are supported. The maximum size of the API definition file is 2MB.</p>"]
     #[serde(rename="body")]
@@ -1743,7 +1753,7 @@ pub struct ImportRestApiRequest {
 }
 
 #[doc="<p>Represents an HTTP, HTTP_PROXY, AWS, AWS_PROXY, or Mock integration.</p> <div class=\"remarks\">In the API Gateway console, the built-in Lambda integration is an AWS integration.</div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html\">Creating an API</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Integration {
     #[doc="<p>Specifies the integration's cache key parameters.</p>"]
     #[serde(rename="cacheKeyParameters")]
@@ -1792,7 +1802,7 @@ pub struct Integration {
 }
 
 #[doc="<p>Represents an integration response. The status code must map to an existing <a>MethodResponse</a>, and parameters and templates can be used to transform the back-end response.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html\">Creating an API</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IntegrationResponse {
     #[doc="<p>Specifies how to handle response payload content type conversions. Supported values are <code>CONVERT_TO_BINARY</code> and <code>CONVERT_TO_TEXT</code>, with the following behaviors:</p> <ul> <li><p><code>CONVERT_TO_BINARY</code>: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p></li> <li><p><code>CONVERT_TO_TEXT</code>: Converts a response payload from a binary blob to a Base64-encoded string.</p></li> </ul> <p>If this property is not defined, the response payload will be passed through from the integration response to the method response without modification.</p>"]
     #[serde(rename="contentHandling")]
@@ -1817,7 +1827,7 @@ pub struct IntegrationResponse {
 }
 
 #[doc="<p> Represents a client-facing interface by which the client calls the API to access back-end resources. A <b>Method</b> resource is integrated with an <a>Integration</a> resource. Both consist of a request and one or more responses. The method request takes the client input that is passed to the back end through the integration request. A method response returns the output from the back end to the client through an integration response. A method request is embodied in a <b>Method</b> resource, whereas an integration request is embodied in an <a>Integration</a> resource. On the other hand, a method response is represented by a <a>MethodResponse</a> resource, whereas an integration response is represented by an <a>IntegrationResponse</a> resource. </p> <div class=\"remarks\"> <p/> <h4>Example: Retrive the GET method on a specified resource</h4> <h5>Request</h5> <p>The following example request retrieves the information about the GET method on an API resource (<code>3kzxbg5sa2</code>) of an API (<code>fugvjdxtri</code>). </p> <pre><code>GET /restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET HTTP/1.1 Content-Type: application/json Host: apigateway.us-east-1.amazonaws.com X-Amz-Date: 20160603T210259Z Authorization: AWS4-HMAC-SHA256 Credential={access_key_ID}/20160603/us-east-1/apigateway/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature={sig4_hash}</code></pre> <h5>Response</h5> <p>The successful response returns a <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ \"_links\": { \"curies\": [ { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-integration-{rel}.html\", \"name\": \"integration\", \"templated\": true }, { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-integration-response-{rel}.html\", \"name\": \"integrationresponse\", \"templated\": true }, { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-{rel}.html\", \"name\": \"method\", \"templated\": true }, { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-response-{rel}.html\", \"name\": \"methodresponse\", \"templated\": true } ], \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET\", \"name\": \"GET\", \"title\": \"GET\" }, \"integration:put\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"method:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET\" }, \"method:integration\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"method:responses\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"method:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET\" }, \"methodresponse:put\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/{status_code}\", \"templated\": true } }, \"apiKeyRequired\": true, \"authorizationType\": \"NONE\", \"httpMethod\": \"GET\", \"_embedded\": { \"method:integration\": { \"_links\": { \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"integration:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"integration:responses\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"integration:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration\" }, \"integrationresponse:put\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/{status_code}\", \"templated\": true } }, \"cacheKeyParameters\": [], \"cacheNamespace\": \"3kzxbg5sa2\", \"credentials\": \"arn:aws:iam::123456789012:role/apigAwsProxyRole\", \"httpMethod\": \"POST\", \"passthroughBehavior\": \"WHEN_NO_MATCH\", \"requestParameters\": { \"integration.request.header.Content-Type\": \"'application/x-amz-json-1.1'\" }, \"requestTemplates\": { \"application/json\": \"{\\n}\" }, \"type\": \"AWS\", \"uri\": \"arn:aws:apigateway:us-east-1:kinesis:action/ListStreams\", \"_embedded\": { \"integration:responses\": { \"_links\": { \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"integrationresponse:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\" }, \"integrationresponse:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200\" } }, \"responseParameters\": { \"method.response.header.Content-Type\": \"'application/xml'\" }, \"responseTemplates\": { \"application/json\": \"$util.urlDecode(\\\"%3CkinesisStreams%3E%23foreach(%24stream%20in%20%24input.path(%27%24.StreamNames%27))%3Cstream%3E%3Cname%3E%24stream%3C%2Fname%3E%3C%2Fstream%3E%23end%3C%2FkinesisStreams%3E\\\")\" }, \"statusCode\": \"200\" } } }, \"method:responses\": { \"_links\": { \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\", \"name\": \"200\", \"title\": \"200\" }, \"methodresponse:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\" }, \"methodresponse:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\" } }, \"responseModels\": { \"application/json\": \"Empty\" }, \"responseParameters\": { \"method.response.header.Content-Type\": false }, \"statusCode\": \"200\" } } }</code></pre> <p>In the example above, the response template for the <code>200 OK</code> response maps the JSON output from the <code>ListStreams</code> action in the back end to an XML output. The mapping template is URL-encoded as <code>%3CkinesisStreams%3E%23foreach(%24stream%20in%20%24input.path(%27%24.StreamNames%27))%3Cstream%3E%3Cname%3E%24stream%3C%2Fname%3E%3C%2Fstream%3E%23end%3C%2FkinesisStreams%3E</code> and the output is decoded using the <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#util-templat-reference\">$util.urlDecode()</a> helper function.</p> </div> <div class=\"seeAlso\"> <a>MethodResponse</a>, <a>Integration</a>, <a>IntegrationResponse</a>, <a>Resource</a>, <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-method-settings.html\">Set up an API's method</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Method {
     #[doc="<p>A boolean flag specifying whether a valid <a>ApiKey</a> is required to invoke this method.</p>"]
     #[serde(rename="apiKeyRequired")]
@@ -1862,7 +1872,7 @@ pub struct Method {
 }
 
 #[doc="<p>Represents a method response of a given HTTP status code returned to the client. The method response is passed from the back end through the associated integration response that can be transformed using a mapping template. </p> <div class=\"remarks\"> <p/> <h4>Example: A <b>MethodResponse</b> instance of an API</h4> <h5>Request</h5> <p>The example request retrieves a <b>MethodResponse</b> of the 200 status code.</p> <pre><code>GET /restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200 HTTP/1.1 Content-Type: application/json Host: apigateway.us-east-1.amazonaws.com X-Amz-Date: 20160603T222952Z Authorization: AWS4-HMAC-SHA256 Credential={access_key_ID}/20160603/us-east-1/apigateway/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature={sig4_hash}</code></pre> <h5>Response</h5> <p>The successful response returns <code>200 OK</code> status and a payload as follows:</p> <pre><code>{ \"_links\": { \"curies\": { \"href\": \"http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-response-{rel}.html\", \"name\": \"methodresponse\", \"templated\": true }, \"self\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\", \"title\": \"200\" }, \"methodresponse:delete\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\" }, \"methodresponse:update\": { \"href\": \"/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200\" } }, \"responseModels\": { \"application/json\": \"Empty\" }, \"responseParameters\": { \"method.response.header.Content-Type\": false }, \"statusCode\": \"200\" }</code></pre> <p/> </div> <div class=\"seeAlso\"> <a>Method</a>, <a>IntegrationResponse</a>, <a>Integration</a> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html\">Creating an API</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MethodResponse {
     #[doc="<p>Specifies the <a>Model</a> resources used for the response's content-type. Response models are represented as a key/value map, with a content-type as the key and a <a>Model</a> name as the value.</p>"]
     #[serde(rename="responseModels")]
@@ -1879,7 +1889,7 @@ pub struct MethodResponse {
 }
 
 #[doc="<p>Specifies the method setting properties.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MethodSetting {
     #[doc="<p>Specifies whether the cached responses are encrypted. The PATCH path for this setting is <code>/{method_setting_key}/caching/dataEncrypted</code>, and the value is a Boolean.</p>"]
     #[serde(rename="cacheDataEncrypted")]
@@ -1924,7 +1934,7 @@ pub struct MethodSetting {
 }
 
 #[doc="<p>Represents a summary of a <a>Method</a> resource, given a particular date and time.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MethodSnapshot {
     #[doc="<p>Specifies whether the method requires a valid <a>ApiKey</a>.</p>"]
     #[serde(rename="apiKeyRequired")]
@@ -1937,7 +1947,7 @@ pub struct MethodSnapshot {
 }
 
 #[doc="<p>Represents the data structure of a method's request or response payload.</p> <div class=\"remarks\"> <p>A request model defines the data structure of the client-supplied request payload. A response model defines the data structure of the response payload returned by the back end. Although not required, models are useful for mapping payloads between the front end and back end.</p> <p>A model is used for generating an API's SDK, validating the input request body, and creating a skeletal mapping template.</p> </div> <div class=\"seeAlso\"> <a>Method</a>, <a>MethodResponse</a>, <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html\">Models and Mappings</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Model {
     #[doc="<p>The content-type for the model.</p>"]
     #[serde(rename="contentType")]
@@ -1962,7 +1972,7 @@ pub struct Model {
 }
 
 #[doc="<p>Represents a collection of <a>Model</a> resources.</p> <div class=\"seeAlso\"> <a>Method</a>, <a>MethodResponse</a>, <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html\">Models and Mappings</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Models {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -1974,7 +1984,7 @@ pub struct Models {
 }
 
 #[doc="A single patch operation to apply to the specified resource. Please refer to http://tools.ietf.org/html/rfc6902#section-4 for an explanation of how each operation is used."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PatchOperation {
     #[doc="<p> Not supported.</p>"]
     #[serde(rename="from")]
@@ -1995,7 +2005,7 @@ pub struct PatchOperation {
 }
 
 #[doc="<p>Creates a customization of a <a>GatewayResponse</a> of a specified response type and status code on the given <a>RestApi</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutGatewayResponseRequest {
     #[doc="<p><p>Response parameters (paths, query strings and headers) of the <a>GatewayResponse</a> as a string-to-string map of key-value pairs.</p></p>"]
     #[serde(rename="responseParameters")]
@@ -2018,7 +2028,7 @@ pub struct PutGatewayResponseRequest {
 }
 
 #[doc="<p>Sets up a method's integration.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutIntegrationRequest {
     #[doc="<p>Specifies a put integration input's cache key parameters.</p>"]
     #[serde(rename="cacheKeyParameters")]
@@ -2071,7 +2081,7 @@ pub struct PutIntegrationRequest {
 }
 
 #[doc="<p>Represents a put integration response request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutIntegrationResponseRequest {
     #[doc="<p>Specifies how to handle response payload content type conversions. Supported values are <code>CONVERT_TO_BINARY</code> and <code>CONVERT_TO_TEXT</code>, with the following behaviors:</p> <ul> <li><p><code>CONVERT_TO_BINARY</code>: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p></li> <li><p><code>CONVERT_TO_TEXT</code>: Converts a response payload from a binary blob to a Base64-encoded string.</p></li> </ul> <p>If this property is not defined, the response payload will be passed through from the integration response to the method response without modification.</p>"]
     #[serde(rename="contentHandling")]
@@ -2104,7 +2114,7 @@ pub struct PutIntegrationResponseRequest {
 }
 
 #[doc="<p>Request to add a method to an existing <a>Resource</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutMethodRequest {
     #[doc="<p>Specifies whether the method required a valid <a>ApiKey</a>.</p>"]
     #[serde(rename="apiKeyRequired")]
@@ -2145,7 +2155,7 @@ pub struct PutMethodRequest {
 }
 
 #[doc="<p>Request to add a <a>MethodResponse</a> to an existing <a>Method</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutMethodResponseRequest {
     #[doc="<p>The HTTP verb of the <a>Method</a> resource.</p>"]
     #[serde(rename="httpMethod")]
@@ -2170,7 +2180,7 @@ pub struct PutMethodResponseRequest {
 }
 
 #[doc="<p>A PUT request to update an existing API, with external API definitions specified as the request body.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRestApiRequest {
     #[doc="<p>The PUT request body containing external API definitions. Currently, only Swagger definition JSON files are supported. The maximum size of the API definition file is 2MB.</p>"]
     #[serde(rename="body")]
@@ -2215,7 +2225,7 @@ pub struct QuotaSettings {
 }
 
 #[doc="<p>A set of validation rules for incoming <a>Method</a> requests.</p> <div class=\"remarks\"> <p>In Swagger, a <a>RequestValidator</a> of an API is defined by the <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html#api-gateway-swagger-extensions-request-validators.requestValidator.html\">x-amazon-apigateway-request-validators.requestValidator</a> object. It the referenced using the <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html#api-gateway-swagger-extensions-request-validator\">x-amazon-apigateway-request-validator</a> property.</p> </div> <div class=\"seeAlso\"><a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-request-validation.html\">Enable Basic Request Validation in API Gateway</a></div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestValidator {
     #[doc="<p>The identifier of this <a>RequestValidator</a>.</p>"]
     #[serde(rename="id")]
@@ -2236,7 +2246,7 @@ pub struct RequestValidator {
 }
 
 #[doc="<p>A collection of <a>RequestValidator</a> resources of a given <a>RestApi</a>.</p> <div class=\"remarks\"> <p>In Swagger, the <a>RequestValidators</a> of an API is defined by the <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html#api-gateway-swagger-extensions-request-validators.html\">x-amazon-apigateway-request-validators</a> extension.</p> </div> <div class=\"seeAlso\"><a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-request-validation.html\">Enable Basic Request Validation in API Gateway</a></div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestValidators {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -2248,7 +2258,7 @@ pub struct RequestValidators {
 }
 
 #[doc="<p>Represents an API resource.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html\">Create an API</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Resource {
     #[doc="<p>The resource's identifier.</p>"]
     #[serde(rename="id")]
@@ -2273,7 +2283,7 @@ pub struct Resource {
 }
 
 #[doc="<p>Represents a collection of <a>Resource</a> resources.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html\">Create an API</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Resources {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -2285,7 +2295,7 @@ pub struct Resources {
 }
 
 #[doc="<p>Represents a REST API.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html\">Create an API</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestApi {
     #[doc="<p>The list of binary media types supported by the <a>RestApi</a>. By default, the <a>RestApi</a> supports only UTF-8-encoded text payloads.</p>"]
     #[serde(rename="binaryMediaTypes")]
@@ -2318,7 +2328,7 @@ pub struct RestApi {
 }
 
 #[doc="<p>Contains references to your APIs and links that guide you in how to interact with your collection. A collection offers a paginated view of your APIs.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html\">Create an API</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestApis {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -2330,7 +2340,7 @@ pub struct RestApis {
 }
 
 #[doc="<p>A configuration property of an SDK type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SdkConfigurationProperty {
     #[doc="<p>The default value of an <a>SdkType</a> configuration property.</p>"]
     #[serde(rename="defaultValue")]
@@ -2355,18 +2365,28 @@ pub struct SdkConfigurationProperty {
 }
 
 #[doc="<p>The binary blob response to <a>GetSdk</a>, which contains the generated SDK.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SdkResponse {
     #[doc="<p>The binary blob response to <a>GetSdk</a>, which contains the generated SDK.</p>"]
+    #[serde(rename="body")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub body: Option<Vec<u8>>,
     #[doc="<p>The content-disposition header value in the HTTP response.</p>"]
+    #[serde(rename="contentDisposition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_disposition: Option<String>,
     #[doc="<p>The content-type header value in the HTTP response.</p>"]
+    #[serde(rename="contentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_type: Option<String>,
 }
 
 #[doc="<p>A type of SDK that API Gateway can generate.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SdkType {
     #[doc="<p>A list of configuration properties of an <a>SdkType</a>.</p>"]
     #[serde(rename="configurationProperties")]
@@ -2387,7 +2407,7 @@ pub struct SdkType {
 }
 
 #[doc="<p>The collection of <a>SdkType</a> instances.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SdkTypes {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -2399,7 +2419,7 @@ pub struct SdkTypes {
 }
 
 #[doc="<p>Represents a unique identifier for a version of a deployed <a>RestApi</a> that is callable by users.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html\">Deploy an API</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Stage {
     #[doc="<p>Specifies whether a cache cluster is enabled for the stage.</p>"]
     #[serde(rename="cacheClusterEnabled")]
@@ -2452,7 +2472,7 @@ pub struct Stage {
 }
 
 #[doc="<p>A reference to a unique stage identified in the format <code>{restApiId}/{stage}</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StageKey {
     #[doc="<p>The string identifier of the associated <a>RestApi</a>.</p>"]
     #[serde(rename="restApiId")]
@@ -2465,7 +2485,7 @@ pub struct StageKey {
 }
 
 #[doc="<p>A list of <a>Stage</a> resources that are associated with the <a>ApiKey</a> resource.</p> <div class=\"seeAlso\"><a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/stages.html\">Deploying API in Stages</a></div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Stages {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="item")]
@@ -2474,7 +2494,7 @@ pub struct Stages {
 }
 
 #[doc="<p>Represents a mapping template used to transform a payload.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-mappings\">Mapping Templates</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Template {
     #[doc="<p>The Apache <a href=\"http://velocity.apache.org/engine/devel/vtl-reference-guide.html\" target=\"_blank\">Velocity Template Language (VTL)</a> template content used for the template resource.</p>"]
     #[serde(rename="value")]
@@ -2483,7 +2503,7 @@ pub struct Template {
 }
 
 #[doc="<p>Make a request to simulate the execution of an <a>Authorizer</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestInvokeAuthorizerRequest {
     #[doc="<p>[Optional] A key-value map of additional context variables.</p>"]
     #[serde(rename="additionalContext")]
@@ -2514,7 +2534,7 @@ pub struct TestInvokeAuthorizerRequest {
 }
 
 #[doc="<p>Represents the response of the test invoke request for a custom <a>Authorizer</a></p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestInvokeAuthorizerResponse {
     #[serde(rename="authorization")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -2546,7 +2566,7 @@ pub struct TestInvokeAuthorizerResponse {
 }
 
 #[doc="<p>Make a request to simulate the execution of a <a>Method</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestInvokeMethodRequest {
     #[doc="<p>The simulated request body of an incoming invocation request.</p>"]
     #[serde(rename="body")]
@@ -2580,7 +2600,7 @@ pub struct TestInvokeMethodRequest {
 }
 
 #[doc="<p>Represents the response of the test invoke request in the HTTP method.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-test-method.html#how-to-test-method-console\">Test API using the API Gateway console</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestInvokeMethodResponse {
     #[doc="<p>The body of the HTTP response.</p>"]
     #[serde(rename="body")]
@@ -2618,7 +2638,7 @@ pub struct ThrottleSettings {
 }
 
 #[doc="<p>Requests Amazon API Gateway to change information about the current <a>Account</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAccountRequest {
     #[doc="<p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>"]
     #[serde(rename="patchOperations")]
@@ -2627,7 +2647,7 @@ pub struct UpdateAccountRequest {
 }
 
 #[doc="<p>A request to change information about an <a>ApiKey</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateApiKeyRequest {
     #[doc="<p>The identifier of the <a>ApiKey</a> resource to be updated.</p>"]
     #[serde(rename="apiKey")]
@@ -2639,7 +2659,7 @@ pub struct UpdateApiKeyRequest {
 }
 
 #[doc="<p>Request to update an existing <a>Authorizer</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAuthorizerRequest {
     #[doc="<p>The identifier of the <a>Authorizer</a> resource.</p>"]
     #[serde(rename="authorizerId")]
@@ -2654,7 +2674,7 @@ pub struct UpdateAuthorizerRequest {
 }
 
 #[doc="<p>A request to change information about the <a>BasePathMapping</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateBasePathMappingRequest {
     #[doc="<p>The base path of the <a>BasePathMapping</a> resource to change.</p>"]
     #[serde(rename="basePath")]
@@ -2669,7 +2689,7 @@ pub struct UpdateBasePathMappingRequest {
 }
 
 #[doc="<p>A request to change information about an <a>ClientCertificate</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateClientCertificateRequest {
     #[doc="<p>The identifier of the <a>ClientCertificate</a> resource to be updated.</p>"]
     #[serde(rename="clientCertificateId")]
@@ -2681,7 +2701,7 @@ pub struct UpdateClientCertificateRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to change information about a <a>Deployment</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDeploymentRequest {
     #[doc="<p>The replacement identifier for the <a>Deployment</a> resource to change information about.</p>"]
     #[serde(rename="deploymentId")]
@@ -2696,7 +2716,7 @@ pub struct UpdateDeploymentRequest {
 }
 
 #[doc="<p>Updates an existing documentation part of a given API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDocumentationPartRequest {
     #[doc="<p>[Required] The identifier of the to-be-updated documentation part.</p>"]
     #[serde(rename="documentationPartId")]
@@ -2711,7 +2731,7 @@ pub struct UpdateDocumentationPartRequest {
 }
 
 #[doc="<p>Updates an existing documentation version of an API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDocumentationVersionRequest {
     #[doc="<p>[Required] The version identifier of the to-be-updated documentation version.</p>"]
     #[serde(rename="documentationVersion")]
@@ -2726,7 +2746,7 @@ pub struct UpdateDocumentationVersionRequest {
 }
 
 #[doc="<p>A request to change information about the <a>DomainName</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDomainNameRequest {
     #[doc="<p>The name of the <a>DomainName</a> resource to be changed.</p>"]
     #[serde(rename="domainName")]
@@ -2738,7 +2758,7 @@ pub struct UpdateDomainNameRequest {
 }
 
 #[doc="<p>Updates a <a>GatewayResponse</a> of a specified response type on the given <a>RestApi</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGatewayResponseRequest {
     #[doc="<p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>"]
     #[serde(rename="patchOperations")]
@@ -2753,7 +2773,7 @@ pub struct UpdateGatewayResponseRequest {
 }
 
 #[doc="<p>Represents an update integration request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateIntegrationRequest {
     #[doc="<p>Represents an update integration request's HTTP method.</p>"]
     #[serde(rename="httpMethod")]
@@ -2771,7 +2791,7 @@ pub struct UpdateIntegrationRequest {
 }
 
 #[doc="<p>Represents an update integration response request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateIntegrationResponseRequest {
     #[doc="<p>Specifies an update integration response request's HTTP method.</p>"]
     #[serde(rename="httpMethod")]
@@ -2792,7 +2812,7 @@ pub struct UpdateIntegrationResponseRequest {
 }
 
 #[doc="<p>Request to update an existing <a>Method</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMethodRequest {
     #[doc="<p>The HTTP verb of the <a>Method</a> resource.</p>"]
     #[serde(rename="httpMethod")]
@@ -2810,7 +2830,7 @@ pub struct UpdateMethodRequest {
 }
 
 #[doc="<p>A request to update an existing <a>MethodResponse</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMethodResponseRequest {
     #[doc="<p>The HTTP verb of the <a>Method</a> resource.</p>"]
     #[serde(rename="httpMethod")]
@@ -2831,7 +2851,7 @@ pub struct UpdateMethodResponseRequest {
 }
 
 #[doc="<p>Request to update an existing model in an existing <a>RestApi</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateModelRequest {
     #[doc="<p>The name of the model to update.</p>"]
     #[serde(rename="modelName")]
@@ -2846,7 +2866,7 @@ pub struct UpdateModelRequest {
 }
 
 #[doc="<p>Updates a <a>RequestValidator</a> of a given <a>RestApi</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRequestValidatorRequest {
     #[doc="<p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>"]
     #[serde(rename="patchOperations")]
@@ -2861,7 +2881,7 @@ pub struct UpdateRequestValidatorRequest {
 }
 
 #[doc="<p>Request to change information about a <a>Resource</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateResourceRequest {
     #[doc="<p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>"]
     #[serde(rename="patchOperations")]
@@ -2876,7 +2896,7 @@ pub struct UpdateResourceRequest {
 }
 
 #[doc="<p>Request to update an existing <a>RestApi</a> resource in your collection.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRestApiRequest {
     #[doc="<p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>"]
     #[serde(rename="patchOperations")]
@@ -2888,7 +2908,7 @@ pub struct UpdateRestApiRequest {
 }
 
 #[doc="<p>Requests Amazon API Gateway to change information about a <a>Stage</a> resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateStageRequest {
     #[doc="<p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>"]
     #[serde(rename="patchOperations")]
@@ -2903,7 +2923,7 @@ pub struct UpdateStageRequest {
 }
 
 #[doc="<p>The PATCH request to update a usage plan of a given plan Id.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUsagePlanRequest {
     #[doc="<p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>"]
     #[serde(rename="patchOperations")]
@@ -2915,7 +2935,7 @@ pub struct UpdateUsagePlanRequest {
 }
 
 #[doc="<p>The PATCH request to grant a temporary extension to the remaining quota of a usage plan associated with a specified API key.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUsageRequest {
     #[doc="<p>The identifier of the API key associated with the usage plan in which a temporary extension is granted to the remaining quota.</p>"]
     #[serde(rename="keyId")]
@@ -2930,7 +2950,7 @@ pub struct UpdateUsageRequest {
 }
 
 #[doc="<p>Represents the usage data of a usage plan.</p> <div class=\"remarks\"/> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html\">Create and Use Usage Plans</a>, <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-usage-plans-with-console.html#api-gateway-usage-plan-manage-usage\">Manage Usage in a Usage Plan</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Usage {
     #[doc="<p>The ending date of the usage data.</p>"]
     #[serde(rename="endDate")]
@@ -2954,7 +2974,7 @@ pub struct Usage {
 }
 
 #[doc="<p>Represents a usage plan than can specify who can assess associated API stages with specified request limits and quotas.</p> <div class=\"remarks\"> <p>In a usage plan, you associate an API by specifying the API's Id and a stage name of the specified API. You add plan customers by adding API keys to the plan. </p> </div> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html\">Create and Use Usage Plans</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UsagePlan {
     #[doc="<p>The associated API stages of a usage plan.</p>"]
     #[serde(rename="apiStages")]
@@ -2987,7 +3007,7 @@ pub struct UsagePlan {
 }
 
 #[doc="<p>Represents a usage plan key to identify a plan customer.</p> <div class=\"remarks\"> <p>To associate an API stage with a selected API key in a usage plan, you must create a UsagePlanKey resource to represent the selected <a>ApiKey</a>.</p> </div>\" <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html\">Create and Use Usage Plans</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UsagePlanKey {
     #[doc="<p>The Id of a usage plan key.</p>"]
     #[serde(rename="id")]
@@ -3008,7 +3028,7 @@ pub struct UsagePlanKey {
 }
 
 #[doc="<p>Represents the collection of usage plan keys added to usage plans for the associated API keys and, possibly, other types of keys.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html\">Create and Use Usage Plans</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UsagePlanKeys {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]
@@ -3020,7 +3040,7 @@ pub struct UsagePlanKeys {
 }
 
 #[doc="<p>Represents a collection of usage plans for an AWS account.</p> <div class=\"seeAlso\"> <a href=\"http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html\">Create and Use Usage Plans</a> </div>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UsagePlans {
     #[doc="<p>The current page of elements from this collection.</p>"]
     #[serde(rename="items")]

--- a/rusoto/services/application-autoscaling/src/generated.rs
+++ b/rusoto/services/application-autoscaling/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Represents a CloudWatch alarm associated with a scaling policy.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Alarm {
     #[doc="<p>The Amazon Resource Name (ARN) of the alarm.</p>"]
     #[serde(rename="AlarmARN")]
@@ -61,7 +61,7 @@ pub struct CustomizedMetricSpecification {
     pub unit: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteScalingPolicyRequest {
     #[doc="<p>The name of the scaling policy.</p>"]
     #[serde(rename="PolicyName")]
@@ -77,10 +77,10 @@ pub struct DeleteScalingPolicyRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteScalingPolicyResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterScalableTargetRequest {
     #[doc="<p>The identifier of the resource associated with the scalable target. This string consists of the resource type and unique identifier.</p> <ul> <li> <p>ECS service - The resource type is <code>service</code> and the unique identifier is the cluster name and service name. Example: <code>service/default/sample-webapp</code>.</p> </li> <li> <p>Spot fleet request - The resource type is <code>spot-fleet-request</code> and the unique identifier is the Spot fleet request ID. Example: <code>spot-fleet-request/sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE</code>.</p> </li> <li> <p>EMR cluster - The resource type is <code>instancegroup</code> and the unique identifier is the cluster ID and instance group ID. Example: <code>instancegroup/j-2EEZNYKUA1NTV/ig-1791Y4E1L8YI0</code>.</p> </li> <li> <p>AppStream 2.0 fleet - The resource type is <code>fleet</code> and the unique identifier is the fleet name. Example: <code>fleet/sample-fleet</code>.</p> </li> <li> <p>DynamoDB table - The resource type is <code>table</code> and the unique identifier is the resource ID. Example: <code>table/my-table</code>.</p> </li> <li> <p>DynamoDB global secondary index - The resource type is <code>index</code> and the unique identifier is the resource ID. Example: <code>table/my-table/index/my-table-index</code>.</p> </li> </ul>"]
     #[serde(rename="ResourceId")]
@@ -93,10 +93,10 @@ pub struct DeregisterScalableTargetRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterScalableTargetResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScalableTargetsRequest {
     #[doc="<p>The maximum number of scalable target results. This value can be between 1 and 50. The default value is 50.</p> <p>If this parameter is used, the operation returns up to <code>MaxResults</code> results at a time, along with a <code>NextToken</code> value. To get the next set of results, include the <code>NextToken</code> value in a subsequent call. If this parameter is not used, the operation returns up to 50 results and a <code>NextToken</code> value, if applicable.</p>"]
     #[serde(rename="MaxResults")]
@@ -119,7 +119,7 @@ pub struct DescribeScalableTargetsRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScalableTargetsResponse {
     #[doc="<p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>"]
     #[serde(rename="NextToken")]
@@ -131,7 +131,7 @@ pub struct DescribeScalableTargetsResponse {
     pub scalable_targets: Option<Vec<ScalableTarget>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScalingActivitiesRequest {
     #[doc="<p>The maximum number of scalable target results. This value can be between 1 and 50. The default value is 50.</p> <p>If this parameter is used, the operation returns up to <code>MaxResults</code> results at a time, along with a <code>NextToken</code> value. To get the next set of results, include the <code>NextToken</code> value in a subsequent call. If this parameter is not used, the operation returns up to 50 results and a <code>NextToken</code> value, if applicable.</p>"]
     #[serde(rename="MaxResults")]
@@ -154,7 +154,7 @@ pub struct DescribeScalingActivitiesRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScalingActivitiesResponse {
     #[doc="<p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>"]
     #[serde(rename="NextToken")]
@@ -166,7 +166,7 @@ pub struct DescribeScalingActivitiesResponse {
     pub scaling_activities: Option<Vec<ScalingActivity>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScalingPoliciesRequest {
     #[doc="<p>The maximum number of scalable target results. This value can be between 1 and 50. The default value is 50.</p> <p>If this parameter is used, the operation returns up to <code>MaxResults</code> results at a time, along with a <code>NextToken</code> value. To get the next set of results, include the <code>NextToken</code> value in a subsequent call. If this parameter is not used, the operation returns up to 50 results and a <code>NextToken</code> value, if applicable.</p>"]
     #[serde(rename="MaxResults")]
@@ -193,7 +193,7 @@ pub struct DescribeScalingPoliciesRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScalingPoliciesResponse {
     #[doc="<p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>"]
     #[serde(rename="NextToken")]
@@ -228,7 +228,7 @@ pub struct PredefinedMetricSpecification {
     pub resource_label: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutScalingPolicyRequest {
     #[doc="<p>The name of the scaling policy.</p>"]
     #[serde(rename="PolicyName")]
@@ -257,7 +257,7 @@ pub struct PutScalingPolicyRequest {
         Option<TargetTrackingScalingPolicyConfiguration>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutScalingPolicyResponse {
     #[doc="<p>The CloudWatch alarms created for the target tracking policy.</p>"]
     #[serde(rename="Alarms")]
@@ -268,7 +268,7 @@ pub struct PutScalingPolicyResponse {
     pub policy_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterScalableTargetRequest {
     #[doc="<p>The maximum value to scale to in response to a scale out event. This parameter is required if you are registering a scalable target and optional if you are updating one.</p>"]
     #[serde(rename="MaxCapacity")]
@@ -293,11 +293,11 @@ pub struct RegisterScalableTargetRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterScalableTargetResponse;
 
 #[doc="<p>Represents a scalable target.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScalableTarget {
     #[doc="<p>The Unix timestamp for when the scalable target was created.</p>"]
     #[serde(rename="CreationTime")]
@@ -323,7 +323,7 @@ pub struct ScalableTarget {
 }
 
 #[doc="<p>Represents a scaling activity.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScalingActivity {
     #[doc="<p>The unique identifier of the scaling activity.</p>"]
     #[serde(rename="ActivityId")]
@@ -364,7 +364,7 @@ pub struct ScalingActivity {
 }
 
 #[doc="<p>Represents a scaling policy.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScalingPolicy {
     #[doc="<p>The CloudWatch alarms associated with the scaling policy.</p>"]
     #[serde(rename="Alarms")]

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>An entry for a single application in the application catalog.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Application {
     #[doc="<p>The name of the application shown to the end users.</p>"]
     #[serde(rename="DisplayName")]
@@ -61,7 +61,7 @@ pub struct Application {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateFleetRequest {
     #[doc="<p>The name of the fleet to associate.</p>"]
     #[serde(rename="FleetName")]
@@ -71,11 +71,11 @@ pub struct AssociateFleetRequest {
     pub stack_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateFleetResult;
 
 #[doc="<p>The capacity configuration for the fleet.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComputeCapacity {
     #[doc="<p>The desired number of streaming instances.</p>"]
     #[serde(rename="DesiredInstances")]
@@ -83,7 +83,7 @@ pub struct ComputeCapacity {
 }
 
 #[doc="<p>The capacity information for the fleet.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComputeCapacityStatus {
     #[doc="<p>The number of currently available instances that can be used to stream sessions.</p>"]
     #[serde(rename="Available")]
@@ -102,7 +102,7 @@ pub struct ComputeCapacityStatus {
     pub running: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDirectoryConfigRequest {
     #[doc="<p>The fully qualified name of the directory, such as corp.example.com</p>"]
     #[serde(rename="DirectoryName")]
@@ -115,7 +115,7 @@ pub struct CreateDirectoryConfigRequest {
     pub service_account_credentials: ServiceAccountCredentials,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDirectoryConfigResult {
     #[doc="<p>Directory configuration details.</p>"]
     #[serde(rename="DirectoryConfig")]
@@ -124,7 +124,7 @@ pub struct CreateDirectoryConfigResult {
 }
 
 #[doc="<p>Contains the parameters for the new fleet to create.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFleetRequest {
     #[doc="<p>The parameters for the capacity allocated to the fleet.</p>"]
     #[serde(rename="ComputeCapacity")]
@@ -168,7 +168,7 @@ pub struct CreateFleetRequest {
     pub vpc_config: Option<VpcConfig>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFleetResult {
     #[doc="<p>The details for the created fleet.</p>"]
     #[serde(rename="Fleet")]
@@ -176,7 +176,7 @@ pub struct CreateFleetResult {
     pub fleet: Option<Fleet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStackRequest {
     #[doc="<p>The description displayed to end users on the AppStream 2.0 portal.</p>"]
     #[serde(rename="Description")]
@@ -195,7 +195,7 @@ pub struct CreateStackRequest {
     pub storage_connectors: Option<Vec<StorageConnector>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStackResult {
     #[doc="<p>The details for the created stack.</p>"]
     #[serde(rename="Stack")]
@@ -203,7 +203,7 @@ pub struct CreateStackResult {
     pub stack: Option<Stack>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStreamingURLRequest {
     #[doc="<p>The ID of the application that must be launched after the session starts.</p>"]
     #[serde(rename="ApplicationId")]
@@ -228,7 +228,7 @@ pub struct CreateStreamingURLRequest {
     pub validity: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStreamingURLResult {
     #[doc="<p>Elapsed seconds after the Unix epoch, when this URL expires.</p>"]
     #[serde(rename="Expires")]
@@ -240,37 +240,37 @@ pub struct CreateStreamingURLResult {
     pub streaming_url: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDirectoryConfigRequest {
     #[doc="<p>The name of the directory configuration to be deleted.</p>"]
     #[serde(rename="DirectoryName")]
     pub directory_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDirectoryConfigResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFleetRequest {
     #[doc="<p>The name of the fleet to be deleted.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFleetResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStackRequest {
     #[doc="<p>The name of the stack to delete.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStackResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDirectoryConfigsRequest {
     #[doc="<p>A specific list of directory names.</p>"]
     #[serde(rename="DirectoryNames")]
@@ -286,7 +286,7 @@ pub struct DescribeDirectoryConfigsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDirectoryConfigsResult {
     #[doc="<p>The list of directory configurations.</p>"]
     #[serde(rename="DirectoryConfigs")]
@@ -298,7 +298,7 @@ pub struct DescribeDirectoryConfigsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetsRequest {
     #[doc="<p>The fleet names to describe. Use null to describe all the fleets for the AWS account.</p>"]
     #[serde(rename="Names")]
@@ -310,7 +310,7 @@ pub struct DescribeFleetsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetsResult {
     #[doc="<p>The list of fleet details.</p>"]
     #[serde(rename="Fleets")]
@@ -322,7 +322,7 @@ pub struct DescribeFleetsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImagesRequest {
     #[doc="<p>A specific list of images to describe.</p>"]
     #[serde(rename="Names")]
@@ -330,7 +330,7 @@ pub struct DescribeImagesRequest {
     pub names: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImagesResult {
     #[doc="<p>The list of images.</p>"]
     #[serde(rename="Images")]
@@ -338,7 +338,7 @@ pub struct DescribeImagesResult {
     pub images: Option<Vec<Image>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSessionsRequest {
     #[doc="<p>The authentication method of the user. It can be <code>API</code> for a user authenticated using a streaming URL, or <code>SAML</code> for a SAML federated user. If an authentication type is not provided, the operation defaults to users authenticated using a streaming URL.</p>"]
     #[serde(rename="AuthenticationType")]
@@ -364,7 +364,7 @@ pub struct DescribeSessionsRequest {
     pub user_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSessionsResult {
     #[doc="<p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextToken")]
@@ -376,7 +376,7 @@ pub struct DescribeSessionsResult {
     pub sessions: Option<Vec<Session>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStacksRequest {
     #[doc="<p>The stack names to describe. Use null to describe all the stacks for the AWS account.</p>"]
     #[serde(rename="Names")]
@@ -388,7 +388,7 @@ pub struct DescribeStacksRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStacksResult {
     #[doc="<p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextToken")]
@@ -401,7 +401,7 @@ pub struct DescribeStacksResult {
 }
 
 #[doc="<p>Full directory configuration details, which are used to join domains for the AppStream 2.0 streaming instances.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DirectoryConfig {
     #[doc="<p>The time stamp when the directory configuration was created within AppStream 2.0.</p>"]
     #[serde(rename="CreatedTime")]
@@ -420,7 +420,7 @@ pub struct DirectoryConfig {
     pub service_account_credentials: Option<ServiceAccountCredentials>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateFleetRequest {
     #[doc="<p>The name of the fleet to disassociate.</p>"]
     #[serde(rename="FleetName")]
@@ -430,7 +430,7 @@ pub struct DisassociateFleetRequest {
     pub stack_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateFleetResult;
 
 #[doc="<p>The <i>DirectoryName</i> and <i>OrganizationalUnitDistinguishedName</i> values, which are used to join domains for the AppStream 2.0 streaming instances.</p>"]
@@ -446,18 +446,18 @@ pub struct DomainJoinInfo {
     pub organizational_unit_distinguished_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExpireSessionRequest {
     #[doc="<p>The unique identifier of the streaming session to be stopped.</p>"]
     #[serde(rename="SessionId")]
     pub session_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExpireSessionResult;
 
 #[doc="<p>Contains the parameters for a fleet.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Fleet {
     #[doc="<p>The ARN for the fleet.</p>"]
     #[serde(rename="Arn")]
@@ -516,7 +516,7 @@ pub struct Fleet {
 }
 
 #[doc="<p>The details of the fleet error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FleetError {
     #[doc="<p>The error code for the fleet error.</p>"]
     #[serde(rename="ErrorCode")]
@@ -529,7 +529,7 @@ pub struct FleetError {
 }
 
 #[doc="<p>New streaming instances are booted from images. The image stores the application catalog and is connected to fleets.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Image {
     #[doc="<p>The applications associated with an image.</p>"]
     #[serde(rename="Applications")]
@@ -585,7 +585,7 @@ pub struct Image {
 }
 
 #[doc="<p>The reason why the last state change occurred.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImageStateChangeReason {
     #[doc="<p>The state change reason code of the image.</p>"]
     #[serde(rename="Code")]
@@ -597,7 +597,7 @@ pub struct ImageStateChangeReason {
     pub message: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssociatedFleetsRequest {
     #[doc="<p>The pagination token to use to retrieve the next page of results for this operation. If this value is null, it retrieves the first page.</p>"]
     #[serde(rename="NextToken")]
@@ -609,7 +609,7 @@ pub struct ListAssociatedFleetsRequest {
 }
 
 #[doc="<p>The response from a successful operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssociatedFleetsResult {
     #[doc="<p>The names of associated fleets.</p>"]
     #[serde(rename="Names")]
@@ -621,7 +621,7 @@ pub struct ListAssociatedFleetsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssociatedStacksRequest {
     #[doc="<p>The name of the fleet whose associated stacks are listed.</p>"]
     #[serde(rename="FleetName")]
@@ -633,7 +633,7 @@ pub struct ListAssociatedStacksRequest {
 }
 
 #[doc="<p>The response from a successful operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssociatedStacksResult {
     #[doc="<p>The names of associated stacks.</p>"]
     #[serde(rename="Names")]
@@ -657,7 +657,7 @@ pub struct ServiceAccountCredentials {
 }
 
 #[doc="<p>Contains the parameters for a streaming session.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Session {
     #[doc="<p>The authentication method of the user for whom the session was created. It can be <code>API</code> for a user authenticated using a streaming URL or <code>SAML</code> for a SAML federated user.</p>"]
     #[serde(rename="AuthenticationType")]
@@ -681,7 +681,7 @@ pub struct Session {
 }
 
 #[doc="<p>Details about a stack.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Stack {
     #[doc="<p>The ARN of the stack.</p>"]
     #[serde(rename="Arn")]
@@ -713,7 +713,7 @@ pub struct Stack {
 }
 
 #[doc="<p>Contains the parameters for a stack error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackError {
     #[doc="<p>The error code of a stack error.</p>"]
     #[serde(rename="ErrorCode")]
@@ -725,24 +725,24 @@ pub struct StackError {
     pub error_message: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartFleetRequest {
     #[doc="<p>The name of the fleet to start.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartFleetResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopFleetRequest {
     #[doc="<p>The name of the fleet to stop.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopFleetResult;
 
 #[doc="<p>Contains the parameters for a storage connector.</p>"]
@@ -757,7 +757,7 @@ pub struct StorageConnector {
     pub resource_identifier: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDirectoryConfigRequest {
     #[doc="<p>The name of the existing directory configuration to be updated.</p>"]
     #[serde(rename="DirectoryName")]
@@ -772,7 +772,7 @@ pub struct UpdateDirectoryConfigRequest {
     pub service_account_credentials: Option<ServiceAccountCredentials>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDirectoryConfigResult {
     #[doc="<p>The updated directory configuration details.</p>"]
     #[serde(rename="DirectoryConfig")]
@@ -780,7 +780,7 @@ pub struct UpdateDirectoryConfigResult {
     pub directory_config: Option<DirectoryConfig>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFleetRequest {
     #[doc="<p>Fleet attributes to be deleted.</p>"]
     #[serde(rename="AttributesToDelete")]
@@ -831,7 +831,7 @@ pub struct UpdateFleetRequest {
     pub vpc_config: Option<VpcConfig>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFleetResult {
     #[doc="<p>A list of fleet details.</p>"]
     #[serde(rename="Fleet")]
@@ -839,7 +839,7 @@ pub struct UpdateFleetResult {
     pub fleet: Option<Fleet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateStackRequest {
     #[doc="<p>Remove all the storage connectors currently enabled for the stack.</p>"]
     #[serde(rename="DeleteStorageConnectors")]
@@ -862,7 +862,7 @@ pub struct UpdateStackRequest {
     pub storage_connectors: Option<Vec<StorageConnector>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateStackResult {
     #[doc="<p>A list of stack details.</p>"]
     #[serde(rename="Stack")]

--- a/rusoto/services/athena/src/generated.rs
+++ b/rusoto/services/athena/src/generated.rs
@@ -28,14 +28,14 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetNamedQueryInput {
     #[doc="<p>An array of query IDs.</p>"]
     #[serde(rename="NamedQueryIds")]
     pub named_query_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetNamedQueryOutput {
     #[doc="<p>Information about the named query IDs submitted.</p>"]
     #[serde(rename="NamedQueries")]
@@ -47,14 +47,14 @@ pub struct BatchGetNamedQueryOutput {
     pub unprocessed_named_query_ids: Option<Vec<UnprocessedNamedQueryId>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetQueryExecutionInput {
     #[doc="<p>An array of query execution IDs.</p>"]
     #[serde(rename="QueryExecutionIds")]
     pub query_execution_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetQueryExecutionOutput {
     #[doc="<p>Information about a query execution.</p>"]
     #[serde(rename="QueryExecutions")]
@@ -67,7 +67,7 @@ pub struct BatchGetQueryExecutionOutput {
 }
 
 #[doc="<p>Information about the columns in a query execution result.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ColumnInfo {
     #[doc="<p>Indicates whether values in the column are case-sensitive.</p>"]
     #[serde(rename="CaseSensitive")]
@@ -109,7 +109,7 @@ pub struct ColumnInfo {
     pub type_: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNamedQueryInput {
     #[doc="<p>A unique case-sensitive string used to ensure the request to create the query is idempotent (executes only once). If another <code>CreateNamedQuery</code> request is received, the same response is returned and another query is not created. If a parameter has changed, for example, the <code>QueryString</code>, an error is returned.</p> <important> <p>This token is listed as not required because AWS SDKs (for example the AWS SDK for Java) auto-generate the token for users. If you are not using the AWS SDK or the AWS CLI, you must provide this token or the action will fail.</p> </important>"]
     #[serde(rename="ClientRequestToken")]
@@ -130,7 +130,7 @@ pub struct CreateNamedQueryInput {
     pub query_string: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNamedQueryOutput {
     #[doc="<p>The unique ID of the query.</p>"]
     #[serde(rename="NamedQueryId")]
@@ -139,7 +139,7 @@ pub struct CreateNamedQueryOutput {
 }
 
 #[doc="<p>A piece of data (a field in the table).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Datum {
     #[doc="<p>The value of the datum.</p>"]
     #[serde(rename="VarCharValue")]
@@ -147,14 +147,14 @@ pub struct Datum {
     pub var_char_value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNamedQueryInput {
     #[doc="<p>The unique ID of the query to delete.</p>"]
     #[serde(rename="NamedQueryId")]
     pub named_query_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNamedQueryOutput;
 
 #[doc="<p>If query results are encrypted in Amazon S3, indicates the Amazon S3 encryption option used.</p>"]
@@ -169,14 +169,14 @@ pub struct EncryptionConfiguration {
     pub kms_key: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetNamedQueryInput {
     #[doc="<p>The unique ID of the query. Use <a>ListNamedQueries</a> to get query IDs.</p>"]
     #[serde(rename="NamedQueryId")]
     pub named_query_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetNamedQueryOutput {
     #[doc="<p>Information about the query.</p>"]
     #[serde(rename="NamedQuery")]
@@ -184,14 +184,14 @@ pub struct GetNamedQueryOutput {
     pub named_query: Option<NamedQuery>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQueryExecutionInput {
     #[doc="<p>The unique ID of the query execution.</p>"]
     #[serde(rename="QueryExecutionId")]
     pub query_execution_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQueryExecutionOutput {
     #[doc="<p>Information about the query execution.</p>"]
     #[serde(rename="QueryExecution")]
@@ -199,7 +199,7 @@ pub struct GetQueryExecutionOutput {
     pub query_execution: Option<QueryExecution>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQueryResultsInput {
     #[doc="<p>The maximum number of results (rows) to return in this request.</p>"]
     #[serde(rename="MaxResults")]
@@ -214,7 +214,7 @@ pub struct GetQueryResultsInput {
     pub query_execution_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQueryResultsOutput {
     #[doc="<p>A token to be used by the next request if this request is truncated.</p>"]
     #[serde(rename="NextToken")]
@@ -226,7 +226,7 @@ pub struct GetQueryResultsOutput {
     pub result_set: Option<ResultSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListNamedQueriesInput {
     #[doc="<p>The maximum number of queries to return in this request.</p>"]
     #[serde(rename="MaxResults")]
@@ -238,7 +238,7 @@ pub struct ListNamedQueriesInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListNamedQueriesOutput {
     #[doc="<p>The list of unique query IDs.</p>"]
     #[serde(rename="NamedQueryIds")]
@@ -250,7 +250,7 @@ pub struct ListNamedQueriesOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListQueryExecutionsInput {
     #[doc="<p>The maximum number of query executions to return in this request.</p>"]
     #[serde(rename="MaxResults")]
@@ -262,7 +262,7 @@ pub struct ListQueryExecutionsInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListQueryExecutionsOutput {
     #[doc="<p>A token to be used by the next request if this request is truncated.</p>"]
     #[serde(rename="NextToken")]
@@ -275,7 +275,7 @@ pub struct ListQueryExecutionsOutput {
 }
 
 #[doc="<p>A query, where <code>QueryString</code> is the SQL query statements that comprise the query.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NamedQuery {
     #[doc="<p>The database to which the query belongs.</p>"]
     #[serde(rename="Database")]
@@ -297,7 +297,7 @@ pub struct NamedQuery {
 }
 
 #[doc="<p>Information about a single instance of a query execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct QueryExecution {
     #[doc="<p>The SQL query statements which the query execution ran.</p>"]
     #[serde(rename="Query")]
@@ -335,7 +335,7 @@ pub struct QueryExecutionContext {
 }
 
 #[doc="<p>The amount of data scanned during the query execution and the amount of time that it took to execute.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct QueryExecutionStatistics {
     #[doc="<p>The number of bytes in the data that was queried.</p>"]
     #[serde(rename="DataScannedInBytes")]
@@ -348,7 +348,7 @@ pub struct QueryExecutionStatistics {
 }
 
 #[doc="<p>The completion date, current state, submission time, and state change reason (if applicable) for the query execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct QueryExecutionStatus {
     #[doc="<p>The date and time that the query completed.</p>"]
     #[serde(rename="CompletionDateTime")]
@@ -381,7 +381,7 @@ pub struct ResultConfiguration {
 }
 
 #[doc="<p>The metadata and rows that comprise a query result set. The metadata describes the column structure and data types.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResultSet {
     #[doc="<p>The metadata that describes the column structure and data types of a table of query results.</p>"]
     #[serde(rename="ResultSetMetadata")]
@@ -394,7 +394,7 @@ pub struct ResultSet {
 }
 
 #[doc="<p>The metadata that describes the column structure and data types of a table of query results.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResultSetMetadata {
     #[doc="<p>Information about the columns in a query execution result.</p>"]
     #[serde(rename="ColumnInfo")]
@@ -403,7 +403,7 @@ pub struct ResultSetMetadata {
 }
 
 #[doc="<p>The rows that comprise a query result table.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Row {
     #[doc="<p>The data that populates a row in a query result table.</p>"]
     #[serde(rename="Data")]
@@ -411,7 +411,7 @@ pub struct Row {
     pub data: Option<Vec<Datum>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartQueryExecutionInput {
     #[doc="<p>A unique case-sensitive string used to ensure the request to create the query is idempotent (executes only once). If another <code>StartQueryExecution</code> request is received, the same response is returned and another query is not created. If a parameter has changed, for example, the <code>QueryString</code>, an error is returned.</p> <important> <p>This token is listed as not required because AWS SDKs (for example the AWS SDK for Java) auto-generate the token for users. If you are not using the AWS SDK or the AWS CLI, you must provide this token or the action will fail.</p> </important>"]
     #[serde(rename="ClientRequestToken")]
@@ -429,7 +429,7 @@ pub struct StartQueryExecutionInput {
     pub result_configuration: ResultConfiguration,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartQueryExecutionOutput {
     #[doc="<p>The unique ID of the query that ran as a result of this request.</p>"]
     #[serde(rename="QueryExecutionId")]
@@ -437,18 +437,18 @@ pub struct StartQueryExecutionOutput {
     pub query_execution_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopQueryExecutionInput {
     #[doc="<p>The unique ID of the query execution to stop.</p>"]
     #[serde(rename="QueryExecutionId")]
     pub query_execution_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopQueryExecutionOutput;
 
 #[doc="<p>Information about a named query ID that could not be processed.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnprocessedNamedQueryId {
     #[doc="<p>The error code returned when the processing request for the named query failed, if applicable.</p>"]
     #[serde(rename="ErrorCode")]
@@ -465,7 +465,7 @@ pub struct UnprocessedNamedQueryId {
 }
 
 #[doc="<p>Describes a query execution that failed to process.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnprocessedQueryExecutionId {
     #[doc="<p>The error code returned when the query execution failed to process, if applicable.</p>"]
     #[serde(rename="ErrorCode")]

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -81,11 +81,14 @@ impl ActivitiesDeserializer {
     }
 }
 #[doc="<p>Contains the output of DescribeScalingActivities.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivitiesType {
     #[doc="<p>The scaling activities. Activities are sorted by start time. Activities still in progress are described first.</p>"]
+    #[serde(rename="Activities")]
     pub activities: Vec<Activity>,
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -136,27 +139,42 @@ impl ActivitiesTypeDeserializer {
     }
 }
 #[doc="<p>Describes scaling activity, which is a long-running process that represents a change to your Auto Scaling group, such as changing its size or replacing an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Activity {
     #[doc="<p>The ID of the activity.</p>"]
+    #[serde(rename="ActivityId")]
     pub activity_id: String,
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The reason the activity began.</p>"]
+    #[serde(rename="Cause")]
     pub cause: String,
     #[doc="<p>A friendly, more verbose description of the activity.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The details about the activity.</p>"]
+    #[serde(rename="Details")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub details: Option<String>,
     #[doc="<p>The end time of the activity.</p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>A value between 0 and 100 that indicates the progress of the activity.</p>"]
+    #[serde(rename="Progress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress: Option<i64>,
     #[doc="<p>The start time of the activity.</p>"]
+    #[serde(rename="StartTime")]
     pub start_time: String,
     #[doc="<p>The current status of the activity.</p>"]
+    #[serde(rename="StatusCode")]
     pub status_code: String,
     #[doc="<p>A friendly, more verbose description of the activity status.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
 }
 
@@ -255,9 +273,11 @@ impl ActivityIdsSerializer {
 }
 
 #[doc="<p>Contains the output of TerminateInstancesInAutoScalingGroup.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityType {
     #[doc="<p>A scaling activity.</p>"]
+    #[serde(rename="Activity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub activity: Option<Activity>,
 }
 
@@ -304,9 +324,11 @@ impl ActivityTypeDeserializer {
     }
 }
 #[doc="<p>Describes a policy adjustment type.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-scale-based-on-demand.html\">Dynamic Scaling</a> in the <i>Auto Scaling User Guide</i>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdjustmentType {
     #[doc="<p>The policy adjustment type. The valid values are <code>ChangeInCapacity</code>, <code>ExactCapacity</code>, and <code>PercentChangeInCapacity</code>.</p>"]
+    #[serde(rename="AdjustmentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub adjustment_type: Option<String>,
 }
 
@@ -395,11 +417,15 @@ impl AdjustmentTypesDeserializer {
     }
 }
 #[doc="<p>Describes an alarm.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Alarm {
     #[doc="<p>The Amazon Resource Name (ARN) of the alarm.</p>"]
+    #[serde(rename="AlarmARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_arn: Option<String>,
     #[doc="<p>The name of the alarm.</p>"]
+    #[serde(rename="AlarmName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_name: Option<String>,
 }
 
@@ -521,11 +547,14 @@ impl AssociatePublicIpAddressDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AttachInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachInstancesQuery {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more instance IDs.</p>"]
+    #[serde(rename="InstanceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_ids: Option<Vec<String>>,
 }
 
@@ -550,7 +579,7 @@ impl AttachInstancesQuerySerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachLoadBalancerTargetGroupsResultType;
 
 struct AttachLoadBalancerTargetGroupsResultTypeDeserializer;
@@ -571,11 +600,13 @@ impl AttachLoadBalancerTargetGroupsResultTypeDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AttachLoadBalancerTargetGroups.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachLoadBalancerTargetGroupsType {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The Amazon Resource Names (ARN) of the target groups.</p>"]
+    #[serde(rename="TargetGroupARNs")]
     pub target_group_ar_ns: Vec<String>,
 }
 
@@ -599,7 +630,7 @@ impl AttachLoadBalancerTargetGroupsTypeSerializer {
 }
 
 #[doc="<p>Contains the output of AttachLoadBalancers.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachLoadBalancersResultType;
 
 struct AttachLoadBalancersResultTypeDeserializer;
@@ -619,11 +650,13 @@ impl AttachLoadBalancersResultTypeDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AttachLoadBalancers.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachLoadBalancersType {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more load balancer names.</p>"]
+    #[serde(rename="LoadBalancerNames")]
     pub load_balancer_names: Vec<String>,
 }
 
@@ -647,51 +680,87 @@ impl AttachLoadBalancersTypeSerializer {
 }
 
 #[doc="<p>Describes an Auto Scaling group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoScalingGroup {
     #[doc="<p>The Amazon Resource Name (ARN) of the group.</p>"]
+    #[serde(rename="AutoScalingGroupARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_arn: Option<String>,
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more Availability Zones for the group.</p>"]
+    #[serde(rename="AvailabilityZones")]
     pub availability_zones: Vec<String>,
     #[doc="<p>The date and time the group was created.</p>"]
+    #[serde(rename="CreatedTime")]
     pub created_time: String,
     #[doc="<p>The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.</p>"]
+    #[serde(rename="DefaultCooldown")]
     pub default_cooldown: i64,
     #[doc="<p>The desired size of the group.</p>"]
+    #[serde(rename="DesiredCapacity")]
     pub desired_capacity: i64,
     #[doc="<p>The metrics enabled for the group.</p>"]
+    #[serde(rename="EnabledMetrics")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled_metrics: Option<Vec<EnabledMetric>>,
     #[doc="<p>The amount of time, in seconds, that Auto Scaling waits before checking the health status of an EC2 instance that has come into service.</p>"]
+    #[serde(rename="HealthCheckGracePeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_grace_period: Option<i64>,
     #[doc="<p>The service to use for the health checks. The valid values are <code>EC2</code> and <code>ELB</code>.</p>"]
+    #[serde(rename="HealthCheckType")]
     pub health_check_type: String,
     #[doc="<p>The EC2 instances associated with the group.</p>"]
+    #[serde(rename="Instances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instances: Option<Vec<Instance>>,
     #[doc="<p>The name of the associated launch configuration.</p>"]
+    #[serde(rename="LaunchConfigurationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_configuration_name: Option<String>,
     #[doc="<p>One or more load balancers associated with the group.</p>"]
+    #[serde(rename="LoadBalancerNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_names: Option<Vec<String>>,
     #[doc="<p>The maximum size of the group.</p>"]
+    #[serde(rename="MaxSize")]
     pub max_size: i64,
     #[doc="<p>The minimum size of the group.</p>"]
+    #[serde(rename="MinSize")]
     pub min_size: i64,
     #[doc="<p>Indicates whether newly launched instances are protected from termination by Auto Scaling when scaling in.</p>"]
+    #[serde(rename="NewInstancesProtectedFromScaleIn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_instances_protected_from_scale_in: Option<bool>,
     #[doc="<p>The name of the placement group into which you'll launch your instances, if any. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html\">Placement Groups</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="PlacementGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement_group: Option<String>,
     #[doc="<p>The current state of the group when <a>DeleteAutoScalingGroup</a> is in progress.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The suspended processes associated with the group.</p>"]
+    #[serde(rename="SuspendedProcesses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub suspended_processes: Option<Vec<SuspendedProcess>>,
     #[doc="<p>The tags for the group.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<TagDescription>>,
     #[doc="<p>The Amazon Resource Names (ARN) of the target groups for your load balancer.</p>"]
+    #[serde(rename="TargetGroupARNs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_group_ar_ns: Option<Vec<String>>,
     #[doc="<p>The termination policies for the group.</p>"]
+    #[serde(rename="TerminationPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub termination_policies: Option<Vec<String>>,
     #[doc="<p>One or more subnet IDs, if applicable, separated by commas.</p> <p>If you specify <code>VPCZoneIdentifier</code> and <code>AvailabilityZones</code>, ensure that the Availability Zones of the subnets match the values for <code>AvailabilityZones</code>.</p>"]
+    #[serde(rename="VPCZoneIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_zone_identifier: Option<String>,
 }
 
@@ -893,13 +962,19 @@ impl AutoScalingGroupNamesSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribeAutoScalingGroups.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoScalingGroupNamesType {
     #[doc="<p>The group names. If you omit this parameter, all Auto Scaling groups are described.</p>"]
+    #[serde(rename="AutoScalingGroupNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_names: Option<Vec<String>>,
     #[doc="<p>The maximum number of items to return with this call. The default value is 50 and the maximum value is 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a previous call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -974,11 +1049,14 @@ impl AutoScalingGroupsDeserializer {
     }
 }
 #[doc="<p>Contains the output for DescribeAutoScalingGroups.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoScalingGroupsType {
     #[doc="<p>The groups.</p>"]
+    #[serde(rename="AutoScalingGroups")]
     pub auto_scaling_groups: Vec<AutoScalingGroup>,
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1030,21 +1108,28 @@ impl AutoScalingGroupsTypeDeserializer {
     }
 }
 #[doc="<p>Describes an EC2 instance associated with an Auto Scaling group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoScalingInstanceDetails {
     #[doc="<p>The name of the Auto Scaling group associated with the instance.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The Availability Zone for the instance.</p>"]
+    #[serde(rename="AvailabilityZone")]
     pub availability_zone: String,
     #[doc="<p>The last reported health status of this instance. \"Healthy\" means that the instance is healthy and should remain in service. \"Unhealthy\" means that the instance is unhealthy and Auto Scaling should terminate and replace it.</p>"]
+    #[serde(rename="HealthStatus")]
     pub health_status: String,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>The launch configuration used to launch the instance. This value is not available if you attached the instance to the Auto Scaling group.</p>"]
+    #[serde(rename="LaunchConfigurationName")]
     pub launch_configuration_name: String,
     #[doc="<p>The lifecycle state for the instance. For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroupLifecycle.html\">Auto Scaling Lifecycle</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="LifecycleState")]
     pub lifecycle_state: String,
     #[doc="<p>Indicates whether the instance is protected from termination by Auto Scaling when scaling in.</p>"]
+    #[serde(rename="ProtectedFromScaleIn")]
     pub protected_from_scale_in: bool,
 }
 
@@ -1165,11 +1250,15 @@ impl AutoScalingInstancesDeserializer {
     }
 }
 #[doc="<p>Contains the output of DescribeAutoScalingInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoScalingInstancesType {
     #[doc="<p>The instances.</p>"]
+    #[serde(rename="AutoScalingInstances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_instances: Option<Vec<AutoScalingInstanceDetails>>,
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1399,15 +1488,22 @@ impl BlockDeviceEbsVolumeTypeDeserializer {
     }
 }
 #[doc="<p>Describes a block device mapping.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BlockDeviceMapping {
     #[doc="<p>The device name exposed to the EC2 instance (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>"]
+    #[serde(rename="DeviceName")]
     pub device_name: String,
     #[doc="<p>The information about the Amazon EBS volume.</p>"]
+    #[serde(rename="Ebs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs: Option<Ebs>,
     #[doc="<p>Suppresses a device mapping.</p> <p>If this parameter is true for the root device, the instance might fail the EC2 health check. Auto Scaling launches a replacement instance if the instance fails the health check.</p>"]
+    #[serde(rename="NoDevice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub no_device: Option<bool>,
     #[doc="<p>The name of the virtual device (for example, <code>ephemeral0</code>).</p>"]
+    #[serde(rename="VirtualName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub virtual_name: Option<String>,
 }
 
@@ -1602,7 +1698,7 @@ impl ClassicLinkVPCSecurityGroupsSerializer {
 }
 
 #[doc="<p>Contains the output of CompleteLifecycleAction.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompleteLifecycleActionAnswer;
 
 struct CompleteLifecycleActionAnswerDeserializer;
@@ -1622,17 +1718,24 @@ impl CompleteLifecycleActionAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CompleteLifecycleAction.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompleteLifecycleActionType {
     #[doc="<p>The name of the group for the lifecycle hook.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The action for the group to take. This parameter can be either <code>CONTINUE</code> or <code>ABANDON</code>.</p>"]
+    #[serde(rename="LifecycleActionResult")]
     pub lifecycle_action_result: String,
     #[doc="<p>A universally unique identifier (UUID) that identifies a specific lifecycle action associated with an instance. Auto Scaling sends this token to the notification target you specified when you created the lifecycle hook.</p>"]
+    #[serde(rename="LifecycleActionToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lifecycle_action_token: Option<String>,
     #[doc="<p>The name of the lifecycle hook.</p>"]
+    #[serde(rename="LifecycleHookName")]
     pub lifecycle_hook_name: String,
 }
 
@@ -1679,41 +1782,72 @@ impl CooldownDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateAutoScalingGroup.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAutoScalingGroupType {
     #[doc="<p>The name of the group. This name must be unique within the scope of your AWS account.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more Availability Zones for the group. This parameter is optional if you specify one or more subnets.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<String>>,
     #[doc="<p>The amount of time, in seconds, after a scaling activity completes before another scaling activity can start. The default is 300.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/Cooldown.html\">Auto Scaling Cooldowns</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="DefaultCooldown")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_cooldown: Option<i64>,
     #[doc="<p>The number of EC2 instances that should be running in the group. This number must be greater than or equal to the minimum size of the group and less than or equal to the maximum size of the group.</p>"]
+    #[serde(rename="DesiredCapacity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub desired_capacity: Option<i64>,
     #[doc="<p>The amount of time, in seconds, that Auto Scaling waits before checking the health status of an EC2 instance that has come into service. During this time, any health check failures for the instance are ignored. The default is 0.</p> <p>This parameter is required if you are adding an <code>ELB</code> health check.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/healthcheck.html\">Health Checks</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="HealthCheckGracePeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_grace_period: Option<i64>,
     #[doc="<p>The service to use for the health checks. The valid values are <code>EC2</code> and <code>ELB</code>.</p> <p>By default, health checks use Amazon EC2 instance status checks to determine the health of an instance. For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/healthcheck.html\">Health Checks</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="HealthCheckType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_type: Option<String>,
     #[doc="<p>The ID of the instance used to create a launch configuration for the group. Alternatively, specify a launch configuration instead of an EC2 instance.</p> <p>When you specify an ID of an instance, Auto Scaling creates a new launch configuration and associates it with the group. This launch configuration derives its attributes from the specified instance, with the exception of the block device mapping.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/create-asg-from-instance.html\">Create an Auto Scaling Group Using an EC2 Instance</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The name of the launch configuration. Alternatively, specify an EC2 instance instead of a launch configuration.</p>"]
+    #[serde(rename="LaunchConfigurationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_configuration_name: Option<String>,
     #[doc="<p>One or more Classic Load Balancers. To specify an Application Load Balancer, use <code>TargetGroupARNs</code> instead.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/create-asg-from-instance.html\">Using a Load Balancer With an Auto Scaling Group</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="LoadBalancerNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_names: Option<Vec<String>>,
     #[doc="<p>The maximum size of the group.</p>"]
+    #[serde(rename="MaxSize")]
     pub max_size: i64,
     #[doc="<p>The minimum size of the group.</p>"]
+    #[serde(rename="MinSize")]
     pub min_size: i64,
     #[doc="<p>Indicates whether newly launched instances are protected from termination by Auto Scaling when scaling in.</p>"]
+    #[serde(rename="NewInstancesProtectedFromScaleIn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_instances_protected_from_scale_in: Option<bool>,
     #[doc="<p>The name of the placement group into which you'll launch your instances, if any. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html\">Placement Groups</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="PlacementGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement_group: Option<String>,
     #[doc="<p>One or more tags.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/autoscaling-tagging.html\">Tagging Auto Scaling Groups and Instances</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The Amazon Resource Names (ARN) of the target groups.</p>"]
+    #[serde(rename="TargetGroupARNs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_group_ar_ns: Option<Vec<String>>,
     #[doc="<p>One or more termination policies used to select the instance to terminate. These policies are executed in the order that they are listed.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-termination.html\">Controlling Which Instances Auto Scaling Terminates During Scale In</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="TerminationPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub termination_policies: Option<Vec<String>>,
     #[doc="<p>A comma-separated list of subnet identifiers for your virtual private cloud (VPC).</p> <p>If you specify subnets and Availability Zones with this call, ensure that the subnets' Availability Zones match the Availability Zones specified.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/asg-in-vpc.html\">Launching Auto Scaling Instances in a VPC</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="VPCZoneIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_zone_identifier: Option<String>,
 }
 
@@ -1799,43 +1933,78 @@ impl CreateAutoScalingGroupTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for CreateLaunchConfiguration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLaunchConfigurationType {
     #[doc="<p>Used for groups that launch instances into a virtual private cloud (VPC). Specifies whether to assign a public IP address to each instance. For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/asg-in-vpc.html\">Launching Auto Scaling Instances in a VPC</a> in the <i>Auto Scaling User Guide</i>.</p> <p>If you specify this parameter, be sure to specify at least one subnet when you create your group.</p> <p>Default: If the instance is launched into a default subnet, the default is <code>true</code>. If the instance is launched into a nondefault subnet, the default is <code>false</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html\">Supported Platforms</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="AssociatePublicIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub associate_public_ip_address: Option<bool>,
     #[doc="<p>One or more mappings that specify how block devices are exposed to the instance. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html\">Block Device Mapping</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
     #[doc="<p>The ID of a ClassicLink-enabled VPC to link your EC2-Classic instances to. This parameter is supported only if you are launching EC2-Classic instances. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-classiclink.html\">ClassicLink</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="ClassicLinkVPCId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub classic_link_vpc_id: Option<String>,
     #[doc="<p>The IDs of one or more security groups for the specified ClassicLink-enabled VPC. This parameter is required if you specify a ClassicLink-enabled VPC, and is not supported otherwise. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-classiclink.html\">ClassicLink</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="ClassicLinkVPCSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub classic_link_vpc_security_groups: Option<Vec<String>>,
     #[doc="<p>Indicates whether the instance is optimized for Amazon EBS I/O. By default, the instance is not optimized for EBS I/O. The optimization provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal I/O performance. This optimization is not available with all instance types. Additional usage charges apply. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html\">Amazon EBS-Optimized Instances</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="EbsOptimized")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs_optimized: Option<bool>,
     #[doc="<p>The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance.</p> <p>EC2 instances launched with an IAM role will automatically have AWS security credentials available. You can use IAM roles with Auto Scaling to automatically enable applications running on your EC2 instances to securely access other AWS resources. For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/us-iam-role.html\">Launch Auto Scaling Instances with an IAM Role</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="IamInstanceProfile")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile: Option<String>,
     #[doc="<p>The ID of the Amazon Machine Image (AMI) to use to launch your EC2 instances. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/finding-an-ami.html\">Finding an AMI</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
     #[doc="<p>The ID of the instance to use to create the launch configuration.</p> <p>The new launch configuration derives attributes from the instance, with the exception of the block device mapping.</p> <p>To create a launch configuration with a block device mapping or override any other instance attributes, specify them as part of the same request.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/create-lc-with-instanceID.html\">Create a Launch Configuration Using an EC2 Instance</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>Enables detailed monitoring (<code>true</code>) or basic monitoring (<code>false</code>) for the Auto Scaling instances.</p>"]
+    #[serde(rename="InstanceMonitoring")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_monitoring: Option<InstanceMonitoring>,
     #[doc="<p>The instance type of the EC2 instance. For information about available instance types, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#AvailableInstanceTypes\"> Available Instance Types</a> in the <i>Amazon Elastic Compute Cloud User Guide.</i> </p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The ID of the kernel associated with the AMI.</p>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<String>,
     #[doc="<p>The name of the key pair. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html\">Amazon EC2 Key Pairs</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="KeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_name: Option<String>,
     #[doc="<p>The name of the launch configuration. This name must be unique within the scope of your AWS account.</p>"]
+    #[serde(rename="LaunchConfigurationName")]
     pub launch_configuration_name: String,
     #[doc="<p>The tenancy of the instance. An instance with a tenancy of <code>dedicated</code> runs on single-tenant hardware and can only be launched into a VPC.</p> <p>You must set the value of this parameter to <code>dedicated</code> if want to launch Dedicated Instances into a shared tenancy VPC (VPC with instance placement tenancy attribute set to <code>default</code>).</p> <p>If you specify this parameter, be sure to specify at least one subnet when you create your group.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/asg-in-vpc.html\">Launching Auto Scaling Instances in a VPC</a> in the <i>Auto Scaling User Guide</i>.</p> <p>Valid values: <code>default</code> | <code>dedicated</code> </p>"]
+    #[serde(rename="PlacementTenancy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement_tenancy: Option<String>,
     #[doc="<p>The ID of the RAM disk associated with the AMI.</p>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<String>,
     #[doc="<p>One or more security groups with which to associate the instances.</p> <p>If your instances are launched in EC2-Classic, you can either specify security group names or the security group IDs. For more information about security groups for EC2-Classic, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html\">Amazon EC2 Security Groups</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p> <p>If your instances are launched into a VPC, specify security group IDs. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html\">Security Groups for Your VPC</a> in the <i>Amazon Virtual Private Cloud User Guide</i>.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<String>>,
     #[doc="<p>The maximum hourly price to be paid for any Spot Instance launched to fulfill the request. Spot Instances are launched when the price you specify exceeds the current Spot market price. For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/US-SpotInstances.html\">Launching Spot Instances in Your Auto Scaling Group</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="SpotPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_price: Option<String>,
     #[doc="<p>The user data to make available to the launched EC2 instances. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html\">Instance Metadata and User Data</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="UserData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_data: Option<String>,
 }
 
@@ -1932,9 +2101,10 @@ impl CreateLaunchConfigurationTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for CreateOrUpdateTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateOrUpdateTagsType {
     #[doc="<p>One or more tags.</p>"]
+    #[serde(rename="Tags")]
     pub tags: Vec<Tag>,
 }
 
@@ -1954,17 +2124,24 @@ impl CreateOrUpdateTagsTypeSerializer {
 }
 
 #[doc="<p>Configures a customized metric for a target tracking policy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CustomizedMetricSpecification {
     #[doc="<p>The dimensions of the metric.</p>"]
+    #[serde(rename="Dimensions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dimensions: Option<Vec<MetricDimension>>,
     #[doc="<p>The name of the metric.</p>"]
+    #[serde(rename="MetricName")]
     pub metric_name: String,
     #[doc="<p>The namespace of the metric.</p>"]
+    #[serde(rename="Namespace")]
     pub namespace: String,
     #[doc="<p>The statistic of the metric.</p>"]
+    #[serde(rename="Statistic")]
     pub statistic: String,
     #[doc="<p>The unit of the metric.</p>"]
+    #[serde(rename="Unit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unit: Option<String>,
 }
 
@@ -2057,11 +2234,14 @@ impl CustomizedMetricSpecificationSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteAutoScalingGroup.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAutoScalingGroupType {
     #[doc="<p>The name of the group to delete.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>Specifies that the group will be deleted along with all instances associated with the group, without waiting for all instances to be terminated. This parameter also deletes any lifecycle actions associated with the group.</p>"]
+    #[serde(rename="ForceDelete")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub force_delete: Option<bool>,
 }
 
@@ -2086,7 +2266,7 @@ impl DeleteAutoScalingGroupTypeSerializer {
 }
 
 #[doc="<p>Contains the output of DeleteLifecycleHook.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLifecycleHookAnswer;
 
 struct DeleteLifecycleHookAnswerDeserializer;
@@ -2106,11 +2286,13 @@ impl DeleteLifecycleHookAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteLifecycleHook.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLifecycleHookType {
     #[doc="<p>The name of the Auto Scaling group for the lifecycle hook.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The name of the lifecycle hook.</p>"]
+    #[serde(rename="LifecycleHookName")]
     pub lifecycle_hook_name: String,
 }
 
@@ -2133,11 +2315,13 @@ impl DeleteLifecycleHookTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteNotificationConfiguration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNotificationConfigurationType {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic.</p>"]
+    #[serde(rename="TopicARN")]
     pub topic_arn: String,
 }
 
@@ -2160,11 +2344,14 @@ impl DeleteNotificationConfigurationTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeletePolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePolicyType {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_name: Option<String>,
     #[doc="<p>The name or Amazon Resource Name (ARN) of the policy.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -2189,11 +2376,13 @@ impl DeletePolicyTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteScheduledAction.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteScheduledActionType {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The name of the action to delete.</p>"]
+    #[serde(rename="ScheduledActionName")]
     pub scheduled_action_name: String,
 }
 
@@ -2216,9 +2405,10 @@ impl DeleteScheduledActionTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsType {
     #[doc="<p>One or more tags.</p>"]
+    #[serde(rename="Tags")]
     pub tags: Vec<Tag>,
 }
 
@@ -2238,15 +2428,23 @@ impl DeleteTagsTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribeAccountLimits.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountLimitsAnswer {
     #[doc="<p>The maximum number of groups allowed for your AWS account. The default limit is 20 per region.</p>"]
+    #[serde(rename="MaxNumberOfAutoScalingGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_number_of_auto_scaling_groups: Option<i64>,
     #[doc="<p>The maximum number of launch configurations allowed for your AWS account. The default limit is 100 per region.</p>"]
+    #[serde(rename="MaxNumberOfLaunchConfigurations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_number_of_launch_configurations: Option<i64>,
     #[doc="<p>The current number of groups for your AWS account.</p>"]
+    #[serde(rename="NumberOfAutoScalingGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub number_of_auto_scaling_groups: Option<i64>,
     #[doc="<p>The current number of launch configurations for your AWS account.</p>"]
+    #[serde(rename="NumberOfLaunchConfigurations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub number_of_launch_configurations: Option<i64>,
 }
 
@@ -2301,9 +2499,11 @@ impl DescribeAccountLimitsAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeAdjustmentTypes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAdjustmentTypesAnswer {
     #[doc="<p>The policy adjustment types.</p>"]
+    #[serde(rename="AdjustmentTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub adjustment_types: Option<Vec<AdjustmentType>>,
 }
 
@@ -2351,13 +2551,19 @@ impl DescribeAdjustmentTypesAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeAutoScalingInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAutoScalingInstancesType {
     #[doc="<p>The instances to describe; up to 50 instance IDs. If you omit this parameter, all Auto Scaling instances are described. If you specify an ID that does not exist, it is ignored with no error.</p>"]
+    #[serde(rename="InstanceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_ids: Option<Vec<String>>,
     #[doc="<p>The maximum number of items to return with this call. The default value is 50 and the maximum value is 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a previous call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -2389,9 +2595,11 @@ impl DescribeAutoScalingInstancesTypeSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeAutoScalingNotificationTypes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAutoScalingNotificationTypesAnswer {
     #[doc="<p>The notification types.</p>"]
+    #[serde(rename="AutoScalingNotificationTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_notification_types: Option<Vec<String>>,
 }
 
@@ -2438,9 +2646,11 @@ impl DescribeAutoScalingNotificationTypesAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the output of DescribeLifecycleHookTypes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLifecycleHookTypesAnswer {
     #[doc="<p>The lifecycle hook types.</p>"]
+    #[serde(rename="LifecycleHookTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lifecycle_hook_types: Option<Vec<String>>,
 }
 
@@ -2487,9 +2697,11 @@ impl DescribeLifecycleHookTypesAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the output of DescribeLifecycleHooks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLifecycleHooksAnswer {
     #[doc="<p>The lifecycle hooks for the specified group.</p>"]
+    #[serde(rename="LifecycleHooks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lifecycle_hooks: Option<Vec<LifecycleHook>>,
 }
 
@@ -2537,11 +2749,14 @@ impl DescribeLifecycleHooksAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeLifecycleHooks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLifecycleHooksType {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The names of one or more lifecycle hooks. If you omit this parameter, all lifecycle hooks are described.</p>"]
+    #[serde(rename="LifecycleHookNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lifecycle_hook_names: Option<Vec<String>>,
 }
 
@@ -2567,13 +2782,18 @@ impl DescribeLifecycleHooksTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribeLoadBalancerTargetGroups.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancerTargetGroupsRequest {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The maximum number of items to return with this call. The default value is 50 and the maximum value is 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a previous call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -2602,11 +2822,15 @@ impl DescribeLoadBalancerTargetGroupsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeLoadBalancerTargetGroups.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancerTargetGroupsResponse {
     #[doc="<p>Information about the target groups.</p>"]
+    #[serde(rename="LoadBalancerTargetGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_target_groups: Option<Vec<LoadBalancerTargetGroupState>>,
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -2657,13 +2881,18 @@ impl DescribeLoadBalancerTargetGroupsResponseDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeLoadBalancers.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancersRequest {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The maximum number of items to return with this call. The default value is 50 and the maximum value is 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a previous call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -2692,11 +2921,15 @@ impl DescribeLoadBalancersRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeLoadBalancers.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancersResponse {
     #[doc="<p>The load balancers.</p>"]
+    #[serde(rename="LoadBalancers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancers: Option<Vec<LoadBalancerState>>,
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -2748,11 +2981,15 @@ impl DescribeLoadBalancersResponseDeserializer {
     }
 }
 #[doc="<p>Contains the output of DescribeMetricsCollectionTypes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMetricCollectionTypesAnswer {
     #[doc="<p>The granularities for the metrics.</p>"]
+    #[serde(rename="Granularities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub granularities: Option<Vec<MetricGranularityType>>,
     #[doc="<p>One or more metrics.</p>"]
+    #[serde(rename="Metrics")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metrics: Option<Vec<MetricCollectionType>>,
 }
 
@@ -2806,11 +3043,14 @@ impl DescribeMetricCollectionTypesAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the output from DescribeNotificationConfigurations.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNotificationConfigurationsAnswer {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The notification configurations.</p>"]
+    #[serde(rename="NotificationConfigurations")]
     pub notification_configurations: Vec<NotificationConfiguration>,
 }
 
@@ -2863,13 +3103,19 @@ impl DescribeNotificationConfigurationsAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeNotificationConfigurations.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNotificationConfigurationsType {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_names: Option<Vec<String>>,
     #[doc="<p>The maximum number of items to return with this call. The default value is 50 and the maximum value is 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a previous call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -2903,17 +3149,27 @@ impl DescribeNotificationConfigurationsTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribePolicies.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePoliciesType {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_name: Option<String>,
     #[doc="<p>The maximum number of items to be returned with each call. The default value is 50 and the maximum value is 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a previous call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>One or more policy names or policy ARNs to be described. If you omit this parameter, all policy names are described. If an group name is provided, the results are limited to that group. This list is limited to 50 items. If you specify an unknown policy name, it is ignored with no error.</p>"]
+    #[serde(rename="PolicyNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_names: Option<Vec<String>>,
     #[doc="<p>One or more policy types. Valid values are <code>SimpleScaling</code> and <code>StepScaling</code>.</p>"]
+    #[serde(rename="PolicyTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_types: Option<Vec<String>>,
 }
 
@@ -2954,15 +3210,23 @@ impl DescribePoliciesTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribeScalingActivities.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScalingActivitiesType {
     #[doc="<p>The activity IDs of the desired scaling activities. If you omit this parameter, all activities for the past six weeks are described. If you specify an Auto Scaling group, the results are limited to that group. The list of requested activities cannot contain more than 50 items. If unknown activities are requested, they are ignored with no error.</p>"]
+    #[serde(rename="ActivityIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub activity_ids: Option<Vec<String>>,
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_name: Option<String>,
     #[doc="<p>The maximum number of items to return with this call. The default value is 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a previous call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -2998,19 +3262,31 @@ impl DescribeScalingActivitiesTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribeScheduledActions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScheduledActionsType {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_name: Option<String>,
     #[doc="<p>The latest scheduled start time to return. If scheduled action names are provided, this parameter is ignored.</p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>The maximum number of items to return with this call. The default value is 50 and the maximum value is 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a previous call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Describes one or more scheduled actions. If you omit this parameter, all scheduled actions are described. If you specify an unknown scheduled action, it is ignored with no error.</p> <p>You can describe up to a maximum of 50 instances with a single call. If there are more items to return, the call returns a token. To get the next set of items, repeat the call with the returned token.</p>"]
+    #[serde(rename="ScheduledActionNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheduled_action_names: Option<Vec<String>>,
     #[doc="<p>The earliest scheduled start time to return. If scheduled action names are provided, this parameter is ignored.</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
 }
 
@@ -3056,13 +3332,19 @@ impl DescribeScheduledActionsTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribeTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsType {
     #[doc="<p>A filter used to scope the tags to return.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of items to return with this call. The default value is 50 and the maximum value is 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a previous call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3092,9 +3374,11 @@ impl DescribeTagsTypeSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeTerminationPolicyTypes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTerminationPolicyTypesAnswer {
     #[doc="<p>The termination policies supported by Auto Scaling (<code>OldestInstance</code>, <code>OldestLaunchConfiguration</code>, <code>NewestInstance</code>, <code>ClosestToNextInstanceHour</code>, and <code>Default</code>).</p>"]
+    #[serde(rename="TerminationPolicyTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub termination_policy_types: Option<Vec<String>>,
 }
 
@@ -3143,9 +3427,11 @@ impl DescribeTerminationPolicyTypesAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the output of DetachInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachInstancesAnswer {
     #[doc="<p>The activities related to detaching the instances from the Auto Scaling group.</p>"]
+    #[serde(rename="Activities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub activities: Option<Vec<Activity>>,
 }
 
@@ -3192,13 +3478,17 @@ impl DetachInstancesAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DetachInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachInstancesQuery {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more instance IDs.</p>"]
+    #[serde(rename="InstanceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_ids: Option<Vec<String>>,
     #[doc="<p>If <code>True</code>, the Auto Scaling group decrements the desired capacity value by the number of instances detached.</p>"]
+    #[serde(rename="ShouldDecrementDesiredCapacity")]
     pub should_decrement_desired_capacity: bool,
 }
 
@@ -3227,7 +3517,7 @@ impl DetachInstancesQuerySerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachLoadBalancerTargetGroupsResultType;
 
 struct DetachLoadBalancerTargetGroupsResultTypeDeserializer;
@@ -3247,11 +3537,13 @@ impl DetachLoadBalancerTargetGroupsResultTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachLoadBalancerTargetGroupsType {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The Amazon Resource Names (ARN) of the target groups.</p>"]
+    #[serde(rename="TargetGroupARNs")]
     pub target_group_ar_ns: Vec<String>,
 }
 
@@ -3275,7 +3567,7 @@ impl DetachLoadBalancerTargetGroupsTypeSerializer {
 }
 
 #[doc="<p>Contains the output for DetachLoadBalancers.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachLoadBalancersResultType;
 
 struct DetachLoadBalancersResultTypeDeserializer;
@@ -3295,11 +3587,13 @@ impl DetachLoadBalancersResultTypeDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DetachLoadBalancers.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachLoadBalancersType {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more load balancer names.</p>"]
+    #[serde(rename="LoadBalancerNames")]
     pub load_balancer_names: Vec<String>,
 }
 
@@ -3323,11 +3617,14 @@ impl DetachLoadBalancersTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for DisableMetricsCollection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableMetricsCollectionQuery {
     #[doc="<p>The name or Amazon Resource Name (ARN) of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more of the following metrics. If you omit this parameter, all metrics are disabled.</p> <ul> <li> <p> <code>GroupMinSize</code> </p> </li> <li> <p> <code>GroupMaxSize</code> </p> </li> <li> <p> <code>GroupDesiredCapacity</code> </p> </li> <li> <p> <code>GroupInServiceInstances</code> </p> </li> <li> <p> <code>GroupPendingInstances</code> </p> </li> <li> <p> <code>GroupStandbyInstances</code> </p> </li> <li> <p> <code>GroupTerminatingInstances</code> </p> </li> <li> <p> <code>GroupTotalInstances</code> </p> </li> </ul>"]
+    #[serde(rename="Metrics")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metrics: Option<Vec<String>>,
 }
 
@@ -3365,19 +3662,31 @@ impl DisableScaleInDeserializer {
     }
 }
 #[doc="<p>Describes an Amazon EBS volume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Ebs {
     #[doc="<p>Indicates whether the volume is deleted on instance termination.</p> <p>Default: <code>true</code> </p>"]
+    #[serde(rename="DeleteOnTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_on_termination: Option<bool>,
     #[doc="<p>Indicates whether the volume should be encrypted. Encrypted EBS volumes must be attached to instances that support Amazon EBS encryption. Volumes that are created from encrypted snapshots are automatically encrypted. There is no way to create an encrypted volume from an unencrypted snapshot or an unencrypted volume from an encrypted snapshot. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html\">Amazon EBS Encryption</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>The number of I/O operations per second (IOPS) to provision for the volume.</p> <p>Constraint: Required when the volume type is <code>io1</code>.</p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>The ID of the snapshot.</p>"]
+    #[serde(rename="SnapshotId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_id: Option<String>,
     #[doc="<p>The volume size, in GiB. For <code>standard</code> volumes, specify a value from 1 to 1,024. For <code>io1</code> volumes, specify a value from 4 to 16,384. For <code>gp2</code> volumes, specify a value from 1 to 16,384. If you specify a snapshot, the volume size must be equal to or larger than the snapshot size.</p> <p>Default: If you create a volume from a snapshot and you don't specify a volume size, the default is the snapshot size.</p>"]
+    #[serde(rename="VolumeSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_size: Option<i64>,
     #[doc="<p>The volume type. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html\">Amazon EBS Volume Types</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p> <p>Valid values: <code>standard</code> | <code>io1</code> | <code>gp2</code> </p> <p>Default: <code>standard</code> </p>"]
+    #[serde(rename="VolumeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_type: Option<String>,
 }
 
@@ -3496,13 +3805,17 @@ impl EbsOptimizedDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for EnableMetricsCollection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableMetricsCollectionQuery {
     #[doc="<p>The name or ARN of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The granularity to associate with the metrics to collect. The only valid value is <code>1Minute</code>.</p>"]
+    #[serde(rename="Granularity")]
     pub granularity: String,
     #[doc="<p>One or more of the following metrics. If you omit this parameter, all metrics are enabled.</p> <ul> <li> <p> <code>GroupMinSize</code> </p> </li> <li> <p> <code>GroupMaxSize</code> </p> </li> <li> <p> <code>GroupDesiredCapacity</code> </p> </li> <li> <p> <code>GroupInServiceInstances</code> </p> </li> <li> <p> <code>GroupPendingInstances</code> </p> </li> <li> <p> <code>GroupStandbyInstances</code> </p> </li> <li> <p> <code>GroupTerminatingInstances</code> </p> </li> <li> <p> <code>GroupTotalInstances</code> </p> </li> </ul>"]
+    #[serde(rename="Metrics")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metrics: Option<Vec<String>>,
 }
 
@@ -3528,11 +3841,15 @@ impl EnableMetricsCollectionQuerySerializer {
 }
 
 #[doc="<p>Describes an enabled metric.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnabledMetric {
     #[doc="<p>The granularity of the metric. The only valid value is <code>1Minute</code>.</p>"]
+    #[serde(rename="Granularity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub granularity: Option<String>,
     #[doc="<p>One of the following metrics:</p> <ul> <li> <p> <code>GroupMinSize</code> </p> </li> <li> <p> <code>GroupMaxSize</code> </p> </li> <li> <p> <code>GroupDesiredCapacity</code> </p> </li> <li> <p> <code>GroupInServiceInstances</code> </p> </li> <li> <p> <code>GroupPendingInstances</code> </p> </li> <li> <p> <code>GroupStandbyInstances</code> </p> </li> <li> <p> <code>GroupTerminatingInstances</code> </p> </li> <li> <p> <code>GroupTotalInstances</code> </p> </li> </ul>"]
+    #[serde(rename="Metric")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric: Option<String>,
 }
 
@@ -3626,9 +3943,11 @@ impl EnabledMetricsDeserializer {
     }
 }
 #[doc="<p>Contains the output of EnterStandby.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnterStandbyAnswer {
     #[doc="<p>The activities related to moving instances into <code>Standby</code> mode.</p>"]
+    #[serde(rename="Activities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub activities: Option<Vec<Activity>>,
 }
 
@@ -3675,13 +3994,17 @@ impl EnterStandbyAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for EnteStandby.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnterStandbyQuery {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more instances to move into <code>Standby</code> mode. You must specify at least one instance ID.</p>"]
+    #[serde(rename="InstanceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_ids: Option<Vec<String>>,
     #[doc="<p>Specifies whether the instances moved to <code>Standby</code> mode count as part of the Auto Scaling group's desired capacity. If set, the desired capacity for the Auto Scaling group decrements by the number of instances moved to <code>Standby</code> mode.</p>"]
+    #[serde(rename="ShouldDecrementDesiredCapacity")]
     pub should_decrement_desired_capacity: bool,
 }
 
@@ -3725,17 +4048,26 @@ impl EstimatedInstanceWarmupDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ExecutePolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecutePolicyType {
     #[doc="<p>The name or Amazon Resource Name (ARN) of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_name: Option<String>,
     #[doc="<p>The breach threshold for the alarm.</p> <p>This parameter is required if the policy type is <code>StepScaling</code> and not supported otherwise.</p>"]
+    #[serde(rename="BreachThreshold")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub breach_threshold: Option<f64>,
     #[doc="<p>If this parameter is true, Auto Scaling waits for the cooldown period to complete before executing the policy. Otherwise, Auto Scaling executes the policy without waiting for the cooldown period to complete.</p> <p>This parameter is not supported if the policy type is <code>StepScaling</code>.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/Cooldown.html\">Auto Scaling Cooldowns</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="HonorCooldown")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub honor_cooldown: Option<bool>,
     #[doc="<p>The metric value to compare to <code>BreachThreshold</code>. This enables you to execute a policy of type <code>StepScaling</code> and determine which step adjustment to use. For example, if the breach threshold is 50 and you want to use a step adjustment with a lower bound of 0 and an upper bound of 10, you can set the metric value to 59.</p> <p>If you specify a metric value that doesn't correspond to a step adjustment for the policy, the call returns an error.</p> <p>This parameter is required if the policy type is <code>StepScaling</code> and not supported otherwise.</p>"]
+    #[serde(rename="MetricValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric_value: Option<f64>,
     #[doc="<p>The name or ARN of the policy.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -3772,9 +4104,11 @@ impl ExecutePolicyTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for ExitStandby.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExitStandbyAnswer {
     #[doc="<p>The activities related to moving instances out of <code>Standby</code> mode.</p>"]
+    #[serde(rename="Activities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub activities: Option<Vec<Activity>>,
 }
 
@@ -3821,11 +4155,14 @@ impl ExitStandbyAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ExitStandby.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExitStandbyQuery {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more instance IDs. You must specify at least one instance ID.</p>"]
+    #[serde(rename="InstanceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_ids: Option<Vec<String>>,
 }
 
@@ -3851,11 +4188,15 @@ impl ExitStandbyQuerySerializer {
 }
 
 #[doc="<p>Describes a filter.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Filter {
     #[doc="<p>The name of the filter. The valid values are: <code>\"auto-scaling-group\"</code>, <code>\"key\"</code>, <code>\"value\"</code>, and <code>\"propagate-at-launch\"</code>.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The value of the filter.</p>"]
+    #[serde(rename="Values")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub values: Option<Vec<String>>,
 }
 
@@ -3935,19 +4276,25 @@ impl HeartbeatTimeoutDeserializer {
     }
 }
 #[doc="<p>Describes an EC2 instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Instance {
     #[doc="<p>The Availability Zone in which the instance is running.</p>"]
+    #[serde(rename="AvailabilityZone")]
     pub availability_zone: String,
     #[doc="<p>The last reported health status of the instance. \"Healthy\" means that the instance is healthy and should remain in service. \"Unhealthy\" means that the instance is unhealthy and Auto Scaling should terminate and replace it.</p>"]
+    #[serde(rename="HealthStatus")]
     pub health_status: String,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>The launch configuration associated with the instance.</p>"]
+    #[serde(rename="LaunchConfigurationName")]
     pub launch_configuration_name: String,
     #[doc="<p>A description of the current lifecycle state. Note that the <code>Quarantined</code> state is not used.</p>"]
+    #[serde(rename="LifecycleState")]
     pub lifecycle_state: String,
     #[doc="<p>Indicates whether the instance is protected from termination by Auto Scaling when scaling in.</p>"]
+    #[serde(rename="ProtectedFromScaleIn")]
     pub protected_from_scale_in: bool,
 }
 
@@ -4032,9 +4379,11 @@ impl InstanceIdsSerializer {
 }
 
 #[doc="<p>Describes whether instance monitoring is enabled.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceMonitoring {
     #[doc="<p>If <code>True</code>, instance monitoring is enabled.</p>"]
+    #[serde(rename="Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled: Option<bool>,
 }
 
@@ -4155,45 +4504,79 @@ impl InstancesDeserializer {
     }
 }
 #[doc="<p>Describes a launch configuration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LaunchConfiguration {
     #[doc="<p>[EC2-VPC] Indicates whether to assign a public IP address to each instance.</p>"]
+    #[serde(rename="AssociatePublicIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub associate_public_ip_address: Option<bool>,
     #[doc="<p>A block device mapping, which specifies the block devices for the instance.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
     #[doc="<p>The ID of a ClassicLink-enabled VPC to link your EC2-Classic instances to. This parameter can only be used if you are launching EC2-Classic instances. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-classiclink.html\">ClassicLink</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="ClassicLinkVPCId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub classic_link_vpc_id: Option<String>,
     #[doc="<p>The IDs of one or more security groups for the VPC specified in <code>ClassicLinkVPCId</code>. This parameter is required if you specify a ClassicLink-enabled VPC, and cannot be used otherwise. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-classiclink.html\">ClassicLink</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="ClassicLinkVPCSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub classic_link_vpc_security_groups: Option<Vec<String>>,
     #[doc="<p>The creation date and time for the launch configuration.</p>"]
+    #[serde(rename="CreatedTime")]
     pub created_time: String,
     #[doc="<p>Controls whether the instance is optimized for EBS I/O (<code>true</code>) or not (<code>false</code>).</p>"]
+    #[serde(rename="EbsOptimized")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs_optimized: Option<bool>,
     #[doc="<p>The name or Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance.</p>"]
+    #[serde(rename="IamInstanceProfile")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile: Option<String>,
     #[doc="<p>The ID of the Amazon Machine Image (AMI).</p>"]
+    #[serde(rename="ImageId")]
     pub image_id: String,
     #[doc="<p>Controls whether instances in this group are launched with detailed (<code>true</code>) or basic (<code>false</code>) monitoring.</p>"]
+    #[serde(rename="InstanceMonitoring")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_monitoring: Option<InstanceMonitoring>,
     #[doc="<p>The instance type for the instances.</p>"]
+    #[serde(rename="InstanceType")]
     pub instance_type: String,
     #[doc="<p>The ID of the kernel associated with the AMI.</p>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<String>,
     #[doc="<p>The name of the key pair.</p>"]
+    #[serde(rename="KeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_name: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the launch configuration.</p>"]
+    #[serde(rename="LaunchConfigurationARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_configuration_arn: Option<String>,
     #[doc="<p>The name of the launch configuration.</p>"]
+    #[serde(rename="LaunchConfigurationName")]
     pub launch_configuration_name: String,
     #[doc="<p>The tenancy of the instance, either <code>default</code> or <code>dedicated</code>. An instance with <code>dedicated</code> tenancy runs in an isolated, single-tenant hardware and can only be launched into a VPC.</p>"]
+    #[serde(rename="PlacementTenancy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement_tenancy: Option<String>,
     #[doc="<p>The ID of the RAM disk associated with the AMI.</p>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<String>,
     #[doc="<p>The security groups to associate with the instances.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<String>>,
     #[doc="<p>The price to bid when launching Spot Instances.</p>"]
+    #[serde(rename="SpotPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_price: Option<String>,
     #[doc="<p>The user data available to the instances.</p>"]
+    #[serde(rename="UserData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_data: Option<String>,
 }
 
@@ -4324,9 +4707,10 @@ impl LaunchConfigurationDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteLaunchConfiguration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LaunchConfigurationNameType {
     #[doc="<p>The name of the launch configuration.</p>"]
+    #[serde(rename="LaunchConfigurationName")]
     pub launch_configuration_name: String,
 }
 
@@ -4359,13 +4743,19 @@ impl LaunchConfigurationNamesSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribeLaunchConfigurations.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LaunchConfigurationNamesType {
     #[doc="<p>The launch configuration names. If you omit this parameter, all launch configurations are described.</p>"]
+    #[serde(rename="LaunchConfigurationNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_configuration_names: Option<Vec<String>>,
     #[doc="<p>The maximum number of items to return with this call. The default value is 50 and the maximum value is 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a previous call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -4441,11 +4831,14 @@ impl LaunchConfigurationsDeserializer {
     }
 }
 #[doc="<p>Contains the output of DescribeLaunchConfigurations.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LaunchConfigurationsType {
     #[doc="<p>The launch configurations.</p>"]
+    #[serde(rename="LaunchConfigurations")]
     pub launch_configurations: Vec<LaunchConfiguration>,
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -4511,25 +4904,43 @@ impl LifecycleActionResultDeserializer {
     }
 }
 #[doc="<p>Describes a lifecycle hook, which tells Auto Scaling that you want to perform an action when an instance launches or terminates. When you have a lifecycle hook in place, the Auto Scaling group will either:</p> <ul> <li> <p>Pause the instance after it launches, but before it is put into service</p> </li> <li> <p>Pause the instance as it terminates, but before it is fully terminated</p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroupLifecycle.html\">Auto Scaling Lifecycle</a> in the <i>Auto Scaling User Guide</i>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LifecycleHook {
     #[doc="<p>The name of the Auto Scaling group for the lifecycle hook.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_name: Option<String>,
     #[doc="<p>Defines the action the Auto Scaling group should take when the lifecycle hook timeout elapses or if an unexpected failure occurs. The valid values are <code>CONTINUE</code> and <code>ABANDON</code>. The default value is <code>CONTINUE</code>.</p>"]
+    #[serde(rename="DefaultResult")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_result: Option<String>,
     #[doc="<p>The maximum time, in seconds, that an instance can remain in a <code>Pending:Wait</code> or <code>Terminating:Wait</code> state. The maximum is 172800 seconds (48 hours) or 100 times <code>HeartbeatTimeout</code>, whichever is smaller.</p>"]
+    #[serde(rename="GlobalTimeout")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub global_timeout: Option<i64>,
     #[doc="<p>The maximum time, in seconds, that can elapse before the lifecycle hook times out. The default is 3600 seconds (1 hour). When the lifecycle hook times out, Auto Scaling performs the default action. You can prevent the lifecycle hook from timing out by calling <a>RecordLifecycleActionHeartbeat</a>.</p>"]
+    #[serde(rename="HeartbeatTimeout")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub heartbeat_timeout: Option<i64>,
     #[doc="<p>The name of the lifecycle hook.</p>"]
+    #[serde(rename="LifecycleHookName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lifecycle_hook_name: Option<String>,
     #[doc="<p>The state of the EC2 instance to which you want to attach the lifecycle hook. For a list of lifecycle hook types, see <a>DescribeLifecycleHookTypes</a>.</p>"]
+    #[serde(rename="LifecycleTransition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lifecycle_transition: Option<String>,
     #[doc="<p>Additional information that you want to include any time Auto Scaling sends a message to the notification target.</p>"]
+    #[serde(rename="NotificationMetadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_metadata: Option<String>,
     #[doc="<p>The ARN of the notification target that Auto Scaling uses to notify you when an instance is in the transition state for the lifecycle hook. This ARN target can be either an SQS queue or an SNS topic. The notification message sent to the target includes the following:</p> <ul> <li> <p>Lifecycle action token</p> </li> <li> <p>User account ID</p> </li> <li> <p>Name of the Auto Scaling group</p> </li> <li> <p>Lifecycle hook name</p> </li> <li> <p>EC2 instance ID</p> </li> <li> <p>Lifecycle transition</p> </li> <li> <p>Notification metadata</p> </li> </ul>"]
+    #[serde(rename="NotificationTargetARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_target_arn: Option<String>,
     #[doc="<p>The ARN of the IAM role that allows the Auto Scaling group to publish to the specified notification target.</p>"]
+    #[serde(rename="RoleARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
 }
 
@@ -4751,11 +5162,15 @@ impl LoadBalancerNamesSerializer {
 }
 
 #[doc="<p>Describes the state of a Classic Load Balancer.</p> <p>If you specify a load balancer when creating the Auto Scaling group, the state of the load balancer is <code>InService</code>.</p> <p>If you attach a load balancer to an existing Auto Scaling group, the initial state is <code>Adding</code>. The state transitions to <code>Added</code> after all instances in the group are registered with the load balancer. If ELB health checks are enabled for the load balancer, the state transitions to <code>InService</code> after at least one instance in the group passes the health check. If EC2 health checks are enabled instead, the load balancer remains in the <code>Added</code> state.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBalancerState {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_name: Option<String>,
     #[doc="<p>One of the following load balancer states:</p> <ul> <li> <p> <code>Adding</code> - The instances in the group are being registered with the load balancer.</p> </li> <li> <p> <code>Added</code> - All instances in the group are registered with the load balancer.</p> </li> <li> <p> <code>InService</code> - At least one instance in the group passed an ELB health check.</p> </li> <li> <p> <code>Removing</code> - The instances in the group are being deregistered from the load balancer. If connection draining is enabled, Elastic Load Balancing waits for in-flight requests to complete before deregistering the instances.</p> </li> <li> <p> <code>Removed</code> - All instances in the group are deregistered from the load balancer.</p> </li> </ul>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -4849,11 +5264,15 @@ impl LoadBalancerStatesDeserializer {
     }
 }
 #[doc="<p>Describes the state of a target group.</p> <p>If you attach a target group to an existing Auto Scaling group, the initial state is <code>Adding</code>. The state transitions to <code>Added</code> after all Auto Scaling instances are registered with the target group. If ELB health checks are enabled, the state transitions to <code>InService</code> after at least one Auto Scaling instance passes the health check. If EC2 health checks are enabled instead, the target group remains in the <code>Added</code> state.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBalancerTargetGroupState {
     #[doc="<p>The Amazon Resource Name (ARN) of the target group.</p>"]
+    #[serde(rename="LoadBalancerTargetGroupARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_target_group_arn: Option<String>,
     #[doc="<p>The state of the target group.</p> <ul> <li> <p> <code>Adding</code> - The Auto Scaling instances are being registered with the target group.</p> </li> <li> <p> <code>Added</code> - All Auto Scaling instances are registered with the target group.</p> </li> <li> <p> <code>InService</code> - At least one Auto Scaling instance passed an ELB health check.</p> </li> <li> <p> <code>Removing</code> - The Auto Scaling instances are being deregistered from the target group. If connection draining is enabled, Elastic Load Balancing waits for in-flight requests to complete before deregistering the instances.</p> </li> <li> <p> <code>Removed</code> - All Auto Scaling instances are deregistered from the target group.</p> </li> </ul>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -4976,9 +5395,11 @@ impl MaxNumberOfLaunchConfigurationsDeserializer {
     }
 }
 #[doc="<p>Describes a metric.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MetricCollectionType {
     #[doc="<p>One of the following metrics:</p> <ul> <li> <p> <code>GroupMinSize</code> </p> </li> <li> <p> <code>GroupMaxSize</code> </p> </li> <li> <p> <code>GroupDesiredCapacity</code> </p> </li> <li> <p> <code>GroupInServiceInstances</code> </p> </li> <li> <p> <code>GroupPendingInstances</code> </p> </li> <li> <p> <code>GroupStandbyInstances</code> </p> </li> <li> <p> <code>GroupTerminatingInstances</code> </p> </li> <li> <p> <code>GroupTotalInstances</code> </p> </li> </ul>"]
+    #[serde(rename="Metric")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric: Option<String>,
 }
 
@@ -5068,11 +5489,13 @@ impl MetricCollectionTypesDeserializer {
     }
 }
 #[doc="<p>Describes the dimension of a metric.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MetricDimension {
     #[doc="<p>The name of the dimension.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The value of the dimension.</p>"]
+    #[serde(rename="Value")]
     pub value: String,
 }
 
@@ -5222,9 +5645,11 @@ impl MetricDimensionsSerializer {
 }
 
 #[doc="<p>Describes a granularity of a metric.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MetricGranularityType {
     #[doc="<p>The granularity. The only valid value is <code>1Minute</code>.</p>"]
+    #[serde(rename="Granularity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub granularity: Option<String>,
 }
 
@@ -5466,13 +5891,19 @@ impl NoDeviceDeserializer {
     }
 }
 #[doc="<p>Describes a notification.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotificationConfiguration {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_name: Option<String>,
     #[doc="<p>One of the following event notification types:</p> <ul> <li> <p> <code>autoscaling:EC2_INSTANCE_LAUNCH</code> </p> </li> <li> <p> <code>autoscaling:EC2_INSTANCE_LAUNCH_ERROR</code> </p> </li> <li> <p> <code>autoscaling:EC2_INSTANCE_TERMINATE</code> </p> </li> <li> <p> <code>autoscaling:EC2_INSTANCE_TERMINATE_ERROR</code> </p> </li> <li> <p> <code>autoscaling:TEST_NOTIFICATION</code> </p> </li> </ul>"]
+    #[serde(rename="NotificationType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_type: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic.</p>"]
+    #[serde(rename="TopicARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
 }
 
@@ -5600,11 +6031,15 @@ impl NumberOfLaunchConfigurationsDeserializer {
     }
 }
 #[doc="<p>Contains the output of DescribePolicies.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PoliciesType {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The scaling policies.</p>"]
+    #[serde(rename="ScalingPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scaling_policies: Option<Vec<ScalingPolicy>>,
 }
 
@@ -5656,11 +6091,15 @@ impl PoliciesTypeDeserializer {
     }
 }
 #[doc="<p>Contains the output of PutScalingPolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyARNType {
     #[doc="<p>The CloudWatch alarms created for the target tracking policy. This parameter will be empty if the policy type is anything other than <code>TargetTrackingScaling</code>.</p>"]
+    #[serde(rename="Alarms")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarms: Option<Vec<Alarm>>,
     #[doc="<p>The Amazon Resource Name (ARN) of the policy.</p>"]
+    #[serde(rename="PolicyARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_arn: Option<String>,
 }
 
@@ -5750,11 +6189,14 @@ impl PolicyTypesSerializer {
 }
 
 #[doc="<p>Configures a predefined metric for a target tracking policy. The following predefined metrics are available:</p> <ul> <li> <p> <code>ASGAverageCPUUtilization</code> - average CPU utilization of the Auto Scaling group</p> </li> <li> <p> <code>ASGAverageNetworkIn</code> - average number of bytes received on all network interfaces by the Auto Scaling group</p> </li> <li> <p> <code>ASGAverageNetworkOut</code> - average number of bytes sent out on all network interfaces by the Auto Scaling group</p> </li> <li> <p> <code>ALBRequestCountPerTarget</code> - number of requests completed per target in an Application Load Balancer target group</p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PredefinedMetricSpecification {
     #[doc="<p>The metric type.</p>"]
+    #[serde(rename="PredefinedMetricType")]
     pub predefined_metric_type: String,
     #[doc="<p>Identifies the resource associated with the metric type. For predefined metric types <code>ASGAverageCPUUtilization</code>, <code>ASGAverageNetworkIn</code> and <code>ASGAverageNetworkOut</code>, the parameter must not be specified as the resource associated with the metric type is the Auto Scaling group. For predefined metric type <code>ALBRequestCountPerTarget</code>, the parameter must be specified in the format <code>app/<i>load-balancer-name</i>/<i>load-balancer-id</i>/targetgroup/<i>target-group-name</i>/<i>target-group-id</i> </code>, where <code>app/<i>load-balancer-name</i>/<i>load-balancer-id</i> </code> is the final portion of the load balancer ARN, and <code>targetgroup/<i>target-group-name</i>/<i>target-group-id</i> </code> is the final portion of the target group ARN. The target group must be attached to the Auto Scaling group.</p>"]
+    #[serde(rename="ResourceLabel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_label: Option<String>,
 }
 
@@ -5839,9 +6281,10 @@ impl ProcessNamesSerializer {
 }
 
 #[doc="<p>Describes a process type.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html#process-types\">Auto Scaling Processes</a> in the <i>Auto Scaling User Guide</i>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProcessType {
     #[doc="<p>One of the following processes:</p> <ul> <li> <p> <code>Launch</code> </p> </li> <li> <p> <code>Terminate</code> </p> </li> <li> <p> <code>AddToLoadBalancer</code> </p> </li> <li> <p> <code>AlarmNotification</code> </p> </li> <li> <p> <code>AZRebalance</code> </p> </li> <li> <p> <code>HealthCheck</code> </p> </li> <li> <p> <code>ReplaceUnhealthy</code> </p> </li> <li> <p> <code>ScheduledActions</code> </p> </li> </ul>"]
+    #[serde(rename="ProcessName")]
     pub process_name: String,
 }
 
@@ -5930,9 +6373,11 @@ impl ProcessesDeserializer {
     }
 }
 #[doc="<p>Contains the output of DescribeScalingProcessTypes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProcessesType {
     #[doc="<p>The names of the process types.</p>"]
+    #[serde(rename="Processes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub processes: Option<Vec<ProcessType>>,
 }
 
@@ -6007,7 +6452,7 @@ impl PropagateAtLaunchDeserializer {
     }
 }
 #[doc="<p>Contains the output of PutLifecycleHook.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutLifecycleHookAnswer;
 
 struct PutLifecycleHookAnswerDeserializer;
@@ -6027,23 +6472,37 @@ impl PutLifecycleHookAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for PutLifecycleHook.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutLifecycleHookType {
     #[doc="<p>The name of the Auto Scaling group to which you want to assign the lifecycle hook.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>Defines the action the Auto Scaling group should take when the lifecycle hook timeout elapses or if an unexpected failure occurs. This parameter can be either <code>CONTINUE</code> or <code>ABANDON</code>. The default value is <code>ABANDON</code>.</p>"]
+    #[serde(rename="DefaultResult")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_result: Option<String>,
     #[doc="<p>The amount of time, in seconds, that can elapse before the lifecycle hook times out. When the lifecycle hook times out, Auto Scaling performs the default action. You can prevent the lifecycle hook from timing out by calling <a>RecordLifecycleActionHeartbeat</a>. The default is 3600 seconds (1 hour).</p>"]
+    #[serde(rename="HeartbeatTimeout")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub heartbeat_timeout: Option<i64>,
     #[doc="<p>The name of the lifecycle hook.</p>"]
+    #[serde(rename="LifecycleHookName")]
     pub lifecycle_hook_name: String,
     #[doc="<p>The instance state to which you want to attach the lifecycle hook. For a list of lifecycle hook types, see <a>DescribeLifecycleHookTypes</a>.</p> <p>This parameter is required for new lifecycle hooks, but optional when updating existing hooks.</p>"]
+    #[serde(rename="LifecycleTransition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lifecycle_transition: Option<String>,
     #[doc="<p>Contains additional information that you want to include any time Auto Scaling sends a message to the notification target.</p>"]
+    #[serde(rename="NotificationMetadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_metadata: Option<String>,
     #[doc="<p>The ARN of the notification target that Auto Scaling will use to notify you when an instance is in the transition state for the lifecycle hook. This target can be either an SQS queue or an SNS topic. If you specify an empty string, this overrides the current ARN.</p> <p>This operation uses the JSON format when sending notifications to an Amazon SQS queue, and an email key/value pair format when sending notifications to an Amazon SNS topic.</p> <p>When you specify a notification target, Auto Scaling sends it a test message. Test messages contains the following additional key/value pair: <code>\"Event\": \"autoscaling:TEST_NOTIFICATION\"</code>.</p>"]
+    #[serde(rename="NotificationTargetARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_target_arn: Option<String>,
     #[doc="<p>The ARN of the IAM role that allows the Auto Scaling group to publish to the specified notification target.</p> <p>This parameter is required for new lifecycle hooks, but optional when updating existing hooks.</p>"]
+    #[serde(rename="RoleARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
 }
 
@@ -6090,13 +6549,16 @@ impl PutLifecycleHookTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for PutNotificationConfiguration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutNotificationConfigurationType {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The type of event that will cause the notification to be sent. For details about notification types supported by Auto Scaling, see <a>DescribeAutoScalingNotificationTypes</a>.</p>"]
+    #[serde(rename="NotificationTypes")]
     pub notification_types: Vec<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic.</p>"]
+    #[serde(rename="TopicARN")]
     pub topic_arn: String,
 }
 
@@ -6124,31 +6586,53 @@ impl PutNotificationConfigurationTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for PutScalingPolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutScalingPolicyType {
     #[doc="<p>The adjustment type. The valid values are <code>ChangeInCapacity</code>, <code>ExactCapacity</code>, and <code>PercentChangeInCapacity</code>.</p> <p>This parameter is supported if the policy type is <code>SimpleScaling</code> or <code>StepScaling</code>.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/as-scale-based-on-demand.html\">Dynamic Scaling</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="AdjustmentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub adjustment_type: Option<String>,
     #[doc="<p>The name or ARN of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start. If this parameter is not specified, the default cooldown period for the group applies.</p> <p>This parameter is supported if the policy type is <code>SimpleScaling</code>.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/Cooldown.html\">Auto Scaling Cooldowns</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="Cooldown")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cooldown: Option<i64>,
     #[doc="<p>The estimated time, in seconds, until a newly launched instance can contribute to the CloudWatch metrics. The default is to use the value specified for the default cooldown period for the group.</p> <p>This parameter is supported if the policy type is <code>StepScaling</code> or <code>TargetTrackingScaling</code>.</p>"]
+    #[serde(rename="EstimatedInstanceWarmup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub estimated_instance_warmup: Option<i64>,
     #[doc="<p>The aggregation type for the CloudWatch metrics. The valid values are <code>Minimum</code>, <code>Maximum</code>, and <code>Average</code>. If the aggregation type is null, the value is treated as <code>Average</code>.</p> <p>This parameter is supported if the policy type is <code>StepScaling</code>.</p>"]
+    #[serde(rename="MetricAggregationType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric_aggregation_type: Option<String>,
     #[doc="<p>The minimum number of instances to scale. If the value of <code>AdjustmentType</code> is <code>PercentChangeInCapacity</code>, the scaling policy changes the <code>DesiredCapacity</code> of the Auto Scaling group by at least this many instances. Otherwise, the error is <code>ValidationError</code>.</p> <p>This parameter is supported if the policy type is <code>SimpleScaling</code> or <code>StepScaling</code>.</p>"]
+    #[serde(rename="MinAdjustmentMagnitude")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_adjustment_magnitude: Option<i64>,
     #[doc="<p>Available for backward compatibility. Use <code>MinAdjustmentMagnitude</code> instead.</p>"]
+    #[serde(rename="MinAdjustmentStep")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_adjustment_step: Option<i64>,
     #[doc="<p>The name of the policy.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
     #[doc="<p>The policy type. The valid values are <code>SimpleScaling</code>, <code>StepScaling</code>, and <code>TargetTrackingScaling</code>. If the policy type is null, the value is treated as <code>SimpleScaling</code>.</p>"]
+    #[serde(rename="PolicyType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_type: Option<String>,
     #[doc="<p>The amount by which to scale, based on the specified adjustment type. A positive value adds to the current capacity while a negative number removes from the current capacity.</p> <p>This parameter is required if the policy type is <code>SimpleScaling</code> and not supported otherwise.</p>"]
+    #[serde(rename="ScalingAdjustment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scaling_adjustment: Option<i64>,
     #[doc="<p>A set of adjustments that enable you to scale based on the size of the alarm breach.</p> <p>This parameter is required if the policy type is <code>StepScaling</code> and not supported otherwise.</p>"]
+    #[serde(rename="StepAdjustments")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub step_adjustments: Option<Vec<StepAdjustment>>,
     #[doc="<p>The configuration of a target tracking policy.</p> <p>This parameter is required if the policy type is <code>TargetTrackingScaling</code> and not supported otherwise.</p>"]
+    #[serde(rename="TargetTrackingConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_tracking_configuration: Option<TargetTrackingConfiguration>,
 }
 
@@ -6215,25 +6699,41 @@ impl PutScalingPolicyTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for PutScheduledUpdateGroupAction.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutScheduledUpdateGroupActionType {
     #[doc="<p>The name or Amazon Resource Name (ARN) of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The number of EC2 instances that should be running in the group.</p>"]
+    #[serde(rename="DesiredCapacity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub desired_capacity: Option<i64>,
     #[doc="<p>The time for the recurring schedule to end. Auto Scaling does not perform the action after this time.</p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>The maximum size for the Auto Scaling group.</p>"]
+    #[serde(rename="MaxSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_size: Option<i64>,
     #[doc="<p>The minimum size for the Auto Scaling group.</p>"]
+    #[serde(rename="MinSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_size: Option<i64>,
     #[doc="<p>The recurring schedule for this action, in Unix cron syntax format. For more information, see <a href=\"http://en.wikipedia.org/wiki/Cron\">Cron</a> in Wikipedia.</p>"]
+    #[serde(rename="Recurrence")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurrence: Option<String>,
     #[doc="<p>The name of this scaling action.</p>"]
+    #[serde(rename="ScheduledActionName")]
     pub scheduled_action_name: String,
     #[doc="<p>The time for this action to start, in \"YYYY-MM-DDThh:mm:ssZ\" format in UTC/GMT only (for example, <code>2014-06-01T00:00:00Z</code>).</p> <p>If you specify <code>Recurrence</code> and <code>StartTime</code>, Auto Scaling performs the action at this time, and then performs the action based on the specified recurrence.</p> <p>If you try to schedule your action in the past, Auto Scaling returns an error message.</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
     #[doc="<p>This parameter is deprecated.</p>"]
+    #[serde(rename="Time")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub time: Option<String>,
 }
 
@@ -6284,7 +6784,7 @@ impl PutScheduledUpdateGroupActionTypeSerializer {
 }
 
 #[doc="<p>Contains the output of RecordLifecycleActionHeartBeat.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecordLifecycleActionHeartbeatAnswer;
 
 struct RecordLifecycleActionHeartbeatAnswerDeserializer;
@@ -6305,15 +6805,21 @@ impl RecordLifecycleActionHeartbeatAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for RecordLifecycleActionHeartbeat.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecordLifecycleActionHeartbeatType {
     #[doc="<p>The name of the Auto Scaling group for the hook.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>A token that uniquely identifies a specific lifecycle action associated with an instance. Auto Scaling sends this token to the notification target you specified when you created the lifecycle hook.</p>"]
+    #[serde(rename="LifecycleActionToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lifecycle_action_token: Option<String>,
     #[doc="<p>The name of the lifecycle hook.</p>"]
+    #[serde(rename="LifecycleHookName")]
     pub lifecycle_hook_name: String,
 }
 
@@ -6413,35 +6919,63 @@ impl ScalingPoliciesDeserializer {
     }
 }
 #[doc="<p>Describes a scaling policy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScalingPolicy {
     #[doc="<p>The adjustment type, which specifies how <code>ScalingAdjustment</code> is interpreted. Valid values are <code>ChangeInCapacity</code>, <code>ExactCapacity</code>, and <code>PercentChangeInCapacity</code>.</p>"]
+    #[serde(rename="AdjustmentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub adjustment_type: Option<String>,
     #[doc="<p>The CloudWatch alarms related to the policy.</p>"]
+    #[serde(rename="Alarms")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarms: Option<Vec<Alarm>>,
     #[doc="<p>The name of the Auto Scaling group associated with this scaling policy.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_name: Option<String>,
     #[doc="<p>The amount of time, in seconds, after a scaling activity completes before any further trigger-related scaling activities can start.</p>"]
+    #[serde(rename="Cooldown")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cooldown: Option<i64>,
     #[doc="<p>The estimated time, in seconds, until a newly launched instance can contribute to the CloudWatch metrics.</p>"]
+    #[serde(rename="EstimatedInstanceWarmup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub estimated_instance_warmup: Option<i64>,
     #[doc="<p>The aggregation type for the CloudWatch metrics. Valid values are <code>Minimum</code>, <code>Maximum</code>, and <code>Average</code>.</p>"]
+    #[serde(rename="MetricAggregationType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric_aggregation_type: Option<String>,
     #[doc="<p>The minimum number of instances to scale. If the value of <code>AdjustmentType</code> is <code>PercentChangeInCapacity</code>, the scaling policy changes the <code>DesiredCapacity</code> of the Auto Scaling group by at least this many instances. Otherwise, the error is <code>ValidationError</code>.</p>"]
+    #[serde(rename="MinAdjustmentMagnitude")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_adjustment_magnitude: Option<i64>,
     #[doc="<p>Available for backward compatibility. Use <code>MinAdjustmentMagnitude</code> instead.</p>"]
+    #[serde(rename="MinAdjustmentStep")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_adjustment_step: Option<i64>,
     #[doc="<p>The Amazon Resource Name (ARN) of the policy.</p>"]
+    #[serde(rename="PolicyARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_arn: Option<String>,
     #[doc="<p>The name of the scaling policy.</p>"]
+    #[serde(rename="PolicyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_name: Option<String>,
     #[doc="<p>The policy type. Valid values are <code>SimpleScaling</code> and <code>StepScaling</code>.</p>"]
+    #[serde(rename="PolicyType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_type: Option<String>,
     #[doc="<p>The amount by which to scale, based on the specified adjustment type. A positive value adds to the current capacity while a negative number removes from the current capacity.</p>"]
+    #[serde(rename="ScalingAdjustment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scaling_adjustment: Option<i64>,
     #[doc="<p>A set of adjustments that enable you to scale based on the size of the alarm breach.</p>"]
+    #[serde(rename="StepAdjustments")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub step_adjustments: Option<Vec<StepAdjustment>>,
     #[doc="<p>A target tracking policy.</p>"]
+    #[serde(rename="TargetTrackingConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_tracking_configuration: Option<TargetTrackingConfiguration>,
 }
 
@@ -6550,11 +7084,14 @@ impl ScalingPolicyDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for SuspendProcesses and ResumeProcesses.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScalingProcessQuery {
     #[doc="<p>The name or Amazon Resource Name (ARN) of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more of the following processes. If you omit this parameter, all processes are specified.</p> <ul> <li> <p> <code>Launch</code> </p> </li> <li> <p> <code>Terminate</code> </p> </li> <li> <p> <code>HealthCheck</code> </p> </li> <li> <p> <code>ReplaceUnhealthy</code> </p> </li> <li> <p> <code>AZRebalance</code> </p> </li> <li> <p> <code>AlarmNotification</code> </p> </li> <li> <p> <code>ScheduledActions</code> </p> </li> <li> <p> <code>AddToLoadBalancer</code> </p> </li> </ul>"]
+    #[serde(rename="ScalingProcesses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scaling_processes: Option<Vec<String>>,
 }
 
@@ -6592,11 +7129,15 @@ impl ScheduledActionNamesSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeScheduledActions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledActionsType {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The scheduled actions.</p>"]
+    #[serde(rename="ScheduledUpdateGroupActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheduled_update_group_actions: Option<Vec<ScheduledUpdateGroupAction>>,
 }
 
@@ -6646,27 +7187,47 @@ impl ScheduledActionsTypeDeserializer {
     }
 }
 #[doc="<p>Describes a scheduled update to an Auto Scaling group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledUpdateGroupAction {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_group_name: Option<String>,
     #[doc="<p>The number of instances you prefer to maintain in the group.</p>"]
+    #[serde(rename="DesiredCapacity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub desired_capacity: Option<i64>,
     #[doc="<p>The date and time that the action is scheduled to end. This date and time can be up to one month in the future.</p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>The maximum size of the group.</p>"]
+    #[serde(rename="MaxSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_size: Option<i64>,
     #[doc="<p>The minimum size of the group.</p>"]
+    #[serde(rename="MinSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_size: Option<i64>,
     #[doc="<p>The recurring schedule for the action.</p>"]
+    #[serde(rename="Recurrence")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurrence: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the scheduled action.</p>"]
+    #[serde(rename="ScheduledActionARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheduled_action_arn: Option<String>,
     #[doc="<p>The name of the scheduled action.</p>"]
+    #[serde(rename="ScheduledActionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheduled_action_name: Option<String>,
     #[doc="<p>The date and time that the action is scheduled to begin. This date and time can be up to one month in the future.</p> <p>When <code>StartTime</code> and <code>EndTime</code> are specified with <code>Recurrence</code>, they form the boundaries of when the recurring action will start and stop.</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
     #[doc="<p>This parameter is deprecated.</p>"]
+    #[serde(rename="Time")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub time: Option<String>,
 }
 
@@ -6852,13 +7413,17 @@ impl SecurityGroupsSerializer {
 }
 
 #[doc="<p>Contains the parameters for SetDesiredCapacity.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetDesiredCapacityType {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>The number of EC2 instances that should be running in the Auto Scaling group.</p>"]
+    #[serde(rename="DesiredCapacity")]
     pub desired_capacity: i64,
     #[doc="<p>By default, <code>SetDesiredCapacity</code> overrides any cooldown period associated with the Auto Scaling group. Specify <code>True</code> to make Auto Scaling to wait for the cool-down period associated with the Auto Scaling group to complete before initiating a scaling activity to set your Auto Scaling group to its new capacity.</p>"]
+    #[serde(rename="HonorCooldown")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub honor_cooldown: Option<bool>,
 }
 
@@ -6885,13 +7450,17 @@ impl SetDesiredCapacityTypeSerializer {
 }
 
 #[doc="<p>Contains the parameters for SetInstanceHealth.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetInstanceHealthQuery {
     #[doc="<p>The health status of the instance. Set to <code>Healthy</code> if you want the instance to remain in service. Set to <code>Unhealthy</code> if you want the instance to be out of service. Auto Scaling will terminate and replace the unhealthy instance.</p>"]
+    #[serde(rename="HealthStatus")]
     pub health_status: String,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>If the Auto Scaling group of the specified instance has a <code>HealthCheckGracePeriod</code> specified for the group, by default, this call will respect the grace period. Set this to <code>False</code>, if you do not want the call to respect the grace period associated with the group.</p> <p>For more information, see the description of the health check grace period for <a>CreateAutoScalingGroup</a>.</p>"]
+    #[serde(rename="ShouldRespectGracePeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub should_respect_grace_period: Option<bool>,
 }
 
@@ -6918,7 +7487,7 @@ impl SetInstanceHealthQuerySerializer {
 }
 
 #[doc="<p>Contains the output of SetInstanceProtection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetInstanceProtectionAnswer;
 
 struct SetInstanceProtectionAnswerDeserializer;
@@ -6938,13 +7507,16 @@ impl SetInstanceProtectionAnswerDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for SetInstanceProtection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetInstanceProtectionQuery {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more instance IDs.</p>"]
+    #[serde(rename="InstanceIds")]
     pub instance_ids: Vec<String>,
     #[doc="<p>Indicates whether the instance is protected from termination by Auto Scaling when scaling in.</p>"]
+    #[serde(rename="ProtectedFromScaleIn")]
     pub protected_from_scale_in: bool,
 }
 
@@ -6984,13 +7556,18 @@ impl SpotPriceDeserializer {
     }
 }
 #[doc="<p>Describes an adjustment based on the difference between the value of the aggregated CloudWatch metric and the breach threshold that you've defined for the alarm.</p> <p>For the following examples, suppose that you have an alarm with a breach threshold of 50:</p> <ul> <li> <p>If you want the adjustment to be triggered when the metric is greater than or equal to 50 and less than 60, specify a lower bound of 0 and an upper bound of 10.</p> </li> <li> <p>If you want the adjustment to be triggered when the metric is greater than 40 and less than or equal to 50, specify a lower bound of -10 and an upper bound of 0.</p> </li> </ul> <p>There are a few rules for the step adjustments for your step policy:</p> <ul> <li> <p>The ranges of your step adjustments can't overlap or have a gap.</p> </li> <li> <p>At most one step adjustment can have a null lower bound. If one step adjustment has a negative lower bound, then there must be a step adjustment with a null lower bound.</p> </li> <li> <p>At most one step adjustment can have a null upper bound. If one step adjustment has a positive upper bound, then there must be a step adjustment with a null upper bound.</p> </li> <li> <p>The upper and lower bound can't be null in the same step adjustment.</p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StepAdjustment {
     #[doc="<p>The lower bound for the difference between the alarm threshold and the CloudWatch metric. If the metric value is above the breach threshold, the lower bound is inclusive (the metric must be greater than or equal to the threshold plus the lower bound). Otherwise, it is exclusive (the metric must be greater than the threshold plus the lower bound). A null value indicates negative infinity.</p>"]
+    #[serde(rename="MetricIntervalLowerBound")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric_interval_lower_bound: Option<f64>,
     #[doc="<p>The upper bound for the difference between the alarm threshold and the CloudWatch metric. If the metric value is above the breach threshold, the upper bound is exclusive (the metric must be less than the threshold plus the upper bound). Otherwise, it is inclusive (the metric must be less than or equal to the threshold plus the upper bound). A null value indicates positive infinity.</p> <p>The upper bound must be greater than the lower bound.</p>"]
+    #[serde(rename="MetricIntervalUpperBound")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric_interval_upper_bound: Option<f64>,
     #[doc="<p>The amount by which to scale, based on the specified adjustment type. A positive value adds to the current capacity while a negative number removes from the current capacity.</p>"]
+    #[serde(rename="ScalingAdjustment")]
     pub scaling_adjustment: i64,
 }
 
@@ -7125,11 +7702,15 @@ impl StepAdjustmentsSerializer {
 }
 
 #[doc="<p>Describes an Auto Scaling process that has been suspended. For more information, see <a>ProcessType</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SuspendedProcess {
     #[doc="<p>The name of the suspended process.</p>"]
+    #[serde(rename="ProcessName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub process_name: Option<String>,
     #[doc="<p>The reason that the process was suspended.</p>"]
+    #[serde(rename="SuspensionReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub suspension_reason: Option<String>,
 }
 
@@ -7223,17 +7804,26 @@ impl SuspendedProcessesDeserializer {
     }
 }
 #[doc="<p>Describes a tag for an Auto Scaling group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>The tag key.</p>"]
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="<p>Determines whether the tag is added to new instances as they are launched in the group.</p>"]
+    #[serde(rename="PropagateAtLaunch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub propagate_at_launch: Option<bool>,
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="ResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_id: Option<String>,
     #[doc="<p>The type of resource. The only supported value is <code>auto-scaling-group</code>.</p>"]
+    #[serde(rename="ResourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
     #[doc="<p>The tag value.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -7270,17 +7860,27 @@ impl TagSerializer {
 }
 
 #[doc="<p>Describes a tag for an Auto Scaling group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagDescription {
     #[doc="<p>The tag key.</p>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>Determines whether the tag is added to new instances as they are launched in the group.</p>"]
+    #[serde(rename="PropagateAtLaunch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub propagate_at_launch: Option<bool>,
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="ResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_id: Option<String>,
     #[doc="<p>The type of resource. The only supported value is <code>auto-scaling-group</code>.</p>"]
+    #[serde(rename="ResourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
     #[doc="<p>The tag value.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -7425,11 +8025,15 @@ impl TagsSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagsType {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>One or more tags.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<TagDescription>>,
 }
 
@@ -7535,15 +8139,22 @@ impl TargetGroupARNsSerializer {
 }
 
 #[doc="<p>Represents a target tracking policy configuration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TargetTrackingConfiguration {
     #[doc="<p>A customized metric.</p>"]
+    #[serde(rename="CustomizedMetricSpecification")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub customized_metric_specification: Option<CustomizedMetricSpecification>,
     #[doc="<p>If the parameter is true, then scale-in will be disabled for the target tracking policy, i.e. the target tracking policy will not scale in the Auto Scaling group. The default value is false.</p>"]
+    #[serde(rename="DisableScaleIn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disable_scale_in: Option<bool>,
     #[doc="<p>A predefined metric. You can specify either a predefined metric or a customized metric.</p>"]
+    #[serde(rename="PredefinedMetricSpecification")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub predefined_metric_specification: Option<PredefinedMetricSpecification>,
     #[doc="<p>The target value for the metric.</p>"]
+    #[serde(rename="TargetValue")]
     pub target_value: f64,
 }
 
@@ -7635,11 +8246,13 @@ impl TargetTrackingConfigurationSerializer {
 }
 
 #[doc="<p>Contains the parameters for TerminateInstanceInAutoScalingGroup.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateInstanceInAutoScalingGroupType {
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>If <code>true</code>, terminating the instance also decrements the size of the Auto Scaling group.</p>"]
+    #[serde(rename="ShouldDecrementDesiredCapacity")]
     pub should_decrement_desired_capacity: bool,
 }
 
@@ -7732,33 +8345,58 @@ impl TimestampTypeDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for UpdateAutoScalingGroup.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAutoScalingGroupType {
     #[doc="<p>The name of the Auto Scaling group.</p>"]
+    #[serde(rename="AutoScalingGroupName")]
     pub auto_scaling_group_name: String,
     #[doc="<p>One or more Availability Zones for the group.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<String>>,
     #[doc="<p>The amount of time, in seconds, after a scaling activity completes before another scaling activity can start. The default is 300.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/Cooldown.html\">Auto Scaling Cooldowns</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="DefaultCooldown")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_cooldown: Option<i64>,
     #[doc="<p>The number of EC2 instances that should be running in the Auto Scaling group. This number must be greater than or equal to the minimum size of the group and less than or equal to the maximum size of the group.</p>"]
+    #[serde(rename="DesiredCapacity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub desired_capacity: Option<i64>,
     #[doc="<p>The amount of time, in seconds, that Auto Scaling waits before checking the health status of an EC2 instance that has come into service. The default is 0.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/healthcheck.html\">Health Checks</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="HealthCheckGracePeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_grace_period: Option<i64>,
     #[doc="<p>The service to use for the health checks. The valid values are <code>EC2</code> and <code>ELB</code>.</p>"]
+    #[serde(rename="HealthCheckType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_type: Option<String>,
     #[doc="<p>The name of the launch configuration.</p>"]
+    #[serde(rename="LaunchConfigurationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_configuration_name: Option<String>,
     #[doc="<p>The maximum size of the Auto Scaling group.</p>"]
+    #[serde(rename="MaxSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_size: Option<i64>,
     #[doc="<p>The minimum size of the Auto Scaling group.</p>"]
+    #[serde(rename="MinSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_size: Option<i64>,
     #[doc="<p>Indicates whether newly launched instances are protected from termination by Auto Scaling when scaling in.</p>"]
+    #[serde(rename="NewInstancesProtectedFromScaleIn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_instances_protected_from_scale_in: Option<bool>,
     #[doc="<p>The name of the placement group into which you'll launch your instances, if any. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html\">Placement Groups</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="PlacementGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement_group: Option<String>,
     #[doc="<p>A standalone termination policy or a list of termination policies used to select the instance to terminate. The policies are executed in the order that they are listed.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-termination.html\">Controlling Which Instances Auto Scaling Terminates During Scale In</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="TerminationPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub termination_policies: Option<Vec<String>>,
     #[doc="<p>The ID of the subnet, if you are launching into a VPC. You can specify several subnets in a comma-separated list.</p> <p>When you specify <code>VPCZoneIdentifier</code> with <code>AvailabilityZones</code>, ensure that the subnets' Availability Zones match the values you specify for <code>AvailabilityZones</code>.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/autoscaling/latest/userguide/asg-in-vpc.html\">Launching Auto Scaling Instances in a VPC</a> in the <i>Auto Scaling User Guide</i>.</p>"]
+    #[serde(rename="VPCZoneIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_zone_identifier: Option<String>,
 }
 

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 #[doc="<p>An object representing the details of a container that is part of a job attempt.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttemptContainerDetail {
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon ECS container instance that hosts the job attempt.</p>"]
     #[serde(rename="containerInstanceArn")]
@@ -53,7 +53,7 @@ pub struct AttemptContainerDetail {
 }
 
 #[doc="<p>An object representing a job attempt.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttemptDetail {
     #[doc="<p>Details about the container in this job attempt.</p>"]
     #[serde(rename="container")]
@@ -73,7 +73,7 @@ pub struct AttemptDetail {
     pub stopped_at: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelJobRequest {
     #[doc="<p>A list of up to 100 job IDs to cancel.</p>"]
     #[serde(rename="jobId")]
@@ -83,11 +83,11 @@ pub struct CancelJobRequest {
     pub reason: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelJobResponse;
 
 #[doc="<p>An object representing an AWS Batch compute environment.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComputeEnvironmentDetail {
     #[doc="<p>The Amazon Resource Name (ARN) of the compute environment. </p>"]
     #[serde(rename="computeEnvironmentArn")]
@@ -186,7 +186,7 @@ pub struct ComputeResource {
 }
 
 #[doc="<p>An object representing the attributes of a compute environment that can be updated.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComputeResourceUpdate {
     #[doc="<p>The desired number of EC2 vCPUS in the compute environment.</p>"]
     #[serde(rename="desiredvCpus")]
@@ -203,7 +203,7 @@ pub struct ComputeResourceUpdate {
 }
 
 #[doc="<p>An object representing the details of a container that is part of a job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ContainerDetail {
     #[doc="<p>The command that is passed to the container. </p>"]
     #[serde(rename="command")]
@@ -275,7 +275,7 @@ pub struct ContainerDetail {
 }
 
 #[doc="<p>The overrides that should be sent to a container.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ContainerOverrides {
     #[doc="<p>The command to send to the container that overrides the default command from the Docker image or the job definition.</p>"]
     #[serde(rename="command")]
@@ -345,7 +345,7 @@ pub struct ContainerProperties {
     pub volumes: Option<Vec<Volume>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateComputeEnvironmentRequest {
     #[doc="<p>The name for your compute environment. Up to 128 letters (uppercase and lowercase), numbers, and underscores are allowed.</p>"]
     #[serde(rename="computeEnvironmentName")]
@@ -366,7 +366,7 @@ pub struct CreateComputeEnvironmentRequest {
     pub type_: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateComputeEnvironmentResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the compute environment. </p>"]
     #[serde(rename="computeEnvironmentArn")]
@@ -378,7 +378,7 @@ pub struct CreateComputeEnvironmentResponse {
     pub compute_environment_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobQueueRequest {
     #[doc="<p>The set of compute environments mapped to a job queue and their order relative to each other. The job scheduler uses this parameter to determine which compute environment should execute a given job. Compute environments must be in the <code>VALID</code> state before you can associate them with a job queue. You can associate up to 3 compute environments with a job queue.</p>"]
     #[serde(rename="computeEnvironmentOrder")]
@@ -395,7 +395,7 @@ pub struct CreateJobQueueRequest {
     pub state: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobQueueResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the job queue.</p>"]
     #[serde(rename="jobQueueArn")]
@@ -405,37 +405,37 @@ pub struct CreateJobQueueResponse {
     pub job_queue_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteComputeEnvironmentRequest {
     #[doc="<p>The name or Amazon Resource Name (ARN) of the compute environment to delete. </p>"]
     #[serde(rename="computeEnvironment")]
     pub compute_environment: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteComputeEnvironmentResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteJobQueueRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the queue to delete. </p>"]
     #[serde(rename="jobQueue")]
     pub job_queue: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteJobQueueResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterJobDefinitionRequest {
     #[doc="<p>The name and revision (<code>name:revision</code>) or full Amazon Resource Name (ARN) of the job definition to deregister. </p>"]
     #[serde(rename="jobDefinition")]
     pub job_definition: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterJobDefinitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeComputeEnvironmentsRequest {
     #[doc="<p>A list of up to 100 compute environment names or full Amazon Resource Name (ARN) entries. </p>"]
     #[serde(rename="computeEnvironments")]
@@ -451,7 +451,7 @@ pub struct DescribeComputeEnvironmentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeComputeEnvironmentsResponse {
     #[doc="<p>The list of compute environments.</p>"]
     #[serde(rename="computeEnvironments")]
@@ -463,7 +463,7 @@ pub struct DescribeComputeEnvironmentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeJobDefinitionsRequest {
     #[doc="<p>The name of the job definition to describe.</p>"]
     #[serde(rename="jobDefinitionName")]
@@ -487,7 +487,7 @@ pub struct DescribeJobDefinitionsRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeJobDefinitionsResponse {
     #[doc="<p>The list of job definitions. </p>"]
     #[serde(rename="jobDefinitions")]
@@ -499,7 +499,7 @@ pub struct DescribeJobDefinitionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeJobQueuesRequest {
     #[doc="<p>A list of up to 100 queue names or full queue Amazon Resource Name (ARN) entries.</p>"]
     #[serde(rename="jobQueues")]
@@ -515,7 +515,7 @@ pub struct DescribeJobQueuesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeJobQueuesResponse {
     #[doc="<p>The list of job queues. </p>"]
     #[serde(rename="jobQueues")]
@@ -527,14 +527,14 @@ pub struct DescribeJobQueuesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeJobsRequest {
     #[doc="<p>A space-separated list of up to 100 job IDs.</p>"]
     #[serde(rename="jobs")]
     pub jobs: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeJobsResponse {
     #[doc="<p>The list of jobs. </p>"]
     #[serde(rename="jobs")]
@@ -552,7 +552,7 @@ pub struct Host {
 }
 
 #[doc="<p>An object representing an AWS Batch job definition.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobDefinition {
     #[doc="<p>An object with various properties specific to container-based jobs. </p>"]
     #[serde(rename="containerProperties")]
@@ -594,7 +594,7 @@ pub struct JobDependency {
 }
 
 #[doc="<p>An object representing an AWS Batch job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobDetail {
     #[doc="<p>A list of job attempts associated with this job.</p>"]
     #[serde(rename="attempts")]
@@ -649,7 +649,7 @@ pub struct JobDetail {
 }
 
 #[doc="<p>An object representing the details of an AWS Batch job queue.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobQueueDetail {
     #[doc="<p>The compute environments that are attached to the job queue and the order in which job placement is preferred. Compute environments are selected for job placement in ascending order.</p>"]
     #[serde(rename="computeEnvironmentOrder")]
@@ -677,7 +677,7 @@ pub struct JobQueueDetail {
 }
 
 #[doc="<p>An object representing summary details of a job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobSummary {
     #[doc="<p>The ID of the job.</p>"]
     #[serde(rename="jobId")]
@@ -700,7 +700,7 @@ pub struct KeyValuePair {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsRequest {
     #[doc="<p>The name or full Amazon Resource Name (ARN) of the job queue with which to list jobs.</p>"]
     #[serde(rename="jobQueue")]
@@ -719,7 +719,7 @@ pub struct ListJobsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsResponse {
     #[doc="<p>A list of job summaries that match the request.</p>"]
     #[serde(rename="jobSummaryList")]
@@ -747,7 +747,7 @@ pub struct MountPoint {
     pub source_volume: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterJobDefinitionRequest {
     #[doc="<p>An object with various properties specific for container-based jobs. This parameter is required if the <code>type</code> parameter is <code>container</code>.</p>"]
     #[serde(rename="containerProperties")]
@@ -769,7 +769,7 @@ pub struct RegisterJobDefinitionRequest {
     pub type_: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterJobDefinitionResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the job definition. </p>"]
     #[serde(rename="jobDefinitionArn")]
@@ -791,7 +791,7 @@ pub struct RetryStrategy {
     pub attempts: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubmitJobRequest {
     #[doc="<p>A list of container overrides in JSON format that specify the name of a container in the specified job definition and the overrides it should receive. You can override the default command for a container (that is specified in the job definition or the Docker image) with a <code>command</code> override. You can also override existing environment variables (that are specified in the job definition or Docker image) on a container or add new environment variables to it with an <code>environment</code> override.</p>"]
     #[serde(rename="containerOverrides")]
@@ -820,7 +820,7 @@ pub struct SubmitJobRequest {
     pub retry_strategy: Option<RetryStrategy>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubmitJobResponse {
     #[doc="<p>The unique identifier for the job.</p>"]
     #[serde(rename="jobId")]
@@ -830,7 +830,7 @@ pub struct SubmitJobResponse {
     pub job_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateJobRequest {
     #[doc="<p>Job IDs to be terminated. Up to 100 jobs can be specified.</p>"]
     #[serde(rename="jobId")]
@@ -840,7 +840,7 @@ pub struct TerminateJobRequest {
     pub reason: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateJobResponse;
 
 #[doc="<p>The <code>ulimit</code> settings to pass to the container.</p>"]
@@ -857,7 +857,7 @@ pub struct Ulimit {
     pub soft_limit: i64,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateComputeEnvironmentRequest {
     #[doc="<p>The name or full Amazon Resource Name (ARN) of the compute environment to update.</p>"]
     #[serde(rename="computeEnvironment")]
@@ -876,7 +876,7 @@ pub struct UpdateComputeEnvironmentRequest {
     pub state: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateComputeEnvironmentResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the compute environment. </p>"]
     #[serde(rename="computeEnvironmentArn")]
@@ -888,7 +888,7 @@ pub struct UpdateComputeEnvironmentResponse {
     pub compute_environment_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateJobQueueRequest {
     #[doc="<p>Details the set of compute environments mapped to a job queue and their order relative to each other. This is one of the parameters used by the job scheduler to determine which compute environment should execute a given job. </p>"]
     #[serde(rename="computeEnvironmentOrder")]
@@ -907,7 +907,7 @@ pub struct UpdateJobQueueRequest {
     pub state: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateJobQueueResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the job queue.</p>"]
     #[serde(rename="jobQueueArn")]

--- a/rusoto/services/budgets/src/generated.rs
+++ b/rusoto/services/budgets/src/generated.rs
@@ -73,7 +73,7 @@ pub struct CostTypes {
 }
 
 #[doc="Request of CreateBudget"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBudgetRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -85,11 +85,11 @@ pub struct CreateBudgetRequest {
 }
 
 #[doc="Response of CreateBudget"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBudgetResponse;
 
 #[doc="Request of CreateNotification"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNotificationRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -102,11 +102,11 @@ pub struct CreateNotificationRequest {
 }
 
 #[doc="Response of CreateNotification"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNotificationResponse;
 
 #[doc="Request of CreateSubscriber"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubscriberRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -119,11 +119,11 @@ pub struct CreateSubscriberRequest {
 }
 
 #[doc="Response of CreateSubscriber"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubscriberResponse;
 
 #[doc="Request of DeleteBudget"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBudgetRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -132,11 +132,11 @@ pub struct DeleteBudgetRequest {
 }
 
 #[doc="Response of DeleteBudget"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBudgetResponse;
 
 #[doc="Request of DeleteNotification"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNotificationRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -147,11 +147,11 @@ pub struct DeleteNotificationRequest {
 }
 
 #[doc="Response of DeleteNotification"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNotificationResponse;
 
 #[doc="Request of DeleteSubscriber"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSubscriberRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -164,11 +164,11 @@ pub struct DeleteSubscriberRequest {
 }
 
 #[doc="Response of DeleteSubscriber"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSubscriberResponse;
 
 #[doc="Request of DescribeBudget"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBudgetRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -177,7 +177,7 @@ pub struct DescribeBudgetRequest {
 }
 
 #[doc="Response of DescribeBudget"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBudgetResponse {
     #[serde(rename="Budget")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -185,7 +185,7 @@ pub struct DescribeBudgetResponse {
 }
 
 #[doc="Request of DescribeBudgets"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBudgetsRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -198,7 +198,7 @@ pub struct DescribeBudgetsRequest {
 }
 
 #[doc="Response of DescribeBudgets"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBudgetsResponse {
     #[serde(rename="Budgets")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -209,7 +209,7 @@ pub struct DescribeBudgetsResponse {
 }
 
 #[doc="Request of DescribeNotificationsForBudget"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNotificationsForBudgetRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -224,7 +224,7 @@ pub struct DescribeNotificationsForBudgetRequest {
 }
 
 #[doc="Response of GetNotificationsForBudget"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNotificationsForBudgetResponse {
     #[serde(rename="NextToken")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -235,7 +235,7 @@ pub struct DescribeNotificationsForBudgetResponse {
 }
 
 #[doc="Request of DescribeSubscribersForNotification"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSubscribersForNotificationRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -252,7 +252,7 @@ pub struct DescribeSubscribersForNotificationRequest {
 }
 
 #[doc="Response of DescribeSubscribersForNotification"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSubscribersForNotificationResponse {
     #[serde(rename="NextToken")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -274,7 +274,7 @@ pub struct Notification {
 }
 
 #[doc="A structure to relate notification and a list of subscribers who belong to the notification."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotificationWithSubscribers {
     #[serde(rename="Notification")]
     pub notification: Notification,
@@ -310,7 +310,7 @@ pub struct TimePeriod {
 }
 
 #[doc="Request of UpdateBudget"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateBudgetRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -319,11 +319,11 @@ pub struct UpdateBudgetRequest {
 }
 
 #[doc="Response of UpdateBudget"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateBudgetResponse;
 
 #[doc="Request of UpdateNotification"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateNotificationRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -336,11 +336,11 @@ pub struct UpdateNotificationRequest {
 }
 
 #[doc="Response of UpdateNotification"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateNotificationResponse;
 
 #[doc="Request of UpdateSubscriber"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSubscriberRequest {
     #[serde(rename="AccountId")]
     pub account_id: String,
@@ -355,7 +355,7 @@ pub struct UpdateSubscriberRequest {
 }
 
 #[doc="Response of UpdateSubscriber"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSubscriberResponse;
 
 /// Errors returned by CreateBudget

--- a/rusoto/services/clouddirectory/src/generated.rs
+++ b/rusoto/services/clouddirectory/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddFacetToObjectRequest {
     #[doc="<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -45,10 +45,10 @@ pub struct AddFacetToObjectRequest {
     pub schema_facet: SchemaFacet,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddFacetToObjectResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplySchemaRequest {
     #[doc="<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> into which the schema is copied. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -58,7 +58,7 @@ pub struct ApplySchemaRequest {
     pub published_schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplySchemaResponse {
     #[doc="<p>The applied schema ARN that is associated with the copied schema in the <a>Directory</a>. You can use this ARN to describe the schema information applied on this directory. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="AppliedSchemaArn")]
@@ -70,7 +70,7 @@ pub struct ApplySchemaResponse {
     pub directory_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachObjectRequest {
     #[doc="<p>The child object reference to be attached to the object.</p>"]
     #[serde(rename="ChildReference")]
@@ -86,7 +86,7 @@ pub struct AttachObjectRequest {
     pub parent_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachObjectResponse {
     #[doc="<p>The attached <code>ObjectIdentifier</code>, which is the child <code>ObjectIdentifier</code>.</p>"]
     #[serde(rename="AttachedObjectIdentifier")]
@@ -94,7 +94,7 @@ pub struct AttachObjectResponse {
     pub attached_object_identifier: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachPolicyRequest {
     #[doc="<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where both objects reside. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -108,10 +108,10 @@ pub struct AttachPolicyRequest {
     pub policy_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachPolicyResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachToIndexRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the directory where the object and index exist.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -124,7 +124,7 @@ pub struct AttachToIndexRequest {
     pub target_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachToIndexResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> of the object that was attached to the index.</p>"]
     #[serde(rename="AttachedObjectIdentifier")]
@@ -132,7 +132,7 @@ pub struct AttachToIndexResponse {
     pub attached_object_identifier: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachTypedLinkRequest {
     #[doc="<p>A set of attributes that are associated with the typed link.</p>"]
     #[serde(rename="Attributes")]
@@ -151,7 +151,7 @@ pub struct AttachTypedLinkRequest {
     pub typed_link_facet: TypedLinkSchemaAndFacetName,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachTypedLinkResponse {
     #[doc="<p>Returns a typed link specifier as output.</p>"]
     #[serde(rename="TypedLinkSpecifier")]
@@ -196,7 +196,7 @@ pub struct AttributeNameAndValue {
 }
 
 #[doc="<p>Represents the output of a batch add facet to object operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchAddFacetToObject {
     #[doc="<p>The attributes to set on the object.</p>"]
     #[serde(rename="ObjectAttributeList")]
@@ -210,11 +210,11 @@ pub struct BatchAddFacetToObject {
 }
 
 #[doc="<p>The result of a batch add facet to object operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchAddFacetToObjectResponse;
 
 #[doc="<p>Represents the output of an <a>AttachObject</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchAttachObject {
     #[doc="<p>The child object reference that is to be attached to the object.</p>"]
     #[serde(rename="ChildReference")]
@@ -228,7 +228,7 @@ pub struct BatchAttachObject {
 }
 
 #[doc="<p>Represents the output batch <a>AttachObject</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchAttachObjectResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> of the object that has been attached.</p>"]
     #[serde(rename="attachedObjectIdentifier")]
@@ -237,7 +237,7 @@ pub struct BatchAttachObjectResponse {
 }
 
 #[doc="<p>Attaches a policy object to a regular object inside a <a>BatchRead</a> operation. For more information, see <a>AttachPolicy</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchAttachPolicy {
     #[doc="<p>The reference that identifies the object to which the policy will be attached.</p>"]
     #[serde(rename="ObjectReference")]
@@ -248,11 +248,11 @@ pub struct BatchAttachPolicy {
 }
 
 #[doc="<p>Represents the output of an <a>AttachPolicy</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchAttachPolicyResponse;
 
 #[doc="<p>Attaches the specified object to the specified index inside a <a>BatchRead</a> operation. For more information, see <a>AttachToIndex</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchAttachToIndex {
     #[doc="<p>A reference to the index that you are attaching the object to.</p>"]
     #[serde(rename="IndexReference")]
@@ -263,7 +263,7 @@ pub struct BatchAttachToIndex {
 }
 
 #[doc="<p>Represents the output of a <a>AttachToIndex</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchAttachToIndexResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> of the object that was attached to the index.</p>"]
     #[serde(rename="AttachedObjectIdentifier")]
@@ -272,7 +272,7 @@ pub struct BatchAttachToIndexResponse {
 }
 
 #[doc="<p>Attaches a typed link to a specified source and target object inside a <a>BatchRead</a> operation. For more information, see <a>AttachTypedLink</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchAttachTypedLink {
     #[doc="<p>A set of attributes that are associated with the typed link.</p>"]
     #[serde(rename="Attributes")]
@@ -289,7 +289,7 @@ pub struct BatchAttachTypedLink {
 }
 
 #[doc="<p>Represents the output of a <a>AttachTypedLink</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchAttachTypedLinkResponse {
     #[doc="<p>Returns a typed link specifier as output.</p>"]
     #[serde(rename="TypedLinkSpecifier")]
@@ -298,7 +298,7 @@ pub struct BatchAttachTypedLinkResponse {
 }
 
 #[doc="<p>Creates an index object inside of a <a>BatchRead</a> operation. For more information, see <a>CreateIndex</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchCreateIndex {
     #[doc="<p>The batch reference name. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#batches\">Batches</a> for more information.</p>"]
     #[serde(rename="BatchReferenceName")]
@@ -321,7 +321,7 @@ pub struct BatchCreateIndex {
 }
 
 #[doc="<p>Represents the output of a <a>CreateIndex</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchCreateIndexResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> of the index created by this operation.</p>"]
     #[serde(rename="ObjectIdentifier")]
@@ -330,7 +330,7 @@ pub struct BatchCreateIndexResponse {
 }
 
 #[doc="<p>Represents the output of a <a>CreateObject</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchCreateObject {
     #[doc="<p>The batch reference name. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#batches\">Batches</a> for more information.</p>"]
     #[serde(rename="BatchReferenceName")]
@@ -350,7 +350,7 @@ pub struct BatchCreateObject {
 }
 
 #[doc="<p>Represents the output of a <a>CreateObject</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchCreateObjectResponse {
     #[doc="<p>The ID that is associated with the object.</p>"]
     #[serde(rename="ObjectIdentifier")]
@@ -359,7 +359,7 @@ pub struct BatchCreateObjectResponse {
 }
 
 #[doc="<p>Represents the output of a <a>DeleteObject</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDeleteObject {
     #[doc="<p>The reference that identifies the object.</p>"]
     #[serde(rename="ObjectReference")]
@@ -367,11 +367,11 @@ pub struct BatchDeleteObject {
 }
 
 #[doc="<p>Represents the output of a <a>DeleteObject</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDeleteObjectResponse;
 
 #[doc="<p>Detaches the specified object from the specified index inside a <a>BatchRead</a> operation. For more information, see <a>DetachFromIndex</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDetachFromIndex {
     #[doc="<p>A reference to the index object.</p>"]
     #[serde(rename="IndexReference")]
@@ -382,7 +382,7 @@ pub struct BatchDetachFromIndex {
 }
 
 #[doc="<p>Represents the output of a <a>DetachFromIndex</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDetachFromIndexResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> of the object that was detached from the index.</p>"]
     #[serde(rename="DetachedObjectIdentifier")]
@@ -391,7 +391,7 @@ pub struct BatchDetachFromIndexResponse {
 }
 
 #[doc="<p>Represents the output of a <a>DetachObject</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDetachObject {
     #[doc="<p>The batch reference name. See <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#batches\">Batches</a> for more information.</p>"]
     #[serde(rename="BatchReferenceName")]
@@ -405,7 +405,7 @@ pub struct BatchDetachObject {
 }
 
 #[doc="<p>Represents the output of a <a>DetachObject</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDetachObjectResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> of the detached object.</p>"]
     #[serde(rename="detachedObjectIdentifier")]
@@ -414,7 +414,7 @@ pub struct BatchDetachObjectResponse {
 }
 
 #[doc="<p>Detaches the specified policy from the specified directory inside a <a>BatchRead</a> operation. For more information, see <a>DetachPolicy</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDetachPolicy {
     #[doc="<p>Reference that identifies the object whose policy object will be detached.</p>"]
     #[serde(rename="ObjectReference")]
@@ -425,11 +425,11 @@ pub struct BatchDetachPolicy {
 }
 
 #[doc="<p>Represents the output of a <a>DetachPolicy</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDetachPolicyResponse;
 
 #[doc="<p>Detaches a typed link from a specified source and target object inside a <a>BatchRead</a> operation. For more information, see <a>DetachTypedLink</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDetachTypedLink {
     #[doc="<p>Used to accept a typed link specifier as input.</p>"]
     #[serde(rename="TypedLinkSpecifier")]
@@ -437,11 +437,11 @@ pub struct BatchDetachTypedLink {
 }
 
 #[doc="<p>Represents the output of a <a>DetachTypedLink</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDetachTypedLinkResponse;
 
 #[doc="<p>Retrieves metadata about an object inside a <a>BatchRead</a> operation. For more information, see <a>GetObjectInformation</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetObjectInformation {
     #[doc="<p>A reference to the object.</p>"]
     #[serde(rename="ObjectReference")]
@@ -449,7 +449,7 @@ pub struct BatchGetObjectInformation {
 }
 
 #[doc="<p>Represents the output of a <a>GetObjectInformation</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetObjectInformationResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> of the specified object.</p>"]
     #[serde(rename="ObjectIdentifier")]
@@ -462,7 +462,7 @@ pub struct BatchGetObjectInformationResponse {
 }
 
 #[doc="<p>Lists indices attached to an object inside a <a>BatchRead</a> operation. For more information, see <a>ListAttachedIndices</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListAttachedIndices {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -478,7 +478,7 @@ pub struct BatchListAttachedIndices {
 }
 
 #[doc="<p>Represents the output of a <a>ListAttachedIndices</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListAttachedIndicesResponse {
     #[doc="<p>The indices attached to the specified object.</p>"]
     #[serde(rename="IndexAttachments")]
@@ -491,7 +491,7 @@ pub struct BatchListAttachedIndicesResponse {
 }
 
 #[doc="<p>Returns a paginated list of all the incoming <a>TypedLinkSpecifier</a> information for an object inside a <a>BatchRead</a> operation. For more information, see <a>ListIncomingTypedLinks</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListIncomingTypedLinks {
     #[doc="<p>Provides range filters for multiple attributes. When providing ranges to typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range.</p>"]
     #[serde(rename="FilterAttributeRanges")]
@@ -515,7 +515,7 @@ pub struct BatchListIncomingTypedLinks {
 }
 
 #[doc="<p>Represents the output of a <a>ListIncomingTypedLinks</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListIncomingTypedLinksResponse {
     #[doc="<p>Returns one or more typed link specifiers as output.</p>"]
     #[serde(rename="LinkSpecifiers")]
@@ -528,7 +528,7 @@ pub struct BatchListIncomingTypedLinksResponse {
 }
 
 #[doc="<p>Lists objects attached to the specified index inside a <a>BatchRead</a> operation. For more information, see <a>ListIndex</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListIndex {
     #[doc="<p>The reference to the index to list.</p>"]
     #[serde(rename="IndexReference")]
@@ -548,7 +548,7 @@ pub struct BatchListIndex {
 }
 
 #[doc="<p>Represents the output of a <a>ListIndex</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListIndexResponse {
     #[doc="<p>The objects and indexed values attached to the index.</p>"]
     #[serde(rename="IndexAttachments")]
@@ -561,7 +561,7 @@ pub struct BatchListIndexResponse {
 }
 
 #[doc="<p>Represents the output of a <a>ListObjectAttributes</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListObjectAttributes {
     #[doc="<p>Used to filter the list of object attributes that are associated with a certain facet.</p>"]
     #[serde(rename="FacetFilter")]
@@ -581,7 +581,7 @@ pub struct BatchListObjectAttributes {
 }
 
 #[doc="<p>Represents the output of a <a>ListObjectAttributes</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListObjectAttributesResponse {
     #[doc="<p>The attributes map that is associated with the object. <code>AttributeArn</code> is the key; attribute value is the value.</p>"]
     #[serde(rename="Attributes")]
@@ -594,7 +594,7 @@ pub struct BatchListObjectAttributesResponse {
 }
 
 #[doc="<p>Represents the output of a <a>ListObjectChildren</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListObjectChildren {
     #[doc="<p>Maximum number of items to be retrieved in a single call. This is an approximate number.</p>"]
     #[serde(rename="MaxResults")]
@@ -610,7 +610,7 @@ pub struct BatchListObjectChildren {
 }
 
 #[doc="<p>Represents the output of a <a>ListObjectChildren</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListObjectChildrenResponse {
     #[doc="<p>The children structure, which is a map with the key as the <code>LinkName</code> and <code>ObjectIdentifier</code> as the value.</p>"]
     #[serde(rename="Children")]
@@ -623,7 +623,7 @@ pub struct BatchListObjectChildrenResponse {
 }
 
 #[doc="<p>Retrieves all available parent paths for any object type such as node, leaf node, policy node, and index node objects inside a <a>BatchRead</a> operation. For more information, see <a>ListObjectParentPaths</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListObjectParentPaths {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -639,7 +639,7 @@ pub struct BatchListObjectParentPaths {
 }
 
 #[doc="<p>Represents the output of a <a>ListObjectParentPaths</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListObjectParentPathsResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -652,7 +652,7 @@ pub struct BatchListObjectParentPathsResponse {
 }
 
 #[doc="<p>Returns policies attached to an object in pagination fashion inside a <a>BatchRead</a> operation. For more information, see <a>ListObjectPolicies</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListObjectPolicies {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -668,7 +668,7 @@ pub struct BatchListObjectPolicies {
 }
 
 #[doc="<p>Represents the output of a <a>ListObjectPolicies</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListObjectPoliciesResponse {
     #[doc="<p>A list of policy <code>ObjectIdentifiers</code>, that are attached to the object.</p>"]
     #[serde(rename="AttachedPolicyIds")]
@@ -681,7 +681,7 @@ pub struct BatchListObjectPoliciesResponse {
 }
 
 #[doc="<p>Returns a paginated list of all the outgoing <a>TypedLinkSpecifier</a> information for an object inside a <a>BatchRead</a> operation. For more information, see <a>ListOutgoingTypedLinks</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListOutgoingTypedLinks {
     #[doc="<p>Provides range filters for multiple attributes. When providing ranges to typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range.</p>"]
     #[serde(rename="FilterAttributeRanges")]
@@ -705,7 +705,7 @@ pub struct BatchListOutgoingTypedLinks {
 }
 
 #[doc="<p>Represents the output of a <a>ListOutgoingTypedLinks</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListOutgoingTypedLinksResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -718,7 +718,7 @@ pub struct BatchListOutgoingTypedLinksResponse {
 }
 
 #[doc="<p>Returns all of the <code>ObjectIdentifiers</code> to which a given policy is attached inside a <a>BatchRead</a> operation. For more information, see <a>ListPolicyAttachments</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListPolicyAttachments {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -734,7 +734,7 @@ pub struct BatchListPolicyAttachments {
 }
 
 #[doc="<p>Represents the output of a <a>ListPolicyAttachments</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchListPolicyAttachmentsResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -747,7 +747,7 @@ pub struct BatchListPolicyAttachmentsResponse {
 }
 
 #[doc="<p>Lists all policies from the root of the Directory to the object specified inside a <a>BatchRead</a> operation. For more information, see <a>LookupPolicy</a> and <a>BatchReadRequest$Operations</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchLookupPolicy {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -763,7 +763,7 @@ pub struct BatchLookupPolicy {
 }
 
 #[doc="<p>Represents the output of a <a>LookupPolicy</a> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchLookupPolicyResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -776,7 +776,7 @@ pub struct BatchLookupPolicyResponse {
 }
 
 #[doc="<p>The batch read exception structure, which contains the exception type and message.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchReadException {
     #[doc="<p>An exception message that is associated with the failure.</p>"]
     #[serde(rename="Message")]
@@ -789,7 +789,7 @@ pub struct BatchReadException {
 }
 
 #[doc="<p>Represents the output of a <code>BatchRead</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchReadOperation {
     #[doc="<p>Retrieves metadata about an object.</p>"]
     #[serde(rename="GetObjectInformation")]
@@ -838,7 +838,7 @@ pub struct BatchReadOperation {
 }
 
 #[doc="<p>Represents the output of a <code>BatchRead</code> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchReadOperationResponse {
     #[doc="<p>Identifies which operation in a batch has failed.</p>"]
     #[serde(rename="ExceptionResponse")]
@@ -850,7 +850,7 @@ pub struct BatchReadOperationResponse {
     pub successful_response: Option<BatchReadSuccessfulResponse>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchReadRequest {
     #[doc="<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>"]
     #[serde(rename="ConsistencyLevel")]
@@ -864,7 +864,7 @@ pub struct BatchReadRequest {
     pub operations: Vec<BatchReadOperation>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchReadResponse {
     #[doc="<p>A list of all the responses for each batch read.</p>"]
     #[serde(rename="Responses")]
@@ -873,7 +873,7 @@ pub struct BatchReadResponse {
 }
 
 #[doc="<p>Represents the output of a <code>BatchRead</code> success response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchReadSuccessfulResponse {
     #[doc="<p>Retrieves metadata about an object.</p>"]
     #[serde(rename="GetObjectInformation")]
@@ -922,7 +922,7 @@ pub struct BatchReadSuccessfulResponse {
 }
 
 #[doc="<p>A batch operation to remove a facet from an object.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchRemoveFacetFromObject {
     #[doc="<p>A reference to the object whose facet will be removed.</p>"]
     #[serde(rename="ObjectReference")]
@@ -933,11 +933,11 @@ pub struct BatchRemoveFacetFromObject {
 }
 
 #[doc="<p>An empty result that represents success.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchRemoveFacetFromObjectResponse;
 
 #[doc="<p>Represents the output of a <code>BatchUpdate</code> operation. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchUpdateObjectAttributes {
     #[doc="<p>Attributes update structure.</p>"]
     #[serde(rename="AttributeUpdates")]
@@ -948,7 +948,7 @@ pub struct BatchUpdateObjectAttributes {
 }
 
 #[doc="<p>Represents the output of a <code>BatchUpdate</code> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchUpdateObjectAttributesResponse {
     #[doc="<p>ID that is associated with the object.</p>"]
     #[serde(rename="ObjectIdentifier")]
@@ -957,7 +957,7 @@ pub struct BatchUpdateObjectAttributesResponse {
 }
 
 #[doc="<p>Represents the output of a <code>BatchWrite</code> operation. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchWriteOperation {
     #[doc="<p>A batch operation that adds a facet to an object.</p>"]
     #[serde(rename="AddFacetToObject")]
@@ -1018,7 +1018,7 @@ pub struct BatchWriteOperation {
 }
 
 #[doc="<p>Represents the output of a <code>BatchWrite</code> response operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchWriteOperationResponse {
     #[doc="<p>The result of an add facet to object batch operation.</p>"]
     #[serde(rename="AddFacetToObject")]
@@ -1078,7 +1078,7 @@ pub struct BatchWriteOperationResponse {
     pub update_object_attributes: Option<BatchUpdateObjectAttributesResponse>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchWriteRequest {
     #[doc="<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -1088,7 +1088,7 @@ pub struct BatchWriteRequest {
     pub operations: Vec<BatchWriteOperation>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchWriteResponse {
     #[doc="<p>A list of all the responses for each batch write.</p>"]
     #[serde(rename="Responses")]
@@ -1096,7 +1096,7 @@ pub struct BatchWriteResponse {
     pub responses: Option<Vec<BatchWriteOperationResponse>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDirectoryRequest {
     #[doc="<p>The name of the <a>Directory</a>. Should be unique per account, per region.</p>"]
     #[serde(rename="Name")]
@@ -1106,7 +1106,7 @@ pub struct CreateDirectoryRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDirectoryResponse {
     #[doc="<p>The ARN of the published schema in the <a>Directory</a>. Once a published schema is copied into the directory, it has its own ARN, which is referred to applied schema ARN. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="AppliedSchemaArn")]
@@ -1122,7 +1122,7 @@ pub struct CreateDirectoryResponse {
     pub object_identifier: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFacetRequest {
     #[doc="<p>The attributes that are associated with the <a>Facet</a>.</p>"]
     #[serde(rename="Attributes")]
@@ -1139,10 +1139,10 @@ pub struct CreateFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFacetResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateIndexRequest {
     #[doc="<p>The ARN of the directory where the index should be created.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -1163,7 +1163,7 @@ pub struct CreateIndexRequest {
     pub parent_reference: Option<ObjectReference>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateIndexResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> of the index created by this operation.</p>"]
     #[serde(rename="ObjectIdentifier")]
@@ -1171,7 +1171,7 @@ pub struct CreateIndexResponse {
     pub object_identifier: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateObjectRequest {
     #[doc="<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> in which the object will be created. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -1193,7 +1193,7 @@ pub struct CreateObjectRequest {
     pub schema_facets: Vec<SchemaFacet>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateObjectResponse {
     #[doc="<p>The identifier that is associated with the object.</p>"]
     #[serde(rename="ObjectIdentifier")]
@@ -1201,14 +1201,14 @@ pub struct CreateObjectResponse {
     pub object_identifier: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSchemaRequest {
     #[doc="<p>The name that is associated with the schema. This is unique to each account and in each region.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSchemaResponse {
     #[doc="<p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="SchemaArn")]
@@ -1216,7 +1216,7 @@ pub struct CreateSchemaResponse {
     pub schema_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTypedLinkFacetRequest {
     #[doc="<p> <a>Facet</a> structure that is associated with the typed link facet.</p>"]
     #[serde(rename="Facet")]
@@ -1226,24 +1226,24 @@ pub struct CreateTypedLinkFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTypedLinkFacetResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDirectoryRequest {
     #[doc="<p>The ARN of the directory to delete.</p>"]
     #[serde(rename="DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDirectoryResponse {
     #[doc="<p>The ARN of the deleted directory.</p>"]
     #[serde(rename="DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFacetRequest {
     #[doc="<p>The name of the facet to delete.</p>"]
     #[serde(rename="Name")]
@@ -1253,10 +1253,10 @@ pub struct DeleteFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFacetResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteObjectRequest {
     #[doc="<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -1266,17 +1266,17 @@ pub struct DeleteObjectRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteObjectResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSchemaRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the development schema. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="SchemaArn")]
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSchemaResponse {
     #[doc="<p>The input ARN that is returned as part of the response. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="SchemaArn")]
@@ -1284,7 +1284,7 @@ pub struct DeleteSchemaResponse {
     pub schema_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTypedLinkFacetRequest {
     #[doc="<p>The unique name of the typed link facet.</p>"]
     #[serde(rename="Name")]
@@ -1294,10 +1294,10 @@ pub struct DeleteTypedLinkFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTypedLinkFacetResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachFromIndexRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the directory the index and object exist in.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -1310,7 +1310,7 @@ pub struct DetachFromIndexRequest {
     pub target_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachFromIndexResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> of the object that was detached from the index.</p>"]
     #[serde(rename="DetachedObjectIdentifier")]
@@ -1318,7 +1318,7 @@ pub struct DetachFromIndexResponse {
     pub detached_object_identifier: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachObjectRequest {
     #[doc="<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where objects reside. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -1331,7 +1331,7 @@ pub struct DetachObjectRequest {
     pub parent_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachObjectResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> that was detached from the object.</p>"]
     #[serde(rename="DetachedObjectIdentifier")]
@@ -1339,7 +1339,7 @@ pub struct DetachObjectResponse {
     pub detached_object_identifier: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachPolicyRequest {
     #[doc="<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where both objects reside. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -1352,10 +1352,10 @@ pub struct DetachPolicyRequest {
     pub policy_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachPolicyResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachTypedLinkRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the directory where you want to detach the typed link.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -1366,7 +1366,7 @@ pub struct DetachTypedLinkRequest {
 }
 
 #[doc="<p>Directory structure that includes the directory name and directory ARN.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Directory {
     #[doc="<p>The date and time when the directory was created.</p>"]
     #[serde(rename="CreationDateTime")]
@@ -1386,28 +1386,28 @@ pub struct Directory {
     pub state: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableDirectoryRequest {
     #[doc="<p>The ARN of the directory to disable.</p>"]
     #[serde(rename="DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableDirectoryResponse {
     #[doc="<p>The ARN of the directory that has been disabled.</p>"]
     #[serde(rename="DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableDirectoryRequest {
     #[doc="<p>The ARN of the directory to enable.</p>"]
     #[serde(rename="DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableDirectoryResponse {
     #[doc="<p>The ARN of the enabled directory.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -1415,7 +1415,7 @@ pub struct EnableDirectoryResponse {
 }
 
 #[doc="<p>A structure that contains <code>Name</code>, <code>ARN</code>, <code>Attributes</code>, <a>Rule</a>s, and <code>ObjectTypes</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Facet {
     #[doc="<p>The name of the <a>Facet</a>.</p>"]
     #[serde(rename="Name")]
@@ -1479,7 +1479,7 @@ pub struct FacetAttributeReference {
 }
 
 #[doc="<p>A structure that contains information used to update an attribute.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FacetAttributeUpdate {
     #[doc="<p>The action to perform when updating the attribute.</p>"]
     #[serde(rename="Action")]
@@ -1491,21 +1491,21 @@ pub struct FacetAttributeUpdate {
     pub attribute: Option<FacetAttribute>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDirectoryRequest {
     #[doc="<p>The ARN of the directory.</p>"]
     #[serde(rename="DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDirectoryResponse {
     #[doc="<p>Metadata about the directory.</p>"]
     #[serde(rename="Directory")]
     pub directory: Directory,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFacetRequest {
     #[doc="<p>The name of the facet to retrieve.</p>"]
     #[serde(rename="Name")]
@@ -1515,7 +1515,7 @@ pub struct GetFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFacetResponse {
     #[doc="<p>The <a>Facet</a> structure that is associated with the facet.</p>"]
     #[serde(rename="Facet")]
@@ -1523,7 +1523,7 @@ pub struct GetFacetResponse {
     pub facet: Option<Facet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetObjectInformationRequest {
     #[doc="<p>The consistency level at which to retrieve the object information.</p>"]
     #[serde(rename="ConsistencyLevel")]
@@ -1537,7 +1537,7 @@ pub struct GetObjectInformationRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetObjectInformationResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> of the specified object.</p>"]
     #[serde(rename="ObjectIdentifier")]
@@ -1549,14 +1549,14 @@ pub struct GetObjectInformationResponse {
     pub schema_facets: Option<Vec<SchemaFacet>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSchemaAsJsonRequest {
     #[doc="<p>The ARN of the schema to retrieve.</p>"]
     #[serde(rename="SchemaArn")]
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSchemaAsJsonResponse {
     #[doc="<p>The JSON representation of the schema document.</p>"]
     #[serde(rename="Document")]
@@ -1568,7 +1568,7 @@ pub struct GetSchemaAsJsonResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTypedLinkFacetInformationRequest {
     #[doc="<p>The unique name of the typed link facet.</p>"]
     #[serde(rename="Name")]
@@ -1578,7 +1578,7 @@ pub struct GetTypedLinkFacetInformationRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTypedLinkFacetInformationResponse {
     #[doc="<p>The order of identity attributes for the facet, from most significant to least significant. The ability to filter typed links considers the order that the attributes are defined on the typed link facet. When providing ranges to typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range. Filters are interpreted in the order of the attributes on the typed link facet, not the order in which they are supplied to any API calls. For more information about identity attributes, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink\">Typed link</a>.</p>"]
     #[serde(rename="IdentityAttributeOrder")]
@@ -1587,7 +1587,7 @@ pub struct GetTypedLinkFacetInformationResponse {
 }
 
 #[doc="<p>Represents an index and an attached object.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IndexAttachment {
     #[doc="<p>The indexed attribute values.</p>"]
     #[serde(rename="IndexedAttributes")]
@@ -1599,7 +1599,7 @@ pub struct IndexAttachment {
     pub object_identifier: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAppliedSchemaArnsRequest {
     #[doc="<p>The ARN of the directory you are listing.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -1614,7 +1614,7 @@ pub struct ListAppliedSchemaArnsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAppliedSchemaArnsResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -1626,7 +1626,7 @@ pub struct ListAppliedSchemaArnsResponse {
     pub schema_arns: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttachedIndicesRequest {
     #[doc="<p>The consistency level to use for this operation.</p>"]
     #[serde(rename="ConsistencyLevel")]
@@ -1648,7 +1648,7 @@ pub struct ListAttachedIndicesRequest {
     pub target_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttachedIndicesResponse {
     #[doc="<p>The indices attached to the specified object.</p>"]
     #[serde(rename="IndexAttachments")]
@@ -1660,7 +1660,7 @@ pub struct ListAttachedIndicesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDevelopmentSchemaArnsRequest {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -1672,7 +1672,7 @@ pub struct ListDevelopmentSchemaArnsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDevelopmentSchemaArnsResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -1684,7 +1684,7 @@ pub struct ListDevelopmentSchemaArnsResponse {
     pub schema_arns: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDirectoriesRequest {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -1700,7 +1700,7 @@ pub struct ListDirectoriesRequest {
     pub state: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDirectoriesResponse {
     #[doc="<p>Lists all directories that are associated with your account in pagination fashion.</p>"]
     #[serde(rename="Directories")]
@@ -1711,7 +1711,7 @@ pub struct ListDirectoriesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFacetAttributesRequest {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -1729,7 +1729,7 @@ pub struct ListFacetAttributesRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFacetAttributesResponse {
     #[doc="<p>The attributes attached to the facet.</p>"]
     #[serde(rename="Attributes")]
@@ -1741,7 +1741,7 @@ pub struct ListFacetAttributesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFacetNamesRequest {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -1756,7 +1756,7 @@ pub struct ListFacetNamesRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFacetNamesResponse {
     #[doc="<p>The names of facets that exist within the schema.</p>"]
     #[serde(rename="FacetNames")]
@@ -1768,7 +1768,7 @@ pub struct ListFacetNamesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIncomingTypedLinksRequest {
     #[doc="<p>The consistency level to execute the request at.</p>"]
     #[serde(rename="ConsistencyLevel")]
@@ -1798,7 +1798,7 @@ pub struct ListIncomingTypedLinksRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIncomingTypedLinksResponse {
     #[doc="<p>Returns one or more typed link specifiers as output.</p>"]
     #[serde(rename="LinkSpecifiers")]
@@ -1810,7 +1810,7 @@ pub struct ListIncomingTypedLinksResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIndexRequest {
     #[doc="<p>The consistency level to execute the request at.</p>"]
     #[serde(rename="ConsistencyLevel")]
@@ -1836,7 +1836,7 @@ pub struct ListIndexRequest {
     pub ranges_on_indexed_values: Option<Vec<ObjectAttributeRange>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIndexResponse {
     #[doc="<p>The objects and indexed values attached to the index.</p>"]
     #[serde(rename="IndexAttachments")]
@@ -1848,7 +1848,7 @@ pub struct ListIndexResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListObjectAttributesRequest {
     #[doc="<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>"]
     #[serde(rename="ConsistencyLevel")]
@@ -1874,7 +1874,7 @@ pub struct ListObjectAttributesRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListObjectAttributesResponse {
     #[doc="<p>Attributes map that is associated with the object. <code>AttributeArn</code> is the key, and attribute value is the value.</p>"]
     #[serde(rename="Attributes")]
@@ -1886,7 +1886,7 @@ pub struct ListObjectAttributesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListObjectChildrenRequest {
     #[doc="<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>"]
     #[serde(rename="ConsistencyLevel")]
@@ -1908,7 +1908,7 @@ pub struct ListObjectChildrenRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListObjectChildrenResponse {
     #[doc="<p>Children structure, which is a map with key as the <code>LinkName</code> and <code>ObjectIdentifier</code> as the value.</p>"]
     #[serde(rename="Children")]
@@ -1920,7 +1920,7 @@ pub struct ListObjectChildrenResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListObjectParentPathsRequest {
     #[doc="<p>The ARN of the directory to which the parent path applies.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -1938,7 +1938,7 @@ pub struct ListObjectParentPathsRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListObjectParentPathsResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -1950,7 +1950,7 @@ pub struct ListObjectParentPathsResponse {
     pub path_to_object_identifiers_list: Option<Vec<PathToObjectIdentifiers>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListObjectParentsRequest {
     #[doc="<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>"]
     #[serde(rename="ConsistencyLevel")]
@@ -1972,7 +1972,7 @@ pub struct ListObjectParentsRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListObjectParentsResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -1984,7 +1984,7 @@ pub struct ListObjectParentsResponse {
     pub parents: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListObjectPoliciesRequest {
     #[doc="<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>"]
     #[serde(rename="ConsistencyLevel")]
@@ -2006,7 +2006,7 @@ pub struct ListObjectPoliciesRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListObjectPoliciesResponse {
     #[doc="<p>A list of policy <code>ObjectIdentifiers</code>, that are attached to the object.</p>"]
     #[serde(rename="AttachedPolicyIds")]
@@ -2018,7 +2018,7 @@ pub struct ListObjectPoliciesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOutgoingTypedLinksRequest {
     #[doc="<p>The consistency level to execute the request at.</p>"]
     #[serde(rename="ConsistencyLevel")]
@@ -2048,7 +2048,7 @@ pub struct ListOutgoingTypedLinksRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOutgoingTypedLinksResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -2060,7 +2060,7 @@ pub struct ListOutgoingTypedLinksResponse {
     pub typed_link_specifiers: Option<Vec<TypedLinkSpecifier>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPolicyAttachmentsRequest {
     #[doc="<p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>"]
     #[serde(rename="ConsistencyLevel")]
@@ -2082,7 +2082,7 @@ pub struct ListPolicyAttachmentsRequest {
     pub policy_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPolicyAttachmentsResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -2094,7 +2094,7 @@ pub struct ListPolicyAttachmentsResponse {
     pub object_identifiers: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPublishedSchemaArnsRequest {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -2106,7 +2106,7 @@ pub struct ListPublishedSchemaArnsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPublishedSchemaArnsResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -2118,7 +2118,7 @@ pub struct ListPublishedSchemaArnsResponse {
     pub schema_arns: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceRequest {
     #[doc="<p>The <code>MaxResults</code> parameter sets the maximum number of results returned in a single page. This is for future use and is not supported currently.</p>"]
     #[serde(rename="MaxResults")]
@@ -2133,7 +2133,7 @@ pub struct ListTagsForResourceRequest {
     pub resource_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceResponse {
     #[doc="<p>The token to use to retrieve the next page of results. This value is null when there are no more results to return.</p>"]
     #[serde(rename="NextToken")]
@@ -2145,7 +2145,7 @@ pub struct ListTagsForResourceResponse {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTypedLinkFacetAttributesRequest {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -2163,7 +2163,7 @@ pub struct ListTypedLinkFacetAttributesRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTypedLinkFacetAttributesResponse {
     #[doc="<p>An ordered set of attributes associate with the typed link.</p>"]
     #[serde(rename="Attributes")]
@@ -2175,7 +2175,7 @@ pub struct ListTypedLinkFacetAttributesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTypedLinkFacetNamesRequest {
     #[doc="<p>The maximum number of results to retrieve.</p>"]
     #[serde(rename="MaxResults")]
@@ -2190,7 +2190,7 @@ pub struct ListTypedLinkFacetNamesRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTypedLinkFacetNamesResponse {
     #[doc="<p>The names of typed link facets that exist within the schema.</p>"]
     #[serde(rename="FacetNames")]
@@ -2202,7 +2202,7 @@ pub struct ListTypedLinkFacetNamesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LookupPolicyRequest {
     #[doc="<p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -2220,7 +2220,7 @@ pub struct LookupPolicyRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LookupPolicyResponse {
     #[doc="<p>The pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -2233,7 +2233,7 @@ pub struct LookupPolicyResponse {
 }
 
 #[doc="<p>The action to take on the object attribute.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ObjectAttributeAction {
     #[doc="<p>A type that can be either <code>Update</code> or <code>Delete</code>.</p>"]
     #[serde(rename="ObjectAttributeActionType")]
@@ -2246,7 +2246,7 @@ pub struct ObjectAttributeAction {
 }
 
 #[doc="<p>A range of attributes.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ObjectAttributeRange {
     #[doc="<p>The key of the attribute that the attribute range covers.</p>"]
     #[serde(rename="AttributeKey")]
@@ -2259,7 +2259,7 @@ pub struct ObjectAttributeRange {
 }
 
 #[doc="<p>Structure that contains attribute update information.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ObjectAttributeUpdate {
     #[doc="<p>The action to perform as part of the attribute update.</p>"]
     #[serde(rename="ObjectAttributeAction")]
@@ -2281,7 +2281,7 @@ pub struct ObjectReference {
 }
 
 #[doc="<p>Returns the path to the <code>ObjectIdentifiers</code> that is associated with the directory.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PathToObjectIdentifiers {
     #[doc="<p>Lists <code>ObjectIdentifiers</code> starting from directory root to the object in the request.</p>"]
     #[serde(rename="ObjectIdentifiers")]
@@ -2294,7 +2294,7 @@ pub struct PathToObjectIdentifiers {
 }
 
 #[doc="<p>Contains the <code>PolicyType</code>, <code>PolicyId</code>, and the <code>ObjectIdentifier</code> to which it is attached. For more information, see <a href=\"http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies\">Policies</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyAttachment {
     #[doc="<p>The <code>ObjectIdentifier</code> that is associated with <code>PolicyAttachment</code>.</p>"]
     #[serde(rename="ObjectIdentifier")]
@@ -2311,7 +2311,7 @@ pub struct PolicyAttachment {
 }
 
 #[doc="<p>Used when a regular object exists in a <a>Directory</a> and you want to find all of the policies that are associated with that object and the parent to that object.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyToPath {
     #[doc="<p>The path that is referenced from the root.</p>"]
     #[serde(rename="Path")]
@@ -2323,7 +2323,7 @@ pub struct PolicyToPath {
     pub policies: Option<Vec<PolicyAttachment>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PublishSchemaRequest {
     #[doc="<p>The Amazon Resource Name (ARN) that is associated with the development schema. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="DevelopmentSchemaArn")]
@@ -2337,7 +2337,7 @@ pub struct PublishSchemaRequest {
     pub version: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PublishSchemaResponse {
     #[doc="<p>The ARN that is associated with the published schema. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="PublishedSchemaArn")]
@@ -2345,7 +2345,7 @@ pub struct PublishSchemaResponse {
     pub published_schema_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutSchemaFromJsonRequest {
     #[doc="<p>The replacement JSON schema.</p>"]
     #[serde(rename="Document")]
@@ -2355,7 +2355,7 @@ pub struct PutSchemaFromJsonRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutSchemaFromJsonResponse {
     #[doc="<p>The ARN of the schema to update.</p>"]
     #[serde(rename="Arn")]
@@ -2363,7 +2363,7 @@ pub struct PutSchemaFromJsonResponse {
     pub arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveFacetFromObjectRequest {
     #[doc="<p>The ARN of the directory in which the object resides.</p>"]
     #[serde(rename="DirectoryArn")]
@@ -2376,7 +2376,7 @@ pub struct RemoveFacetFromObjectRequest {
     pub schema_facet: SchemaFacet,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveFacetFromObjectResponse;
 
 #[doc="<p>Contains an Amazon Resource Name (ARN) and parameters that are associated with the rule.</p>"]
@@ -2418,7 +2418,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource. Tagging is only supported for directories.</p>"]
     #[serde(rename="ResourceArn")]
@@ -2428,7 +2428,7 @@ pub struct TagResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceResponse;
 
 #[doc="<p>Represents the data for a typed attribute. You can set one, and only one, of the elements. Each attribute in an item is a name-value pair. Attributes have a single value.</p>"]
@@ -2461,7 +2461,7 @@ pub struct TypedAttributeValue {
 }
 
 #[doc="<p>A range of attribute values.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TypedAttributeValueRange {
     #[doc="<p>The inclusive or exclusive range end.</p>"]
     #[serde(rename="EndMode")]
@@ -2506,7 +2506,7 @@ pub struct TypedLinkAttributeDefinition {
 }
 
 #[doc="<p>Identifies the range of attributes that are used by a specified filter.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TypedLinkAttributeRange {
     #[doc="<p>The unique name of the typed link attribute.</p>"]
     #[serde(rename="AttributeName")]
@@ -2518,7 +2518,7 @@ pub struct TypedLinkAttributeRange {
 }
 
 #[doc="<p>Defines the typed links structure and its attributes. To create a typed link facet, use the <a>CreateTypedLinkFacet</a> API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TypedLinkFacet {
     #[doc="<p>A set of key-value pairs associated with the typed link. Typed link attributes are used when you have data values that are related to the link itself, and not to one of the two objects being linked. Identity attributes also serve to distinguish the link from others of the same type between the same objects.</p>"]
     #[serde(rename="Attributes")]
@@ -2532,7 +2532,7 @@ pub struct TypedLinkFacet {
 }
 
 #[doc="<p>A typed link facet attribute update.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TypedLinkFacetAttributeUpdate {
     #[doc="<p>The action to perform when updating the attribute.</p>"]
     #[serde(rename="Action")]
@@ -2570,7 +2570,7 @@ pub struct TypedLinkSpecifier {
     pub typed_link_facet: TypedLinkSchemaAndFacetName,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource. Tagging is only supported for directories.</p>"]
     #[serde(rename="ResourceArn")]
@@ -2580,10 +2580,10 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFacetRequest {
     #[doc="<p>List of attributes that need to be updated in a given schema <a>Facet</a>. Each attribute is followed by <code>AttributeAction</code>, which specifies the type of update operation to perform. </p>"]
     #[serde(rename="AttributeUpdates")]
@@ -2601,10 +2601,10 @@ pub struct UpdateFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFacetResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateObjectAttributesRequest {
     #[doc="<p>The attributes update structure.</p>"]
     #[serde(rename="AttributeUpdates")]
@@ -2617,7 +2617,7 @@ pub struct UpdateObjectAttributesRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateObjectAttributesResponse {
     #[doc="<p>The <code>ObjectIdentifier</code> of the updated object.</p>"]
     #[serde(rename="ObjectIdentifier")]
@@ -2625,7 +2625,7 @@ pub struct UpdateObjectAttributesResponse {
     pub object_identifier: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSchemaRequest {
     #[doc="<p>The name of the schema.</p>"]
     #[serde(rename="Name")]
@@ -2635,7 +2635,7 @@ pub struct UpdateSchemaRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSchemaResponse {
     #[doc="<p>The ARN that is associated with the updated schema. For more information, see <a>arns</a>.</p>"]
     #[serde(rename="SchemaArn")]
@@ -2643,7 +2643,7 @@ pub struct UpdateSchemaResponse {
     pub schema_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTypedLinkFacetRequest {
     #[doc="<p>Attributes update structure.</p>"]
     #[serde(rename="AttributeUpdates")]
@@ -2659,7 +2659,7 @@ pub struct UpdateTypedLinkFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTypedLinkFacetResponse;
 
 /// Errors returned by AddFacetToObject

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -54,11 +54,15 @@ impl AccountDeserializer {
     }
 }
 #[doc="<p>Structure that contains the results of the account gate function which AWS CloudFormation invokes, if present, before proceeding with a stack set operation in an account and region.</p> <p>For each account and region, AWS CloudFormation lets you specify a Lamdba function that encapsulates any requirements that must be met before CloudFormation can proceed with a stack set operation in that account and region. CloudFormation invokes the function each time a stack set operation is requested for that account and region; if the function returns <code>FAILED</code>, CloudFormation cancels the operation in that account and region, and sets the stack set operation result status for that account and region to <code>FAILED</code>. </p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-account-gating.html\">Configuring a target account gate</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountGateResult {
     #[doc="<p>The status of the account gate function.</p> <ul> <li> <p> <code>SUCCEEDED</code>: The account gate function has determined that the account and region passes any requirements for a stack set operation to occur. AWS CloudFormation proceeds with the stack operation in that account and region. </p> </li> <li> <p> <code>FAILED</code>: The account gate function has determined that the account and region does not meet the requirements for a stack set operation to occur. AWS CloudFormation cancels the stack set operation in that account and region, and sets the stack set operation result status for that account and region to <code>FAILED</code>. </p> </li> <li> <p> <code>SKIPPED</code>: AWS CloudFormation has skipped calling the account gate function for this account and region, for one of the following reasons:</p> <ul> <li> <p>An account gate function has not been specified for the account and region. AWS CloudFormation proceeds with the stack set operation in this account and region.</p> </li> <li> <p>The <code>AWSCloudFormationStackSetExecutionRole</code> of the stack set adminstration account lacks permissions to invoke the function. AWS CloudFormation proceeds with the stack set operation in this account and region.</p> </li> <li> <p>Either no action is necessary, or no action is possible, on the stack. AWS CloudFormation skips the stack set operation in this account and region.</p> </li> </ul> </li> </ul>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The reason for the account gate status assigned to this account and region for the stack set operation.</p>"]
+    #[serde(rename="StatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_reason: Option<String>,
 }
 
@@ -139,11 +143,15 @@ impl AccountGateStatusReasonDeserializer {
     }
 }
 #[doc="<p>The AccountLimit data type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountLimit {
     #[doc="<p>The name of the account limit. Currently, the only account limit is <code>StackLimit</code>.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The value that is associated with the account limit name.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<i64>,
 }
 
@@ -316,11 +324,14 @@ impl ArnDeserializer {
     }
 }
 #[doc="<p>The input for the <a>CancelUpdateStack</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelUpdateStackInput {
     #[doc="<p>A unique identifier for this <code>CancelUpdateStack</code> request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to cancel an update on a stack with the same name. You might retry <code>CancelUpdateStack</code> requests to ensure that AWS CloudFormation successfully received them.</p>"]
+    #[serde(rename="ClientRequestToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_request_token: Option<String>,
     #[doc="<p>The name or the unique stack ID that is associated with the stack.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
 }
 
@@ -440,11 +451,15 @@ impl CausingEntityDeserializer {
     }
 }
 #[doc="<p>The <code>Change</code> structure describes the changes AWS CloudFormation will perform if you execute the change set.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Change {
     #[doc="<p>A <code>ResourceChange</code> structure that describes the resource and action that AWS CloudFormation will perform.</p>"]
+    #[serde(rename="ResourceChange")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_change: Option<ResourceChange>,
     #[doc="<p>The type of entity that AWS CloudFormation changes. Currently, the only entity type is <code>Resource</code>.</p>"]
+    #[serde(rename="Type")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
 }
 
@@ -607,25 +622,43 @@ impl ChangeSetSummariesDeserializer {
     }
 }
 #[doc="<p>The <code>ChangeSetSummary</code> structure describes a change set, its status, and the stack with which it's associated.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChangeSetSummary {
     #[doc="<p>The ID of the change set.</p>"]
+    #[serde(rename="ChangeSetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub change_set_id: Option<String>,
     #[doc="<p>The name of the change set.</p>"]
+    #[serde(rename="ChangeSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub change_set_name: Option<String>,
     #[doc="<p>The start time when the change set was created, in UTC.</p>"]
+    #[serde(rename="CreationTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub creation_time: Option<String>,
     #[doc="<p>Descriptive information about the change set.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>If the change set execution status is <code>AVAILABLE</code>, you can execute the change set. If you can’t execute the change set, the status indicates why. For example, a change set might be in an <code>UNAVAILABLE</code> state because AWS CloudFormation is still creating it or in an <code>OBSOLETE</code> state because the stack was already updated.</p>"]
+    #[serde(rename="ExecutionStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub execution_status: Option<String>,
     #[doc="<p>The ID of the stack with which the change set is associated.</p>"]
+    #[serde(rename="StackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_id: Option<String>,
     #[doc="<p>The name of the stack with which the change set is associated.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
     #[doc="<p>The state of the change set, such as <code>CREATE_IN_PROGRESS</code>, <code>CREATE_COMPLETE</code>, or <code>FAILED</code>.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>A description of the change set's status. For example, if your change set is in the <code>FAILED</code> state, AWS CloudFormation shows the error message.</p>"]
+    #[serde(rename="StatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_reason: Option<String>,
 }
 
@@ -794,15 +827,22 @@ impl ClientRequestTokenDeserializer {
     }
 }
 #[doc="<p>The input for the <a>ContinueUpdateRollback</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ContinueUpdateRollbackInput {
     #[doc="<p>A unique identifier for this <code>ContinueUpdateRollback</code> request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to continue the rollback to a stack with the same name. You might retry <code>ContinueUpdateRollback</code> requests to ensure that AWS CloudFormation successfully received them.</p>"]
+    #[serde(rename="ClientRequestToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_request_token: Option<String>,
     #[doc="<p>A list of the logical IDs of the resources that AWS CloudFormation skips during the continue update rollback operation. You can specify only resources that are in the <code>UPDATE_FAILED</code> state because a rollback failed. You can't specify resources that are in the <code>UPDATE_FAILED</code> state for other reasons, for example, because an update was cancelled. To check why a resource update failed, use the <a>DescribeStackResources</a> action, and view the resource status reason. </p> <important> <p>Specify this property to skip rolling back resources that AWS CloudFormation can't successfully roll back. We recommend that you <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html#troubleshooting-errors-update-rollback-failed\"> troubleshoot</a> resources before skipping them. AWS CloudFormation sets the status of the specified resources to <code>UPDATE_COMPLETE</code> and continues to roll back the stack. After the rollback is complete, the state of the skipped resources will be inconsistent with the state of the resources in the stack template. Before performing another stack update, you must update the stack or resources to be consistent with each other. If you don't, subsequent stack updates might fail, and the stack will become unrecoverable. </p> </important> <p>Specify the minimum number of resources required to successfully roll back your stack. For example, a failed resource update might cause dependent resources to fail. In this case, it might not be necessary to skip the dependent resources. </p> <p>To skip resources that are part of nested stacks, use the following format: <code>NestedStackName.ResourceLogicalID</code>. If you want to specify the logical ID of a stack resource (<code>Type: AWS::CloudFormation::Stack</code>) in the <code>ResourcesToSkip</code> list, then its corresponding embedded stack must be in one of the following states: <code>DELETE_IN_PROGRESS</code>, <code>DELETE_COMPLETE</code>, or <code>DELETE_FAILED</code>. </p> <note> <p>Don't confuse a child stack's name with its corresponding logical ID defined in the parent stack. For an example of a continue update rollback operation with nested stacks, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-continueupdaterollback.html#nested-stacks\">Using ResourcesToSkip to recover a nested stacks hierarchy</a>. </p> </note>"]
+    #[serde(rename="ResourcesToSkip")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resources_to_skip: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) of an AWS Identity and Access Management (IAM) role that AWS CloudFormation assumes to roll back the stack. AWS CloudFormation uses the role's credentials to make calls on your behalf. AWS CloudFormation always uses this role for all future operations on the stack. As long as users have permission to operate on the stack, AWS CloudFormation uses this role even if the users don't have permission to pass it. Ensure that the role grants least privilege.</p> <p>If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials.</p>"]
+    #[serde(rename="RoleARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
     #[doc="<p>The name or the unique ID of the stack that you want to continue rolling back.</p> <note> <p>Don't specify the name of a nested stack (a stack that was created by using the <code>AWS::CloudFormation::Stack</code> resource). Instead, use this operation on the parent stack (the stack that contains the <code>AWS::CloudFormation::Stack</code> resource).</p> </note>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
 }
 
@@ -836,7 +876,7 @@ impl ContinueUpdateRollbackInputSerializer {
 }
 
 #[doc="<p>The output for a <a>ContinueUpdateRollback</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ContinueUpdateRollbackOutput;
 
 struct ContinueUpdateRollbackOutputDeserializer;
@@ -856,37 +896,65 @@ impl ContinueUpdateRollbackOutputDeserializer {
     }
 }
 #[doc="<p>The input for the <a>CreateChangeSet</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateChangeSetInput {
     #[doc="<p>A list of values that you must specify before AWS CloudFormation can update certain stacks. Some stack templates might include resources that can affect permissions in your AWS account, for example, by creating new AWS Identity and Access Management (IAM) users. For those stacks, you must explicitly acknowledge their capabilities by specifying this parameter.</p> <p>The only valid values are <code>CAPABILITY_IAM</code> and <code>CAPABILITY_NAMED_IAM</code>. The following resources require you to specify this parameter: <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html\"> AWS::IAM::AccessKey</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html\"> AWS::IAM::Group</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html\"> AWS::IAM::InstanceProfile</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html\"> AWS::IAM::Policy</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html\"> AWS::IAM::Role</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html\"> AWS::IAM::User</a>, and <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html\"> AWS::IAM::UserToGroupAddition</a>. If your stack template contains these resources, we recommend that you review all permissions associated with them and edit their permissions if necessary.</p> <p>If you have IAM resources, you can specify either capability. If you have IAM resources with custom names, you must specify <code>CAPABILITY_NAMED_IAM</code>. If you don't specify this parameter, this action returns an <code>InsufficientCapabilities</code> error.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities\">Acknowledging IAM Resources in AWS CloudFormation Templates</a>.</p>"]
+    #[serde(rename="Capabilities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities: Option<Vec<String>>,
     #[doc="<p>The name of the change set. The name must be unique among all change sets that are associated with the specified stack.</p> <p>A change set name can contain only alphanumeric, case sensitive characters and hyphens. It must start with an alphabetic character and cannot exceed 128 characters.</p>"]
+    #[serde(rename="ChangeSetName")]
     pub change_set_name: String,
     #[doc="<p>The type of change set operation. To create a change set for a new stack, specify <code>CREATE</code>. To create a change set for an existing stack, specify <code>UPDATE</code>.</p> <p>If you create a change set for a new stack, AWS Cloudformation creates a stack with a unique stack ID, but no template or resources. The stack will be in the <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html#d0e11995\"> <code>REVIEW_IN_PROGRESS</code> </a> state until you execute the change set.</p> <p>By default, AWS CloudFormation specifies <code>UPDATE</code>. You can't use the <code>UPDATE</code> type to create a change set for a new stack or the <code>CREATE</code> type to create a change set for an existing stack.</p>"]
+    #[serde(rename="ChangeSetType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub change_set_type: Option<String>,
     #[doc="<p>A unique identifier for this <code>CreateChangeSet</code> request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to create another change set with the same name. You might retry <code>CreateChangeSet</code> requests to ensure that AWS CloudFormation successfully received them.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>A description to help you identify this change set.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The Amazon Resource Names (ARNs) of Amazon Simple Notification Service (Amazon SNS) topics that AWS CloudFormation associates with the stack. To remove all associated notification topics, specify an empty list.</p>"]
+    #[serde(rename="NotificationARNs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_ar_ns: Option<Vec<String>>,
     #[doc="<p>A list of <code>Parameter</code> structures that specify input parameters for the change set. For more information, see the <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_Parameter.html\">Parameter</a> data type.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p>The template resource types that you have permissions to work with if you execute this change set, such as <code>AWS::EC2::Instance</code>, <code>AWS::EC2::*</code>, or <code>Custom::MyCustomInstance</code>.</p> <p>If the list of resource types doesn't include a resource type that you're updating, the stack update fails. By default, AWS CloudFormation grants permissions to all resource types. AWS Identity and Access Management (IAM) uses this parameter for condition keys in IAM policies for AWS CloudFormation. For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html\">Controlling Access with AWS Identity and Access Management</a> in the AWS CloudFormation User Guide.</p>"]
+    #[serde(rename="ResourceTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_types: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) of an AWS Identity and Access Management (IAM) role that AWS CloudFormation assumes when executing the change set. AWS CloudFormation uses the role's credentials to make calls on your behalf. AWS CloudFormation uses this role for all future operations on the stack. As long as users have permission to operate on the stack, AWS CloudFormation uses this role even if the users don't have permission to pass it. Ensure that the role grants least privilege.</p> <p>If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials.</p>"]
+    #[serde(rename="RoleARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
     #[doc="<p>The rollback triggers for AWS CloudFormation to monitor during stack creation and updating operations, and for the specified monitoring period afterwards.</p>"]
+    #[serde(rename="RollbackConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rollback_configuration: Option<RollbackConfiguration>,
     #[doc="<p>The name or the unique ID of the stack for which you are creating a change set. AWS CloudFormation generates the change set by comparing this stack's information with the information that you submit, such as a modified template or different parameter input values.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
     #[doc="<p>Key-value pairs to associate with this stack. AWS CloudFormation also propagates these tags to resources in the stack. You can specify a maximum of 50 tags.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>A structure that contains the body of the revised template, with a minimum length of 1 byte and a maximum length of 51,200 bytes. AWS CloudFormation generates the change set by comparing this template with the template of the stack that you specified.</p> <p>Conditional: You must specify only <code>TemplateBody</code> or <code>TemplateURL</code>.</p>"]
+    #[serde(rename="TemplateBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_body: Option<String>,
     #[doc="<p>The location of the file that contains the revised template. The URL must point to a template (max size: 460,800 bytes) that is located in an S3 bucket. AWS CloudFormation generates the change set by comparing this template with the stack that you specified.</p> <p>Conditional: You must specify only <code>TemplateBody</code> or <code>TemplateURL</code>.</p>"]
+    #[serde(rename="TemplateURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_url: Option<String>,
     #[doc="<p>Whether to reuse the template that is associated with the stack to create the change set.</p>"]
+    #[serde(rename="UsePreviousTemplate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub use_previous_template: Option<bool>,
 }
 
@@ -967,11 +1035,15 @@ impl CreateChangeSetInputSerializer {
 }
 
 #[doc="<p>The output for the <a>CreateChangeSet</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateChangeSetOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the change set.</p>"]
+    #[serde(rename="Id")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
     #[doc="<p>The unique ID of the stack.</p>"]
+    #[serde(rename="StackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_id: Option<String>,
 }
 
@@ -1021,39 +1093,70 @@ impl CreateChangeSetOutputDeserializer {
     }
 }
 #[doc="<p>The input for <a>CreateStack</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStackInput {
     #[doc="<p>A list of values that you must specify before AWS CloudFormation can create certain stacks. Some stack templates might include resources that can affect permissions in your AWS account, for example, by creating new AWS Identity and Access Management (IAM) users. For those stacks, you must explicitly acknowledge their capabilities by specifying this parameter.</p> <p>The only valid values are <code>CAPABILITY_IAM</code> and <code>CAPABILITY_NAMED_IAM</code>. The following resources require you to specify this parameter: <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html\"> AWS::IAM::AccessKey</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html\"> AWS::IAM::Group</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html\"> AWS::IAM::InstanceProfile</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html\"> AWS::IAM::Policy</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html\"> AWS::IAM::Role</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html\"> AWS::IAM::User</a>, and <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html\"> AWS::IAM::UserToGroupAddition</a>. If your stack template contains these resources, we recommend that you review all permissions associated with them and edit their permissions if necessary.</p> <p>If you have IAM resources, you can specify either capability. If you have IAM resources with custom names, you must specify <code>CAPABILITY_NAMED_IAM</code>. If you don't specify this parameter, this action returns an <code>InsufficientCapabilities</code> error.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities\">Acknowledging IAM Resources in AWS CloudFormation Templates</a>.</p>"]
+    #[serde(rename="Capabilities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities: Option<Vec<String>>,
     #[doc="<p>A unique identifier for this <code>CreateStack</code> request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to create a stack with the same name. You might retry <code>CreateStack</code> requests to ensure that AWS CloudFormation successfully received them.</p> <p>All events triggered by a given stack operation are assigned the same client request token, which you can use to track operations. For example, if you execute a <code>CreateStack</code> operation with the token <code>token1</code>, then all the <code>StackEvents</code> generated by that operation will have <code>ClientRequestToken</code> set as <code>token1</code>.</p> <p>In the console, stack operations display the client request token on the Events tab. Stack operations that are initiated from the console use the token format <i>Console-StackOperation-ID</i>, which helps you easily identify the stack operation . For example, if you create a stack using the console, each stack event would be assigned the same token in the following format: <code>Console-CreateStack-7f59c3cf-00d2-40c7-b2ff-e75db0987002</code>. </p>"]
+    #[serde(rename="ClientRequestToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_request_token: Option<String>,
     #[doc="<p>Set to <code>true</code> to disable rollback of the stack if stack creation failed. You can specify either <code>DisableRollback</code> or <code>OnFailure</code>, but not both.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="DisableRollback")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disable_rollback: Option<bool>,
     #[doc="<p>The Simple Notification Service (SNS) topic ARNs to publish stack related events. You can find your SNS topic ARNs using the SNS console or your Command Line Interface (CLI).</p>"]
+    #[serde(rename="NotificationARNs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_ar_ns: Option<Vec<String>>,
     #[doc="<p>Determines what action will be taken if stack creation fails. This must be one of: DO_NOTHING, ROLLBACK, or DELETE. You can specify either <code>OnFailure</code> or <code>DisableRollback</code>, but not both.</p> <p>Default: <code>ROLLBACK</code> </p>"]
+    #[serde(rename="OnFailure")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub on_failure: Option<String>,
     #[doc="<p>A list of <code>Parameter</code> structures that specify input parameters for the stack. For more information, see the <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_Parameter.html\">Parameter</a> data type.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p>The template resource types that you have permissions to work with for this create stack action, such as <code>AWS::EC2::Instance</code>, <code>AWS::EC2::*</code>, or <code>Custom::MyCustomInstance</code>. Use the following syntax to describe template resource types: <code>AWS::*</code> (for all AWS resource), <code>Custom::*</code> (for all custom resources), <code>Custom::<i>logical_ID</i> </code> (for a specific custom resource), <code>AWS::<i>service_name</i>::*</code> (for all resources of a particular AWS service), and <code>AWS::<i>service_name</i>::<i>resource_logical_ID</i> </code> (for a specific AWS resource).</p> <p>If the list of resource types doesn't include a resource that you're creating, the stack creation fails. By default, AWS CloudFormation grants permissions to all resource types. AWS Identity and Access Management (IAM) uses this parameter for AWS CloudFormation-specific condition keys in IAM policies. For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html\">Controlling Access with AWS Identity and Access Management</a>.</p>"]
+    #[serde(rename="ResourceTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_types: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) of an AWS Identity and Access Management (IAM) role that AWS CloudFormation assumes to create the stack. AWS CloudFormation uses the role's credentials to make calls on your behalf. AWS CloudFormation always uses this role for all future operations on the stack. As long as users have permission to operate on the stack, AWS CloudFormation uses this role even if the users don't have permission to pass it. Ensure that the role grants least privilege.</p> <p>If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials.</p>"]
+    #[serde(rename="RoleARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
     #[doc="<p>The rollback triggers for AWS CloudFormation to monitor during stack creation and updating operations, and for the specified monitoring period afterwards.</p>"]
+    #[serde(rename="RollbackConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rollback_configuration: Option<RollbackConfiguration>,
     #[doc="<p>The name that is associated with the stack. The name must be unique in the region in which you are creating the stack.</p> <note> <p>A stack name can contain only alphanumeric characters (case sensitive) and hyphens. It must start with an alphabetic character and cannot be longer than 128 characters.</p> </note>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
     #[doc="<p>Structure containing the stack policy body. For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html\"> Prevent Updates to Stack Resources</a> in the <i>AWS CloudFormation User Guide</i>. You can specify either the <code>StackPolicyBody</code> or the <code>StackPolicyURL</code> parameter, but not both.</p>"]
+    #[serde(rename="StackPolicyBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_policy_body: Option<String>,
     #[doc="<p>Location of a file containing the stack policy. The URL must point to a policy (maximum size: 16 KB) located in an S3 bucket in the same region as the stack. You can specify either the <code>StackPolicyBody</code> or the <code>StackPolicyURL</code> parameter, but not both.</p>"]
+    #[serde(rename="StackPolicyURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_policy_url: Option<String>,
     #[doc="<p>Key-value pairs to associate with this stack. AWS CloudFormation also propagates these tags to the resources created in the stack. A maximum number of 50 tags can be specified.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>Structure containing the template body with a minimum length of 1 byte and a maximum length of 51,200 bytes. For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must specify either the <code>TemplateBody</code> or the <code>TemplateURL</code> parameter, but not both.</p>"]
+    #[serde(rename="TemplateBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_body: Option<String>,
     #[doc="<p>Location of file containing the template body. The URL must point to a template (max size: 460,800 bytes) that is located in an Amazon S3 bucket. For more information, go to the <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must specify either the <code>TemplateBody</code> or the <code>TemplateURL</code> parameter, but not both.</p>"]
+    #[serde(rename="TemplateURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_url: Option<String>,
     #[doc="<p>The amount of time that can pass before the stack status becomes CREATE_FAILED; if <code>DisableRollback</code> is not set or is set to <code>false</code>, the stack will be rolled back.</p>"]
+    #[serde(rename="TimeoutInMinutes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timeout_in_minutes: Option<i64>,
 }
 
@@ -1139,17 +1242,24 @@ impl CreateStackInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStackInstancesInput {
     #[doc="<p>The names of one or more AWS accounts that you want to create stack instances in the specified region(s) for.</p>"]
+    #[serde(rename="Accounts")]
     pub accounts: Vec<String>,
     #[doc="<p>The unique identifier for this stack set operation. </p> <p>The operation ID also functions as an idempotency token, to ensure that AWS CloudFormation performs the stack set operation only once, even if you retry the request multiple times. You might retry stack set operation requests to ensure that AWS CloudFormation successfully received them.</p> <p>If you don't specify an operation ID, the SDK generates one automatically. </p> <p>Repeating this stack set operation with a new operation ID retries all stack instances whose status is <code>OUTDATED</code>. </p>"]
+    #[serde(rename="OperationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_id: Option<String>,
     #[doc="<p>Preferences for how AWS CloudFormation performs this stack set operation.</p>"]
+    #[serde(rename="OperationPreferences")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_preferences: Option<StackSetOperationPreferences>,
     #[doc="<p>The names of one or more regions where you want to create stack instances using the specified AWS account(s). </p>"]
+    #[serde(rename="Regions")]
     pub regions: Vec<String>,
     #[doc="<p>The name or unique ID of the stack set that you want to create stack instances from.</p>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
 }
 
@@ -1184,9 +1294,11 @@ impl CreateStackInstancesInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStackInstancesOutput {
     #[doc="<p>The unique identifier for this stack set operation.</p>"]
+    #[serde(rename="OperationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_id: Option<String>,
 }
 
@@ -1234,9 +1346,11 @@ impl CreateStackInstancesOutputDeserializer {
     }
 }
 #[doc="<p>The output for a <a>CreateStack</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStackOutput {
     #[doc="<p>Unique identifier of the stack.</p>"]
+    #[serde(rename="StackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_id: Option<String>,
 }
 
@@ -1282,23 +1396,38 @@ impl CreateStackOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStackSetInput {
     #[doc="<p>A list of values that you must specify before AWS CloudFormation can create certain stack sets. Some stack set templates might include resources that can affect permissions in your AWS account—for example, by creating new AWS Identity and Access Management (IAM) users. For those stack sets, you must explicitly acknowledge their capabilities by specifying this parameter.</p> <p>The only valid values are CAPABILITY_IAM and CAPABILITY_NAMED_IAM. The following resources require you to specify this parameter: </p> <ul> <li> <p>AWS::IAM::AccessKey</p> </li> <li> <p>AWS::IAM::Group</p> </li> <li> <p>AWS::IAM::InstanceProfile</p> </li> <li> <p>AWS::IAM::Policy</p> </li> <li> <p>AWS::IAM::Role</p> </li> <li> <p>AWS::IAM::User</p> </li> <li> <p>AWS::IAM::UserToGroupAddition</p> </li> </ul> <p>If your stack template contains these resources, we recommend that you review all permissions that are associated with them and edit their permissions if necessary.</p> <p>If you have IAM resources, you can specify either capability. If you have IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM. If you don't specify this parameter, this action returns an <code>InsufficientCapabilities</code> error.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities\">Acknowledging IAM Resources in AWS CloudFormation Templates.</a> </p>"]
+    #[serde(rename="Capabilities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities: Option<Vec<String>>,
     #[doc="<p>A unique identifier for this <code>CreateStackSet</code> request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to create another stack set with the same name. You might retry <code>CreateStackSet</code> requests to ensure that AWS CloudFormation successfully received them.</p> <p>If you don't specify an operation ID, the SDK generates one automatically. </p>"]
+    #[serde(rename="ClientRequestToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_request_token: Option<String>,
     #[doc="<p>A description of the stack set. You can use the description to identify the stack set's purpose or other important information.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The input parameters for the stack set template. </p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p>The name to associate with the stack set. The name must be unique in the region where you create your stack set.</p> <note> <p>A stack name can contain only alphanumeric characters (case-sensitive) and hyphens. It must start with an alphabetic character and can't be longer than 128 characters.</p> </note>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
     #[doc="<p>The key-value pairs to associate with this stack set and the stacks created from it. AWS CloudFormation also propagates these tags to supported resources that are created in the stacks. A maximum number of 50 tags can be specified.</p> <p>If you specify tags as part of a <code>CreateStackSet</code> action, AWS CloudFormation checks to see if you have the required IAM permission to tag resources. If you don't, the entire <code>CreateStackSet</code> action fails with an <code>access denied</code> error, and the stack set is not created.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The structure that contains the template body, with a minimum length of 1 byte and a maximum length of 51,200 bytes. For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must specify either the TemplateBody or the TemplateURL parameter, but not both.</p>"]
+    #[serde(rename="TemplateBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_body: Option<String>,
     #[doc="<p>The location of the file that contains the template body. The URL must point to a template (maximum size: 460,800 bytes) that's located in an Amazon S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must specify either the TemplateBody or the TemplateURL parameter, but not both.</p>"]
+    #[serde(rename="TemplateURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_url: Option<String>,
 }
 
@@ -1347,9 +1476,11 @@ impl CreateStackSetInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStackSetOutput {
     #[doc="<p>The ID of the stack set that you're creating.</p>"]
+    #[serde(rename="StackSetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_set_id: Option<String>,
 }
 
@@ -1411,11 +1542,14 @@ impl CreationTimeDeserializer {
     }
 }
 #[doc="<p>The input for the <a>DeleteChangeSet</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteChangeSetInput {
     #[doc="<p>The name or Amazon Resource Name (ARN) of the change set that you want to delete.</p>"]
+    #[serde(rename="ChangeSetName")]
     pub change_set_name: String,
     #[doc="<p>If you specified the name of a change set to delete, specify the stack name or ID (ARN) that is associated with it.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
 }
 
@@ -1440,7 +1574,7 @@ impl DeleteChangeSetInputSerializer {
 }
 
 #[doc="<p>The output for the <a>DeleteChangeSet</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteChangeSetOutput;
 
 struct DeleteChangeSetOutputDeserializer;
@@ -1460,15 +1594,22 @@ impl DeleteChangeSetOutputDeserializer {
     }
 }
 #[doc="<p>The input for <a>DeleteStack</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStackInput {
     #[doc="<p>A unique identifier for this <code>DeleteStack</code> request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to delete a stack with the same name. You might retry <code>DeleteStack</code> requests to ensure that AWS CloudFormation successfully received them.</p> <p>All events triggered by a given stack operation are assigned the same client request token, which you can use to track operations. For example, if you execute a <code>CreateStack</code> operation with the token <code>token1</code>, then all the <code>StackEvents</code> generated by that operation will have <code>ClientRequestToken</code> set as <code>token1</code>.</p> <p>In the console, stack operations display the client request token on the Events tab. Stack operations that are initiated from the console use the token format <i>Console-StackOperation-ID</i>, which helps you easily identify the stack operation . For example, if you create a stack using the console, each stack event would be assigned the same token in the following format: <code>Console-CreateStack-7f59c3cf-00d2-40c7-b2ff-e75db0987002</code>. </p>"]
+    #[serde(rename="ClientRequestToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_request_token: Option<String>,
     #[doc="<p>For stacks in the <code>DELETE_FAILED</code> state, a list of resource logical IDs that are associated with the resources you want to retain. During deletion, AWS CloudFormation deletes the stack but does not delete the retained resources.</p> <p>Retaining resources is useful when you cannot delete a resource, such as a non-empty S3 bucket, but you want to delete the stack.</p>"]
+    #[serde(rename="RetainResources")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub retain_resources: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) of an AWS Identity and Access Management (IAM) role that AWS CloudFormation assumes to delete the stack. AWS CloudFormation uses the role's credentials to make calls on your behalf.</p> <p>If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials.</p>"]
+    #[serde(rename="RoleARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
     #[doc="<p>The name or the unique stack ID that is associated with the stack.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
 }
 
@@ -1501,19 +1642,27 @@ impl DeleteStackInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStackInstancesInput {
     #[doc="<p>The names of the AWS accounts that you want to delete stack instances for.</p>"]
+    #[serde(rename="Accounts")]
     pub accounts: Vec<String>,
     #[doc="<p>The unique identifier for this stack set operation. </p> <p>If you don't specify an operation ID, the SDK generates one automatically. </p> <p>The operation ID also functions as an idempotency token, to ensure that AWS CloudFormation performs the stack set operation only once, even if you retry the request multiple times. You can retry stack set operation requests to ensure that AWS CloudFormation successfully received them.</p> <p>Repeating this stack set operation with a new operation ID retries all stack instances whose status is <code>OUTDATED</code>. </p>"]
+    #[serde(rename="OperationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_id: Option<String>,
     #[doc="<p>Preferences for how AWS CloudFormation performs this stack set operation.</p>"]
+    #[serde(rename="OperationPreferences")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_preferences: Option<StackSetOperationPreferences>,
     #[doc="<p>The regions where you want to delete stack set instances. </p>"]
+    #[serde(rename="Regions")]
     pub regions: Vec<String>,
     #[doc="<p>Removes the stack instances from the specified stack set, but doesn't delete the stacks. You can't reassociate a retained stack or add an existing, saved stack to a new stack set.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-concepts.html#stackset-ops-options\">Stack set operation options</a>.</p>"]
+    #[serde(rename="RetainStacks")]
     pub retain_stacks: bool,
     #[doc="<p>The name or unique ID of the stack set that you want to delete stack instances for.</p>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
 }
 
@@ -1550,9 +1699,11 @@ impl DeleteStackInstancesInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStackInstancesOutput {
     #[doc="<p>The unique identifier for this stack set operation.</p>"]
+    #[serde(rename="OperationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_id: Option<String>,
 }
 
@@ -1599,9 +1750,10 @@ impl DeleteStackInstancesOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStackSetInput {
     #[doc="<p>The name or unique ID of the stack set that you're deleting. You can obtain this value by running <a>ListStackSets</a>.</p>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
 }
 
@@ -1621,7 +1773,7 @@ impl DeleteStackSetInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStackSetOutput;
 
 struct DeleteStackSetOutputDeserializer;
@@ -1655,9 +1807,11 @@ impl DeletionTimeDeserializer {
     }
 }
 #[doc="<p>The input for the <a>DescribeAccountLimits</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountLimitsInput {
     #[doc="<p>A string that identifies the next page of limits that you want to retrieve.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1680,11 +1834,15 @@ impl DescribeAccountLimitsInputSerializer {
 }
 
 #[doc="<p>The output for the <a>DescribeAccountLimits</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountLimitsOutput {
     #[doc="<p>An account limit structure that contain a list of AWS CloudFormation account limits and their values.</p>"]
+    #[serde(rename="AccountLimits")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account_limits: Option<Vec<AccountLimit>>,
     #[doc="<p>If the output exceeds 1 MB in size, a string that identifies the next page of limits. If no additional page exists, this value is null.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1736,13 +1894,18 @@ impl DescribeAccountLimitsOutputDeserializer {
     }
 }
 #[doc="<p>The input for the <a>DescribeChangeSet</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeChangeSetInput {
     #[doc="<p>The name or Amazon Resource Name (ARN) of the change set that you want to describe.</p>"]
+    #[serde(rename="ChangeSetName")]
     pub change_set_name: String,
     #[doc="<p>A string (provided by the <a>DescribeChangeSet</a> response output) that identifies the next page of information that you want to retrieve.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>If you specified the name of a change set, specify the stack name or ID (ARN) of the change set you want to describe.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
 }
 
@@ -1771,39 +1934,71 @@ impl DescribeChangeSetInputSerializer {
 }
 
 #[doc="<p>The output for the <a>DescribeChangeSet</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeChangeSetOutput {
     #[doc="<p>If you execute the change set, the list of capabilities that were explicitly acknowledged when the change set was created.</p>"]
+    #[serde(rename="Capabilities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities: Option<Vec<String>>,
     #[doc="<p>The ARN of the change set.</p>"]
+    #[serde(rename="ChangeSetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub change_set_id: Option<String>,
     #[doc="<p>The name of the change set.</p>"]
+    #[serde(rename="ChangeSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub change_set_name: Option<String>,
     #[doc="<p>A list of <code>Change</code> structures that describes the resources AWS CloudFormation changes if you execute the change set.</p>"]
+    #[serde(rename="Changes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub changes: Option<Vec<Change>>,
     #[doc="<p>The start time when the change set was created, in UTC.</p>"]
+    #[serde(rename="CreationTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub creation_time: Option<String>,
     #[doc="<p>Information about the change set.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>If the change set execution status is <code>AVAILABLE</code>, you can execute the change set. If you can’t execute the change set, the status indicates why. For example, a change set might be in an <code>UNAVAILABLE</code> state because AWS CloudFormation is still creating it or in an <code>OBSOLETE</code> state because the stack was already updated.</p>"]
+    #[serde(rename="ExecutionStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub execution_status: Option<String>,
     #[doc="<p>If the output exceeds 1 MB, a string that identifies the next page of changes. If there is no additional page, this value is null.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The ARNs of the Amazon Simple Notification Service (Amazon SNS) topics that will be associated with the stack if you execute the change set.</p>"]
+    #[serde(rename="NotificationARNs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_ar_ns: Option<Vec<String>>,
     #[doc="<p>A list of <code>Parameter</code> structures that describes the input parameters and their values used to create the change set. For more information, see the <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_Parameter.html\">Parameter</a> data type.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p>The rollback triggers for AWS CloudFormation to monitor during stack creation and updating operations, and for the specified monitoring period afterwards.</p>"]
+    #[serde(rename="RollbackConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rollback_configuration: Option<RollbackConfiguration>,
     #[doc="<p>The ARN of the stack that is associated with the change set.</p>"]
+    #[serde(rename="StackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_id: Option<String>,
     #[doc="<p>The name of the stack that is associated with the change set.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
     #[doc="<p>The current status of the change set, such as <code>CREATE_IN_PROGRESS</code>, <code>CREATE_COMPLETE</code>, or <code>FAILED</code>.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>A description of the change set's status. For example, if your attempt to create a change set failed, AWS CloudFormation shows the error message.</p>"]
+    #[serde(rename="StatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_reason: Option<String>,
     #[doc="<p>If you execute the change set, the tags that will be associated with the stack.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -1919,11 +2114,15 @@ impl DescribeChangeSetOutputDeserializer {
     }
 }
 #[doc="<p>The input for <a>DescribeStackEvents</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackEventsInput {
     #[doc="<p>A string that identifies the next page of events that you want to retrieve.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The name or the unique stack ID that is associated with the stack, which are not always interchangeable:</p> <ul> <li> <p>Running stacks: You can specify either the stack's name or its unique stack ID.</p> </li> <li> <p>Deleted stacks: You must specify the unique stack ID.</p> </li> </ul> <p>Default: There is no default value.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
 }
 
@@ -1950,11 +2149,15 @@ impl DescribeStackEventsInputSerializer {
 }
 
 #[doc="<p>The output for a <a>DescribeStackEvents</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackEventsOutput {
     #[doc="<p>If the output exceeds 1 MB in size, a string that identifies the next page of events. If no additional page exists, this value is null.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of <code>StackEvents</code> structures.</p>"]
+    #[serde(rename="StackEvents")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_events: Option<Vec<StackEvent>>,
 }
 
@@ -2005,13 +2208,16 @@ impl DescribeStackEventsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackInstanceInput {
     #[doc="<p>The ID of an AWS account that's associated with this stack instance.</p>"]
+    #[serde(rename="StackInstanceAccount")]
     pub stack_instance_account: String,
     #[doc="<p>The name of a region that's associated with this stack instance.</p>"]
+    #[serde(rename="StackInstanceRegion")]
     pub stack_instance_region: String,
     #[doc="<p>The name or the unique stack ID of the stack set that you want to get stack instance information for.</p>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
 }
 
@@ -2035,9 +2241,11 @@ impl DescribeStackInstanceInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackInstanceOutput {
     #[doc="<p>The stack instance that matches the specified request parameters.</p>"]
+    #[serde(rename="StackInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_instance: Option<StackInstance>,
 }
 
@@ -2085,11 +2293,13 @@ impl DescribeStackInstanceOutputDeserializer {
     }
 }
 #[doc="<p>The input for <a>DescribeStackResource</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackResourceInput {
     #[doc="<p>The logical name of the resource as specified in the template.</p> <p>Default: There is no default value.</p>"]
+    #[serde(rename="LogicalResourceId")]
     pub logical_resource_id: String,
     #[doc="<p>The name or the unique stack ID that is associated with the stack, which are not always interchangeable:</p> <ul> <li> <p>Running stacks: You can specify either the stack's name or its unique stack ID.</p> </li> <li> <p>Deleted stacks: You must specify the unique stack ID.</p> </li> </ul> <p>Default: There is no default value.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
 }
 
@@ -2112,9 +2322,11 @@ impl DescribeStackResourceInputSerializer {
 }
 
 #[doc="<p>The output for a <a>DescribeStackResource</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackResourceOutput {
     #[doc="<p>A <code>StackResourceDetail</code> structure containing the description of the specified resource in the specified stack.</p>"]
+    #[serde(rename="StackResourceDetail")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_resource_detail: Option<StackResourceDetail>,
 }
 
@@ -2162,13 +2374,19 @@ impl DescribeStackResourceOutputDeserializer {
     }
 }
 #[doc="<p>The input for <a>DescribeStackResources</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackResourcesInput {
     #[doc="<p>The logical name of the resource as specified in the template.</p> <p>Default: There is no default value.</p>"]
+    #[serde(rename="LogicalResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub logical_resource_id: Option<String>,
     #[doc="<p>The name or unique identifier that corresponds to a physical instance ID of a resource supported by AWS CloudFormation.</p> <p>For example, for an Amazon Elastic Compute Cloud (EC2) instance, <code>PhysicalResourceId</code> corresponds to the <code>InstanceId</code>. You can pass the EC2 <code>InstanceId</code> to <code>DescribeStackResources</code> to find which stack the instance belongs to and what other resources are part of the stack.</p> <p>Required: Conditional. If you do not specify <code>PhysicalResourceId</code>, you must specify <code>StackName</code>.</p> <p>Default: There is no default value.</p>"]
+    #[serde(rename="PhysicalResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub physical_resource_id: Option<String>,
     #[doc="<p>The name or the unique stack ID that is associated with the stack, which are not always interchangeable:</p> <ul> <li> <p>Running stacks: You can specify either the stack's name or its unique stack ID.</p> </li> <li> <p>Deleted stacks: You must specify the unique stack ID.</p> </li> </ul> <p>Default: There is no default value.</p> <p>Required: Conditional. If you do not specify <code>StackName</code>, you must specify <code>PhysicalResourceId</code>.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
 }
 
@@ -2199,9 +2417,11 @@ impl DescribeStackResourcesInputSerializer {
 }
 
 #[doc="<p>The output for a <a>DescribeStackResources</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackResourcesOutput {
     #[doc="<p>A list of <code>StackResource</code> structures.</p>"]
+    #[serde(rename="StackResources")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_resources: Option<Vec<StackResource>>,
 }
 
@@ -2248,9 +2468,10 @@ impl DescribeStackResourcesOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackSetInput {
     #[doc="<p>The name or unique ID of the stack set whose description you want.</p>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
 }
 
@@ -2270,11 +2491,13 @@ impl DescribeStackSetInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackSetOperationInput {
     #[doc="<p>The unique ID of the stack set operation. </p>"]
+    #[serde(rename="OperationId")]
     pub operation_id: String,
     #[doc="<p>The name or the unique stack ID of the stack set for the stack operation.</p>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
 }
 
@@ -2296,9 +2519,11 @@ impl DescribeStackSetOperationInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackSetOperationOutput {
     #[doc="<p>The specified stack set operation.</p>"]
+    #[serde(rename="StackSetOperation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_set_operation: Option<StackSetOperation>,
 }
 
@@ -2346,9 +2571,11 @@ impl DescribeStackSetOperationOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackSetOutput {
     #[doc="<p>The specified stack set.</p>"]
+    #[serde(rename="StackSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_set: Option<StackSet>,
 }
 
@@ -2395,11 +2622,15 @@ impl DescribeStackSetOutputDeserializer {
     }
 }
 #[doc="<p>The input for <a>DescribeStacks</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStacksInput {
     #[doc="<p>A string that identifies the next page of stacks that you want to retrieve.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The name or the unique stack ID that is associated with the stack, which are not always interchangeable:</p> <ul> <li> <p>Running stacks: You can specify either the stack's name or its unique stack ID.</p> </li> <li> <p>Deleted stacks: You must specify the unique stack ID.</p> </li> </ul> <p>Default: There is no default value.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
 }
 
@@ -2426,11 +2657,15 @@ impl DescribeStacksInputSerializer {
 }
 
 #[doc="<p>The output for a <a>DescribeStacks</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStacksOutput {
     #[doc="<p>If the output exceeds 1 MB in size, a string that identifies the next page of stacks. If no additional page exists, this value is null.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of stack structures.</p>"]
+    #[serde(rename="Stacks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stacks: Option<Vec<Stack>>,
 }
 
@@ -2509,13 +2744,19 @@ impl DisableRollbackDeserializer {
     }
 }
 #[doc="<p>The input for an <a>EstimateTemplateCost</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EstimateTemplateCostInput {
     #[doc="<p>A list of <code>Parameter</code> structures that specify input parameters.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p>Structure containing the template body with a minimum length of 1 byte and a maximum length of 51,200 bytes. (For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.)</p> <p>Conditional: You must pass <code>TemplateBody</code> or <code>TemplateURL</code>. If both are passed, only <code>TemplateBody</code> is used.</p>"]
+    #[serde(rename="TemplateBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_body: Option<String>,
     #[doc="<p>Location of file containing the template body. The URL must point to a template that is located in an Amazon S3 bucket. For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must pass <code>TemplateURL</code> or <code>TemplateBody</code>. If both are passed, only <code>TemplateBody</code> is used.</p>"]
+    #[serde(rename="TemplateURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_url: Option<String>,
 }
 
@@ -2547,9 +2788,11 @@ impl EstimateTemplateCostInputSerializer {
 }
 
 #[doc="<p>The output for a <a>EstimateTemplateCost</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EstimateTemplateCostOutput {
     #[doc="<p>An AWS Simple Monthly Calculator URL with a query string that describes the resources required to run the template.</p>"]
+    #[serde(rename="Url")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
 }
 
@@ -2623,13 +2866,18 @@ impl EventIdDeserializer {
     }
 }
 #[doc="<p>The input for the <a>ExecuteChangeSet</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecuteChangeSetInput {
     #[doc="<p>The name or ARN of the change set that you want use to update the specified stack.</p>"]
+    #[serde(rename="ChangeSetName")]
     pub change_set_name: String,
     #[doc="<p>A unique identifier for this <code>ExecuteChangeSet</code> request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to execute a change set to update a stack with the same name. You might retry <code>ExecuteChangeSet</code> requests to ensure that AWS CloudFormation successfully received them.</p>"]
+    #[serde(rename="ClientRequestToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_request_token: Option<String>,
     #[doc="<p>If you specified the name of a change set, specify the stack name or ID (ARN) that is associated with the change set you want to execute.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
 }
 
@@ -2658,7 +2906,7 @@ impl ExecuteChangeSetInputSerializer {
 }
 
 #[doc="<p>The output for the <a>ExecuteChangeSet</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecuteChangeSetOutput;
 
 struct ExecuteChangeSetOutputDeserializer;
@@ -2692,13 +2940,19 @@ impl ExecutionStatusDeserializer {
     }
 }
 #[doc="<p>The <code>Export</code> structure describes the exported output values for a stack.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Export {
     #[doc="<p>The stack that contains the exported output name and value.</p>"]
+    #[serde(rename="ExportingStackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub exporting_stack_id: Option<String>,
     #[doc="<p>The name of exported output value. Use this name and the <code>Fn::ImportValue</code> function to import the associated value into other stacks. The name is defined in the <code>Export</code> field in the associated stack's <code>Outputs</code> section.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The value of the exported output, such as a resource physical ID. This value is defined in the <code>Export</code> field in the associated stack's <code>Outputs</code> section.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -2851,9 +3105,10 @@ impl FailureTolerancePercentageDeserializer {
     }
 }
 #[doc="<p>The input for the <a>GetStackPolicy</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetStackPolicyInput {
     #[doc="<p>The name or unique stack ID that is associated with the stack whose policy you want to get.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
 }
 
@@ -2874,9 +3129,11 @@ impl GetStackPolicyInputSerializer {
 }
 
 #[doc="<p>The output for the <a>GetStackPolicy</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetStackPolicyOutput {
     #[doc="<p>Structure containing the stack policy body. (For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html\"> Prevent Updates to Stack Resources</a> in the AWS CloudFormation User Guide.)</p>"]
+    #[serde(rename="StackPolicyBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_policy_body: Option<String>,
 }
 
@@ -2924,13 +3181,19 @@ impl GetStackPolicyOutputDeserializer {
     }
 }
 #[doc="<p>The input for a <a>GetTemplate</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTemplateInput {
     #[doc="<p>The name or Amazon Resource Name (ARN) of a change set for which AWS CloudFormation returns the associated template. If you specify a name, you must also specify the <code>StackName</code>.</p>"]
+    #[serde(rename="ChangeSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub change_set_name: Option<String>,
     #[doc="<p>The name or the unique stack ID that is associated with the stack, which are not always interchangeable:</p> <ul> <li> <p>Running stacks: You can specify either the stack's name or its unique stack ID.</p> </li> <li> <p>Deleted stacks: You must specify the unique stack ID.</p> </li> </ul> <p>Default: There is no default value.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
     #[doc="<p>For templates that include transforms, the stage of the template that AWS CloudFormation returns. To get the user-submitted template, specify <code>Original</code>. To get the template after AWS CloudFormation has processed all transforms, specify <code>Processed</code>. </p> <p>If the template doesn't include transforms, <code>Original</code> and <code>Processed</code> return the same template. By default, AWS CloudFormation specifies <code>Original</code>. </p>"]
+    #[serde(rename="TemplateStage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_stage: Option<String>,
 }
 
@@ -2961,11 +3224,15 @@ impl GetTemplateInputSerializer {
 }
 
 #[doc="<p>The output for <a>GetTemplate</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTemplateOutput {
     #[doc="<p>The stage of the template that you can retrieve. For stacks, the <code>Original</code> and <code>Processed</code> templates are always available. For change sets, the <code>Original</code> template is always available. After AWS CloudFormation finishes creating the change set, the <code>Processed</code> template becomes available.</p>"]
+    #[serde(rename="StagesAvailable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stages_available: Option<Vec<String>>,
     #[doc="<p>Structure containing the template body. (For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.)</p> <p>AWS CloudFormation returns the same template that was used when the stack was created.</p>"]
+    #[serde(rename="TemplateBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_body: Option<String>,
 }
 
@@ -3018,15 +3285,23 @@ impl GetTemplateOutputDeserializer {
     }
 }
 #[doc="<p>The input for the <a>GetTemplateSummary</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTemplateSummaryInput {
     #[doc="<p>The name or the stack ID that is associated with the stack, which are not always interchangeable. For running stacks, you can specify either the stack's name or its unique stack ID. For deleted stack, you must specify the unique stack ID.</p> <p>Conditional: You must specify only one of the following parameters: <code>StackName</code>, <code>StackSetName</code>, <code>TemplateBody</code>, or <code>TemplateURL</code>.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
     #[doc="<p>The name or unique ID of the stack set from which the stack was created.</p> <p>Conditional: You must specify only one of the following parameters: <code>StackName</code>, <code>StackSetName</code>, <code>TemplateBody</code>, or <code>TemplateURL</code>.</p>"]
+    #[serde(rename="StackSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_set_name: Option<String>,
     #[doc="<p>Structure containing the template body with a minimum length of 1 byte and a maximum length of 51,200 bytes. For more information about templates, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must specify only one of the following parameters: <code>StackName</code>, <code>StackSetName</code>, <code>TemplateBody</code>, or <code>TemplateURL</code>.</p>"]
+    #[serde(rename="TemplateBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_body: Option<String>,
     #[doc="<p>Location of file containing the template body. The URL must point to a template (max size: 460,800 bytes) that is located in an Amazon S3 bucket. For more information about templates, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must specify only one of the following parameters: <code>StackName</code>, <code>StackSetName</code>, <code>TemplateBody</code>, or <code>TemplateURL</code>.</p>"]
+    #[serde(rename="TemplateURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_url: Option<String>,
 }
 
@@ -3061,23 +3336,39 @@ impl GetTemplateSummaryInputSerializer {
 }
 
 #[doc="<p>The output for the <a>GetTemplateSummary</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTemplateSummaryOutput {
     #[doc="<p>The capabilities found within the template. If your template contains IAM resources, you must specify the CAPABILITY_IAM or CAPABILITY_NAMED_IAM value for this parameter when you use the <a>CreateStack</a> or <a>UpdateStack</a> actions with your template; otherwise, those actions return an InsufficientCapabilities error.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities\">Acknowledging IAM Resources in AWS CloudFormation Templates</a>.</p>"]
+    #[serde(rename="Capabilities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities: Option<Vec<String>>,
     #[doc="<p>The list of resources that generated the values in the <code>Capabilities</code> response element.</p>"]
+    #[serde(rename="CapabilitiesReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities_reason: Option<String>,
     #[doc="<p>A list of the transforms that are declared in the template.</p>"]
+    #[serde(rename="DeclaredTransforms")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub declared_transforms: Option<Vec<String>>,
     #[doc="<p>The value that is defined in the <code>Description</code> property of the template.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The value that is defined for the <code>Metadata</code> property of the template.</p>"]
+    #[serde(rename="Metadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metadata: Option<String>,
     #[doc="<p>A list of parameter declarations that describe various properties for each parameter.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<ParameterDeclaration>>,
     #[doc="<p>A list of all the template resource types that are defined in the template, such as <code>AWS::EC2::Instance</code>, <code>AWS::Dynamo::Table</code>, and <code>Custom::MyCustomInstance</code>.</p>"]
+    #[serde(rename="ResourceTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_types: Option<Vec<String>>,
     #[doc="<p>The AWS template format version, which identifies the capabilities of the template.</p>"]
+    #[serde(rename="Version")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version: Option<String>,
 }
 
@@ -3241,11 +3532,14 @@ impl LimitValueDeserializer {
     }
 }
 #[doc="<p>The input for the <a>ListChangeSets</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListChangeSetsInput {
     #[doc="<p>A string (provided by the <a>ListChangeSets</a> response output) that identifies the next page of change sets that you want to retrieve.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The name or the Amazon Resource Name (ARN) of the stack for which you want to list change sets.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
 }
 
@@ -3270,11 +3564,15 @@ impl ListChangeSetsInputSerializer {
 }
 
 #[doc="<p>The output for the <a>ListChangeSets</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListChangeSetsOutput {
     #[doc="<p>If the output exceeds 1 MB, a string that identifies the next page of change sets. If there is no additional page, this value is null.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of <code>ChangeSetSummary</code> structures that provides the ID and status of each change set for the specified stack.</p>"]
+    #[serde(rename="Summaries")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub summaries: Option<Vec<ChangeSetSummary>>,
 }
 
@@ -3325,9 +3623,11 @@ impl ListChangeSetsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListExportsInput {
     #[doc="<p>A string (provided by the <a>ListExports</a> response output) that identifies the next page of exported output values that you asked to retrieve.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3349,11 +3649,15 @@ impl ListExportsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListExportsOutput {
     #[doc="<p>The output for the <a>ListExports</a> action.</p>"]
+    #[serde(rename="Exports")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub exports: Option<Vec<Export>>,
     #[doc="<p>If the output exceeds 100 exported output values, a string that identifies the next page of exports. If there is no additional page, this value is null.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3403,11 +3707,14 @@ impl ListExportsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListImportsInput {
     #[doc="<p>The name of the exported output value. AWS CloudFormation returns the stack names that are importing this value. </p>"]
+    #[serde(rename="ExportName")]
     pub export_name: String,
     #[doc="<p>A string (provided by the <a>ListImports</a> response output) that identifies the next page of stacks that are importing the specified exported output value. </p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3431,11 +3738,15 @@ impl ListImportsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListImportsOutput {
     #[doc="<p>A list of stack names that are importing the specified exported output value. </p>"]
+    #[serde(rename="Imports")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub imports: Option<Vec<String>>,
     #[doc="<p>A string that identifies the next page of exports. If there is no additional page, this value is null.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3485,17 +3796,26 @@ impl ListImportsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStackInstancesInput {
     #[doc="<p>The maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>If the previous request didn't return all of the remaining results, the response's <code>NextToken</code> parameter value is set to a token. To retrieve the next set of results, call <code>ListStackInstances</code> again and assign that token to the request object's <code>NextToken</code> parameter. If there are no remaining results, the previous response object's <code>NextToken</code> parameter is set to <code>null</code>.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The name of the AWS account that you want to list stack instances for.</p>"]
+    #[serde(rename="StackInstanceAccount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_instance_account: Option<String>,
     #[doc="<p>The name of the region where you want to list stack instances. </p>"]
+    #[serde(rename="StackInstanceRegion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_instance_region: Option<String>,
     #[doc="<p>The name or unique ID of the stack set that you want to list stack instances for.</p>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
 }
 
@@ -3531,11 +3851,15 @@ impl ListStackInstancesInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStackInstancesOutput {
     #[doc="<p>If the request doesn't return all of the remaining results, <code>NextToken</code> is set to a token. To retrieve the next set of results, call <code>ListStackInstances</code> again and assign that token to the request object's <code>NextToken</code> parameter. If the request returns all results, <code>NextToken</code> is set to <code>null</code>.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of <code>StackInstanceSummary</code> structures that contain information about the specified stack instances.</p>"]
+    #[serde(rename="Summaries")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub summaries: Option<Vec<StackInstanceSummary>>,
 }
 
@@ -3587,11 +3911,14 @@ impl ListStackInstancesOutputDeserializer {
     }
 }
 #[doc="<p>The input for the <a>ListStackResource</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStackResourcesInput {
     #[doc="<p>A string that identifies the next page of stack resources that you want to retrieve.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The name or the unique stack ID that is associated with the stack, which are not always interchangeable:</p> <ul> <li> <p>Running stacks: You can specify either the stack's name or its unique stack ID.</p> </li> <li> <p>Deleted stacks: You must specify the unique stack ID.</p> </li> </ul> <p>Default: There is no default value.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
 }
 
@@ -3616,11 +3943,15 @@ impl ListStackResourcesInputSerializer {
 }
 
 #[doc="<p>The output for a <a>ListStackResources</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStackResourcesOutput {
     #[doc="<p>If the output exceeds 1 MB, a string that identifies the next page of stack resources. If no additional page exists, this value is null.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of <code>StackResourceSummary</code> structures.</p>"]
+    #[serde(rename="StackResourceSummaries")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_resource_summaries: Option<Vec<StackResourceSummary>>,
 }
 
@@ -3671,15 +4002,21 @@ impl ListStackResourcesOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStackSetOperationResultsInput {
     #[doc="<p>The maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>If the previous request didn't return all of the remaining results, the response object's <code>NextToken</code> parameter value is set to a token. To retrieve the next set of results, call <code>ListStackSetOperationResults</code> again and assign that token to the request object's <code>NextToken</code> parameter. If there are no remaining results, the previous response object's <code>NextToken</code> parameter is set to <code>null</code>.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The ID of the stack set operation.</p>"]
+    #[serde(rename="OperationId")]
     pub operation_id: String,
     #[doc="<p>The name or unique ID of the stack set that you want to get operation results for.</p>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
 }
 
@@ -3709,11 +4046,15 @@ impl ListStackSetOperationResultsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStackSetOperationResultsOutput {
     #[doc="<p>If the request doesn't return all results, <code>NextToken</code> is set to a token. To retrieve the next set of results, call <code>ListOperationResults</code> again and assign that token to the request object's <code>NextToken</code> parameter. If there are no remaining results, <code>NextToken</code> is set to <code>null</code>.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of <code>StackSetOperationResultSummary</code> structures that contain information about the specified operation results, for accounts and regions that are included in the operation.</p>"]
+    #[serde(rename="Summaries")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub summaries: Option<Vec<StackSetOperationResultSummary>>,
 }
 
@@ -3763,13 +4104,18 @@ impl ListStackSetOperationResultsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStackSetOperationsInput {
     #[doc="<p>The maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>If the previous paginated request didn't return all of the remaining results, the response object's <code>NextToken</code> parameter value is set to a token. To retrieve the next set of results, call <code>ListStackSetOperations</code> again and assign that token to the request object's <code>NextToken</code> parameter. If there are no remaining results, the previous response object's <code>NextToken</code> parameter is set to <code>null</code>.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The name or unique ID of the stack set that you want to get operation summaries for.</p>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
 }
 
@@ -3797,11 +4143,15 @@ impl ListStackSetOperationsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStackSetOperationsOutput {
     #[doc="<p>If the request doesn't return all results, <code>NextToken</code> is set to a token. To retrieve the next set of results, call <code>ListOperationResults</code> again and assign that token to the request object's <code>NextToken</code> parameter. If there are no remaining results, <code>NextToken</code> is set to <code>null</code>.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of <code>StackSetOperationSummary</code> structures that contain summary information about operations for the specified stack set.</p>"]
+    #[serde(rename="Summaries")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub summaries: Option<Vec<StackSetOperationSummary>>,
 }
 
@@ -3850,13 +4200,19 @@ impl ListStackSetOperationsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStackSetsInput {
     #[doc="<p>The maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>If the previous paginated request didn't return all of the remaining results, the response object's <code>NextToken</code> parameter value is set to a token. To retrieve the next set of results, call <code>ListStackSets</code> again and assign that token to the request object's <code>NextToken</code> parameter. If there are no remaining results, the previous response object's <code>NextToken</code> parameter is set to <code>null</code>.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The status of the stack sets that you want to get summary information about.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -3886,11 +4242,15 @@ impl ListStackSetsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStackSetsOutput {
     #[doc="<p>If the request doesn't return all of the remaining results, <code>NextToken</code> is set to a token. To retrieve the next set of results, call <code>ListStackInstances</code> again and assign that token to the request object's <code>NextToken</code> parameter. If the request returns all results, <code>NextToken</code> is set to <code>null</code>.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of <code>StackSetSummary</code> structures that contain information about the user's stack sets.</p>"]
+    #[serde(rename="Summaries")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub summaries: Option<Vec<StackSetSummary>>,
 }
 
@@ -3942,11 +4302,15 @@ impl ListStackSetsOutputDeserializer {
     }
 }
 #[doc="<p>The input for <a>ListStacks</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStacksInput {
     #[doc="<p>A string that identifies the next page of stacks that you want to retrieve.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Stack status to use as a filter. Specify one or more stack status codes to list only stacks with the specified status codes. For a complete list of stack status codes, see the <code>StackStatus</code> parameter of the <a>Stack</a> data type.</p>"]
+    #[serde(rename="StackStatusFilter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_status_filter: Option<Vec<String>>,
 }
 
@@ -3974,11 +4338,15 @@ impl ListStacksInputSerializer {
 }
 
 #[doc="<p>The output for <a>ListStacks</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStacksOutput {
     #[doc="<p>If the output exceeds 1 MB in size, a string that identifies the next page of stacks. If no additional page exists, this value is null.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of <code>StackSummary</code> structures containing information about the specified stacks.</p>"]
+    #[serde(rename="StackSummaries")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_summaries: Option<Vec<StackSummary>>,
 }
 
@@ -4195,15 +4563,23 @@ impl NotificationARNsSerializer {
 }
 
 #[doc="<p>The Output data type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Output {
     #[doc="<p>User defined description associated with the output.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The name of the export associated with the output.</p>"]
+    #[serde(rename="ExportName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub export_name: Option<String>,
     #[doc="<p>The key associated with the output.</p>"]
+    #[serde(rename="OutputKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub output_key: Option<String>,
     #[doc="<p>The value associated with the output.</p>"]
+    #[serde(rename="OutputValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub output_value: Option<String>,
 }
 
@@ -4334,13 +4710,19 @@ impl OutputsDeserializer {
     }
 }
 #[doc="<p>The Parameter data type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Parameter {
     #[doc="<p>The key associated with the parameter. If you don't specify a key and value for a particular parameter, AWS CloudFormation uses the default value that is specified in your template.</p>"]
+    #[serde(rename="ParameterKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_key: Option<String>,
     #[doc="<p>The value associated with the parameter.</p>"]
+    #[serde(rename="ParameterValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_value: Option<String>,
     #[doc="<p>During a stack update, use the existing parameter value that the stack is using for a given parameter key. If you specify <code>true</code>, do not specify a parameter value.</p>"]
+    #[serde(rename="UsePreviousValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub use_previous_value: Option<bool>,
 }
 
@@ -4424,9 +4806,11 @@ impl ParameterSerializer {
 }
 
 #[doc="<p>A set of criteria that AWS CloudFormation uses to validate parameter values. Although other constraints might be defined in the stack template, AWS CloudFormation returns only the <code>AllowedValues</code> property.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ParameterConstraints {
     #[doc="<p>A list of values that are permitted for a parameter.</p>"]
+    #[serde(rename="AllowedValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allowed_values: Option<Vec<String>>,
 }
 
@@ -4474,19 +4858,31 @@ impl ParameterConstraintsDeserializer {
     }
 }
 #[doc="<p>The ParameterDeclaration data type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ParameterDeclaration {
     #[doc="<p>The default value of the parameter.</p>"]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>The description that is associate with the parameter.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Flag that indicates whether the parameter value is shown as plain text in logs and in the AWS Management Console.</p>"]
+    #[serde(rename="NoEcho")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub no_echo: Option<bool>,
     #[doc="<p>The criteria that AWS CloudFormation uses to validate parameter values.</p>"]
+    #[serde(rename="ParameterConstraints")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_constraints: Option<ParameterConstraints>,
     #[doc="<p>The name that is associated with the parameter.</p>"]
+    #[serde(rename="ParameterKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_key: Option<String>,
     #[doc="<p>The type of parameter.</p>"]
+    #[serde(rename="ParameterType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_type: Option<String>,
 }
 
@@ -4846,21 +5242,35 @@ impl ResourceAttributeDeserializer {
     }
 }
 #[doc="<p>The <code>ResourceChange</code> structure describes the resource and the action that AWS CloudFormation will perform on it if you execute this change set.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceChange {
     #[doc="<p>The action that AWS CloudFormation takes on the resource, such as <code>Add</code> (adds a new resource), <code>Modify</code> (changes a resource), or <code>Remove</code> (deletes a resource).</p>"]
+    #[serde(rename="Action")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action: Option<String>,
     #[doc="<p>For the <code>Modify</code> action, a list of <code>ResourceChangeDetail</code> structures that describes the changes that AWS CloudFormation will make to the resource. </p>"]
+    #[serde(rename="Details")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub details: Option<Vec<ResourceChangeDetail>>,
     #[doc="<p>The resource's logical ID, which is defined in the stack's template.</p>"]
+    #[serde(rename="LogicalResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub logical_resource_id: Option<String>,
     #[doc="<p>The resource's physical ID (resource name). Resources that you are adding don't have physical IDs because they haven't been created.</p>"]
+    #[serde(rename="PhysicalResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub physical_resource_id: Option<String>,
     #[doc="<p>For the <code>Modify</code> action, indicates whether AWS CloudFormation will replace the resource by creating a new one and deleting the old one. This value depends on the value of the <code>RequiresRecreation</code> property in the <code>ResourceTargetDefinition</code> structure. For example, if the <code>RequiresRecreation</code> field is <code>Always</code> and the <code>Evaluation</code> field is <code>Static</code>, <code>Replacement</code> is <code>True</code>. If the <code>RequiresRecreation</code> field is <code>Always</code> and the <code>Evaluation</code> field is <code>Dynamic</code>, <code>Replacement</code> is <code>Conditionally</code>.</p> <p>If you have multiple changes with different <code>RequiresRecreation</code> values, the <code>Replacement</code> value depends on the change with the most impact. A <code>RequiresRecreation</code> value of <code>Always</code> has the most impact, followed by <code>Conditionally</code>, and then <code>Never</code>.</p>"]
+    #[serde(rename="Replacement")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replacement: Option<String>,
     #[doc="<p>The type of AWS CloudFormation resource, such as <code>AWS::S3::Bucket</code>.</p>"]
+    #[serde(rename="ResourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
     #[doc="<p>For the <code>Modify</code> action, indicates which resource attribute is triggering this update, such as a change in the resource attribute's <code>Metadata</code>, <code>Properties</code>, or <code>Tags</code>.</p>"]
+    #[serde(rename="Scope")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scope: Option<Vec<String>>,
 }
 
@@ -4935,15 +5345,23 @@ impl ResourceChangeDeserializer {
     }
 }
 #[doc="<p>For a resource with <code>Modify</code> as the action, the <code>ResourceChange</code> structure describes the changes AWS CloudFormation will make to that resource.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceChangeDetail {
     #[doc="<p>The identity of the entity that triggered this change. This entity is a member of the group that is specified by the <code>ChangeSource</code> field. For example, if you modified the value of the <code>KeyPairName</code> parameter, the <code>CausingEntity</code> is the name of the parameter (<code>KeyPairName</code>).</p> <p>If the <code>ChangeSource</code> value is <code>DirectModification</code>, no value is given for <code>CausingEntity</code>.</p>"]
+    #[serde(rename="CausingEntity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub causing_entity: Option<String>,
     #[doc="<p>The group to which the <code>CausingEntity</code> value belongs. There are five entity groups:</p> <ul> <li> <p> <code>ResourceReference</code> entities are <code>Ref</code> intrinsic functions that refer to resources in the template, such as <code>{ \"Ref\" : \"MyEC2InstanceResource\" }</code>.</p> </li> <li> <p> <code>ParameterReference</code> entities are <code>Ref</code> intrinsic functions that get template parameter values, such as <code>{ \"Ref\" : \"MyPasswordParameter\" }</code>.</p> </li> <li> <p> <code>ResourceAttribute</code> entities are <code>Fn::GetAtt</code> intrinsic functions that get resource attribute values, such as <code>{ \"Fn::GetAtt\" : [ \"MyEC2InstanceResource\", \"PublicDnsName\" ] }</code>.</p> </li> <li> <p> <code>DirectModification</code> entities are changes that are made directly to the template.</p> </li> <li> <p> <code>Automatic</code> entities are <code>AWS::CloudFormation::Stack</code> resource types, which are also known as nested stacks. If you made no changes to the <code>AWS::CloudFormation::Stack</code> resource, AWS CloudFormation sets the <code>ChangeSource</code> to <code>Automatic</code> because the nested stack's template might have changed. Changes to a nested stack's template aren't visible to AWS CloudFormation until you run an update on the parent stack.</p> </li> </ul>"]
+    #[serde(rename="ChangeSource")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub change_source: Option<String>,
     #[doc="<p>Indicates whether AWS CloudFormation can determine the target value, and whether the target value will change before you execute a change set.</p> <p>For <code>Static</code> evaluations, AWS CloudFormation can determine that the target value will change, and its value. For example, if you directly modify the <code>InstanceType</code> property of an EC2 instance, AWS CloudFormation knows that this property value will change, and its value, so this is a <code>Static</code> evaluation.</p> <p>For <code>Dynamic</code> evaluations, cannot determine the target value because it depends on the result of an intrinsic function, such as a <code>Ref</code> or <code>Fn::GetAtt</code> intrinsic function, when the stack is updated. For example, if your template includes a reference to a resource that is conditionally recreated, the value of the reference (the physical ID of the resource) might change, depending on if the resource is recreated. If the resource is recreated, it will have a new physical ID, so all references to that resource will also be updated.</p>"]
+    #[serde(rename="Evaluation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub evaluation: Option<String>,
     #[doc="<p>A <code>ResourceTargetDefinition</code> structure that describes the field that AWS CloudFormation will change and whether the resource will be recreated.</p>"]
+    #[serde(rename="Target")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target: Option<ResourceTargetDefinition>,
 }
 
@@ -5088,13 +5506,19 @@ impl ResourceStatusReasonDeserializer {
     }
 }
 #[doc="<p>The field that AWS CloudFormation will change, such as the name of a resource's property, and whether the resource will be recreated.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceTargetDefinition {
     #[doc="<p>Indicates which resource attribute is triggering this update, such as a change in the resource attribute's <code>Metadata</code>, <code>Properties</code>, or <code>Tags</code>.</p>"]
+    #[serde(rename="Attribute")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute: Option<String>,
     #[doc="<p>If the <code>Attribute</code> value is <code>Properties</code>, the name of the property. For all other attributes, the value is null.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>If the <code>Attribute</code> value is <code>Properties</code>, indicates whether a change to this property causes the resource to be recreated. The value can be <code>Never</code>, <code>Always</code>, or <code>Conditionally</code>. To determine the conditions for a <code>Conditionally</code> recreation, see the update behavior for that <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html\">property</a> in the AWS CloudFormation User Guide.</p>"]
+    #[serde(rename="RequiresRecreation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub requires_recreation: Option<String>,
 }
 
@@ -5270,11 +5694,15 @@ impl RoleARNDeserializer {
     }
 }
 #[doc="<p>Structure containing the rollback triggers for AWS CloudFormation to monitor during stack creation and updating operations, and for the specified monitoring period afterwards.</p> <p>Rollback triggers enable you to have AWS CloudFormation monitor the state of your application during stack creation and updating, and to roll back that operation if the application breaches the threshold of any of the alarms you've specified. For each rollback trigger you create, you specify the Cloudwatch alarm that CloudFormation should monitor. CloudFormation monitors the specified alarms during the stack create or update operation, and for the specified amount of time after all resources have been deployed. If any of the alarms goes to ALERT state during the stack operation or the monitoring period, CloudFormation rolls back the entire stack operation. If the monitoring period expires without any alarms going to ALERT state, CloudFormation proceeds to dispose of old resources as usual.</p> <p>By default, CloudFormation only rolls back stack operations if an alarm goes to ALERT state, not INSUFFICIENT_DATA state. To have CloudFormation roll back the stack operation if an alarm goes to INSUFFICIENT_DATA state as well, edit the CloudWatch alarm to treat missing data as <code>breaching</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html\">Configuring How CloudWatch Alarms Treats Missing Data</a>.</p> <p>AWS CloudFormation does not monitor rollback triggers when it rolls back a stack during an update operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RollbackConfiguration {
     #[doc="<p>The amount of time, in minutes, during which CloudFormation should monitor all the rollback triggers after the stack creation or update operation deploys all necessary resources. If any of the alarms goes to ALERT state during the stack operation or this monitoring period, CloudFormation rolls back the entire stack operation. Then, for update operations, if the monitoring period expires without any alarms going to ALERT state CloudFormation proceeds to dispose of old resources as usual.</p> <p>If you specify a monitoring period but do not specify any rollback triggers, CloudFormation still waits the specified period of time before cleaning up old resources for update operations. You can use this monitoring period to perform any manual stack validation desired, and manually cancel the stack creation or update (using <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CancelUpdateStack.html\">CancelUpdateStack</a>, for example) as necessary.</p> <p>If you specify 0 for this parameter, CloudFormation still monitors the specified rollback triggers during stack creation and update operations. Then, for update operations, it begins disposing of old resources immediately once the operation completes.</p>"]
+    #[serde(rename="MonitoringTimeInMinutes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring_time_in_minutes: Option<i64>,
     #[doc="<p>The triggers to monitor during stack creation or update actions. </p> <p>By default, AWS CloudFormation saves the rollback triggers specified for a stack and applies them to any subsequent update operations for the stack, unless you specify otherwise. If you do specify rollback triggers for this parameter, those triggers replace any list of triggers previously specified for the stack. This means:</p> <ul> <li> <p>If you don't specify this parameter, AWS CloudFormation uses the rollback triggers previously specified for this stack, if any.</p> </li> <li> <p>If you specify any rollback triggers using this parameter, you must specify all the triggers that you want used for this stack, even triggers you've specifed before (for example, when creating the stack or during a previous stack update). Any triggers that you don't include in the updated list of triggers are no longer applied to the stack.</p> </li> <li> <p>If you specify an empty list, AWS CloudFormation removes all currently specified triggers.</p> </li> </ul> <p>If a specified Cloudwatch alarm is missing, the entire stack operation fails and is rolled back. </p>"]
+    #[serde(rename="RollbackTriggers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rollback_triggers: Option<Vec<RollbackTrigger>>,
 }
 
@@ -5350,11 +5778,13 @@ impl RollbackConfigurationSerializer {
 }
 
 #[doc="<p>A rollback trigger AWS CloudFormation monitors during creation and updating of stacks. If any of the alarms you specify goes to ALERT state during the stack operation or within the specified monitoring period afterwards, CloudFormation rolls back the entire stack operation. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RollbackTrigger {
     #[doc="<p>The Amazon Resource Name (ARN) of the rollback trigger.</p>"]
+    #[serde(rename="Arn")]
     pub arn: String,
     #[doc="<p>The resource type of the rollback trigger. Currently, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html\">AWS::CloudWatch::Alarm</a> is the only supported resource type.</p>"]
+    #[serde(rename="Type")]
     pub type_: String,
 }
 
@@ -5515,13 +5945,18 @@ impl ScopeDeserializer {
     }
 }
 #[doc="<p>The input for the <a>SetStackPolicy</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetStackPolicyInput {
     #[doc="<p>The name or unique stack ID that you want to associate a policy with.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
     #[doc="<p>Structure containing the stack policy body. For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html\"> Prevent Updates to Stack Resources</a> in the AWS CloudFormation User Guide. You can specify either the <code>StackPolicyBody</code> or the <code>StackPolicyURL</code> parameter, but not both.</p>"]
+    #[serde(rename="StackPolicyBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_policy_body: Option<String>,
     #[doc="<p>Location of a file containing the stack policy. The URL must point to a policy (maximum size: 16 KB) located in an S3 bucket in the same region as the stack. You can specify either the <code>StackPolicyBody</code> or the <code>StackPolicyURL</code> parameter, but not both.</p>"]
+    #[serde(rename="StackPolicyURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_policy_url: Option<String>,
 }
 
@@ -5550,15 +5985,19 @@ impl SetStackPolicyInputSerializer {
 }
 
 #[doc="<p>The input for the <a>SignalResource</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SignalResourceInput {
     #[doc="<p>The logical ID of the resource that you want to signal. The logical ID is the name of the resource that given in the template.</p>"]
+    #[serde(rename="LogicalResourceId")]
     pub logical_resource_id: String,
     #[doc="<p>The stack name or unique stack ID that includes the resource that you want to signal.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
     #[doc="<p>The status of the signal, which is either success or failure. A failure signal causes AWS CloudFormation to immediately fail the stack creation or update.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>A unique ID of the signal. When you signal Amazon EC2 instances or Auto Scaling groups, specify the instance ID that you are signaling as the unique ID. If you send multiple signals to a single resource (such as signaling a wait condition), each signal requires a different unique ID.</p>"]
+    #[serde(rename="UniqueId")]
     pub unique_id: String,
 }
 
@@ -5585,41 +6024,72 @@ impl SignalResourceInputSerializer {
 }
 
 #[doc="<p>The Stack data type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Stack {
     #[doc="<p>The capabilities allowed in the stack.</p>"]
+    #[serde(rename="Capabilities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities: Option<Vec<String>>,
     #[doc="<p>The unique ID of the change set.</p>"]
+    #[serde(rename="ChangeSetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub change_set_id: Option<String>,
     #[doc="<p>The time at which the stack was created.</p>"]
+    #[serde(rename="CreationTime")]
     pub creation_time: String,
     #[doc="<p>A user-defined description associated with the stack.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Boolean to enable or disable rollback on stack creation failures:</p> <ul> <li> <p> <code>true</code>: disable rollback</p> </li> <li> <p> <code>false</code>: enable rollback</p> </li> </ul>"]
+    #[serde(rename="DisableRollback")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disable_rollback: Option<bool>,
     #[doc="<p>The time the stack was last updated. This field will only be returned if the stack has been updated at least once.</p>"]
+    #[serde(rename="LastUpdatedTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_updated_time: Option<String>,
     #[doc="<p>SNS topic ARNs to which stack related events are published.</p>"]
+    #[serde(rename="NotificationARNs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_ar_ns: Option<Vec<String>>,
     #[doc="<p>A list of output structures.</p>"]
+    #[serde(rename="Outputs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub outputs: Option<Vec<Output>>,
     #[doc="<p>A list of <code>Parameter</code> structures.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p>The Amazon Resource Name (ARN) of an AWS Identity and Access Management (IAM) role that is associated with the stack. During a stack operation, AWS CloudFormation uses this role's credentials to make calls on your behalf.</p>"]
+    #[serde(rename="RoleARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
     #[doc="<p>The rollback triggers for AWS CloudFormation to monitor during stack creation and updating operations, and for the specified monitoring period afterwards.</p>"]
+    #[serde(rename="RollbackConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rollback_configuration: Option<RollbackConfiguration>,
     #[doc="<p>Unique identifier of the stack.</p>"]
+    #[serde(rename="StackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_id: Option<String>,
     #[doc="<p>The name associated with the stack.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
     #[doc="<p>Current status of the stack.</p>"]
+    #[serde(rename="StackStatus")]
     pub stack_status: String,
     #[doc="<p>Success/failure message associated with the stack status.</p>"]
+    #[serde(rename="StackStatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_status_reason: Option<String>,
     #[doc="<p>A list of <code>Tag</code>s that specify information about the stack.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The amount of time within which stack creation should complete.</p>"]
+    #[serde(rename="TimeoutInMinutes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timeout_in_minutes: Option<i64>,
 }
 
@@ -5738,29 +6208,47 @@ impl StackDeserializer {
     }
 }
 #[doc="<p>The StackEvent data type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackEvent {
     #[doc="<p>The token passed to the operation that generated this event.</p> <p>All events triggered by a given stack operation are assigned the same client request token, which you can use to track operations. For example, if you execute a <code>CreateStack</code> operation with the token <code>token1</code>, then all the <code>StackEvents</code> generated by that operation will have <code>ClientRequestToken</code> set as <code>token1</code>.</p> <p>In the console, stack operations display the client request token on the Events tab. Stack operations that are initiated from the console use the token format <i>Console-StackOperation-ID</i>, which helps you easily identify the stack operation . For example, if you create a stack using the console, each stack event would be assigned the same token in the following format: <code>Console-CreateStack-7f59c3cf-00d2-40c7-b2ff-e75db0987002</code>. </p>"]
+    #[serde(rename="ClientRequestToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_request_token: Option<String>,
     #[doc="<p>The unique ID of this event.</p>"]
+    #[serde(rename="EventId")]
     pub event_id: String,
     #[doc="<p>The logical name of the resource specified in the template.</p>"]
+    #[serde(rename="LogicalResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub logical_resource_id: Option<String>,
     #[doc="<p>The name or unique identifier associated with the physical instance of the resource.</p>"]
+    #[serde(rename="PhysicalResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub physical_resource_id: Option<String>,
     #[doc="<p>BLOB of the properties used to create the resource.</p>"]
+    #[serde(rename="ResourceProperties")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_properties: Option<String>,
     #[doc="<p>Current status of the resource.</p>"]
+    #[serde(rename="ResourceStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_status: Option<String>,
     #[doc="<p>Success/failure message associated with the resource.</p>"]
+    #[serde(rename="ResourceStatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_status_reason: Option<String>,
     #[doc="<p>Type of resource. (For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html\"> AWS Resource Types Reference</a> in the AWS CloudFormation User Guide.)</p>"]
+    #[serde(rename="ResourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
     #[doc="<p>The unique ID name of the instance of the stack.</p>"]
+    #[serde(rename="StackId")]
     pub stack_id: String,
     #[doc="<p>The name associated with a stack.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
     #[doc="<p>Time the status was updated.</p>"]
+    #[serde(rename="Timestamp")]
     pub timestamp: String,
 }
 
@@ -5907,19 +6395,31 @@ impl StackIdDeserializer {
     }
 }
 #[doc="<p>An AWS CloudFormation stack, in a specific account and region, that's part of a stack set operation. A stack instance is a reference to an attempted or actual stack in a given account within a given region. A stack instance can exist without a stack—for example, if the stack couldn't be created for some reason. A stack instance is associated with only one stack set. Each stack instance contains the ID of its associated stack set, as well as the ID of the actual stack and the stack status.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackInstance {
     #[doc="<p>The name of the AWS account that the stack instance is associated with.</p>"]
+    #[serde(rename="Account")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account: Option<String>,
     #[doc="<p>The name of the AWS region that the stack instance is associated with.</p>"]
+    #[serde(rename="Region")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub region: Option<String>,
     #[doc="<p>The ID of the stack instance.</p>"]
+    #[serde(rename="StackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_id: Option<String>,
     #[doc="<p>The name or unique ID of the stack set that the stack instance is associated with.</p>"]
+    #[serde(rename="StackSetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_set_id: Option<String>,
     #[doc="<p>The status of the stack instance, in terms of its synchronization with its associated stack set.</p> <ul> <li> <p> <code>INOPERABLE</code>: A <code>DeleteStackInstances</code> operation has failed and left the stack in an unstable state. Stacks in this state are excluded from further <code>UpdateStackSet</code> operations. You might need to perform a <code>DeleteStackInstances</code> operation, with <code>RetainStacks</code> set to <code>true</code>, to delete the stack instance, and then delete the stack manually.</p> </li> <li> <p> <code>OUTDATED</code>: The stack isn't currently up to date with the stack set because:</p> <ul> <li> <p>The associated stack failed during a <code>CreateStackSet</code> or <code>UpdateStackSet</code> operation. </p> </li> <li> <p>The stack was part of a <code>CreateStackSet</code> or <code>UpdateStackSet</code> operation that failed or was stopped before the stack was created or updated. </p> </li> </ul> </li> <li> <p> <code>CURRENT</code>: The stack is currently up to date with the stack set.</p> </li> </ul>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The explanation for the specific status code that is assigned to this stack instance.</p>"]
+    #[serde(rename="StatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_reason: Option<String>,
 }
 
@@ -6044,19 +6544,31 @@ impl StackInstanceSummariesDeserializer {
     }
 }
 #[doc="<p>The structure that contains summary information about a stack instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackInstanceSummary {
     #[doc="<p>The name of the AWS account that the stack instance is associated with.</p>"]
+    #[serde(rename="Account")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account: Option<String>,
     #[doc="<p>The name of the AWS region that the stack instance is associated with.</p>"]
+    #[serde(rename="Region")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub region: Option<String>,
     #[doc="<p>The ID of the stack instance.</p>"]
+    #[serde(rename="StackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_id: Option<String>,
     #[doc="<p>The name or unique ID of the stack set that the stack instance is associated with.</p>"]
+    #[serde(rename="StackSetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_set_id: Option<String>,
     #[doc="<p>The status of the stack instance, in terms of its synchronization with its associated stack set.</p> <ul> <li> <p> <code>INOPERABLE</code>: A <code>DeleteStackInstances</code> operation has failed and left the stack in an unstable state. Stacks in this state are excluded from further <code>UpdateStackSet</code> operations. You might need to perform a <code>DeleteStackInstances</code> operation, with <code>RetainStacks</code> set to <code>true</code>, to delete the stack instance, and then delete the stack manually.</p> </li> <li> <p> <code>OUTDATED</code>: The stack isn't currently up to date with the stack set because:</p> <ul> <li> <p>The associated stack failed during a <code>CreateStackSet</code> or <code>UpdateStackSet</code> operation. </p> </li> <li> <p>The stack was part of a <code>CreateStackSet</code> or <code>UpdateStackSet</code> operation that failed or was stopped before the stack was created or updated. </p> </li> </ul> </li> <li> <p> <code>CURRENT</code>: The stack is currently up to date with the stack set.</p> </li> </ul>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The explanation for the specific status code assigned to this stack instance.</p>"]
+    #[serde(rename="StatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_reason: Option<String>,
 }
 
@@ -6153,25 +6665,39 @@ impl StackPolicyBodyDeserializer {
     }
 }
 #[doc="<p>The StackResource data type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackResource {
     #[doc="<p>User defined description associated with the resource.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The logical name of the resource specified in the template.</p>"]
+    #[serde(rename="LogicalResourceId")]
     pub logical_resource_id: String,
     #[doc="<p>The name or unique identifier that corresponds to a physical instance ID of a resource supported by AWS CloudFormation.</p>"]
+    #[serde(rename="PhysicalResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub physical_resource_id: Option<String>,
     #[doc="<p>Current status of the resource.</p>"]
+    #[serde(rename="ResourceStatus")]
     pub resource_status: String,
     #[doc="<p>Success/failure message associated with the resource.</p>"]
+    #[serde(rename="ResourceStatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_status_reason: Option<String>,
     #[doc="<p>Type of resource. (For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html\"> AWS Resource Types Reference</a> in the AWS CloudFormation User Guide.)</p>"]
+    #[serde(rename="ResourceType")]
     pub resource_type: String,
     #[doc="<p>Unique identifier of the stack.</p>"]
+    #[serde(rename="StackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_id: Option<String>,
     #[doc="<p>The name associated with the stack.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
     #[doc="<p>Time the status was updated.</p>"]
+    #[serde(rename="Timestamp")]
     pub timestamp: String,
 }
 
@@ -6255,27 +6781,43 @@ impl StackResourceDeserializer {
     }
 }
 #[doc="<p>Contains detailed information about the specified stack resource.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackResourceDetail {
     #[doc="<p>User defined description associated with the resource.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Time the status was updated.</p>"]
+    #[serde(rename="LastUpdatedTimestamp")]
     pub last_updated_timestamp: String,
     #[doc="<p>The logical name of the resource specified in the template.</p>"]
+    #[serde(rename="LogicalResourceId")]
     pub logical_resource_id: String,
     #[doc="<p>The content of the <code>Metadata</code> attribute declared for the resource. For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html\">Metadata Attribute</a> in the AWS CloudFormation User Guide.</p>"]
+    #[serde(rename="Metadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metadata: Option<String>,
     #[doc="<p>The name or unique identifier that corresponds to a physical instance ID of a resource supported by AWS CloudFormation.</p>"]
+    #[serde(rename="PhysicalResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub physical_resource_id: Option<String>,
     #[doc="<p>Current status of the resource.</p>"]
+    #[serde(rename="ResourceStatus")]
     pub resource_status: String,
     #[doc="<p>Success/failure message associated with the resource.</p>"]
+    #[serde(rename="ResourceStatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_status_reason: Option<String>,
     #[doc="<p>Type of resource. ((For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html\"> AWS Resource Types Reference</a> in the AWS CloudFormation User Guide.)</p>"]
+    #[serde(rename="ResourceType")]
     pub resource_type: String,
     #[doc="<p>Unique identifier of the stack.</p>"]
+    #[serde(rename="StackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_id: Option<String>,
     #[doc="<p>The name associated with the stack.</p>"]
+    #[serde(rename="StackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_name: Option<String>,
 }
 
@@ -6406,19 +6948,27 @@ impl StackResourceSummariesDeserializer {
     }
 }
 #[doc="<p>Contains high-level information about the specified stack resource.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackResourceSummary {
     #[doc="<p>Time the status was updated.</p>"]
+    #[serde(rename="LastUpdatedTimestamp")]
     pub last_updated_timestamp: String,
     #[doc="<p>The logical name of the resource specified in the template.</p>"]
+    #[serde(rename="LogicalResourceId")]
     pub logical_resource_id: String,
     #[doc="<p>The name or unique identifier that corresponds to a physical instance ID of the resource.</p>"]
+    #[serde(rename="PhysicalResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub physical_resource_id: Option<String>,
     #[doc="<p>Current status of the resource.</p>"]
+    #[serde(rename="ResourceStatus")]
     pub resource_status: String,
     #[doc="<p>Success/failure message associated with the resource.</p>"]
+    #[serde(rename="ResourceStatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_status_reason: Option<String>,
     #[doc="<p>Type of resource. (For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html\"> AWS Resource Types Reference</a> in the AWS CloudFormation User Guide.)</p>"]
+    #[serde(rename="ResourceType")]
     pub resource_type: String,
 }
 
@@ -6531,23 +7081,39 @@ impl StackResourcesDeserializer {
     }
 }
 #[doc="<p>A structure that contains information about a stack set. A stack set enables you to provision stacks into AWS accounts and across regions by using a single CloudFormation template. In the stack set, you specify the template to use, as well as any parameters and capabilities that the template requires. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackSet {
     #[doc="<p>The capabilities that are allowed in the stack set. Some stack set templates might include resources that can affect permissions in your AWS account—for example, by creating new AWS Identity and Access Management (IAM) users. For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities\">Acknowledging IAM Resources in AWS CloudFormation Templates.</a> </p>"]
+    #[serde(rename="Capabilities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities: Option<Vec<String>>,
     #[doc="<p>A description of the stack set that you specify when the stack set is created or updated.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>A list of input parameters for a stack set.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p>The ID of the stack set.</p>"]
+    #[serde(rename="StackSetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_set_id: Option<String>,
     #[doc="<p>The name that's associated with the stack set.</p>"]
+    #[serde(rename="StackSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_set_name: Option<String>,
     #[doc="<p>The status of the stack set.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>A list of tags that specify information about the stack set. A maximum number of 50 tags can be specified.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The structure that contains the body of the template that was used to create or update the stack set.</p>"]
+    #[serde(rename="TemplateBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_body: Option<String>,
 }
 
@@ -6654,23 +7220,39 @@ impl StackSetNameDeserializer {
     }
 }
 #[doc="<p>The structure that contains information about a stack set operation. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackSetOperation {
     #[doc="<p>The type of stack set operation: <code>CREATE</code>, <code>UPDATE</code>, or <code>DELETE</code>. Create and delete operations affect only the specified stack set instances that are associated with the specified stack set. Update operations affect both the stack set itself, as well as <i>all</i> associated stack set instances.</p>"]
+    #[serde(rename="Action")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action: Option<String>,
     #[doc="<p>The time at which the operation was initiated. Note that the creation times for the stack set operation might differ from the creation time of the individual stacks themselves. This is because AWS CloudFormation needs to perform preparatory work for the operation, such as dispatching the work to the requested regions, before actually creating the first stacks.</p>"]
+    #[serde(rename="CreationTimestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub creation_timestamp: Option<String>,
     #[doc="<p>The time at which the stack set operation ended, across all accounts and regions specified. Note that this doesn't necessarily mean that the stack set operation was successful, or even attempted, in each account or region.</p>"]
+    #[serde(rename="EndTimestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_timestamp: Option<String>,
     #[doc="<p>The unique ID of a stack set operation.</p>"]
+    #[serde(rename="OperationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_id: Option<String>,
     #[doc="<p>The preferences for how AWS CloudFormation performs this stack set operation.</p>"]
+    #[serde(rename="OperationPreferences")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_preferences: Option<StackSetOperationPreferences>,
     #[doc="<p>For stack set operations of action type <code>DELETE</code>, specifies whether to remove the stack instances from the specified stack set, but doesn't delete the stacks. You can't reassociate a retained stack, or add an existing, saved stack to a new stack set.</p>"]
+    #[serde(rename="RetainStacks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub retain_stacks: Option<bool>,
     #[doc="<p>The ID of the stack set.</p>"]
+    #[serde(rename="StackSetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_set_id: Option<String>,
     #[doc="<p>The status of the operation. </p> <ul> <li> <p> <code>FAILED</code>: The operation exceeded the specified failure tolerance. The failure tolerance value that you've set for an operation is applied for each region during stack create and update operations. If the number of failed stacks within a region exceeds the failure tolerance, the status of the operation in the region is set to <code>FAILED</code>. This in turn sets the status of the operation as a whole to <code>FAILED</code>, and AWS CloudFormation cancels the operation in any remaining regions.</p> </li> <li> <p> <code>RUNNING</code>: The operation is currently being performed.</p> </li> <li> <p> <code>STOPPED</code>: The user has cancelled the operation.</p> </li> <li> <p> <code>STOPPING</code>: The operation is in the process of stopping, at user request. </p> </li> <li> <p> <code>SUCCEEDED</code>: The operation completed creating or updating all the specified stacks without exceeding the failure tolerance for the operation.</p> </li> </ul>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -6765,17 +7347,27 @@ impl StackSetOperationActionDeserializer {
     }
 }
 #[doc="<p>The user-specified preferences for how AWS CloudFormation performs a stack set operation. </p> <p>For more information on maximum concurrent accounts and failure tolerance, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-concepts.html#stackset-ops-options\">Stack set operation options</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackSetOperationPreferences {
     #[doc="<p>The number of accounts, per region, for which this operation can fail before AWS CloudFormation stops the operation in that region. If the operation is stopped in a region, AWS CloudFormation doesn't attempt the operation in any subsequent regions.</p> <p>Conditional: You must specify either <code>FailureToleranceCount</code> or <code>FailureTolerancePercentage</code> (but not both).</p>"]
+    #[serde(rename="FailureToleranceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub failure_tolerance_count: Option<i64>,
     #[doc="<p>The percentage of accounts, per region, for which this stack operation can fail before AWS CloudFormation stops the operation in that region. If the operation is stopped in a region, AWS CloudFormation doesn't attempt the operation in any subsequent regions.</p> <p>When calculating the number of accounts based on the specified percentage, AWS CloudFormation rounds <i>down</i> to the next whole number.</p> <p>Conditional: You must specify either <code>FailureToleranceCount</code> or <code>FailureTolerancePercentage</code>, but not both.</p>"]
+    #[serde(rename="FailureTolerancePercentage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub failure_tolerance_percentage: Option<i64>,
     #[doc="<p>The maximum number of accounts in which to perform this operation at one time. This is dependent on the value of <code>FailureToleranceCount</code>—<code>MaxConcurrentCount</code> is at most one more than the <code>FailureToleranceCount</code> .</p> <p>Conditional: You must specify either <code>MaxConcurrentCount</code> or <code>MaxConcurrentPercentage</code>, but not both.</p>"]
+    #[serde(rename="MaxConcurrentCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_concurrent_count: Option<i64>,
     #[doc="<p>The maximum percentage of accounts in which to perform this operation at one time.</p> <p>When calculating the number of accounts based on the specified percentage, AWS CloudFormation rounds down to the next whole number. This is true except in cases where rounding down would result is zero. In this case, CloudFormation sets the number as one instead.</p> <p>Conditional: You must specify either <code>MaxConcurrentCount</code> or <code>MaxConcurrentPercentage</code>, but not both.</p>"]
+    #[serde(rename="MaxConcurrentPercentage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_concurrent_percentage: Option<i64>,
     #[doc="<p>The order of the regions in where you want to perform the stack operation.</p>"]
+    #[serde(rename="RegionOrder")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub region_order: Option<Vec<String>>,
 }
 
@@ -6932,17 +7524,27 @@ impl StackSetOperationResultSummariesDeserializer {
     }
 }
 #[doc="<p>The structure that contains information about a specified operation's results for a given account in a given region.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackSetOperationResultSummary {
     #[doc="<p>The name of the AWS account for this operation result.</p>"]
+    #[serde(rename="Account")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account: Option<String>,
     #[doc="<p>The results of the account gate function AWS CloudFormation invokes, if present, before proceeding with stack set operations in an account</p>"]
+    #[serde(rename="AccountGateResult")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account_gate_result: Option<AccountGateResult>,
     #[doc="<p>The name of the AWS region for this operation result.</p>"]
+    #[serde(rename="Region")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub region: Option<String>,
     #[doc="<p>The result status of the stack set operation for the given account in the given region.</p> <ul> <li> <p> <code>CANCELLED</code>: The operation in the specified account and region has been cancelled. This is either because a user has stopped the stack set operation, or because the failure tolerance of the stack set operation has been exceeded.</p> </li> <li> <p> <code>FAILED</code>: The operation in the specified account and region failed. </p> <p>If the stack set operation fails in enough accounts within a region, the failure tolerance for the stack set operation as a whole might be exceeded. </p> </li> <li> <p> <code>RUNNING</code>: The operation in the specified account and region is currently in progress.</p> </li> <li> <p> <code>PENDING</code>: The operation in the specified account and region has yet to start. </p> </li> <li> <p> <code>SUCCEEDED</code>: The operation in the specified account and region completed successfully.</p> </li> </ul>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The reason for the assigned result status.</p>"]
+    #[serde(rename="StatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_reason: Option<String>,
 }
 
@@ -7061,17 +7663,27 @@ impl StackSetOperationSummariesDeserializer {
     }
 }
 #[doc="<p>The structures that contain summary information about the specified operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackSetOperationSummary {
     #[doc="<p>The type of operation: <code>CREATE</code>, <code>UPDATE</code>, or <code>DELETE</code>. Create and delete operations affect only the specified stack instances that are associated with the specified stack set. Update operations affect both the stack set itself as well as <i>all</i> associated stack set instances.</p>"]
+    #[serde(rename="Action")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action: Option<String>,
     #[doc="<p>The time at which the operation was initiated. Note that the creation times for the stack set operation might differ from the creation time of the individual stacks themselves. This is because AWS CloudFormation needs to perform preparatory work for the operation, such as dispatching the work to the requested regions, before actually creating the first stacks.</p>"]
+    #[serde(rename="CreationTimestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub creation_timestamp: Option<String>,
     #[doc="<p>The time at which the stack set operation ended, across all accounts and regions specified. Note that this doesn't necessarily mean that the stack set operation was successful, or even attempted, in each account or region.</p>"]
+    #[serde(rename="EndTimestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_timestamp: Option<String>,
     #[doc="<p>The unique ID of the stack set operation.</p>"]
+    #[serde(rename="OperationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_id: Option<String>,
     #[doc="<p>The overall status of the operation.</p> <ul> <li> <p> <code>FAILED</code>: The operation exceeded the specified failure tolerance. The failure tolerance value that you've set for an operation is applied for each region during stack create and update operations. If the number of failed stacks within a region exceeds the failure tolerance, the status of the operation in the region is set to <code>FAILED</code>. This in turn sets the status of the operation as a whole to <code>FAILED</code>, and AWS CloudFormation cancels the operation in any remaining regions.</p> </li> <li> <p> <code>RUNNING</code>: The operation is currently being performed.</p> </li> <li> <p> <code>STOPPED</code>: The user has cancelled the operation.</p> </li> <li> <p> <code>STOPPING</code>: The operation is in the process of stopping, at user request. </p> </li> <li> <p> <code>SUCCEEDED</code>: The operation completed creating or updating all the specified stacks without exceeding the failure tolerance for the operation.</p> </li> </ul>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -7194,15 +7806,23 @@ impl StackSetSummariesDeserializer {
     }
 }
 #[doc="<p>The structures that contain summary information about the specified stack set.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackSetSummary {
     #[doc="<p>A description of the stack set that you specify when the stack set is created or updated.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of the stack set.</p>"]
+    #[serde(rename="StackSetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_set_id: Option<String>,
     #[doc="<p>The name of the stack set.</p>"]
+    #[serde(rename="StackSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_set_name: Option<String>,
     #[doc="<p>The status of the stack set.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -7345,23 +7965,36 @@ impl StackSummariesDeserializer {
     }
 }
 #[doc="<p>The StackSummary Data Type</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackSummary {
     #[doc="<p>The time the stack was created.</p>"]
+    #[serde(rename="CreationTime")]
     pub creation_time: String,
     #[doc="<p>The time the stack was deleted.</p>"]
+    #[serde(rename="DeletionTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deletion_time: Option<String>,
     #[doc="<p>The time the stack was last updated. This field will only be returned if the stack has been updated at least once.</p>"]
+    #[serde(rename="LastUpdatedTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_updated_time: Option<String>,
     #[doc="<p>Unique stack identifier.</p>"]
+    #[serde(rename="StackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_id: Option<String>,
     #[doc="<p>The name associated with the stack.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
     #[doc="<p>The current status of the stack.</p>"]
+    #[serde(rename="StackStatus")]
     pub stack_status: String,
     #[doc="<p>Success/Failure message associated with the stack status.</p>"]
+    #[serde(rename="StackStatusReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_status_reason: Option<String>,
     #[doc="<p>The template description of the template used to create the stack.</p>"]
+    #[serde(rename="TemplateDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_description: Option<String>,
 }
 
@@ -7521,11 +8154,13 @@ impl StageListDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopStackSetOperationInput {
     #[doc="<p>The ID of the stack operation. </p>"]
+    #[serde(rename="OperationId")]
     pub operation_id: String,
     #[doc="<p>The name or unique ID of the stack set that you want to stop the operation for.</p>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
 }
 
@@ -7547,7 +8182,7 @@ impl StopStackSetOperationInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopStackSetOperationOutput;
 
 struct StopStackSetOperationOutputDeserializer;
@@ -7567,11 +8202,13 @@ impl StopStackSetOperationOutputDeserializer {
     }
 }
 #[doc="<p>The Tag type enables you to specify a key-value pair that can be used to store information about an AWS CloudFormation stack.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p> <i>Required</i>. A string used to identify this tag. You can specify a maximum of 128 characters for a tag key. Tags owned by Amazon Web Services (AWS) have the reserved prefix: <code>aws:</code>.</p>"]
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="<p> <i>Required</i>. A string containing the value for this tag. You can specify a maximum of 256 characters for a tag value.</p>"]
+    #[serde(rename="Value")]
     pub value: String,
 }
 
@@ -7747,15 +8384,23 @@ impl TemplateDescriptionDeserializer {
     }
 }
 #[doc="<p>The TemplateParameter data type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TemplateParameter {
     #[doc="<p>The default value associated with the parameter.</p>"]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>User defined description associated with the parameter.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Flag indicating whether the parameter should be displayed as plain text in logs and UIs.</p>"]
+    #[serde(rename="NoEcho")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub no_echo: Option<bool>,
     #[doc="<p>The name associated with the parameter.</p>"]
+    #[serde(rename="ParameterKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_key: Option<String>,
 }
 
@@ -7969,39 +8614,70 @@ impl TypeDeserializer {
     }
 }
 #[doc="<p>The input for an <a>UpdateStack</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateStackInput {
     #[doc="<p>A list of values that you must specify before AWS CloudFormation can update certain stacks. Some stack templates might include resources that can affect permissions in your AWS account, for example, by creating new AWS Identity and Access Management (IAM) users. For those stacks, you must explicitly acknowledge their capabilities by specifying this parameter.</p> <p>The only valid values are <code>CAPABILITY_IAM</code> and <code>CAPABILITY_NAMED_IAM</code>. The following resources require you to specify this parameter: <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html\"> AWS::IAM::AccessKey</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html\"> AWS::IAM::Group</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html\"> AWS::IAM::InstanceProfile</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html\"> AWS::IAM::Policy</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html\"> AWS::IAM::Role</a>, <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html\"> AWS::IAM::User</a>, and <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html\"> AWS::IAM::UserToGroupAddition</a>. If your stack template contains these resources, we recommend that you review all permissions associated with them and edit their permissions if necessary.</p> <p>If you have IAM resources, you can specify either capability. If you have IAM resources with custom names, you must specify <code>CAPABILITY_NAMED_IAM</code>. If you don't specify this parameter, this action returns an <code>InsufficientCapabilities</code> error.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities\">Acknowledging IAM Resources in AWS CloudFormation Templates</a>.</p>"]
+    #[serde(rename="Capabilities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities: Option<Vec<String>>,
     #[doc="<p>A unique identifier for this <code>UpdateStack</code> request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to update a stack with the same name. You might retry <code>UpdateStack</code> requests to ensure that AWS CloudFormation successfully received them.</p> <p>All events triggered by a given stack operation are assigned the same client request token, which you can use to track operations. For example, if you execute a <code>CreateStack</code> operation with the token <code>token1</code>, then all the <code>StackEvents</code> generated by that operation will have <code>ClientRequestToken</code> set as <code>token1</code>.</p> <p>In the console, stack operations display the client request token on the Events tab. Stack operations that are initiated from the console use the token format <i>Console-StackOperation-ID</i>, which helps you easily identify the stack operation . For example, if you create a stack using the console, each stack event would be assigned the same token in the following format: <code>Console-CreateStack-7f59c3cf-00d2-40c7-b2ff-e75db0987002</code>. </p>"]
+    #[serde(rename="ClientRequestToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_request_token: Option<String>,
     #[doc="<p>Amazon Simple Notification Service topic Amazon Resource Names (ARNs) that AWS CloudFormation associates with the stack. Specify an empty list to remove all notification topics.</p>"]
+    #[serde(rename="NotificationARNs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_ar_ns: Option<Vec<String>>,
     #[doc="<p>A list of <code>Parameter</code> structures that specify input parameters for the stack. For more information, see the <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_Parameter.html\">Parameter</a> data type.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p>The template resource types that you have permissions to work with for this update stack action, such as <code>AWS::EC2::Instance</code>, <code>AWS::EC2::*</code>, or <code>Custom::MyCustomInstance</code>.</p> <p>If the list of resource types doesn't include a resource that you're updating, the stack update fails. By default, AWS CloudFormation grants permissions to all resource types. AWS Identity and Access Management (IAM) uses this parameter for AWS CloudFormation-specific condition keys in IAM policies. For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html\">Controlling Access with AWS Identity and Access Management</a>.</p>"]
+    #[serde(rename="ResourceTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_types: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) of an AWS Identity and Access Management (IAM) role that AWS CloudFormation assumes to update the stack. AWS CloudFormation uses the role's credentials to make calls on your behalf. AWS CloudFormation always uses this role for all future operations on the stack. As long as users have permission to operate on the stack, AWS CloudFormation uses this role even if the users don't have permission to pass it. Ensure that the role grants least privilege.</p> <p>If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials.</p>"]
+    #[serde(rename="RoleARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
     #[doc="<p>The rollback triggers for AWS CloudFormation to monitor during stack creation and updating operations, and for the specified monitoring period afterwards.</p>"]
+    #[serde(rename="RollbackConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rollback_configuration: Option<RollbackConfiguration>,
     #[doc="<p>The name or unique stack ID of the stack to update.</p>"]
+    #[serde(rename="StackName")]
     pub stack_name: String,
     #[doc="<p>Structure containing a new stack policy body. You can specify either the <code>StackPolicyBody</code> or the <code>StackPolicyURL</code> parameter, but not both.</p> <p>You might update the stack policy, for example, in order to protect a new resource that you created during a stack update. If you do not specify a stack policy, the current policy that is associated with the stack is unchanged.</p>"]
+    #[serde(rename="StackPolicyBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_policy_body: Option<String>,
     #[doc="<p>Structure containing the temporary overriding stack policy body. You can specify either the <code>StackPolicyDuringUpdateBody</code> or the <code>StackPolicyDuringUpdateURL</code> parameter, but not both.</p> <p>If you want to update protected resources, specify a temporary overriding stack policy during this update. If you do not specify a stack policy, the current policy that is associated with the stack will be used.</p>"]
+    #[serde(rename="StackPolicyDuringUpdateBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_policy_during_update_body: Option<String>,
     #[doc="<p>Location of a file containing the temporary overriding stack policy. The URL must point to a policy (max size: 16KB) located in an S3 bucket in the same region as the stack. You can specify either the <code>StackPolicyDuringUpdateBody</code> or the <code>StackPolicyDuringUpdateURL</code> parameter, but not both.</p> <p>If you want to update protected resources, specify a temporary overriding stack policy during this update. If you do not specify a stack policy, the current policy that is associated with the stack will be used.</p>"]
+    #[serde(rename="StackPolicyDuringUpdateURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_policy_during_update_url: Option<String>,
     #[doc="<p>Location of a file containing the updated stack policy. The URL must point to a policy (max size: 16KB) located in an S3 bucket in the same region as the stack. You can specify either the <code>StackPolicyBody</code> or the <code>StackPolicyURL</code> parameter, but not both.</p> <p>You might update the stack policy, for example, in order to protect a new resource that you created during a stack update. If you do not specify a stack policy, the current policy that is associated with the stack is unchanged.</p>"]
+    #[serde(rename="StackPolicyURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_policy_url: Option<String>,
     #[doc="<p>Key-value pairs to associate with this stack. AWS CloudFormation also propagates these tags to supported resources in the stack. You can specify a maximum number of 50 tags.</p> <p>If you don't specify this parameter, AWS CloudFormation doesn't modify the stack's tags. If you specify an empty value, AWS CloudFormation removes all associated tags.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>Structure containing the template body with a minimum length of 1 byte and a maximum length of 51,200 bytes. (For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.)</p> <p>Conditional: You must specify only one of the following parameters: <code>TemplateBody</code>, <code>TemplateURL</code>, or set the <code>UsePreviousTemplate</code> to <code>true</code>.</p>"]
+    #[serde(rename="TemplateBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_body: Option<String>,
     #[doc="<p>Location of file containing the template body. The URL must point to a template that is located in an Amazon S3 bucket. For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must specify only one of the following parameters: <code>TemplateBody</code>, <code>TemplateURL</code>, or set the <code>UsePreviousTemplate</code> to <code>true</code>.</p>"]
+    #[serde(rename="TemplateURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_url: Option<String>,
     #[doc="<p>Reuse the existing template that is associated with the stack that you are updating.</p> <p>Conditional: You must specify only one of the following parameters: <code>TemplateBody</code>, <code>TemplateURL</code>, or set the <code>UsePreviousTemplate</code> to <code>true</code>.</p>"]
+    #[serde(rename="UsePreviousTemplate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub use_previous_template: Option<bool>,
 }
 
@@ -8088,9 +8764,11 @@ impl UpdateStackInputSerializer {
 }
 
 #[doc="<p>The output for an <a>UpdateStack</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateStackOutput {
     #[doc="<p>Unique identifier of the stack.</p>"]
+    #[serde(rename="StackId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stack_id: Option<String>,
 }
 
@@ -8136,27 +8814,46 @@ impl UpdateStackOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateStackSetInput {
     #[doc="<p>A list of values that you must specify before AWS CloudFormation can create certain stack sets. Some stack set templates might include resources that can affect permissions in your AWS account—for example, by creating new AWS Identity and Access Management (IAM) users. For those stack sets, you must explicitly acknowledge their capabilities by specifying this parameter.</p> <p>The only valid values are CAPABILITY_IAM and CAPABILITY_NAMED_IAM. The following resources require you to specify this parameter: </p> <ul> <li> <p>AWS::IAM::AccessKey</p> </li> <li> <p>AWS::IAM::Group</p> </li> <li> <p>AWS::IAM::InstanceProfile</p> </li> <li> <p>AWS::IAM::Policy</p> </li> <li> <p>AWS::IAM::Role</p> </li> <li> <p>AWS::IAM::User</p> </li> <li> <p>AWS::IAM::UserToGroupAddition</p> </li> </ul> <p>If your stack template contains these resources, we recommend that you review all permissions that are associated with them and edit their permissions if necessary.</p> <p>If you have IAM resources, you can specify either capability. If you have IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM. If you don't specify this parameter, this action returns an <code>InsufficientCapabilities</code> error.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities\">Acknowledging IAM Resources in AWS CloudFormation Templates.</a> </p>"]
+    #[serde(rename="Capabilities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities: Option<Vec<String>>,
     #[doc="<p>A brief description of updates that you are making.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The unique ID for this stack set operation. </p> <p>The operation ID also functions as an idempotency token, to ensure that AWS CloudFormation performs the stack set operation only once, even if you retry the request multiple times. You might retry stack set operation requests to ensure that AWS CloudFormation successfully received them.</p> <p>If you don't specify an operation ID, AWS CloudFormation generates one automatically.</p> <p>Repeating this stack set operation with a new operation ID retries all stack instances whose status is <code>OUTDATED</code>. </p>"]
+    #[serde(rename="OperationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_id: Option<String>,
     #[doc="<p>Preferences for how AWS CloudFormation performs this stack set operation.</p>"]
+    #[serde(rename="OperationPreferences")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_preferences: Option<StackSetOperationPreferences>,
     #[doc="<p>A list of input parameters for the stack set template. </p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p>The name or unique ID of the stack set that you want to update.</p>"]
+    #[serde(rename="StackSetName")]
     pub stack_set_name: String,
     #[doc="<p>The key-value pairs to associate with this stack set and the stacks created from it. AWS CloudFormation also propagates these tags to supported resources that are created in the stacks. You can specify a maximum number of 50 tags.</p> <p>If you specify tags for this parameter, those tags replace any list of tags that are currently associated with this stack set. This means:</p> <ul> <li> <p>If you don't specify this parameter, AWS CloudFormation doesn't modify the stack's tags. </p> </li> <li> <p>If you specify <i>any</i> tags using this parameter, you must specify <i>all</i> the tags that you want associated with this stack set, even tags you've specifed before (for example, when creating the stack set or during a previous update of the stack set.). Any tags that you don't include in the updated list of tags are removed from the stack set, and therefore from the stacks and resources as well. </p> </li> <li> <p>If you specify an empty value, AWS CloudFormation removes all currently associated tags.</p> </li> </ul> <p>If you specify new tags as part of an <code>UpdateStackSet</code> action, AWS CloudFormation checks to see if you have the required IAM permission to tag resources. If you omit tags that are currently associated with the stack set from the list of tags you specify, AWS CloudFormation assumes that you want to remove those tags from the stack set, and checks to see if you have permission to untag resources. If you don't have the necessary permission(s), the entire <code>UpdateStackSet</code> action fails with an <code>access denied</code> error, and the stack set is not updated.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The structure that contains the template body, with a minimum length of 1 byte and a maximum length of 51,200 bytes. For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must specify only one of the following parameters: <code>TemplateBody</code> or <code>TemplateURL</code>—or set <code>UsePreviousTemplate</code> to true.</p>"]
+    #[serde(rename="TemplateBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_body: Option<String>,
     #[doc="<p>The location of the file that contains the template body. The URL must point to a template (maximum size: 460,800 bytes) that is located in an Amazon S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must specify only one of the following parameters: <code>TemplateBody</code> or <code>TemplateURL</code>—or set <code>UsePreviousTemplate</code> to true. </p>"]
+    #[serde(rename="TemplateURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_url: Option<String>,
     #[doc="<p>Use the existing template that's associated with the stack set that you're updating.</p> <p>Conditional: You must specify only one of the following parameters: <code>TemplateBody</code> or <code>TemplateURL</code>—or set <code>UsePreviousTemplate</code> to true. </p>"]
+    #[serde(rename="UsePreviousTemplate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub use_previous_template: Option<bool>,
 }
 
@@ -8216,9 +8913,11 @@ impl UpdateStackSetInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateStackSetOutput {
     #[doc="<p>The unique ID for this stack set operation.</p>"]
+    #[serde(rename="OperationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_id: Option<String>,
 }
 
@@ -8294,11 +8993,15 @@ impl UsePreviousValueDeserializer {
     }
 }
 #[doc="<p>The input for <a>ValidateTemplate</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ValidateTemplateInput {
     #[doc="<p>Structure containing the template body with a minimum length of 1 byte and a maximum length of 51,200 bytes. For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must pass <code>TemplateURL</code> or <code>TemplateBody</code>. If both are passed, only <code>TemplateBody</code> is used.</p>"]
+    #[serde(rename="TemplateBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_body: Option<String>,
     #[doc="<p>Location of file containing the template body. The URL must point to a template (max size: 460,800 bytes) that is located in an Amazon S3 bucket. For more information, go to <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html\">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must pass <code>TemplateURL</code> or <code>TemplateBody</code>. If both are passed, only <code>TemplateBody</code> is used.</p>"]
+    #[serde(rename="TemplateURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_url: Option<String>,
 }
 
@@ -8325,17 +9028,27 @@ impl ValidateTemplateInputSerializer {
 }
 
 #[doc="<p>The output for <a>ValidateTemplate</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ValidateTemplateOutput {
     #[doc="<p>The capabilities found within the template. If your template contains IAM resources, you must specify the CAPABILITY_IAM or CAPABILITY_NAMED_IAM value for this parameter when you use the <a>CreateStack</a> or <a>UpdateStack</a> actions with your template; otherwise, those actions return an InsufficientCapabilities error.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities\">Acknowledging IAM Resources in AWS CloudFormation Templates</a>.</p>"]
+    #[serde(rename="Capabilities")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities: Option<Vec<String>>,
     #[doc="<p>The list of resources that generated the values in the <code>Capabilities</code> response element.</p>"]
+    #[serde(rename="CapabilitiesReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub capabilities_reason: Option<String>,
     #[doc="<p>A list of the transforms that are declared in the template.</p>"]
+    #[serde(rename="DeclaredTransforms")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub declared_transforms: Option<Vec<String>>,
     #[doc="<p>The description found within the template.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>A list of <code>TemplateParameter</code> structures.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<TemplateParameter>>,
 }
 

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -43,13 +43,17 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>A complex type that lists the AWS accounts, if any, that you included in the <code>TrustedSigners</code> complex type for this distribution. These are the accounts that you want to allow to create signed URLs for private content.</p> <p>The <code>Signer</code> complex type lists the AWS account number of the trusted signer or <code>self</code> if the signer is the AWS account that created the distribution. The <code>Signer</code> element also includes the IDs of any active CloudFront key pairs that are associated with the trusted signer's AWS account. If no <code>KeyPairId</code> element appears for a <code>Signer</code>, that signer can't create signed URLs. </p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private Content through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ActiveTrustedSigners {
     #[doc="<p>Enabled is <code>true</code> if any of the AWS accounts listed in the <code>TrustedSigners</code> complex type for this RTMP distribution have active CloudFront key pairs. If not, <code>Enabled</code> is <code>false</code>.</p> <p>For more information, see <a>ActiveTrustedSigners</a>.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p>A complex type that contains one <code>Signer</code> complex type for each trusted signer that is specified in the <code>TrustedSigners</code> complex type.</p> <p>For more information, see <a>ActiveTrustedSigners</a>. </p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<Signer>>,
     #[doc="<p>A complex type that contains one <code>Signer</code> complex type for each trusted signer specified in the <code>TrustedSigners</code> complex type.</p> <p>For more information, see <a>ActiveTrustedSigners</a>.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -163,11 +167,14 @@ impl AliasListSerializer {
 }
 
 #[doc="<p>A complex type that contains information about CNAMEs (alternate domain names), if any, for this distribution. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Aliases {
     #[doc="<p>A complex type that contains the CNAME aliases, if any, that you want to associate with this distribution.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<String>>,
     #[doc="<p>The number of CNAME aliases, if any, that you want to associate with this distribution.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -241,12 +248,16 @@ impl AliasesSerializer {
 }
 
 #[doc="<p>A complex type that controls which HTTP methods CloudFront processes and forwards to your Amazon S3 bucket or your custom origin. There are three choices:</p> <ul> <li> <p>CloudFront forwards only <code>GET</code> and <code>HEAD</code> requests.</p> </li> <li> <p>CloudFront forwards only <code>GET</code>, <code>HEAD</code>, and <code>OPTIONS</code> requests.</p> </li> <li> <p>CloudFront forwards <code>GET, HEAD, OPTIONS, PUT, PATCH, POST</code>, and <code>DELETE</code> requests.</p> </li> </ul> <p>If you pick the third choice, you may need to restrict access to your Amazon S3 bucket or to your custom origin so users can't perform operations that you don't want them to. For example, you might not want users to have permissions to delete objects from your origin.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AllowedMethods {
+    #[serde(rename="CachedMethods")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cached_methods: Option<CachedMethods>,
     #[doc="<p>A complex type that contains the HTTP methods that you want CloudFront to process and forward to your origin.</p>"]
+    #[serde(rename="Items")]
     pub items: Vec<String>,
     #[doc="<p>The number of HTTP methods that you want CloudFront to forward to your origin. Valid values are 2 (for <code>GET</code> and <code>HEAD</code> requests), 3 (for <code>GET</code>, <code>HEAD</code>, and <code>OPTIONS</code> requests) and 7 (for <code>GET, HEAD, OPTIONS, PUT, PATCH, POST</code>, and <code>DELETE</code> requests).</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -417,30 +428,48 @@ impl BooleanSerializer {
 }
 
 #[doc="<p>A complex type that describes how CloudFront processes requests.</p> <p>You must create at least as many cache behaviors (including the default cache behavior) as you have origins if you want CloudFront to distribute objects from all of the origins. Each cache behavior specifies the one origin from which you want CloudFront to get objects. If you have two origins and only the default cache behavior, the default cache behavior will cause CloudFront to get objects from one of the origins, but the other origin is never used.</p> <p>For the current limit on the number of cache behaviors that you can add to a distribution, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_cloudfront\">Amazon CloudFront Limits</a> in the <i>AWS General Reference</i>.</p> <p>If you don't want to specify any cache behaviors, include only an empty <code>CacheBehaviors</code> element. Don't include an empty <code>CacheBehavior</code> element, or CloudFront returns a <code>MalformedXML</code> error.</p> <p>To delete all cache behaviors in an existing distribution, update the distribution configuration and include only an empty <code>CacheBehaviors</code> element.</p> <p>To add, change, or remove one or more cache behaviors, update the distribution configuration and specify all of the cache behaviors that you want to include in the updated distribution.</p> <p>For more information about cache behaviors, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesCacheBehavior\">Cache Behaviors</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CacheBehavior {
+    #[serde(rename="AllowedMethods")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allowed_methods: Option<AllowedMethods>,
     #[doc="<p>Whether you want CloudFront to automatically compress certain files for this cache behavior. If so, specify true; if not, specify false. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html\">Serving Compressed Files</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="Compress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub compress: Option<bool>,
     #[doc="<p>The default amount of time that you want objects to stay in CloudFront caches before CloudFront forwards another request to your origin to determine whether the object has been updated. The value that you specify applies only when your origin does not add HTTP headers such as <code>Cache-Control max-age</code>, <code>Cache-Control s-maxage</code>, and <code>Expires</code> to objects. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html\">Specifying How Long Objects and Errors Stay in a CloudFront Edge Cache (Expiration)</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="DefaultTTL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_ttl: Option<i64>,
     #[doc="<p>A complex type that specifies how CloudFront handles query strings and cookies.</p>"]
+    #[serde(rename="ForwardedValues")]
     pub forwarded_values: ForwardedValues,
     #[doc="<p>A complex type that contains zero or more Lambda function associations for a cache behavior.</p>"]
+    #[serde(rename="LambdaFunctionAssociations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lambda_function_associations: Option<LambdaFunctionAssociations>,
     #[doc="<p>The maximum amount of time that you want objects to stay in CloudFront caches before CloudFront forwards another request to your origin to determine whether the object has been updated. The value that you specify applies only when your origin adds HTTP headers such as <code>Cache-Control max-age</code>, <code>Cache-Control s-maxage</code>, and <code>Expires</code> to objects. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html\">Specifying How Long Objects and Errors Stay in a CloudFront Edge Cache (Expiration)</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="MaxTTL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_ttl: Option<i64>,
     #[doc="<p>The minimum amount of time that you want objects to stay in CloudFront caches before CloudFront forwards another request to your origin to determine whether the object has been updated. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html\">Specifying How Long Objects and Errors Stay in a CloudFront Edge Cache (Expiration)</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p> <p>You must specify <code>0</code> for <code>MinTTL</code> if you configure CloudFront to forward all headers to your origin (under <code>Headers</code>, if you specify <code>1</code> for <code>Quantity</code> and <code>*</code> for <code>Name</code>).</p>"]
+    #[serde(rename="MinTTL")]
     pub min_ttl: i64,
     #[doc="<p>The pattern (for example, <code>images/*.jpg</code>) that specifies which requests to apply the behavior to. When CloudFront receives a viewer request, the requested path is compared with path patterns in the order in which cache behaviors are listed in the distribution.</p> <note> <p>You can optionally include a slash (<code>/</code>) at the beginning of the path pattern. For example, <code>/images/*.jpg</code>. CloudFront behavior is the same with or without the leading <code>/</code>.</p> </note> <p>The path pattern for the default cache behavior is <code>*</code> and cannot be changed. If the request for an object does not match the path pattern for any cache behaviors, CloudFront applies the behavior in the default cache behavior.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesPathPattern\">Path Pattern</a> in the <i> Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="PathPattern")]
     pub path_pattern: String,
     #[doc="<p>Indicates whether you want to distribute media files in the Microsoft Smooth Streaming format using the origin that is associated with this cache behavior. If so, specify <code>true</code>; if not, specify <code>false</code>. If you specify <code>true</code> for <code>SmoothStreaming</code>, you can still distribute other content using this cache behavior if the content matches the value of <code>PathPattern</code>. </p>"]
+    #[serde(rename="SmoothStreaming")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub smooth_streaming: Option<bool>,
     #[doc="<p>The value of <code>ID</code> for the origin that you want CloudFront to route requests to when a request matches the path pattern either for a cache behavior or for the default cache behavior.</p>"]
+    #[serde(rename="TargetOriginId")]
     pub target_origin_id: String,
     #[doc="<p>A complex type that specifies the AWS accounts, if any, that you want to allow to create signed URLs for private content.</p> <p>If you want to require signed URLs in requests for objects in the target origin that match the <code>PathPattern</code> for this cache behavior, specify <code>true</code> for <code>Enabled</code>, and specify the applicable values for <code>Quantity</code> and <code>Items</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private Content through CloudFront</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p> <p>If you don't want to require signed URLs in requests for objects that match <code>PathPattern</code>, specify <code>false</code> for <code>Enabled</code> and <code>0</code> for <code>Quantity</code>. Omit <code>Items</code>.</p> <p>To add, change, or remove one or more trusted signers, change <code>Enabled</code> to <code>true</code> (if it's currently <code>false</code>), change <code>Quantity</code> as applicable, and specify all of the trusted signers that you want to include in the updated distribution.</p>"]
+    #[serde(rename="TrustedSigners")]
     pub trusted_signers: TrustedSigners,
     #[doc="<p>The protocol that viewers can use to access the files in the origin specified by <code>TargetOriginId</code> when a request matches the path pattern in <code>PathPattern</code>. You can specify the following options:</p> <ul> <li> <p> <code>allow-all</code>: Viewers can use HTTP or HTTPS.</p> </li> <li> <p> <code>redirect-to-https</code>: If a viewer submits an HTTP request, CloudFront returns an HTTP status code of 301 (Moved Permanently) to the viewer along with the HTTPS URL. The viewer then resubmits the request using the new URL. </p> </li> <li> <p> <code>https-only</code>: If a viewer sends an HTTP request, CloudFront returns an HTTP status code of 403 (Forbidden). </p> </li> </ul> <p>For more information about requiring the HTTPS protocol, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html\">Using an HTTPS Connection to Access Your Objects</a> in the <i>Amazon CloudFront Developer Guide</i>.</p> <note> <p>The only way to guarantee that viewers retrieve an object that was fetched from the origin using HTTPS is never to use any other protocol to fetch the object. If you have recently changed from HTTP to HTTPS, we recommend that you clear your objects' cache because cached objects are protocol agnostic. That means that an edge location will return an object from the cache regardless of whether the current request protocol matches the protocol used previously. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html\">Specifying How Long Objects and Errors Stay in a CloudFront Edge Cache (Expiration)</a> in the <i>Amazon CloudFront Developer Guide</i>.</p> </note>"]
+    #[serde(rename="ViewerProtocolPolicy")]
     pub viewer_protocol_policy: String,
 }
 
@@ -669,11 +698,14 @@ impl CacheBehaviorListSerializer {
 }
 
 #[doc="<p>A complex type that contains zero or more <code>CacheBehavior</code> elements. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CacheBehaviors {
     #[doc="<p>Optional: A complex type that contains cache behaviors for this distribution. If <code>Quantity</code> is <code>0</code>, you can omit <code>Items</code>.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<CacheBehavior>>,
     #[doc="<p>The number of cache behaviors for this distribution. </p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -748,11 +780,13 @@ impl CacheBehaviorsSerializer {
 }
 
 #[doc="<p>A complex type that controls whether CloudFront caches the response to requests using the specified HTTP methods. There are two choices:</p> <ul> <li> <p>CloudFront caches responses to <code>GET</code> and <code>HEAD</code> requests.</p> </li> <li> <p>CloudFront caches responses to <code>GET</code>, <code>HEAD</code>, and <code>OPTIONS</code> requests.</p> </li> </ul> <p>If you pick the second choice for your Amazon S3 Origin, you may need to forward Access-Control-Request-Method, Access-Control-Request-Headers, and Origin headers for the responses to be cached correctly. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CachedMethods {
     #[doc="<p>A complex type that contains the HTTP methods that you want CloudFront to cache responses to.</p>"]
+    #[serde(rename="Items")]
     pub items: Vec<String>,
     #[doc="<p>The number of HTTP methods for which you want CloudFront to cache responses. Valid values are <code>2</code> (for caching responses to <code>GET</code> and <code>HEAD</code> requests) and <code>3</code> (for caching responses to <code>GET</code>, <code>HEAD</code>, and <code>OPTIONS</code> requests).</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -823,13 +857,17 @@ impl CachedMethodsSerializer {
 }
 
 #[doc="<p>CloudFront origin access identity.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CloudFrontOriginAccessIdentity {
     #[doc="<p>The current configuration information for the identity. </p>"]
+    #[serde(rename="CloudFrontOriginAccessIdentityConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cloud_front_origin_access_identity_config: Option<CloudFrontOriginAccessIdentityConfig>,
     #[doc="<p>The ID for the origin access identity. For example: <code>E74FTE3AJFJ256A</code>. </p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The Amazon S3 canonical user ID for the origin access identity, used when giving the origin access identity read permission to an object in Amazon S3. </p>"]
+    #[serde(rename="S3CanonicalUserId")]
     pub s3_canonical_user_id: String,
 }
 
@@ -882,11 +920,13 @@ impl CloudFrontOriginAccessIdentityDeserializer {
     }
 }
 #[doc="<p>Origin access identity configuration. Send a <code>GET</code> request to the <code>/<i>CloudFront API version</i>/CloudFront/identity ID/config</code> resource. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CloudFrontOriginAccessIdentityConfig {
     #[doc="<p>A unique number that ensures the request can't be replayed.</p> <p>If the <code>CallerReference</code> is new (no matter the content of the <code>CloudFrontOriginAccessIdentityConfig</code> object), a new origin access identity is created.</p> <p>If the <code>CallerReference</code> is a value already sent in a previous identity request, and the content of the <code>CloudFrontOriginAccessIdentityConfig</code> is identical to the original request (ignoring white space), the response includes the same information returned to the original request. </p> <p>If the <code>CallerReference</code> is a value you already sent in a previous request to create an identity, but the content of the <code>CloudFrontOriginAccessIdentityConfig</code> is different from the original request, CloudFront returns a <code>CloudFrontOriginAccessIdentityAlreadyExists</code> error. </p>"]
+    #[serde(rename="CallerReference")]
     pub caller_reference: String,
     #[doc="<p>Any comments you want to include about the origin access identity. </p>"]
+    #[serde(rename="Comment")]
     pub comment: String,
 }
 
@@ -963,19 +1003,27 @@ impl CloudFrontOriginAccessIdentityConfigSerializer {
 }
 
 #[doc="<p>Lists the origin access identities for CloudFront.Send a <code>GET</code> request to the <code>/<i>CloudFront API version</i>/origin-access-identity/cloudfront</code> resource. The response includes a <code>CloudFrontOriginAccessIdentityList</code> element with zero or more <code>CloudFrontOriginAccessIdentitySummary</code> child elements. By default, your entire list of origin access identities is returned in one single page. If the list is long, you can paginate it using the <code>MaxItems</code> and <code>Marker</code> parameters.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CloudFrontOriginAccessIdentityList {
     #[doc="<p>A flag that indicates whether more origin access identities remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more items in the list.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>A complex type that contains one <code>CloudFrontOriginAccessIdentitySummary</code> element for each origin access identity that was created by the current AWS account.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<CloudFrontOriginAccessIdentitySummary>>,
     #[doc="<p>Use this when paginating results to indicate where to begin in your list of origin access identities. The results include identities in the list that occur after the marker. To get the next page of results, set the <code>Marker</code> to the value of the <code>NextMarker</code> from the current page's response (which is also the ID of the last identity on that page). </p>"]
+    #[serde(rename="Marker")]
     pub marker: String,
     #[doc="<p>The maximum number of origin access identities you want in the response body. </p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: i64,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value you can use for the <code>Marker</code> request parameter to continue listing your origin access identities where they left off. </p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
     #[doc="<p>The number of CloudFront origin access identities that were created by the current AWS account. </p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -1041,13 +1089,16 @@ impl CloudFrontOriginAccessIdentityListDeserializer {
     }
 }
 #[doc="<p>Summary of the information about a CloudFront origin access identity.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CloudFrontOriginAccessIdentitySummary {
     #[doc="<p>The comment for this origin access identity, as originally specified when created.</p>"]
+    #[serde(rename="Comment")]
     pub comment: String,
     #[doc="<p>The ID for the origin access identity. For example: <code>E74FTE3AJFJ256A</code>.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The Amazon S3 canonical user ID for the origin access identity, which you use when giving the origin access identity read permission to an object in Amazon S3.</p>"]
+    #[serde(rename="S3CanonicalUserId")]
     pub s3_canonical_user_id: String,
 }
 
@@ -1203,11 +1254,14 @@ impl CookieNameListSerializer {
 }
 
 #[doc="<p>A complex type that specifies whether you want CloudFront to forward cookies to the origin and, if so, which ones. For more information about forwarding cookies to the origin, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html\">How CloudFront Forwards, Caches, and Logs Cookies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CookieNames {
     #[doc="<p>A complex type that contains one <code>Name</code> element for each cookie that you want CloudFront to forward to the origin for this cache behavior.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<String>>,
     #[doc="<p>The number of different cookies that you want CloudFront to forward to the origin for this cache behavior.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -1281,11 +1335,14 @@ impl CookieNamesSerializer {
 }
 
 #[doc="<p>A complex type that specifies whether you want CloudFront to forward cookies to the origin and, if so, which ones. For more information about forwarding cookies to the origin, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html\">How CloudFront Forwards, Caches, and Logs Cookies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CookiePreference {
     #[doc="<p>Specifies which cookies to forward to the origin for this cache behavior: all, none, or the list of cookies specified in the <code>WhitelistedNames</code> complex type.</p> <p>Amazon S3 doesn't process cookies. When the cache behavior is forwarding requests to an Amazon S3 origin, specify none for the <code>Forward</code> element. </p>"]
+    #[serde(rename="Forward")]
     pub forward: String,
     #[doc="<p>Required if you specify <code>whitelist</code> for the value of <code>Forward:</code>. A complex type that specifies how many different cookies you want CloudFront to forward to the origin for this cache behavior and, if you want to forward selected cookies, the names of those cookies.</p> <p>If you specify <code>all</code> or none for the value of <code>Forward</code>, omit <code>WhitelistedNames</code>. If you change the value of <code>Forward</code> from <code>whitelist</code> to all or none and you don't delete the <code>WhitelistedNames</code> element and its child elements, CloudFront deletes them automatically.</p> <p>For the current limit on the number of cookie names that you can whitelist for each cache behavior, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_cloudfront\">Amazon CloudFront Limits</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="WhitelistedNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub whitelisted_names: Option<CookieNames>,
 }
 
@@ -1360,20 +1417,27 @@ impl CookiePreferenceSerializer {
 }
 
 #[doc="<p>The request to create a new origin access identity.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateCloudFrontOriginAccessIdentityRequest {
     #[doc="<p>The current configuration information for the identity.</p>"]
+    #[serde(rename="CloudFrontOriginAccessIdentityConfig")]
     pub cloud_front_origin_access_identity_config: CloudFrontOriginAccessIdentityConfig,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateCloudFrontOriginAccessIdentityResult {
     #[doc="<p>The origin access identity's information.</p>"]
+    #[serde(rename="CloudFrontOriginAccessIdentity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cloud_front_origin_access_identity: Option<CloudFrontOriginAccessIdentity>,
     #[doc="<p>The current version of the origin access identity created.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="<p>The fully qualified URI of the new origin access identity just created. For example: <code>https://cloudfront.amazonaws.com/2010-11-01/origin-access-identity/cloudfront/E74FTE3AJFJ256A</code>.</p>"]
+    #[serde(rename="Location")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location: Option<String>,
 }
 
@@ -1420,20 +1484,27 @@ impl CreateCloudFrontOriginAccessIdentityResultDeserializer {
     }
 }
 #[doc="<p>The request to create a new distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateDistributionRequest {
     #[doc="<p>The distribution's configuration information.</p>"]
+    #[serde(rename="DistributionConfig")]
     pub distribution_config: DistributionConfig,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateDistributionResult {
     #[doc="<p>The distribution's information.</p>"]
+    #[serde(rename="Distribution")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub distribution: Option<Distribution>,
     #[doc="<p>The current version of the distribution created.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="<p>The fully qualified URI of the new distribution resource just created. For example: <code>https://cloudfront.amazonaws.com/2010-11-01/distribution/EDFDVBD632BHDS5</code>.</p>"]
+    #[serde(rename="Location")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location: Option<String>,
 }
 
@@ -1481,20 +1552,27 @@ impl CreateDistributionResultDeserializer {
     }
 }
 #[doc="<p>The request to create a new distribution with tags. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateDistributionWithTagsRequest {
     #[doc="<p>The distribution's configuration information. </p>"]
+    #[serde(rename="DistributionConfigWithTags")]
     pub distribution_config_with_tags: DistributionConfigWithTags,
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateDistributionWithTagsResult {
     #[doc="<p>The distribution's information. </p>"]
+    #[serde(rename="Distribution")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub distribution: Option<Distribution>,
     #[doc="<p>The current version of the distribution created.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="<p>The fully qualified URI of the new distribution resource just created. For example: <code>https://cloudfront.amazonaws.com/2010-11-01/distribution/EDFDVBD632BHDS5</code>. </p>"]
+    #[serde(rename="Location")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location: Option<String>,
 }
 
@@ -1543,20 +1621,26 @@ impl CreateDistributionWithTagsResultDeserializer {
     }
 }
 #[doc="<p>The request to create an invalidation.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateInvalidationRequest {
     #[doc="<p>The distribution's id.</p>"]
+    #[serde(rename="DistributionId")]
     pub distribution_id: String,
     #[doc="<p>The batch information for the invalidation.</p>"]
+    #[serde(rename="InvalidationBatch")]
     pub invalidation_batch: InvalidationBatch,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateInvalidationResult {
     #[doc="<p>The invalidation's information.</p>"]
+    #[serde(rename="Invalidation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub invalidation: Option<Invalidation>,
     #[doc="<p>The fully qualified URI of the distribution and invalidation batch request, including the <code>Invalidation ID</code>.</p>"]
+    #[serde(rename="Location")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location: Option<String>,
 }
 
@@ -1604,20 +1688,27 @@ impl CreateInvalidationResultDeserializer {
     }
 }
 #[doc="<p>The request to create a new streaming distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateStreamingDistributionRequest {
     #[doc="<p>The streaming distribution's configuration information.</p>"]
+    #[serde(rename="StreamingDistributionConfig")]
     pub streaming_distribution_config: StreamingDistributionConfig,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateStreamingDistributionResult {
     #[doc="<p>The current version of the streaming distribution created.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="<p>The fully qualified URI of the new streaming distribution resource just created. For example: <code>https://cloudfront.amazonaws.com/2010-11-01/streaming-distribution/EGTXBD79H29TRA8</code>.</p>"]
+    #[serde(rename="Location")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location: Option<String>,
     #[doc="<p>The streaming distribution's information.</p>"]
+    #[serde(rename="StreamingDistribution")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub streaming_distribution: Option<StreamingDistribution>,
 }
 
@@ -1666,19 +1757,26 @@ impl CreateStreamingDistributionResultDeserializer {
     }
 }
 #[doc="<p>The request to create a new streaming distribution with tags.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateStreamingDistributionWithTagsRequest {
     #[doc="<p> The streaming distribution's configuration information. </p>"]
+    #[serde(rename="StreamingDistributionConfigWithTags")]
     pub streaming_distribution_config_with_tags: StreamingDistributionConfigWithTags,
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateStreamingDistributionWithTagsResult {
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="<p>The fully qualified URI of the new streaming distribution resource just created. For example:<code> https://cloudfront.amazonaws.com/2010-11-01/streaming-distribution/EGTXBD79H29TRA8</code>.</p>"]
+    #[serde(rename="Location")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location: Option<String>,
     #[doc="<p>The streaming distribution's information. </p>"]
+    #[serde(rename="StreamingDistribution")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub streaming_distribution: Option<StreamingDistribution>,
 }
 
@@ -1727,15 +1825,22 @@ impl CreateStreamingDistributionWithTagsResultDeserializer {
     }
 }
 #[doc="<p>A complex type that controls:</p> <ul> <li> <p>Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range with custom error messages before returning the response to the viewer. </p> </li> <li> <p>How long CloudFront caches HTTP status codes in the 4xx and 5xx range.</p> </li> </ul> <p>For more information about custom error pages, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html\">Customizing Error Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CustomErrorResponse {
     #[doc="<p>The minimum amount of time, in seconds, that you want CloudFront to cache the HTTP status code specified in <code>ErrorCode</code>. When this time period has elapsed, CloudFront queries your origin to see whether the problem that caused the error has been resolved and the requested object is now available.</p> <p>If you don't want to specify a value, include an empty element, <code>&lt;ErrorCachingMinTTL&gt;</code>, in the XML document.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html\">Customizing Error Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="ErrorCachingMinTTL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub error_caching_min_ttl: Option<i64>,
     #[doc="<p>The HTTP status code for which you want to specify a custom error page and/or a caching duration.</p>"]
+    #[serde(rename="ErrorCode")]
     pub error_code: i64,
     #[doc="<p>The HTTP status code that you want CloudFront to return to the viewer along with the custom error page. There are a variety of reasons that you might want CloudFront to return a status code different from the status code that your origin returned to CloudFront, for example:</p> <ul> <li> <p>Some Internet devices (some firewalls and corporate proxies, for example) intercept HTTP 4xx and 5xx and prevent the response from being returned to the viewer. If you substitute <code>200</code>, the response typically won't be intercepted.</p> </li> <li> <p>If you don't care about distinguishing among different client errors or server errors, you can specify <code>400</code> or <code>500</code> as the <code>ResponseCode</code> for all 4xx or 5xx errors.</p> </li> <li> <p>You might want to return a <code>200</code> status code (OK) and static website so your customers don't know that your website is down.</p> </li> </ul> <p>If you specify a value for <code>ResponseCode</code>, you must also specify a value for <code>ResponsePagePath</code>. If you don't want to specify a value, include an empty element, <code>&lt;ResponseCode&gt;</code>, in the XML document.</p>"]
+    #[serde(rename="ResponseCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub response_code: Option<String>,
     #[doc="<p>The path to the custom error page that you want CloudFront to return to a viewer when your origin returns the HTTP status code specified by <code>ErrorCode</code>, for example, <code>/4xx-errors/403-forbidden.html</code>. If you want to store your objects and your custom error pages in different locations, your distribution must include a cache behavior for which the following is true:</p> <ul> <li> <p>The value of <code>PathPattern</code> matches the path to your custom error messages. For example, suppose you saved custom error pages for 4xx errors in an Amazon S3 bucket in a directory named <code>/4xx-errors</code>. Your distribution must include a cache behavior for which the path pattern routes requests for your custom error pages to that location, for example, <code>/4xx-errors/*</code>. </p> </li> <li> <p>The value of <code>TargetOriginId</code> specifies the value of the <code>ID</code> element for the origin that contains your custom error pages.</p> </li> </ul> <p>If you specify a value for <code>ResponsePagePath</code>, you must also specify a value for <code>ResponseCode</code>. If you don't want to specify a value, include an empty element, <code>&lt;ResponsePagePath&gt;</code>, in the XML document.</p> <p>We recommend that you store custom error pages in an Amazon S3 bucket. If you store custom error pages on an HTTP server and the server starts to return 5xx errors, CloudFront can't get the files that you want to return to viewers because the origin server is unavailable.</p>"]
+    #[serde(rename="ResponsePagePath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub response_page_path: Option<String>,
 }
 
@@ -1894,11 +1999,14 @@ impl CustomErrorResponseListSerializer {
 }
 
 #[doc="<p>A complex type that controls:</p> <ul> <li> <p>Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range with custom error messages before returning the response to the viewer.</p> </li> <li> <p>How long CloudFront caches HTTP status codes in the 4xx and 5xx range.</p> </li> </ul> <p>For more information about custom error pages, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html\">Customizing Error Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CustomErrorResponses {
     #[doc="<p>A complex type that contains a <code>CustomErrorResponse</code> element for each HTTP status code for which you want to specify a custom error page and/or a caching duration. </p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<CustomErrorResponse>>,
     #[doc="<p>The number of HTTP status codes for which you want to specify a custom error page and/or a caching duration. If <code>Quantity</code> is <code>0</code>, you can omit <code>Items</code>.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -1973,11 +2081,14 @@ impl CustomErrorResponsesSerializer {
 }
 
 #[doc="<p>A complex type that contains the list of Custom Headers for each origin. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CustomHeaders {
     #[doc="<p> <b>Optional</b>: A list that contains one <code>OriginCustomHeader</code> element for each custom header that you want CloudFront to forward to the origin. If Quantity is <code>0</code>, omit <code>Items</code>.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<OriginCustomHeader>>,
     #[doc="<p>The number of custom headers, if any, for this distribution.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -2052,19 +2163,28 @@ impl CustomHeadersSerializer {
 }
 
 #[doc="<p>A customer origin.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CustomOriginConfig {
     #[doc="<p>The HTTP port the custom origin listens on.</p>"]
+    #[serde(rename="HTTPPort")]
     pub http_port: i64,
     #[doc="<p>The HTTPS port the custom origin listens on.</p>"]
+    #[serde(rename="HTTPSPort")]
     pub https_port: i64,
     #[doc="<p>You can create a custom keep-alive timeout. All timeout units are in seconds. The default keep-alive timeout is 5 seconds, but you can configure custom timeout lengths using the CloudFront API. The minimum timeout length is 1 second; the maximum is 60 seconds.</p> <p>If you need to increase the maximum time limit, contact the <a href=\"https://console.aws.amazon.com/support/home#/\">AWS Support Center</a>.</p>"]
+    #[serde(rename="OriginKeepaliveTimeout")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub origin_keepalive_timeout: Option<i64>,
     #[doc="<p>The origin protocol policy to apply to your origin.</p>"]
+    #[serde(rename="OriginProtocolPolicy")]
     pub origin_protocol_policy: String,
     #[doc="<p>You can create a custom origin read timeout. All timeout units are in seconds. The default origin read timeout is 30 seconds, but you can configure custom timeout lengths using the CloudFront API. The minimum timeout length is 4 seconds; the maximum is 60 seconds.</p> <p>If you need to increase the maximum time limit, contact the <a href=\"https://console.aws.amazon.com/support/home#/\">AWS Support Center</a>.</p>"]
+    #[serde(rename="OriginReadTimeout")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub origin_read_timeout: Option<i64>,
     #[doc="<p>The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS.</p>"]
+    #[serde(rename="OriginSslProtocols")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub origin_ssl_protocols: Option<OriginSslProtocols>,
 }
 
@@ -2181,27 +2301,44 @@ impl CustomOriginConfigSerializer {
 }
 
 #[doc="<p>A complex type that describes the default cache behavior if you do not specify a <code>CacheBehavior</code> element or if files don't match any of the values of <code>PathPattern</code> in <code>CacheBehavior</code> elements. You must create exactly one default cache behavior.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DefaultCacheBehavior {
+    #[serde(rename="AllowedMethods")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allowed_methods: Option<AllowedMethods>,
     #[doc="<p>Whether you want CloudFront to automatically compress certain files for this cache behavior. If so, specify <code>true</code>; if not, specify <code>false</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html\">Serving Compressed Files</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="Compress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub compress: Option<bool>,
     #[doc="<p>The default amount of time that you want objects to stay in CloudFront caches before CloudFront forwards another request to your origin to determine whether the object has been updated. The value that you specify applies only when your origin does not add HTTP headers such as <code>Cache-Control max-age</code>, <code>Cache-Control s-maxage</code>, and <code>Expires</code> to objects. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html\">Specifying How Long Objects and Errors Stay in a CloudFront Edge Cache (Expiration)</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="DefaultTTL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_ttl: Option<i64>,
     #[doc="<p>A complex type that specifies how CloudFront handles query strings and cookies.</p>"]
+    #[serde(rename="ForwardedValues")]
     pub forwarded_values: ForwardedValues,
     #[doc="<p>A complex type that contains zero or more Lambda function associations for a cache behavior.</p>"]
+    #[serde(rename="LambdaFunctionAssociations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lambda_function_associations: Option<LambdaFunctionAssociations>,
+    #[serde(rename="MaxTTL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_ttl: Option<i64>,
     #[doc="<p>The minimum amount of time that you want objects to stay in CloudFront caches before CloudFront forwards another request to your origin to determine whether the object has been updated. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html\">Specifying How Long Objects and Errors Stay in a CloudFront Edge Cache (Expiration)</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p> <p>You must specify <code>0</code> for <code>MinTTL</code> if you configure CloudFront to forward all headers to your origin (under <code>Headers</code>, if you specify <code>1</code> for <code>Quantity</code> and <code>*</code> for <code>Name</code>).</p>"]
+    #[serde(rename="MinTTL")]
     pub min_ttl: i64,
     #[doc="<p>Indicates whether you want to distribute media files in the Microsoft Smooth Streaming format using the origin that is associated with this cache behavior. If so, specify <code>true</code>; if not, specify <code>false</code>. If you specify <code>true</code> for <code>SmoothStreaming</code>, you can still distribute other content using this cache behavior if the content matches the value of <code>PathPattern</code>. </p>"]
+    #[serde(rename="SmoothStreaming")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub smooth_streaming: Option<bool>,
     #[doc="<p>The value of <code>ID</code> for the origin that you want CloudFront to route requests to when a request matches the path pattern either for a cache behavior or for the default cache behavior.</p>"]
+    #[serde(rename="TargetOriginId")]
     pub target_origin_id: String,
     #[doc="<p>A complex type that specifies the AWS accounts, if any, that you want to allow to create signed URLs for private content.</p> <p>If you want to require signed URLs in requests for objects in the target origin that match the <code>PathPattern</code> for this cache behavior, specify <code>true</code> for <code>Enabled</code>, and specify the applicable values for <code>Quantity</code> and <code>Items</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private Content through CloudFront</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p> <p>If you don't want to require signed URLs in requests for objects that match <code>PathPattern</code>, specify <code>false</code> for <code>Enabled</code> and <code>0</code> for <code>Quantity</code>. Omit <code>Items</code>.</p> <p>To add, change, or remove one or more trusted signers, change <code>Enabled</code> to <code>true</code> (if it's currently <code>false</code>), change <code>Quantity</code> as applicable, and specify all of the trusted signers that you want to include in the updated distribution.</p>"]
+    #[serde(rename="TrustedSigners")]
     pub trusted_signers: TrustedSigners,
     #[doc="<p>The protocol that viewers can use to access the files in the origin specified by <code>TargetOriginId</code> when a request matches the path pattern in <code>PathPattern</code>. You can specify the following options:</p> <ul> <li> <p> <code>allow-all</code>: Viewers can use HTTP or HTTPS.</p> </li> <li> <p> <code>redirect-to-https</code>: If a viewer submits an HTTP request, CloudFront returns an HTTP status code of 301 (Moved Permanently) to the viewer along with the HTTPS URL. The viewer then resubmits the request using the new URL.</p> </li> <li> <p> <code>https-only</code>: If a viewer sends an HTTP request, CloudFront returns an HTTP status code of 403 (Forbidden).</p> </li> </ul> <p>For more information about requiring the HTTPS protocol, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html\">Using an HTTPS Connection to Access Your Objects</a> in the <i>Amazon CloudFront Developer Guide</i>.</p> <note> <p>The only way to guarantee that viewers retrieve an object that was fetched from the origin using HTTPS is never to use any other protocol to fetch the object. If you have recently changed from HTTP to HTTPS, we recommend that you clear your objects' cache because cached objects are protocol agnostic. That means that an edge location will return an object from the cache regardless of whether the current request protocol matches the protocol used previously. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html\">Specifying How Long Objects and Errors Stay in a CloudFront Edge Cache (Expiration)</a> in the <i>Amazon CloudFront Developer Guide</i>.</p> </note>"]
+    #[serde(rename="ViewerProtocolPolicy")]
     pub viewer_protocol_policy: String,
 }
 
@@ -2359,50 +2496,67 @@ impl DefaultCacheBehaviorSerializer {
 }
 
 #[doc="<p>Deletes a origin access identity.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteCloudFrontOriginAccessIdentityRequest {
     #[doc="<p>The origin access identity's ID.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The value of the <code>ETag</code> header you received from a previous <code>GET</code> or <code>PUT</code> request. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="IfMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_match: Option<String>,
 }
 
 #[doc="<p>This action deletes a web distribution. To delete a web distribution using the CloudFront API, perform the following steps.</p> <p> <b>To delete a web distribution using the CloudFront API:</b> </p> <ol> <li> <p>Disable the web distribution </p> </li> <li> <p>Submit a <code>GET Distribution Config</code> request to get the current configuration and the <code>Etag</code> header for the distribution.</p> </li> <li> <p>Update the XML document that was returned in the response to your <code>GET Distribution Config</code> request to change the value of <code>Enabled</code> to <code>false</code>.</p> </li> <li> <p>Submit a <code>PUT Distribution Config</code> request to update the configuration for your distribution. In the request body, include the XML document that you updated in Step 3. Set the value of the HTTP <code>If-Match</code> header to the value of the <code>ETag</code> header that CloudFront returned when you submitted the <code>GET Distribution Config</code> request in Step 2.</p> </li> <li> <p>Review the response to the <code>PUT Distribution Config</code> request to confirm that the distribution was successfully disabled.</p> </li> <li> <p>Submit a <code>GET Distribution</code> request to confirm that your changes have propagated. When propagation is complete, the value of <code>Status</code> is <code>Deployed</code>.</p> </li> <li> <p>Submit a <code>DELETE Distribution</code> request. Set the value of the HTTP <code>If-Match</code> header to the value of the <code>ETag</code> header that CloudFront returned when you submitted the <code>GET Distribution Config</code> request in Step 6.</p> </li> <li> <p>Review the response to your <code>DELETE Distribution</code> request to confirm that the distribution was successfully deleted.</p> </li> </ol> <p>For information about deleting a distribution using the CloudFront console, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HowToDeleteDistribution.html\">Deleting a Distribution</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteDistributionRequest {
     #[doc="<p>The distribution ID. </p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The value of the <code>ETag</code> header that you received when you disabled the distribution. For example: <code>E2QWRUHAPOMQZL</code>. </p>"]
+    #[serde(rename="IfMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_match: Option<String>,
 }
 
 #[doc="<p>The request to delete a streaming distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteStreamingDistributionRequest {
     #[doc="<p>The distribution ID. </p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The value of the <code>ETag</code> header that you received when you disabled the streaming distribution. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="IfMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_match: Option<String>,
 }
 
 #[doc="<p>The distribution's information.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Distribution {
     #[doc="<p>The ARN (Amazon Resource Name) for the distribution. For example: <code>arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5</code>, where <code>123456789012</code> is your AWS account ID.</p>"]
+    #[serde(rename="ARN")]
     pub arn: String,
     #[doc="<p>CloudFront automatically adds this element to the response only if you've set up the distribution to serve private content with signed URLs. The element lists the key pair IDs that CloudFront is aware of for each trusted signer. The <code>Signer</code> child element lists the AWS account number of the trusted signer (or an empty <code>Self</code> element if the signer is you). The <code>Signer</code> element also includes the IDs of any active key pairs associated with the trusted signer's AWS account. If no <code>KeyPairId</code> element appears for a <code>Signer</code>, that signer can't create working signed URLs.</p>"]
+    #[serde(rename="ActiveTrustedSigners")]
     pub active_trusted_signers: ActiveTrustedSigners,
     #[doc="<p>The current configuration information for the distribution. Send a <code>GET</code> request to the <code>/<i>CloudFront API version</i>/distribution ID/config</code> resource.</p>"]
+    #[serde(rename="DistributionConfig")]
     pub distribution_config: DistributionConfig,
     #[doc="<p>The domain name corresponding to the distribution. For example: <code>d604721fxaaqy9.cloudfront.net</code>. </p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>The identifier for the distribution. For example: <code>EDFDVBD632BHDS5</code>. </p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The number of invalidation batches currently in progress. </p>"]
+    #[serde(rename="InProgressInvalidationBatches")]
     pub in_progress_invalidation_batches: i64,
     #[doc="<p>The date and time the distribution was last modified. </p>"]
+    #[serde(rename="LastModifiedTime")]
     pub last_modified_time: String,
     #[doc="<p>This response element indicates the current status of the distribution. When the status is <code>Deployed</code>, the distribution's information is fully propagated to all CloudFront edge locations. </p>"]
+    #[serde(rename="Status")]
     pub status: String,
 }
 
@@ -2477,37 +2631,64 @@ impl DistributionDeserializer {
     }
 }
 #[doc="<p>A distribution configuration.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DistributionConfig {
     #[doc="<p>A complex type that contains information about CNAMEs (alternate domain names), if any, for this distribution.</p>"]
+    #[serde(rename="Aliases")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub aliases: Option<Aliases>,
     #[doc="<p>A complex type that contains zero or more <code>CacheBehavior</code> elements. </p>"]
+    #[serde(rename="CacheBehaviors")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_behaviors: Option<CacheBehaviors>,
     #[doc="<p>A unique value (for example, a date-time stamp) that ensures that the request can't be replayed.</p> <p>If the value of <code>CallerReference</code> is new (regardless of the content of the <code>DistributionConfig</code> object), CloudFront creates a new distribution.</p> <p>If <code>CallerReference</code> is a value you already sent in a previous request to create a distribution, and if the content of the <code>DistributionConfig</code> is identical to the original request (ignoring white space), CloudFront returns the same the response that it returned to the original request.</p> <p>If <code>CallerReference</code> is a value you already sent in a previous request to create a distribution but the content of the <code>DistributionConfig</code> is different from the original request, CloudFront returns a <code>DistributionAlreadyExists</code> error.</p>"]
+    #[serde(rename="CallerReference")]
     pub caller_reference: String,
     #[doc="<p>Any comments you want to include about the distribution.</p> <p>If you don't want to specify a comment, include an empty <code>Comment</code> element.</p> <p>To delete an existing comment, update the distribution configuration and include an empty <code>Comment</code> element.</p> <p>To add or change a comment, update the distribution configuration and specify the new comment.</p>"]
+    #[serde(rename="Comment")]
     pub comment: String,
     #[doc="<p>A complex type that controls the following:</p> <ul> <li> <p>Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range with custom error messages before returning the response to the viewer.</p> </li> <li> <p>How long CloudFront caches HTTP status codes in the 4xx and 5xx range.</p> </li> </ul> <p>For more information about custom error pages, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html\">Customizing Error Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="CustomErrorResponses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub custom_error_responses: Option<CustomErrorResponses>,
     #[doc="<p>A complex type that describes the default cache behavior if you do not specify a <code>CacheBehavior</code> element or if files don't match any of the values of <code>PathPattern</code> in <code>CacheBehavior</code> elements. You must create exactly one default cache behavior.</p>"]
+    #[serde(rename="DefaultCacheBehavior")]
     pub default_cache_behavior: DefaultCacheBehavior,
     #[doc="<p>The object that you want CloudFront to request from your origin (for example, <code>index.html</code>) when a viewer requests the root URL for your distribution (<code>http://www.example.com</code>) instead of an object in your distribution (<code>http://www.example.com/product-description.html</code>). Specifying a default root object avoids exposing the contents of your distribution.</p> <p>Specify only the object name, for example, <code>index.html</code>. Do not add a <code>/</code> before the object name.</p> <p>If you don't want to specify a default root object when you create a distribution, include an empty <code>DefaultRootObject</code> element.</p> <p>To delete the default root object from an existing distribution, update the distribution configuration and include an empty <code>DefaultRootObject</code> element.</p> <p>To replace the default root object, update the distribution configuration and specify the new object.</p> <p>For more information about the default root object, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DefaultRootObject.html\">Creating a Default Root Object</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="DefaultRootObject")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_root_object: Option<String>,
     #[doc="<p>From this field, you can enable or disable the selected distribution.</p> <p>If you specify <code>false</code> for <code>Enabled</code> but you specify values for <code>Bucket</code> and <code>Prefix</code>, the values are automatically deleted.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p>(Optional) Specify the maximum HTTP version that you want viewers to use to communicate with CloudFront. The default value for new web distributions is http2. Viewers that don't support HTTP/2 automatically use an earlier HTTP version.</p> <p>For viewers and CloudFront to use HTTP/2, viewers must support TLS 1.2 or later, and must support Server Name Identification (SNI).</p> <p>In general, configuring CloudFront to communicate with viewers using HTTP/2 reduces latency. You can improve performance by optimizing for HTTP/2. For more information, do an Internet search for \"http/2 optimization.\" </p>"]
+    #[serde(rename="HttpVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub http_version: Option<String>,
     #[doc="<p>If you want CloudFront to respond to IPv6 DNS requests with an IPv6 address for your distribution, specify <code>true</code>. If you specify <code>false</code>, CloudFront responds to IPv6 DNS requests with the DNS response code <code>NOERROR</code> and with no IP addresses. This allows viewers to submit a second request, for an IPv4 address for your distribution. </p> <p>In general, you should enable IPv6 if you have users on IPv6 networks who want to access your content. However, if you're using signed URLs or signed cookies to restrict access to your content, and if you're using a custom policy that includes the <code>IpAddress</code> parameter to restrict the IP addresses that can access your content, do not enable IPv6. If you want to restrict access to some content by IP address and not restrict access to other content (or restrict access but not by IP address), you can create two distributions. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-custom-policy.html\">Creating a Signed URL Using a Custom Policy</a> in the <i>Amazon CloudFront Developer Guide</i>.</p> <p>If you're using an Amazon Route 53 alias resource record set to route traffic to your CloudFront distribution, you need to create a second alias resource record set when both of the following are true:</p> <ul> <li> <p>You enable IPv6 for the distribution</p> </li> <li> <p>You're using alternate domain names in the URLs for your objects</p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-cloudfront-distribution.html\">Routing Traffic to an Amazon CloudFront Web Distribution by Using Your Domain Name</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> <p>If you created a CNAME resource record set, either with Amazon Route 53 or with another DNS service, you don't need to make any changes. A CNAME record will route traffic to your distribution regardless of the IP address format of the viewer request.</p>"]
+    #[serde(rename="IsIPV6Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_ipv6_enabled: Option<bool>,
     #[doc="<p>A complex type that controls whether access logs are written for the distribution.</p> <p>For more information about logging, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html\">Access Logs</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="Logging")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub logging: Option<LoggingConfig>,
     #[doc="<p>A complex type that contains information about origins for this distribution. </p>"]
+    #[serde(rename="Origins")]
     pub origins: Origins,
     #[doc="<p>The price class that corresponds with the maximum price that you want to pay for CloudFront service. If you specify <code>PriceClass_All</code>, CloudFront responds to requests for your objects from all CloudFront edge locations.</p> <p>If you specify a price class other than <code>PriceClass_All</code>, CloudFront serves your objects from the CloudFront edge location that has the lowest latency among the edge locations in your price class. Viewers who are in or near regions that are excluded from your specified price class may encounter slower performance.</p> <p>For more information about price classes, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PriceClass.html\">Choosing the Price Class for a CloudFront Distribution</a> in the <i>Amazon CloudFront Developer Guide</i>. For information about CloudFront pricing, including how price classes map to CloudFront regions, see <a href=\"https://aws.amazon.com/cloudfront/pricing/\">Amazon CloudFront Pricing</a>.</p>"]
+    #[serde(rename="PriceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub price_class: Option<String>,
+    #[serde(rename="Restrictions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub restrictions: Option<Restrictions>,
+    #[serde(rename="ViewerCertificate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub viewer_certificate: Option<ViewerCertificate>,
     #[doc="<p>A unique identifier that specifies the AWS WAF web ACL, if any, to associate with this distribution.</p> <p>AWS WAF is a web application firewall that lets you monitor the HTTP and HTTPS requests that are forwarded to CloudFront, and lets you control access to your content. Based on conditions that you specify, such as the IP addresses that requests originate from or the values of query strings, CloudFront responds to requests either with the requested content or with an HTTP 403 status code (Forbidden). You can also configure CloudFront to return a custom error page when a request is blocked. For more information about AWS WAF, see the <a href=\"http://docs.aws.amazon.com/waf/latest/developerguide/what-is-aws-waf.html\">AWS WAF Developer Guide</a>. </p>"]
+    #[serde(rename="WebACLId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub web_acl_id: Option<String>,
 }
 
@@ -2703,11 +2884,13 @@ impl DistributionConfigSerializer {
 }
 
 #[doc="<p>A distribution Configuration and a list of tags to be associated with the distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DistributionConfigWithTags {
     #[doc="<p>A distribution configuration.</p>"]
+    #[serde(rename="DistributionConfig")]
     pub distribution_config: DistributionConfig,
     #[doc="<p>A complex type that contains zero or more <code>Tag</code> elements.</p>"]
+    #[serde(rename="Tags")]
     pub tags: Tags,
 }
 
@@ -2731,19 +2914,27 @@ impl DistributionConfigWithTagsSerializer {
 }
 
 #[doc="<p>A distribution list.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DistributionList {
     #[doc="<p>A flag that indicates whether more distributions remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more distributions in the list.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>A complex type that contains one <code>DistributionSummary</code> element for each distribution that was created by the current AWS account.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<DistributionSummary>>,
     #[doc="<p>The value you provided for the <code>Marker</code> request parameter.</p>"]
+    #[serde(rename="Marker")]
     pub marker: String,
     #[doc="<p>The value you provided for the <code>MaxItems</code> request parameter.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: i64,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value you can use for the <code>Marker</code> request parameter to continue listing your distributions where they left off. </p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
     #[doc="<p>The number of distributions that were created by the current AWS account. </p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -2810,40 +3001,58 @@ impl DistributionListDeserializer {
     }
 }
 #[doc="<p>A summary of the information about a CloudFront distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DistributionSummary {
     #[doc="<p>The ARN (Amazon Resource Name) for the distribution. For example: <code>arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5</code>, where <code>123456789012</code> is your AWS account ID.</p>"]
+    #[serde(rename="ARN")]
     pub arn: String,
     #[doc="<p>A complex type that contains information about CNAMEs (alternate domain names), if any, for this distribution.</p>"]
+    #[serde(rename="Aliases")]
     pub aliases: Aliases,
     #[doc="<p>A complex type that contains zero or more <code>CacheBehavior</code> elements.</p>"]
+    #[serde(rename="CacheBehaviors")]
     pub cache_behaviors: CacheBehaviors,
     #[doc="<p>The comment originally specified when this distribution was created.</p>"]
+    #[serde(rename="Comment")]
     pub comment: String,
     #[doc="<p>A complex type that contains zero or more <code>CustomErrorResponses</code> elements.</p>"]
+    #[serde(rename="CustomErrorResponses")]
     pub custom_error_responses: CustomErrorResponses,
     #[doc="<p>A complex type that describes the default cache behavior if you do not specify a <code>CacheBehavior</code> element or if files don't match any of the values of <code>PathPattern</code> in <code>CacheBehavior</code> elements. You must create exactly one default cache behavior.</p>"]
+    #[serde(rename="DefaultCacheBehavior")]
     pub default_cache_behavior: DefaultCacheBehavior,
     #[doc="<p>The domain name that corresponds to the distribution. For example: <code>d604721fxaaqy9.cloudfront.net</code>.</p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>Whether the distribution is enabled to accept user requests for content.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p> Specify the maximum HTTP version that you want viewers to use to communicate with CloudFront. The default value for new web distributions is <code>http2</code>. Viewers that don't support <code>HTTP/2</code> will automatically use an earlier version.</p>"]
+    #[serde(rename="HttpVersion")]
     pub http_version: String,
     #[doc="<p>The identifier for the distribution. For example: <code>EDFDVBD632BHDS5</code>.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>Whether CloudFront responds to IPv6 DNS requests with an IPv6 address for your distribution.</p>"]
+    #[serde(rename="IsIPV6Enabled")]
     pub is_ipv6_enabled: bool,
     #[doc="<p>The date and time the distribution was last modified.</p>"]
+    #[serde(rename="LastModifiedTime")]
     pub last_modified_time: String,
     #[doc="<p>A complex type that contains information about origins for this distribution.</p>"]
+    #[serde(rename="Origins")]
     pub origins: Origins,
+    #[serde(rename="PriceClass")]
     pub price_class: String,
+    #[serde(rename="Restrictions")]
     pub restrictions: Restrictions,
     #[doc="<p>The current status of the distribution. When the status is <code>Deployed</code>, the distribution's information is propagated to all CloudFront edge locations.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
+    #[serde(rename="ViewerCertificate")]
     pub viewer_certificate: ViewerCertificate,
     #[doc="<p>The Web ACL Id (if any) associated with the distribution.</p>"]
+    #[serde(rename="WebACLId")]
     pub web_acl_id: String,
 }
 
@@ -3028,15 +3237,21 @@ impl EventTypeSerializer {
 }
 
 #[doc="<p>A complex type that specifies how CloudFront handles query strings and cookies.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ForwardedValues {
     #[doc="<p>A complex type that specifies whether you want CloudFront to forward cookies to the origin and, if so, which ones. For more information about forwarding cookies to the origin, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html\">How CloudFront Forwards, Caches, and Logs Cookies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="Cookies")]
     pub cookies: CookiePreference,
     #[doc="<p>A complex type that specifies the <code>Headers</code>, if any, that you want CloudFront to vary upon for this cache behavior. </p>"]
+    #[serde(rename="Headers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub headers: Option<Headers>,
     #[doc="<p>Indicates whether you want CloudFront to forward query strings to the origin that is associated with this cache behavior and cache based on the query string parameters. CloudFront behavior depends on the value of <code>QueryString</code> and on the values that you specify for <code>QueryStringCacheKeys</code>, if any:</p> <p>If you specify true for <code>QueryString</code> and you don't specify any values for <code>QueryStringCacheKeys</code>, CloudFront forwards all query string parameters to the origin and caches based on all query string parameters. Depending on how many query string parameters and values you have, this can adversely affect performance because CloudFront must forward more requests to the origin.</p> <p>If you specify true for <code>QueryString</code> and you specify one or more values for <code>QueryStringCacheKeys</code>, CloudFront forwards all query string parameters to the origin, but it only caches based on the query string parameters that you specify.</p> <p>If you specify false for <code>QueryString</code>, CloudFront doesn't forward any query string parameters to the origin, and doesn't cache based on query string parameters.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/QueryStringParameters.html\">Configuring CloudFront to Cache Based on Query String Parameters</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="QueryString")]
     pub query_string: bool,
     #[doc="<p>A complex type that contains information about the query string parameters that you want CloudFront to use for caching for this cache behavior.</p>"]
+    #[serde(rename="QueryStringCacheKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub query_string_cache_keys: Option<QueryStringCacheKeys>,
 }
 
@@ -3124,13 +3339,17 @@ impl ForwardedValuesSerializer {
 }
 
 #[doc="<p>A complex type that controls the countries in which your content is distributed. CloudFront determines the location of your users using <code>MaxMind</code> GeoIP databases. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GeoRestriction {
     #[doc="<p> A complex type that contains a <code>Location</code> element for each country in which you want CloudFront either to distribute your content (<code>whitelist</code>) or not distribute your content (<code>blacklist</code>).</p> <p>The <code>Location</code> element is a two-letter, uppercase country code for a country that you want to include in your <code>blacklist</code> or <code>whitelist</code>. Include one <code>Location</code> element for each country.</p> <p>CloudFront and <code>MaxMind</code> both use <code>ISO 3166</code> country codes. For the current list of countries and the corresponding codes, see <code>ISO 3166-1-alpha-2</code> code on the <i>International Organization for Standardization</i> website. You can also refer to the country list in the CloudFront console, which includes both country names and codes.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<String>>,
     #[doc="<p>When geo restriction is <code>enabled</code>, this is the number of countries in your <code>whitelist</code> or <code>blacklist</code>. Otherwise, when it is not enabled, <code>Quantity</code> is <code>0</code>, and you can omit <code>Items</code>.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
     #[doc="<p>The method that you want to use to restrict distribution of your content by country:</p> <ul> <li> <p> <code>none</code>: No geo restriction is enabled, meaning access to content is not restricted by client geo location.</p> </li> <li> <p> <code>blacklist</code>: The <code>Location</code> elements specify the countries in which you do not want CloudFront to distribute your content.</p> </li> <li> <p> <code>whitelist</code>: The <code>Location</code> elements specify the countries in which you want CloudFront to distribute your content.</p> </li> </ul>"]
+    #[serde(rename="RestrictionType")]
     pub restriction_type: String,
 }
 
@@ -3247,18 +3466,23 @@ impl GeoRestrictionTypeSerializer {
 }
 
 #[doc="<p>The origin access identity's configuration information. For more information, see <a>CloudFrontOriginAccessIdentityConfigComplexType</a>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetCloudFrontOriginAccessIdentityConfigRequest {
     #[doc="<p>The identity's ID. </p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetCloudFrontOriginAccessIdentityConfigResult {
     #[doc="<p>The origin access identity's configuration information. </p>"]
+    #[serde(rename="CloudFrontOriginAccessIdentityConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cloud_front_origin_access_identity_config: Option<CloudFrontOriginAccessIdentityConfig>,
     #[doc="<p>The current version of the configuration. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
 }
 
@@ -3305,18 +3529,23 @@ impl GetCloudFrontOriginAccessIdentityConfigResultDeserializer {
     }
 }
 #[doc="<p>The request to get an origin access identity's information.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetCloudFrontOriginAccessIdentityRequest {
     #[doc="<p>The identity's ID.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetCloudFrontOriginAccessIdentityResult {
     #[doc="<p>The origin access identity's information.</p>"]
+    #[serde(rename="CloudFrontOriginAccessIdentity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cloud_front_origin_access_identity: Option<CloudFrontOriginAccessIdentity>,
     #[doc="<p>The current version of the origin access identity's information. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
 }
 
@@ -3363,18 +3592,23 @@ impl GetCloudFrontOriginAccessIdentityResultDeserializer {
     }
 }
 #[doc="<p>The request to get a distribution configuration.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetDistributionConfigRequest {
     #[doc="<p>The distribution's ID.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetDistributionConfigResult {
     #[doc="<p>The distribution's configuration information.</p>"]
+    #[serde(rename="DistributionConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub distribution_config: Option<DistributionConfig>,
     #[doc="<p>The current version of the configuration. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
 }
 
@@ -3422,18 +3656,23 @@ impl GetDistributionConfigResultDeserializer {
     }
 }
 #[doc="<p>The request to get a distribution's information.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetDistributionRequest {
     #[doc="<p>The distribution's ID.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetDistributionResult {
     #[doc="<p>The distribution's information.</p>"]
+    #[serde(rename="Distribution")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub distribution: Option<Distribution>,
     #[doc="<p>The current version of the distribution's information. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
 }
 
@@ -3481,18 +3720,22 @@ impl GetDistributionResultDeserializer {
     }
 }
 #[doc="<p>The request to get an invalidation's information. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetInvalidationRequest {
     #[doc="<p>The distribution's ID.</p>"]
+    #[serde(rename="DistributionId")]
     pub distribution_id: String,
     #[doc="<p>The identifier for the invalidation request, for example, <code>IDFDVBD632BHDS5</code>.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetInvalidationResult {
     #[doc="<p>The invalidation's information. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/InvalidationDatatype.html\">Invalidation Complex Type</a>. </p>"]
+    #[serde(rename="Invalidation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub invalidation: Option<Invalidation>,
 }
 
@@ -3540,18 +3783,23 @@ impl GetInvalidationResultDeserializer {
     }
 }
 #[doc="<p>To request to get a streaming distribution configuration.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetStreamingDistributionConfigRequest {
     #[doc="<p>The streaming distribution's ID.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetStreamingDistributionConfigResult {
     #[doc="<p>The current version of the configuration. For example: <code>E2QWRUHAPOMQZL</code>. </p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="<p>The streaming distribution's configuration information.</p>"]
+    #[serde(rename="StreamingDistributionConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub streaming_distribution_config: Option<StreamingDistributionConfig>,
 }
 
@@ -3598,18 +3846,23 @@ impl GetStreamingDistributionConfigResultDeserializer {
     }
 }
 #[doc="<p>The request to get a streaming distribution's information.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetStreamingDistributionRequest {
     #[doc="<p>The streaming distribution's ID.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetStreamingDistributionResult {
     #[doc="<p>The current version of the streaming distribution's information. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="<p>The streaming distribution's information.</p>"]
+    #[serde(rename="StreamingDistribution")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub streaming_distribution: Option<StreamingDistribution>,
 }
 
@@ -3717,11 +3970,14 @@ impl HeaderListSerializer {
 }
 
 #[doc="<p>A complex type that specifies the headers that you want CloudFront to forward to the origin for this cache behavior.</p> <p>For the headers that you specify, CloudFront also caches separate versions of a specified object based on the header values in viewer requests. For example, suppose viewer requests for <code>logo.jpg</code> contain a custom <code>Product</code> header that has a value of either <code>Acme</code> or <code>Apex</code>, and you configure CloudFront to cache your content based on values in the <code>Product</code> header. CloudFront forwards the <code>Product</code> header to the origin and caches the response from the origin once for each header value. For more information about caching based on header values, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html\">How CloudFront Forwards and Caches Headers</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Headers {
     #[doc="<p>A complex type that contains one <code>Name</code> element for each header that you want CloudFront to forward to the origin and to vary on for this cache behavior. If <code>Quantity</code> is <code>0</code>, omit <code>Items</code>.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<String>>,
     #[doc="<p>The number of different headers that you want CloudFront to forward to the origin for this cache behavior. You can configure each cache behavior in a web distribution to do one of the following:</p> <ul> <li> <p> <b>Forward all headers to your origin</b>: Specify <code>1</code> for <code>Quantity</code> and <code>*</code> for <code>Name</code>.</p> <important> <p>If you configure CloudFront to forward all headers to your origin, CloudFront doesn't cache the objects associated with this cache behavior. Instead, it sends every request to the origin.</p> </important> </li> <li> <p> <i>Forward a whitelist of headers you specify</i>: Specify the number of headers that you want to forward, and specify the header names in <code>Name</code> elements. CloudFront caches your objects based on the values in all of the specified headers. CloudFront also forwards the headers that it forwards by default, but it caches your objects based only on the headers that you specify. </p> </li> <li> <p> <b>Forward only the default headers</b>: Specify <code>0</code> for <code>Quantity</code> and omit <code>Items</code>. In this configuration, CloudFront doesn't cache based on the values in the request headers.</p> </li> </ul>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -3859,15 +4115,19 @@ impl IntegerSerializer {
 }
 
 #[doc="<p>An invalidation. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Invalidation {
     #[doc="<p>The date and time the invalidation request was first made. </p>"]
+    #[serde(rename="CreateTime")]
     pub create_time: String,
     #[doc="<p>The identifier for the invalidation request. For example: <code>IDFDVBD632BHDS5</code>.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The current invalidation information for the batch request. </p>"]
+    #[serde(rename="InvalidationBatch")]
     pub invalidation_batch: InvalidationBatch,
     #[doc="<p>The status of the invalidation request. When the invalidation batch is finished, the status is <code>Completed</code>.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
 }
 
@@ -3925,11 +4185,13 @@ impl InvalidationDeserializer {
     }
 }
 #[doc="<p>An invalidation batch.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct InvalidationBatch {
     #[doc="<p>A value that you specify to uniquely identify an invalidation request. CloudFront uses the value to prevent you from accidentally resubmitting an identical request. Whenever you create a new invalidation request, you must specify a new value for <code>CallerReference</code> and change other values in the request as applicable. One way to ensure that the value of <code>CallerReference</code> is unique is to use a <code>timestamp</code>, for example, <code>20120301090000</code>.</p> <p>If you make a second invalidation request with the same value for <code>CallerReference</code>, and if the rest of the request is the same, CloudFront doesn't create a new invalidation request. Instead, CloudFront returns information about the invalidation request that you previously created with the same <code>CallerReference</code>.</p> <p>If <code>CallerReference</code> is a value you already sent in a previous invalidation batch request but the content of any <code>Path</code> is different from the original request, CloudFront returns an <code>InvalidationBatchAlreadyExists</code> error.</p>"]
+    #[serde(rename="CallerReference")]
     pub caller_reference: String,
     #[doc="<p>A complex type that contains information about the objects that you want to invalidate. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#invalidation-specifying-objects\">Specifying the Objects to Invalidate</a> in the <i>Amazon CloudFront Developer Guide</i>. </p>"]
+    #[serde(rename="Paths")]
     pub paths: Paths,
 }
 
@@ -4001,19 +4263,27 @@ impl InvalidationBatchSerializer {
 }
 
 #[doc="<p>The <code>InvalidationList</code> complex type describes the list of invalidation objects. For more information about invalidation, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html\">Invalidating Objects (Web Distributions Only)</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct InvalidationList {
     #[doc="<p>A flag that indicates whether more invalidation batch requests remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more invalidation batches in the list.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>A complex type that contains one <code>InvalidationSummary</code> element for each invalidation batch created by the current AWS account.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<InvalidationSummary>>,
     #[doc="<p>The value that you provided for the <code>Marker</code> request parameter.</p>"]
+    #[serde(rename="Marker")]
     pub marker: String,
     #[doc="<p>The value that you provided for the <code>MaxItems</code> request parameter.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: i64,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value that you can use for the <code>Marker</code> request parameter to continue listing your invalidation batches where they left off.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
     #[doc="<p>The number of invalidation batches that were created by the current AWS account. </p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -4080,12 +4350,15 @@ impl InvalidationListDeserializer {
     }
 }
 #[doc="<p>A summary of an invalidation request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct InvalidationSummary {
+    #[serde(rename="CreateTime")]
     pub create_time: String,
     #[doc="<p>The unique ID for an invalidation request.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The status of an invalidation request.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
 }
 
@@ -4252,11 +4525,14 @@ impl KeyPairIdListDeserializer {
     }
 }
 #[doc="<p>A complex type that lists the active CloudFront key pairs, if any, that are associated with <code>AwsAccountNumber</code>. </p> <p>For more information, see <a>ActiveTrustedSigners</a>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct KeyPairIds {
     #[doc="<p>A complex type that lists the active CloudFront key pairs, if any, that are associated with <code>AwsAccountNumber</code>.</p> <p>For more information, see <a>ActiveTrustedSigners</a>.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<String>>,
     #[doc="<p>The number of active CloudFront key pairs for <code>AwsAccountNumber</code>.</p> <p>For more information, see <a>ActiveTrustedSigners</a>.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -4307,11 +4583,15 @@ impl KeyPairIdsDeserializer {
     }
 }
 #[doc="<p>A complex type that contains a Lambda function association.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct LambdaFunctionAssociation {
     #[doc="<p>Specifies the event type that triggers a Lambda function invocation. Valid values are:</p> <ul> <li> <p> <code>viewer-request</code> </p> </li> <li> <p> <code>origin-request</code> </p> </li> <li> <p> <code>viewer-response</code> </p> </li> <li> <p> <code>origin-response</code> </p> </li> </ul>"]
+    #[serde(rename="EventType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_type: Option<String>,
     #[doc="<p>The ARN of the Lambda function.</p>"]
+    #[serde(rename="LambdaFunctionARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lambda_function_arn: Option<String>,
 }
 
@@ -4452,11 +4732,14 @@ impl LambdaFunctionAssociationListSerializer {
 }
 
 #[doc="<p>A complex type that specifies a list of Lambda functions associations for a cache behavior.</p> <p>If you want to invoke one or more Lambda functions triggered by requests that match the <code>PathPattern</code> of the cache behavior, specify the applicable values for <code>Quantity</code> and <code>Items</code>. Note that there can be up to 4 <code>LambdaFunctionAssociation</code> items in this list (one for each possible value of <code>EventType</code>) and each <code>EventType</code> can be associated with the Lambda function only once.</p> <p>If you don't want to invoke any Lambda functions for the requests that match <code>PathPattern</code>, specify <code>0</code> for <code>Quantity</code> and omit <code>Items</code>. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct LambdaFunctionAssociations {
     #[doc="<p> <b>Optional</b>: A complex type that contains <code>LambdaFunctionAssociation</code> items for this cache behavior. If <code>Quantity</code> is <code>0</code>, you can omit <code>Items</code>.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<LambdaFunctionAssociation>>,
     #[doc="<p>The number of Lambda function associations for this cache behavior.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -4529,18 +4812,24 @@ impl LambdaFunctionAssociationsSerializer {
 }
 
 #[doc="<p>The request to list origin access identities. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListCloudFrontOriginAccessIdentitiesRequest {
     #[doc="<p>Use this when paginating results to indicate where to begin in your list of origin access identities. The results include identities in the list that occur after the marker. To get the next page of results, set the <code>Marker</code> to the value of the <code>NextMarker</code> from the current page's response (which is also the ID of the last identity on that page).</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of origin access identities you want in the response body. </p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListCloudFrontOriginAccessIdentitiesResult {
     #[doc="<p>The <code>CloudFrontOriginAccessIdentityList</code> type. </p>"]
+    #[serde(rename="CloudFrontOriginAccessIdentityList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cloud_front_origin_access_identity_list: Option<CloudFrontOriginAccessIdentityList>,
 }
 
@@ -4587,20 +4876,27 @@ impl ListCloudFrontOriginAccessIdentitiesResultDeserializer {
     }
 }
 #[doc="<p>The request to list distributions that are associated with a specified AWS WAF web ACL. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListDistributionsByWebACLIdRequest {
     #[doc="<p>Use <code>Marker</code> and <code>MaxItems</code> to control pagination of results. If you have more than <code>MaxItems</code> distributions that satisfy the request, the response includes a <code>NextMarker</code> element. To get the next page of results, submit another request. For the value of <code>Marker</code>, specify the value of <code>NextMarker</code> from the last response. (For the first request, omit <code>Marker</code>.) </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of distributions that you want CloudFront to return in the response body. The maximum and default values are both 100.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
     #[doc="<p>The ID of the AWS WAF web ACL that you want to list the associated distributions. If you specify \"null\" for the ID, the request returns a list of the distributions that aren't associated with a web ACL. </p>"]
+    #[serde(rename="WebACLId")]
     pub web_acl_id: String,
 }
 
 #[doc="<p>The response to a request to list the distributions that are associated with a specified AWS WAF web ACL. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListDistributionsByWebACLIdResult {
     #[doc="<p>The <code>DistributionList</code> type. </p>"]
+    #[serde(rename="DistributionList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub distribution_list: Option<DistributionList>,
 }
 
@@ -4649,18 +4945,24 @@ impl ListDistributionsByWebACLIdResultDeserializer {
     }
 }
 #[doc="<p>The request to list your distributions. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListDistributionsRequest {
     #[doc="<p>Use this when paginating results to indicate where to begin in your list of distributions. The results include distributions in the list that occur after the marker. To get the next page of results, set the <code>Marker</code> to the value of the <code>NextMarker</code> from the current page's response (which is also the ID of the last distribution on that page).</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of distributions you want in the response body.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListDistributionsResult {
     #[doc="<p>The <code>DistributionList</code> type. </p>"]
+    #[serde(rename="DistributionList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub distribution_list: Option<DistributionList>,
 }
 
@@ -4708,20 +5010,27 @@ impl ListDistributionsResultDeserializer {
     }
 }
 #[doc="<p>The request to list invalidations. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListInvalidationsRequest {
     #[doc="<p>The distribution's ID.</p>"]
+    #[serde(rename="DistributionId")]
     pub distribution_id: String,
     #[doc="<p>Use this parameter when paginating results to indicate where to begin in your list of invalidation batches. Because the results are returned in decreasing order from most recent to oldest, the most recent results are on the first page, the second page will contain earlier results, and so on. To get the next page of results, set <code>Marker</code> to the value of the <code>NextMarker</code> from the current page's response. This value is the same as the ID of the last invalidation batch on that page. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of invalidation batches that you want in the response body.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListInvalidationsResult {
     #[doc="<p>Information about invalidation batches. </p>"]
+    #[serde(rename="InvalidationList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub invalidation_list: Option<InvalidationList>,
 }
 
@@ -4769,18 +5078,24 @@ impl ListInvalidationsResultDeserializer {
     }
 }
 #[doc="<p>The request to list your streaming distributions. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListStreamingDistributionsRequest {
     #[doc="<p>The value that you provided for the <code>Marker</code> request parameter.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The value that you provided for the <code>MaxItems</code> request parameter.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
 }
 
 #[doc="<p>The returned result of the corresponding request. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListStreamingDistributionsResult {
     #[doc="<p>The <code>StreamingDistributionList</code> type. </p>"]
+    #[serde(rename="StreamingDistributionList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub streaming_distribution_list: Option<StreamingDistributionList>,
 }
 
@@ -4827,16 +5142,18 @@ impl ListStreamingDistributionsResultDeserializer {
     }
 }
 #[doc="<p> The request to list tags for a CloudFront resource.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTagsForResourceRequest {
     #[doc="<p> An ARN of a CloudFront resource.</p>"]
+    #[serde(rename="Resource")]
     pub resource: String,
 }
 
 #[doc="<p> The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTagsForResourceResult {
     #[doc="<p> A complex type that contains zero or more <code>Tag</code> elements.</p>"]
+    #[serde(rename="Tags")]
     pub tags: Tags,
 }
 
@@ -4942,15 +5259,19 @@ impl LocationListSerializer {
 }
 
 #[doc="<p>A complex type that controls whether access logs are written for the distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct LoggingConfig {
     #[doc="<p>The Amazon S3 bucket to store the access logs in, for example, <code>myawslogbucket.s3.amazonaws.com</code>.</p>"]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="<p>Specifies whether you want CloudFront to save access logs to an Amazon S3 bucket. If you do not want to enable logging when you create a distribution or if you want to disable logging for an existing distribution, specify <code>false</code> for <code>Enabled</code>, and specify empty <code>Bucket</code> and <code>Prefix</code> elements. If you specify <code>false</code> for <code>Enabled</code> but you specify values for <code>Bucket</code>, <code>prefix</code>, and <code>IncludeCookies</code>, the values are automatically deleted.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p>Specifies whether you want CloudFront to include cookies in access logs, specify <code>true</code> for <code>IncludeCookies</code>. If you choose to include cookies in logs, CloudFront logs all cookies regardless of how you configure the cache behaviors for this distribution. If you do not want to include cookies when you create a distribution or if you want to disable include cookies for an existing distribution, specify <code>false</code> for <code>IncludeCookies</code>.</p>"]
+    #[serde(rename="IncludeCookies")]
     pub include_cookies: bool,
     #[doc="<p>An optional string that you want CloudFront to prefix to the access log <code>filenames</code> for this distribution, for example, <code>myprefix/</code>. If you want to enable logging, but you do not want to specify a prefix, you still must include an empty <code>Prefix</code> element in the <code>Logging</code> element.</p>"]
+    #[serde(rename="Prefix")]
     pub prefix: String,
 }
 
@@ -5198,19 +5519,29 @@ impl MinimumProtocolVersionSerializer {
 }
 
 #[doc="<p>A complex type that describes the Amazon S3 bucket or the HTTP server (for example, a web server) from which CloudFront gets your files. You must create at least one origin.</p> <p>For the current limit on the number of origins that you can create for a distribution, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_cloudfront\">Amazon CloudFront Limits</a> in the <i>AWS General Reference</i>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Origin {
     #[doc="<p>A complex type that contains names and values for the custom headers that you want.</p>"]
+    #[serde(rename="CustomHeaders")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub custom_headers: Option<CustomHeaders>,
     #[doc="<p>A complex type that contains information about a custom origin. If the origin is an Amazon S3 bucket, use the <code>S3OriginConfig</code> element instead.</p>"]
+    #[serde(rename="CustomOriginConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub custom_origin_config: Option<CustomOriginConfig>,
     #[doc="<p> <b>Amazon S3 origins</b>: The DNS name of the Amazon S3 bucket from which you want CloudFront to get objects for this origin, for example, <code>myawsbucket.s3.amazonaws.com</code>.</p> <p>Constraints for Amazon S3 origins: </p> <ul> <li> <p>If you configured Amazon S3 Transfer Acceleration for your bucket, do not specify the <code>s3-accelerate</code> endpoint for <code>DomainName</code>.</p> </li> <li> <p>The bucket name must be between 3 and 63 characters long (inclusive).</p> </li> <li> <p>The bucket name must contain only lowercase characters, numbers, periods, underscores, and dashes.</p> </li> <li> <p>The bucket name must not contain adjacent periods.</p> </li> </ul> <p> <b>Custom Origins</b>: The DNS domain name for the HTTP server from which you want CloudFront to get objects for this origin, for example, <code>www.example.com</code>. </p> <p>Constraints for custom origins:</p> <ul> <li> <p> <code>DomainName</code> must be a valid DNS name that contains only a-z, A-Z, 0-9, dot (.), hyphen (-), or underscore (_) characters.</p> </li> <li> <p>The name cannot exceed 128 characters.</p> </li> </ul>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>A unique identifier for the origin. The value of <code>Id</code> must be unique within the distribution.</p> <p>When you specify the value of <code>TargetOriginId</code> for the default cache behavior or for another cache behavior, you indicate the origin to which you want the cache behavior to route requests by specifying the value of the <code>Id</code> element for that origin. When a request matches the path pattern for that cache behavior, CloudFront routes the request to the specified origin. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesCacheBehavior\">Cache Behavior Settings</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>An optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin. When you include the <code>OriginPath</code> element, specify the directory name, beginning with a <code>/</code>. CloudFront appends the directory name to the value of <code>DomainName</code>, for example, <code>example.com/production</code>. Do not include a <code>/</code> at the end of the directory name.</p> <p>For example, suppose you've specified the following values for your distribution:</p> <ul> <li> <p> <code>DomainName</code>: An Amazon S3 bucket named <code>myawsbucket</code>.</p> </li> <li> <p> <code>OriginPath</code>: <code>/production</code> </p> </li> <li> <p> <code>CNAME</code>: <code>example.com</code> </p> </li> </ul> <p>When a user enters <code>example.com/index.html</code> in a browser, CloudFront sends a request to Amazon S3 for <code>myawsbucket/production/index.html</code>.</p> <p>When a user enters <code>example.com/acme/index.html</code> in a browser, CloudFront sends a request to Amazon S3 for <code>myawsbucket/production/acme/index.html</code>.</p>"]
+    #[serde(rename="OriginPath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub origin_path: Option<String>,
     #[doc="<p>A complex type that contains information about the Amazon S3 origin. If the origin is a custom origin, use the <code>CustomOriginConfig</code> element instead.</p>"]
+    #[serde(rename="S3OriginConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_origin_config: Option<S3OriginConfig>,
 }
 
@@ -5317,11 +5648,13 @@ impl OriginSerializer {
 }
 
 #[doc="<p>A complex type that contains <code>HeaderName</code> and <code>HeaderValue</code> elements, if any, for this distribution. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct OriginCustomHeader {
     #[doc="<p>The name of a header that you want CloudFront to forward to your origin. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/forward-custom-headers.html\">Forwarding Custom Headers to Your Origin (Web Distributions Only)</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="HeaderName")]
     pub header_name: String,
     #[doc="<p>The value for the header that you specified in the <code>HeaderName</code> field.</p>"]
+    #[serde(rename="HeaderValue")]
     pub header_value: String,
 }
 
@@ -5549,11 +5882,13 @@ impl OriginProtocolPolicySerializer {
 }
 
 #[doc="<p>A complex type that contains information about the SSL/TLS protocols that CloudFront can use when establishing an HTTPS connection with your origin. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct OriginSslProtocols {
     #[doc="<p>A list that contains allowed SSL/TLS protocols for this distribution.</p>"]
+    #[serde(rename="Items")]
     pub items: Vec<String>,
     #[doc="<p>The number of SSL/TLS protocols that you want to allow CloudFront to use when establishing an HTTPS connection with this origin. </p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -5625,11 +5960,14 @@ impl OriginSslProtocolsSerializer {
 }
 
 #[doc="<p>A complex type that contains information about origins for this distribution. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Origins {
     #[doc="<p>A complex type that contains origins for this distribution.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<Origin>>,
     #[doc="<p>The number of origins for this distribution.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -5763,11 +6101,14 @@ impl PathListSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the objects that you want to invalidate. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#invalidation-specifying-objects\">Specifying the Objects to Invalidate</a> in the <i>Amazon CloudFront Developer Guide</i>. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Paths {
     #[doc="<p>A complex type that contains a list of the paths that you want to invalidate.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<String>>,
     #[doc="<p>The number of objects that you want to invalidate.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -5872,11 +6213,14 @@ impl PriceClassSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct QueryStringCacheKeys {
     #[doc="<p>(Optional) A list that contains the query string parameters that you want CloudFront to use as a basis for caching for this cache behavior. If <code>Quantity</code> is 0, you can omit <code>Items</code>. </p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<String>>,
     #[doc="<p>The number of <code>whitelisted</code> query string parameters for this cache behavior.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -6027,8 +6371,9 @@ impl ResourceARNSerializer {
 }
 
 #[doc="<p>A complex type that identifies ways in which you want to restrict distribution of your content.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Restrictions {
+    #[serde(rename="GeoRestriction")]
     pub geo_restriction: GeoRestriction,
 }
 
@@ -6092,11 +6437,13 @@ impl RestrictionsSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the Amazon S3 bucket from which you want CloudFront to get your media files for distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct S3Origin {
     #[doc="<p>The DNS name of the Amazon S3 origin. </p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>The CloudFront origin access identity to associate with the RTMP distribution. Use an origin access identity to configure the distribution so that end users can only access objects in an Amazon S3 bucket through CloudFront.</p> <p>If you want end users to be able to access objects using either the CloudFront URL or the Amazon S3 URL, specify an empty <code>OriginAccessIdentity</code> element.</p> <p>To delete the origin access identity from an existing distribution, update the distribution configuration and include an empty <code>OriginAccessIdentity</code> element.</p> <p>To replace the origin access identity, update the distribution configuration and specify the new origin access identity.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html\">Using an Origin Access Identity to Restrict Access to Your Amazon S3 Content</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="OriginAccessIdentity")]
     pub origin_access_identity: String,
 }
 
@@ -6173,9 +6520,10 @@ impl S3OriginSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the Amazon S3 origin. If the origin is a custom origin, use the <code>CustomOriginConfig</code> element instead.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct S3OriginConfig {
     #[doc="<p>The CloudFront origin access identity to associate with the origin. Use an origin access identity to configure the origin so that viewers can <i>only</i> access objects in an Amazon S3 bucket through CloudFront. The format of the value is:</p> <p>origin-access-identity/cloudfront/<i>ID-of-origin-access-identity</i> </p> <p>where <code> <i>ID-of-origin-access-identity</i> </code> is the value that CloudFront returned in the <code>ID</code> element when you created the origin access identity.</p> <p>If you want viewers to be able to access objects using either the CloudFront URL or the Amazon S3 URL, specify an empty <code>OriginAccessIdentity</code> element.</p> <p>To delete the origin access identity from an existing distribution, update the distribution configuration and include an empty <code>OriginAccessIdentity</code> element.</p> <p>To replace the origin access identity, update the distribution configuration and specify the new origin access identity.</p> <p>For more information about the origin access identity, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private Content through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="OriginAccessIdentity")]
     pub origin_access_identity: String,
 }
 
@@ -6276,11 +6624,15 @@ impl SSLSupportMethodSerializer {
 }
 
 #[doc="<p>A complex type that lists the AWS accounts that were included in the <code>TrustedSigners</code> complex type, as well as their active CloudFront key pair IDs, if any. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Signer {
     #[doc="<p>An AWS account that is included in the <code>TrustedSigners</code> complex type for this RTMP distribution. Valid values include:</p> <ul> <li> <p> <code>self</code>, which is the AWS account used to create the distribution.</p> </li> <li> <p>An AWS account number.</p> </li> </ul>"]
+    #[serde(rename="AwsAccountNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub aws_account_number: Option<String>,
     #[doc="<p>A complex type that lists the active CloudFront key pairs, if any, that are associated with <code>AwsAccountNumber</code>.</p>"]
+    #[serde(rename="KeyPairIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_pair_ids: Option<KeyPairIds>,
 }
 
@@ -6466,20 +6818,28 @@ impl SslProtocolsListSerializer {
 }
 
 #[doc="<p>A streaming distribution. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct StreamingDistribution {
+    #[serde(rename="ARN")]
     pub arn: String,
     #[doc="<p>A complex type that lists the AWS accounts, if any, that you included in the <code>TrustedSigners</code> complex type for this distribution. These are the accounts that you want to allow to create signed URLs for private content.</p> <p>The <code>Signer</code> complex type lists the AWS account number of the trusted signer or <code>self</code> if the signer is the AWS account that created the distribution. The <code>Signer</code> element also includes the IDs of any active CloudFront key pairs that are associated with the trusted signer's AWS account. If no <code>KeyPairId</code> element appears for a <code>Signer</code>, that signer can't create signed URLs.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private Content through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>. </p>"]
+    #[serde(rename="ActiveTrustedSigners")]
     pub active_trusted_signers: ActiveTrustedSigners,
     #[doc="<p>The domain name that corresponds to the streaming distribution. For example: <code>s5c39gqb8ow64r.cloudfront.net</code>. </p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>The identifier for the RTMP distribution. For example: <code>EGTXBD79EXAMPLE</code>.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The date and time that the distribution was last modified. </p>"]
+    #[serde(rename="LastModifiedTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_modified_time: Option<String>,
     #[doc="<p>The current status of the RTMP distribution. When the status is <code>Deployed</code>, the distribution's information is propagated to all CloudFront edge locations.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The current configuration information for the RTMP distribution.</p>"]
+    #[serde(rename="StreamingDistributionConfig")]
     pub streaming_distribution_config: StreamingDistributionConfig,
 }
 
@@ -6550,23 +6910,34 @@ impl StreamingDistributionDeserializer {
     }
 }
 #[doc="<p>The RTMP distribution's configuration information.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct StreamingDistributionConfig {
     #[doc="<p>A complex type that contains information about CNAMEs (alternate domain names), if any, for this streaming distribution. </p>"]
+    #[serde(rename="Aliases")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub aliases: Option<Aliases>,
     #[doc="<p>A unique number that ensures that the request can't be replayed. If the <code>CallerReference</code> is new (no matter the content of the <code>StreamingDistributionConfig</code> object), a new streaming distribution is created. If the <code>CallerReference</code> is a value that you already sent in a previous request to create a streaming distribution, and the content of the <code>StreamingDistributionConfig</code> is identical to the original request (ignoring white space), the response includes the same information returned to the original request. If the <code>CallerReference</code> is a value that you already sent in a previous request to create a streaming distribution but the content of the <code>StreamingDistributionConfig</code> is different from the original request, CloudFront returns a <code>DistributionAlreadyExists</code> error. </p>"]
+    #[serde(rename="CallerReference")]
     pub caller_reference: String,
     #[doc="<p>Any comments you want to include about the streaming distribution. </p>"]
+    #[serde(rename="Comment")]
     pub comment: String,
     #[doc="<p>Whether the streaming distribution is enabled to accept user requests for content.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p>A complex type that controls whether access logs are written for the streaming distribution. </p>"]
+    #[serde(rename="Logging")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub logging: Option<StreamingLoggingConfig>,
     #[doc="<p>A complex type that contains information about price class for this streaming distribution. </p>"]
+    #[serde(rename="PriceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub price_class: Option<String>,
     #[doc="<p>A complex type that contains information about the Amazon S3 bucket from which you want CloudFront to get your media files for distribution. </p>"]
+    #[serde(rename="S3Origin")]
     pub s3_origin: S3Origin,
     #[doc="<p>A complex type that specifies any AWS accounts that you want to permit to create signed URLs for private content. If you want the distribution to use signed URLs, include this element; if you want the distribution to use public URLs, remove this element. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private Content through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>. </p>"]
+    #[serde(rename="TrustedSigners")]
     pub trusted_signers: TrustedSigners,
 }
 
@@ -6687,11 +7058,13 @@ impl StreamingDistributionConfigSerializer {
 }
 
 #[doc="<p>A streaming distribution Configuration and a list of tags to be associated with the streaming distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct StreamingDistributionConfigWithTags {
     #[doc="<p>A streaming distribution Configuration.</p>"]
+    #[serde(rename="StreamingDistributionConfig")]
     pub streaming_distribution_config: StreamingDistributionConfig,
     #[doc="<p>A complex type that contains zero or more <code>Tag</code> elements.</p>"]
+    #[serde(rename="Tags")]
     pub tags: Tags,
 }
 
@@ -6715,19 +7088,27 @@ impl StreamingDistributionConfigWithTagsSerializer {
 }
 
 #[doc="<p>A streaming distribution list. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct StreamingDistributionList {
     #[doc="<p>A flag that indicates whether more streaming distributions remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more distributions in the list. </p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>A complex type that contains one <code>StreamingDistributionSummary</code> element for each distribution that was created by the current AWS account.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<StreamingDistributionSummary>>,
     #[doc="<p>The value you provided for the <code>Marker</code> request parameter. </p>"]
+    #[serde(rename="Marker")]
     pub marker: String,
     #[doc="<p>The value you provided for the <code>MaxItems</code> request parameter. </p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: i64,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value you can use for the <code>Marker</code> request parameter to continue listing your RTMP distributions where they left off. </p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
     #[doc="<p>The number of streaming distributions that were created by the current AWS account. </p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -6792,28 +7173,39 @@ impl StreamingDistributionListDeserializer {
     }
 }
 #[doc="<p> A summary of the information for an Amazon CloudFront streaming distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct StreamingDistributionSummary {
     #[doc="<p> The ARN (Amazon Resource Name) for the streaming distribution. For example: <code>arn:aws:cloudfront::123456789012:streaming-distribution/EDFDVBD632BHDS5</code>, where <code>123456789012</code> is your AWS account ID.</p>"]
+    #[serde(rename="ARN")]
     pub arn: String,
     #[doc="<p>A complex type that contains information about CNAMEs (alternate domain names), if any, for this streaming distribution.</p>"]
+    #[serde(rename="Aliases")]
     pub aliases: Aliases,
     #[doc="<p>The comment originally specified when this distribution was created.</p>"]
+    #[serde(rename="Comment")]
     pub comment: String,
     #[doc="<p>The domain name corresponding to the distribution. For example: <code>d604721fxaaqy9.cloudfront.net</code>.</p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>Whether the distribution is enabled to accept end user requests for content.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p>The identifier for the distribution. For example: <code>EDFDVBD632BHDS5</code>.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The date and time the distribution was last modified.</p>"]
+    #[serde(rename="LastModifiedTime")]
     pub last_modified_time: String,
+    #[serde(rename="PriceClass")]
     pub price_class: String,
     #[doc="<p>A complex type that contains information about the Amazon S3 bucket from which you want CloudFront to get your media files for distribution.</p>"]
+    #[serde(rename="S3Origin")]
     pub s3_origin: S3Origin,
     #[doc="<p> Indicates the current status of the distribution. When the status is <code>Deployed</code>, the distribution's information is fully propagated throughout the Amazon CloudFront system.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>A complex type that specifies the AWS accounts, if any, that you want to allow to create signed URLs for private content. If you want to require signed URLs in requests for objects in the target origin that match the <code>PathPattern</code> for this cache behavior, specify <code>true</code> for <code>Enabled</code>, and specify the applicable values for <code>Quantity</code> and <code>Items</code>.If you don't want to require signed URLs in requests for objects that match <code>PathPattern</code>, specify <code>false</code> for <code>Enabled</code> and <code>0</code> for <code>Quantity</code>. Omit <code>Items</code>. To add, change, or remove one or more trusted signers, change <code>Enabled</code> to <code>true</code> (if it's currently <code>false</code>), change <code>Quantity</code> as applicable, and specify all of the trusted signers that you want to include in the updated distribution.</p>"]
+    #[serde(rename="TrustedSigners")]
     pub trusted_signers: TrustedSigners,
 }
 
@@ -6937,13 +7329,16 @@ impl StreamingDistributionSummaryListDeserializer {
     }
 }
 #[doc="<p>A complex type that controls whether access logs are written for this streaming distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct StreamingLoggingConfig {
     #[doc="<p>The Amazon S3 bucket to store the access logs in, for example, <code>myawslogbucket.s3.amazonaws.com</code>.</p>"]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="<p>Specifies whether you want CloudFront to save access logs to an Amazon S3 bucket. If you do not want to enable logging when you create a streaming distribution or if you want to disable logging for an existing streaming distribution, specify <code>false</code> for <code>Enabled</code>, and specify <code>empty Bucket</code> and <code>Prefix</code> elements. If you specify <code>false</code> for <code>Enabled</code> but you specify values for <code>Bucket</code> and <code>Prefix</code>, the values are automatically deleted. </p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p>An optional string that you want CloudFront to prefix to the access log <code>filenames</code> for this streaming distribution, for example, <code>myprefix/</code>. If you want to enable logging, but you do not want to specify a prefix, you still must include an empty <code>Prefix</code> element in the <code>Logging</code> element.</p>"]
+    #[serde(rename="Prefix")]
     pub prefix: String,
 }
 
@@ -7057,11 +7452,14 @@ impl StringSerializer {
 }
 
 #[doc="<p> A complex type that contains <code>Tag</code> key and <code>Tag</code> value.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p> A string that contains <code>Tag</code> key.</p> <p>The string length should be between 1 and 128 characters. Valid characters include <code>a-z</code>, <code>A-Z</code>, <code>0-9</code>, space, and the special characters <code>_ - . : / = + @</code>.</p>"]
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="<p> A string that contains an optional <code>Tag</code> value.</p> <p>The string length should be between 0 and 256 characters. Valid characters include <code>a-z</code>, <code>A-Z</code>, <code>0-9</code>, space, and the special characters <code>_ - . : / = + @</code>.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -7186,9 +7584,11 @@ impl TagKeyListSerializer {
 }
 
 #[doc="<p> A complex type that contains zero or more <code>Tag</code> elements.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct TagKeys {
     #[doc="<p> A complex type that contains <code>Tag</code> key elements.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<String>>,
 }
 
@@ -7271,11 +7671,13 @@ impl TagListSerializer {
 }
 
 #[doc="<p> The request to add tags to a CloudFront resource.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct TagResourceRequest {
     #[doc="<p> An ARN of a CloudFront resource.</p>"]
+    #[serde(rename="Resource")]
     pub resource: String,
     #[doc="<p> A complex type that contains zero or more <code>Tag</code> elements.</p>"]
+    #[serde(rename="Tags")]
     pub tags: Tags,
 }
 
@@ -7312,9 +7714,11 @@ impl TagValueSerializer {
 }
 
 #[doc="<p> A complex type that contains zero or more <code>Tag</code> elements.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Tags {
     #[doc="<p> A complex type that contains <code>Tag</code> elements.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<Tag>>,
 }
 
@@ -7393,13 +7797,17 @@ impl TimestampDeserializer {
     }
 }
 #[doc="<p>A complex type that specifies the AWS accounts, if any, that you want to allow to create signed URLs for private content.</p> <p>If you want to require signed URLs in requests for objects in the target origin that match the <code>PathPattern</code> for this cache behavior, specify <code>true</code> for <code>Enabled</code>, and specify the applicable values for <code>Quantity</code> and <code>Items</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private Content through CloudFront</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p> <p>If you don't want to require signed URLs in requests for objects that match <code>PathPattern</code>, specify <code>false</code> for <code>Enabled</code> and <code>0</code> for <code>Quantity</code>. Omit <code>Items</code>.</p> <p>To add, change, or remove one or more trusted signers, change <code>Enabled</code> to <code>true</code> (if it's currently <code>false</code>), change <code>Quantity</code> as applicable, and specify all of the trusted signers that you want to include in the updated distribution.</p> <p>For more information about updating the distribution configuration, see <a>DistributionConfig</a> .</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct TrustedSigners {
     #[doc="<p>Specifies whether you want to require viewers to use signed URLs to access the files specified by <code>PathPattern</code> and <code>TargetOriginId</code>.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p> <b>Optional</b>: A complex type that contains trusted signers for this cache behavior. If <code>Quantity</code> is <code>0</code>, you can omit <code>Items</code>.</p>"]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<String>>,
     #[doc="<p>The number of trusted signers for this cache behavior.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -7482,31 +7890,41 @@ impl TrustedSignersSerializer {
 }
 
 #[doc="<p> The request to remove tags from a CloudFront resource.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UntagResourceRequest {
     #[doc="<p> An ARN of a CloudFront resource.</p>"]
+    #[serde(rename="Resource")]
     pub resource: String,
     #[doc="<p> A complex type that contains zero or more <code>Tag</code> key elements.</p>"]
+    #[serde(rename="TagKeys")]
     pub tag_keys: TagKeys,
 }
 
 #[doc="<p>The request to update an origin access identity.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateCloudFrontOriginAccessIdentityRequest {
     #[doc="<p>The identity's configuration information.</p>"]
+    #[serde(rename="CloudFrontOriginAccessIdentityConfig")]
     pub cloud_front_origin_access_identity_config: CloudFrontOriginAccessIdentityConfig,
     #[doc="<p>The identity's id.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The value of the <code>ETag</code> header that you received when retrieving the identity's configuration. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="IfMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_match: Option<String>,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateCloudFrontOriginAccessIdentityResult {
     #[doc="<p>The origin access identity's information.</p>"]
+    #[serde(rename="CloudFrontOriginAccessIdentity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cloud_front_origin_access_identity: Option<CloudFrontOriginAccessIdentity>,
     #[doc="<p>The current version of the configuration. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
 }
 
@@ -7553,22 +7971,30 @@ impl UpdateCloudFrontOriginAccessIdentityResultDeserializer {
     }
 }
 #[doc="<p>The request to update a distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateDistributionRequest {
     #[doc="<p>The distribution's configuration information.</p>"]
+    #[serde(rename="DistributionConfig")]
     pub distribution_config: DistributionConfig,
     #[doc="<p>The distribution's id.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The value of the <code>ETag</code> header that you received when retrieving the distribution's configuration. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="IfMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_match: Option<String>,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateDistributionResult {
     #[doc="<p>The distribution's information.</p>"]
+    #[serde(rename="Distribution")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub distribution: Option<Distribution>,
     #[doc="<p>The current version of the configuration. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
 }
 
@@ -7616,22 +8042,30 @@ impl UpdateDistributionResultDeserializer {
     }
 }
 #[doc="<p>The request to update a streaming distribution.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateStreamingDistributionRequest {
     #[doc="<p>The streaming distribution's id.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The value of the <code>ETag</code> header that you received when retrieving the streaming distribution's configuration. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="IfMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_match: Option<String>,
     #[doc="<p>The streaming distribution's configuration information.</p>"]
+    #[serde(rename="StreamingDistributionConfig")]
     pub streaming_distribution_config: StreamingDistributionConfig,
 }
 
 #[doc="<p>The returned result of the corresponding request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateStreamingDistributionResult {
     #[doc="<p>The current version of the configuration. For example: <code>E2QWRUHAPOMQZL</code>.</p>"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="<p>The streaming distribution's information.</p>"]
+    #[serde(rename="StreamingDistribution")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub streaming_distribution: Option<StreamingDistribution>,
 }
 
@@ -7680,14 +8114,24 @@ impl UpdateStreamingDistributionResultDeserializer {
     }
 }
 #[doc="<p>A complex type that specifies the following:</p> <ul> <li> <p>Which SSL/TLS certificate to use when viewers request objects using HTTPS</p> </li> <li> <p>Whether you want CloudFront to use dedicated IP addresses or SNI when you're using alternate domain names in your object names</p> </li> <li> <p>The minimum protocol version that you want CloudFront to use when communicating with viewers</p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html\">Using an HTTPS Connection to Access Your Objects</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ViewerCertificate {
+    #[serde(rename="ACMCertificateArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub acm_certificate_arn: Option<String>,
+    #[serde(rename="CloudFrontDefaultCertificate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cloud_front_default_certificate: Option<bool>,
+    #[serde(rename="IAMCertificateId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_certificate_id: Option<String>,
     #[doc="<p>Specify the minimum version of the SSL/TLS protocol that you want CloudFront to use for HTTPS connections between viewers and CloudFront: <code>SSLv3</code> or <code>TLSv1</code>. CloudFront serves your objects only to viewers that support SSL/TLS version that you specify and later versions. The <code>TLSv1</code> protocol is more secure, so we recommend that you specify <code>SSLv3</code> only if your users are using browsers or devices that don't support <code>TLSv1</code>. Note the following:</p> <ul> <li> <p>If you specify &lt;CloudFrontDefaultCertificate&gt;true&lt;CloudFrontDefaultCertificate&gt;, the minimum SSL protocol version is <code>TLSv1</code> and can't be changed.</p> </li> <li> <p>If you're using a custom certificate (if you specify a value for <code>ACMCertificateArn</code> or for <code>IAMCertificateId</code>) and if you're using SNI (if you specify <code>sni-only</code> for <code>SSLSupportMethod</code>), you must specify <code>TLSv1</code> for <code>MinimumProtocolVersion</code>.</p> </li> </ul>"]
+    #[serde(rename="MinimumProtocolVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub minimum_protocol_version: Option<String>,
     #[doc="<p>If you specify a value for <code>ACMCertificateArn</code> or for <code>IAMCertificateId</code>, you must also specify how you want CloudFront to serve HTTPS requests: using a method that works for all clients or one that works for most clients:</p> <ul> <li> <p> <code>vip</code>: CloudFront uses dedicated IP addresses for your content and can respond to HTTPS requests from any viewer. However, you will incur additional monthly charges.</p> </li> <li> <p> <code>sni-only</code>: CloudFront can respond to HTTPS requests from viewers that support Server Name Indication (SNI). All modern browsers support SNI, but some browsers still in use don't support SNI. If some of your users' browsers don't support SNI, we recommend that you do one of the following:</p> <ul> <li> <p>Use the <code>vip</code> option (dedicated IP addresses) instead of <code>sni-only</code>.</p> </li> <li> <p>Use the CloudFront SSL/TLS certificate instead of a custom certificate. This requires that you use the CloudFront domain name of your distribution in the URLs for your objects, for example, <code>https://d111111abcdef8.cloudfront.net/logo.png</code>.</p> </li> <li> <p>If you can control which browser your users use, upgrade the browser to one that supports SNI.</p> </li> <li> <p>Use HTTP instead of HTTPS.</p> </li> </ul> </li> </ul> <p>Do not specify a value for <code>SSLSupportMethod</code> if you specified <code>&lt;CloudFrontDefaultCertificate&gt;true&lt;CloudFrontDefaultCertificate&gt;</code>.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html#CNAMEsAndHTTPS.html\">Using Alternate Domain Names and HTTPS</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>"]
+    #[serde(rename="SSLSupportMethod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssl_support_method: Option<String>,
 }
 

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the AWS CloudHSM resource to tag.</p>"]
     #[serde(rename="ResourceArn")]
@@ -38,7 +38,7 @@ pub struct AddTagsToResourceRequest {
     pub tag_list: Vec<Tag>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceResponse {
     #[doc="<p>The status of the operation.</p>"]
     #[serde(rename="Status")]
@@ -46,7 +46,7 @@ pub struct AddTagsToResourceResponse {
 }
 
 #[doc="<p>Contains the inputs for the <a>CreateHapgRequest</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHapgRequest {
     #[doc="<p>The label of the new high-availability partition group.</p>"]
     #[serde(rename="Label")]
@@ -54,7 +54,7 @@ pub struct CreateHapgRequest {
 }
 
 #[doc="<p>Contains the output of the <a>CreateHAPartitionGroup</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHapgResponse {
     #[doc="<p>The ARN of the high-availability partition group.</p>"]
     #[serde(rename="HapgArn")]
@@ -63,7 +63,7 @@ pub struct CreateHapgResponse {
 }
 
 #[doc="<p>Contains the inputs for the <a>CreateHsm</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHsmRequest {
     #[doc="<p>A user-defined token to ensure idempotence. Subsequent calls to this operation with the same token will be ignored.</p>"]
     #[serde(rename="ClientToken")]
@@ -95,7 +95,7 @@ pub struct CreateHsmRequest {
 }
 
 #[doc="<p>Contains the output of the <a>CreateHsm</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHsmResponse {
     #[doc="<p>The ARN of the HSM.</p>"]
     #[serde(rename="HsmArn")]
@@ -104,7 +104,7 @@ pub struct CreateHsmResponse {
 }
 
 #[doc="<p>Contains the inputs for the <a>CreateLunaClient</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLunaClientRequest {
     #[doc="<p>The contents of a Base64-Encoded X.509 v3 certificate to be installed on the HSMs used by this client.</p>"]
     #[serde(rename="Certificate")]
@@ -116,7 +116,7 @@ pub struct CreateLunaClientRequest {
 }
 
 #[doc="<p>Contains the output of the <a>CreateLunaClient</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLunaClientResponse {
     #[doc="<p>The ARN of the client.</p>"]
     #[serde(rename="ClientArn")]
@@ -125,7 +125,7 @@ pub struct CreateLunaClientResponse {
 }
 
 #[doc="<p>Contains the inputs for the <a>DeleteHapg</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteHapgRequest {
     #[doc="<p>The ARN of the high-availability partition group to delete.</p>"]
     #[serde(rename="HapgArn")]
@@ -133,7 +133,7 @@ pub struct DeleteHapgRequest {
 }
 
 #[doc="<p>Contains the output of the <a>DeleteHapg</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteHapgResponse {
     #[doc="<p>The status of the action.</p>"]
     #[serde(rename="Status")]
@@ -141,7 +141,7 @@ pub struct DeleteHapgResponse {
 }
 
 #[doc="<p>Contains the inputs for the <a>DeleteHsm</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteHsmRequest {
     #[doc="<p>The ARN of the HSM to delete.</p>"]
     #[serde(rename="HsmArn")]
@@ -149,21 +149,21 @@ pub struct DeleteHsmRequest {
 }
 
 #[doc="<p>Contains the output of the <a>DeleteHsm</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteHsmResponse {
     #[doc="<p>The status of the operation.</p>"]
     #[serde(rename="Status")]
     pub status: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLunaClientRequest {
     #[doc="<p>The ARN of the client to delete.</p>"]
     #[serde(rename="ClientArn")]
     pub client_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLunaClientResponse {
     #[doc="<p>The status of the action.</p>"]
     #[serde(rename="Status")]
@@ -171,7 +171,7 @@ pub struct DeleteLunaClientResponse {
 }
 
 #[doc="<p>Contains the inputs for the <a>DescribeHapg</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHapgRequest {
     #[doc="<p>The ARN of the high-availability partition group to describe.</p>"]
     #[serde(rename="HapgArn")]
@@ -179,7 +179,7 @@ pub struct DescribeHapgRequest {
 }
 
 #[doc="<p>Contains the output of the <a>DescribeHapg</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHapgResponse {
     #[doc="<p>The ARN of the high-availability partition group.</p>"]
     #[serde(rename="HapgArn")]
@@ -217,7 +217,7 @@ pub struct DescribeHapgResponse {
 }
 
 #[doc="<p>Contains the inputs for the <a>DescribeHsm</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHsmRequest {
     #[doc="<p>The ARN of the HSM. Either the <i>HsmArn</i> or the <i>SerialNumber</i> parameter must be specified.</p>"]
     #[serde(rename="HsmArn")]
@@ -230,7 +230,7 @@ pub struct DescribeHsmRequest {
 }
 
 #[doc="<p>Contains the output of the <a>DescribeHsm</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHsmResponse {
     #[doc="<p>The Availability Zone that the HSM is in.</p>"]
     #[serde(rename="AvailabilityZone")]
@@ -317,7 +317,7 @@ pub struct DescribeHsmResponse {
     pub vpc_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLunaClientRequest {
     #[doc="<p>The certificate fingerprint.</p>"]
     #[serde(rename="CertificateFingerprint")]
@@ -329,7 +329,7 @@ pub struct DescribeLunaClientRequest {
     pub client_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLunaClientResponse {
     #[doc="<p>The certificate installed on the HSMs used by this client.</p>"]
     #[serde(rename="Certificate")]
@@ -353,7 +353,7 @@ pub struct DescribeLunaClientResponse {
     pub last_modified_timestamp: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConfigRequest {
     #[doc="<p>The ARN of the client.</p>"]
     #[serde(rename="ClientArn")]
@@ -366,7 +366,7 @@ pub struct GetConfigRequest {
     pub hapg_list: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConfigResponse {
     #[doc="<p>The certificate file containing the server.pem files of the HSMs.</p>"]
     #[serde(rename="ConfigCred")]
@@ -383,10 +383,10 @@ pub struct GetConfigResponse {
 }
 
 #[doc="<p>Contains the inputs for the <a>ListAvailableZones</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAvailableZonesRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAvailableZonesResponse {
     #[doc="<p>The list of Availability Zones that have available AWS CloudHSM capacity.</p>"]
     #[serde(rename="AZList")]
@@ -394,7 +394,7 @@ pub struct ListAvailableZonesResponse {
     pub az_list: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHapgsRequest {
     #[doc="<p>The <i>NextToken</i> value from a previous call to <a>ListHapgs</a>. Pass null if this is the first call.</p>"]
     #[serde(rename="NextToken")]
@@ -402,7 +402,7 @@ pub struct ListHapgsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHapgsResponse {
     #[doc="<p>The list of high-availability partition groups.</p>"]
     #[serde(rename="HapgList")]
@@ -413,7 +413,7 @@ pub struct ListHapgsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHsmsRequest {
     #[doc="<p>The <i>NextToken</i> value from a previous call to <a>ListHsms</a>. Pass null if this is the first call.</p>"]
     #[serde(rename="NextToken")]
@@ -422,7 +422,7 @@ pub struct ListHsmsRequest {
 }
 
 #[doc="<p>Contains the output of the <a>ListHsms</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHsmsResponse {
     #[doc="<p>The list of ARNs that identify the HSMs.</p>"]
     #[serde(rename="HsmList")]
@@ -434,7 +434,7 @@ pub struct ListHsmsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLunaClientsRequest {
     #[doc="<p>The <i>NextToken</i> value from a previous call to <a>ListLunaClients</a>. Pass null if this is the first call.</p>"]
     #[serde(rename="NextToken")]
@@ -442,7 +442,7 @@ pub struct ListLunaClientsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLunaClientsResponse {
     #[doc="<p>The list of clients.</p>"]
     #[serde(rename="ClientList")]
@@ -453,21 +453,21 @@ pub struct ListLunaClientsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the AWS CloudHSM resource.</p>"]
     #[serde(rename="ResourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceResponse {
     #[doc="<p>One or more tags.</p>"]
     #[serde(rename="TagList")]
     pub tag_list: Vec<Tag>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyHapgRequest {
     #[doc="<p>The ARN of the high-availability partition group to modify.</p>"]
     #[serde(rename="HapgArn")]
@@ -482,7 +482,7 @@ pub struct ModifyHapgRequest {
     pub partition_serial_list: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyHapgResponse {
     #[doc="<p>The ARN of the high-availability partition group.</p>"]
     #[serde(rename="HapgArn")]
@@ -491,7 +491,7 @@ pub struct ModifyHapgResponse {
 }
 
 #[doc="<p>Contains the inputs for the <a>ModifyHsm</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyHsmRequest {
     #[doc="<p>The new IP address for the elastic network interface (ENI) attached to the HSM.</p> <p>If the HSM is moved to a different subnet, and an IP address is not specified, an IP address will be randomly chosen from the CIDR range of the new subnet.</p>"]
     #[serde(rename="EniIp")]
@@ -519,7 +519,7 @@ pub struct ModifyHsmRequest {
 }
 
 #[doc="<p>Contains the output of the <a>ModifyHsm</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyHsmResponse {
     #[doc="<p>The ARN of the HSM.</p>"]
     #[serde(rename="HsmArn")]
@@ -527,7 +527,7 @@ pub struct ModifyHsmResponse {
     pub hsm_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyLunaClientRequest {
     #[doc="<p>The new certificate for the client.</p>"]
     #[serde(rename="Certificate")]
@@ -537,7 +537,7 @@ pub struct ModifyLunaClientRequest {
     pub client_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyLunaClientResponse {
     #[doc="<p>The ARN of the client.</p>"]
     #[serde(rename="ClientArn")]
@@ -545,7 +545,7 @@ pub struct ModifyLunaClientResponse {
     pub client_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the AWS CloudHSM resource.</p>"]
     #[serde(rename="ResourceArn")]
@@ -555,7 +555,7 @@ pub struct RemoveTagsFromResourceRequest {
     pub tag_key_list: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceResponse {
     #[doc="<p>The status of the operation.</p>"]
     #[serde(rename="Status")]

--- a/rusoto/services/cloudhsmv2/src/generated.rs
+++ b/rusoto/services/cloudhsmv2/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Contains information about a backup of an AWS CloudHSM cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Backup {
     #[doc="<p>The identifier (ID) of the backup.</p>"]
     #[serde(rename="BackupId")]
@@ -49,7 +49,7 @@ pub struct Backup {
 }
 
 #[doc="<p>Contains one or more certificates or a certificate signing request (CSR).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Certificates {
     #[doc="<p>The HSM hardware certificate issued (signed) by AWS CloudHSM.</p>"]
     #[serde(rename="AwsHardwareCertificate")]
@@ -74,7 +74,7 @@ pub struct Certificates {
 }
 
 #[doc="<p>Contains information about an AWS CloudHSM cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Cluster {
     #[doc="<p>The cluster's backup policy.</p>"]
     #[serde(rename="BackupPolicy")]
@@ -130,7 +130,7 @@ pub struct Cluster {
     pub vpc_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterRequest {
     #[doc="<p>The type of HSM to use in the cluster. Currently the only allowed value is <code>hsm1.medium</code>.</p>"]
     #[serde(rename="HsmType")]
@@ -144,7 +144,7 @@ pub struct CreateClusterRequest {
     pub subnet_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterResponse {
     #[doc="<p>Information about the cluster that was created.</p>"]
     #[serde(rename="Cluster")]
@@ -152,7 +152,7 @@ pub struct CreateClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHsmRequest {
     #[doc="<p>The Availability Zone where you are creating the HSM. To find the cluster's Availability Zones, use <a>DescribeClusters</a>.</p>"]
     #[serde(rename="AvailabilityZone")]
@@ -166,7 +166,7 @@ pub struct CreateHsmRequest {
     pub ip_address: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHsmResponse {
     #[doc="<p>Information about the HSM that was created.</p>"]
     #[serde(rename="Hsm")]
@@ -174,14 +174,14 @@ pub struct CreateHsmResponse {
     pub hsm: Option<Hsm>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterRequest {
     #[doc="<p>The identifier (ID) of the cluster that you are deleting. To find the cluster ID, use <a>DescribeClusters</a>.</p>"]
     #[serde(rename="ClusterId")]
     pub cluster_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterResponse {
     #[doc="<p>Information about the cluster that was deleted.</p>"]
     #[serde(rename="Cluster")]
@@ -189,7 +189,7 @@ pub struct DeleteClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteHsmRequest {
     #[doc="<p>The identifier (ID) of the cluster that contains the HSM that you are deleting.</p>"]
     #[serde(rename="ClusterId")]
@@ -208,7 +208,7 @@ pub struct DeleteHsmRequest {
     pub hsm_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteHsmResponse {
     #[doc="<p>The identifier (ID) of the HSM that was deleted.</p>"]
     #[serde(rename="HsmId")]
@@ -216,7 +216,7 @@ pub struct DeleteHsmResponse {
     pub hsm_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBackupsRequest {
     #[doc="<p>One or more filters to limit the items returned in the response.</p> <p>Use the <code>backupIds</code> filter to return only the specified backups. Specify backups by their backup identifier (ID).</p> <p>Use the <code>clusterIds</code> filter to return only the backups for the specified clusters. Specify clusters by their cluster identifier (ID).</p> <p>Use the <code>states</code> filter to return only backups that match the specified state.</p>"]
     #[serde(rename="Filters")]
@@ -232,7 +232,7 @@ pub struct DescribeBackupsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBackupsResponse {
     #[doc="<p>A list of backups.</p>"]
     #[serde(rename="Backups")]
@@ -244,7 +244,7 @@ pub struct DescribeBackupsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClustersRequest {
     #[doc="<p>One or more filters to limit the items returned in the response.</p> <p>Use the <code>clusterIds</code> filter to return only the specified clusters. Specify clusters by their cluster identifier (ID).</p> <p>Use the <code>vpcIds</code> filter to return only the clusters in the specified virtual private clouds (VPCs). Specify VPCs by their VPC identifier (ID).</p> <p>Use the <code>states</code> filter to return only clusters that match the specified state.</p>"]
     #[serde(rename="Filters")]
@@ -260,7 +260,7 @@ pub struct DescribeClustersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClustersResponse {
     #[doc="<p>A list of clusters.</p>"]
     #[serde(rename="Clusters")]
@@ -273,7 +273,7 @@ pub struct DescribeClustersResponse {
 }
 
 #[doc="<p>Contains information about a hardware security module (HSM) in an AWS CloudHSM cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Hsm {
     #[doc="<p>The Availability Zone that contains the HSM.</p>"]
     #[serde(rename="AvailabilityZone")]
@@ -308,7 +308,7 @@ pub struct Hsm {
     pub subnet_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitializeClusterRequest {
     #[doc="<p>The identifier (ID) of the cluster that you are claiming. To find the cluster ID, use <a>DescribeClusters</a>.</p>"]
     #[serde(rename="ClusterId")]
@@ -321,7 +321,7 @@ pub struct InitializeClusterRequest {
     pub trust_anchor: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitializeClusterResponse {
     #[doc="<p>The cluster's state.</p>"]
     #[serde(rename="State")]
@@ -333,7 +333,7 @@ pub struct InitializeClusterResponse {
     pub state_message: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsRequest {
     #[doc="<p>The maximum number of tags to return in the response. When there are more tags than the number you specify, the response contains a <code>NextToken</code> value.</p>"]
     #[serde(rename="MaxResults")]
@@ -348,7 +348,7 @@ pub struct ListTagsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsResponse {
     #[doc="<p>An opaque string that indicates that the response contains only a subset of tags. Use this value in a subsequent <code>ListTags</code> request to get more tags.</p>"]
     #[serde(rename="NextToken")]
@@ -370,7 +370,7 @@ pub struct Tag {
     pub value: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceRequest {
     #[doc="<p>The cluster identifier (ID) for the cluster that you are tagging. To find the cluster ID, use <a>DescribeClusters</a>.</p>"]
     #[serde(rename="ResourceId")]
@@ -380,10 +380,10 @@ pub struct TagResourceRequest {
     pub tag_list: Vec<Tag>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceRequest {
     #[doc="<p>The cluster identifier (ID) for the cluster whose tags you are removing. To find the cluster ID, use <a>DescribeClusters</a>.</p>"]
     #[serde(rename="ResourceId")]
@@ -393,7 +393,7 @@ pub struct UntagResourceRequest {
     pub tag_key_list: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceResponse;
 
 /// Errors returned by CreateCluster

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -68,9 +68,11 @@ impl ARNDeserializer {
     }
 }
 #[doc="<p>The configured access rules for the domain's document and search endpoints, and the current status of those rules.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccessPoliciesStatus {
+    #[serde(rename="Options")]
     pub options: String,
+    #[serde(rename="Status")]
     pub status: OptionStatus,
 }
 
@@ -135,17 +137,27 @@ impl AlgorithmicStemmingDeserializer {
     }
 }
 #[doc="<p>Synonyms, stopwords, and stemming options for an analysis scheme. Includes tokenization dictionary for Japanese.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AnalysisOptions {
     #[doc="<p>The level of algorithmic stemming to perform: <code>none</code>, <code>minimal</code>, <code>light</code>, or <code>full</code>. The available levels vary depending on the language. For more information, see <a href=\"http://docs.aws.amazon.com/cloudsearch/latest/developerguide/text-processing.html#text-processing-settings\" target=\"_blank\">Language Specific Text Processing Settings</a> in the <i>Amazon CloudSearch Developer Guide</i> </p>"]
+    #[serde(rename="AlgorithmicStemming")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub algorithmic_stemming: Option<String>,
     #[doc="<p>A JSON array that contains a collection of terms, tokens, readings and part of speech for Japanese Tokenizaiton. The Japanese tokenization dictionary enables you to override the default tokenization for selected terms. This is only valid for Japanese language fields.</p>"]
+    #[serde(rename="JapaneseTokenizationDictionary")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub japanese_tokenization_dictionary: Option<String>,
     #[doc="<p>A JSON object that contains a collection of string:value pairs that each map a term to its stem. For example, <code>{\"term1\": \"stem1\", \"term2\": \"stem2\", \"term3\": \"stem3\"}</code>. The stemming dictionary is applied in addition to any algorithmic stemming. This enables you to override the results of the algorithmic stemming to correct specific cases of overstemming or understemming. The maximum size of a stemming dictionary is 500 KB.</p>"]
+    #[serde(rename="StemmingDictionary")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stemming_dictionary: Option<String>,
     #[doc="<p>A JSON array of terms to ignore during indexing and searching. For example, <code>[\"a\", \"an\", \"the\", \"of\"]</code>. The stopwords dictionary must explicitly list each word you want to ignore. Wildcards and regular expressions are not supported. </p>"]
+    #[serde(rename="Stopwords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stopwords: Option<String>,
     #[doc="<p>A JSON object that defines synonym groups and aliases. A synonym group is an array of arrays, where each sub-array is a group of terms where each term in the group is considered a synonym of every other term in the group. The aliases value is an object that contains a collection of string:value pairs where the string specifies a term and the array of values specifies each of the aliases for that term. An alias is considered a synonym of the specified term, but the term is not considered a synonym of the alias. For more information about specifying synonyms, see <a href=\"http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-analysis-schemes.html#synonyms\">Synonyms</a> in the <i>Amazon CloudSearch Developer Guide</i>.</p>"]
+    #[serde(rename="Synonyms")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub synonyms: Option<String>,
 }
 
@@ -245,10 +257,14 @@ impl AnalysisOptionsSerializer {
 }
 
 #[doc="<p>Configuration information for an analysis scheme. Each analysis scheme has a unique name and specifies the language of the text to be processed. The following options can be configured for an analysis scheme: <code>Synonyms</code>, <code>Stopwords</code>, <code>StemmingDictionary</code>, <code>JapaneseTokenizationDictionary</code> and <code>AlgorithmicStemming</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AnalysisScheme {
+    #[serde(rename="AnalysisOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub analysis_options: Option<AnalysisOptions>,
+    #[serde(rename="AnalysisSchemeLanguage")]
     pub analysis_scheme_language: String,
+    #[serde(rename="AnalysisSchemeName")]
     pub analysis_scheme_name: String,
 }
 
@@ -343,9 +359,11 @@ impl AnalysisSchemeLanguageDeserializer {
     }
 }
 #[doc="<p>The status and configuration of an <code>AnalysisScheme</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AnalysisSchemeStatus {
+    #[serde(rename="Options")]
     pub options: AnalysisScheme,
+    #[serde(rename="Status")]
     pub status: OptionStatus,
 }
 
@@ -438,10 +456,12 @@ impl AnalysisSchemeStatusListDeserializer {
     }
 }
 #[doc="<p>The status and configuration of the domain's availability options.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AvailabilityOptionsStatus {
     #[doc="<p>The availability options configured for the domain.</p>"]
+    #[serde(rename="Options")]
     pub options: bool,
+    #[serde(rename="Status")]
     pub status: OptionStatus,
 }
 
@@ -505,8 +525,9 @@ impl BooleanDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>BuildSuggester</a></code> operation. Specifies the name of the domain you want to update.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BuildSuggestersRequest {
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -527,8 +548,10 @@ impl BuildSuggestersRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>BuildSuggester</code> request. Contains a list of the fields used for suggestions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BuildSuggestersResponse {
+    #[serde(rename="FieldNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub field_names: Option<Vec<String>>,
 }
 
@@ -576,9 +599,10 @@ impl BuildSuggestersResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>CreateDomain</a></code> operation. Specifies a name for the new search domain.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDomainRequest {
     #[doc="<p>A name for the domain you are creating. Allowed characters are a-z (lower-case letters), 0-9, and hyphen (-). Domain names must start with a letter or number and be at least 3 and no more than 28 characters long.</p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -599,8 +623,10 @@ impl CreateDomainRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>CreateDomainRequest</code>. Contains the status of a newly created domain.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDomainResponse {
+    #[serde(rename="DomainStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain_status: Option<DomainStatus>,
 }
 
@@ -648,17 +674,27 @@ impl CreateDomainResponseDeserializer {
     }
 }
 #[doc="<p>Options for a field that contains an array of dates. Present if <code>IndexFieldType</code> specifies the field is of type <code>date-array</code>. All options are enabled by default.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DateArrayOptions {
     #[doc="A value to use for the field if the field isn't specified for a document."]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>Whether facet information can be returned for the field.</p>"]
+    #[serde(rename="FacetEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub facet_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field can be returned in the search results.</p>"]
+    #[serde(rename="ReturnEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field are searchable.</p>"]
+    #[serde(rename="SearchEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_enabled: Option<bool>,
     #[doc="<p>A list of source fields to map to the field. </p>"]
+    #[serde(rename="SourceFields")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_fields: Option<String>,
 }
 
@@ -759,18 +795,30 @@ impl DateArrayOptionsSerializer {
 }
 
 #[doc="<p>Options for a date field. Dates and times are specified in UTC (Coordinated Universal Time) according to IETF RFC3339: yyyy-mm-ddT00:00:00Z. Present if <code>IndexFieldType</code> specifies the field is of type <code>date</code>. All options are enabled by default.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DateOptions {
     #[doc="A value to use for the field if the field isn't specified for a document."]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>Whether facet information can be returned for the field.</p>"]
+    #[serde(rename="FacetEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub facet_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field can be returned in the search results.</p>"]
+    #[serde(rename="ReturnEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field are searchable.</p>"]
+    #[serde(rename="SearchEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_enabled: Option<bool>,
     #[doc="<p>Whether the field can be used to sort the search results.</p>"]
+    #[serde(rename="SortEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sort_enabled: Option<bool>,
+    #[serde(rename="SourceField")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_field: Option<String>,
 }
 
@@ -879,9 +927,11 @@ impl DateOptionsSerializer {
 }
 
 #[doc="<p>Container for the parameters to the <code><a>DefineAnalysisScheme</a></code> operation. Specifies the name of the domain you want to update and the analysis scheme configuration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DefineAnalysisSchemeRequest {
+    #[serde(rename="AnalysisScheme")]
     pub analysis_scheme: AnalysisScheme,
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -905,8 +955,9 @@ impl DefineAnalysisSchemeRequestSerializer {
 }
 
 #[doc="<p>The result of a <code><a>DefineAnalysisScheme</a></code> request. Contains the status of the newly-configured analysis scheme.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DefineAnalysisSchemeResponse {
+    #[serde(rename="AnalysisScheme")]
     pub analysis_scheme: AnalysisSchemeStatus,
 }
 
@@ -954,9 +1005,11 @@ impl DefineAnalysisSchemeResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DefineExpression</a></code> operation. Specifies the name of the domain you want to update and the expression you want to configure.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DefineExpressionRequest {
+    #[serde(rename="DomainName")]
     pub domain_name: String,
+    #[serde(rename="Expression")]
     pub expression: Expression,
 }
 
@@ -980,8 +1033,9 @@ impl DefineExpressionRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DefineExpression</code> request. Contains the status of the newly-configured expression.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DefineExpressionResponse {
+    #[serde(rename="Expression")]
     pub expression: ExpressionStatus,
 }
 
@@ -1028,10 +1082,12 @@ impl DefineExpressionResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DefineIndexField</a></code> operation. Specifies the name of the domain you want to update and the index field configuration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DefineIndexFieldRequest {
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>The index field and field options you want to configure. </p>"]
+    #[serde(rename="IndexField")]
     pub index_field: IndexField,
 }
 
@@ -1055,8 +1111,9 @@ impl DefineIndexFieldRequestSerializer {
 }
 
 #[doc="<p>The result of a <code><a>DefineIndexField</a></code> request. Contains the status of the newly-configured index field.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DefineIndexFieldResponse {
+    #[serde(rename="IndexField")]
     pub index_field: IndexFieldStatus,
 }
 
@@ -1104,9 +1161,11 @@ impl DefineIndexFieldResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DefineSuggester</a></code> operation. Specifies the name of the domain you want to update and the suggester configuration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DefineSuggesterRequest {
+    #[serde(rename="DomainName")]
     pub domain_name: String,
+    #[serde(rename="Suggester")]
     pub suggester: Suggester,
 }
 
@@ -1130,8 +1189,9 @@ impl DefineSuggesterRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DefineSuggester</code> request. Contains the status of the newly-configured suggester.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DefineSuggesterResponse {
+    #[serde(rename="Suggester")]
     pub suggester: SuggesterStatus,
 }
 
@@ -1178,10 +1238,12 @@ impl DefineSuggesterResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DeleteAnalysisScheme</a></code> operation. Specifies the name of the domain you want to update and the analysis scheme you want to delete. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAnalysisSchemeRequest {
     #[doc="<p>The name of the analysis scheme you want to delete.</p>"]
+    #[serde(rename="AnalysisSchemeName")]
     pub analysis_scheme_name: String,
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -1204,9 +1266,10 @@ impl DeleteAnalysisSchemeRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DeleteAnalysisScheme</code> request. Contains the status of the deleted analysis scheme.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAnalysisSchemeResponse {
     #[doc="<p>The status of the analysis scheme being deleted.</p>"]
+    #[serde(rename="AnalysisScheme")]
     pub analysis_scheme: AnalysisSchemeStatus,
 }
 
@@ -1254,9 +1317,10 @@ impl DeleteAnalysisSchemeResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DeleteDomain</a></code> operation. Specifies the name of the domain you want to delete.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDomainRequest {
     #[doc="<p>The name of the domain you want to permanently delete.</p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -1277,8 +1341,10 @@ impl DeleteDomainRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DeleteDomain</code> request. Contains the status of a newly deleted domain, or no status if the domain has already been completely deleted.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDomainResponse {
+    #[serde(rename="DomainStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain_status: Option<DomainStatus>,
 }
 
@@ -1326,10 +1392,12 @@ impl DeleteDomainResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DeleteExpression</a></code> operation. Specifies the name of the domain you want to update and the name of the expression you want to delete.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteExpressionRequest {
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>The name of the <code><a>Expression</a></code> to delete.</p>"]
+    #[serde(rename="ExpressionName")]
     pub expression_name: String,
 }
 
@@ -1352,9 +1420,10 @@ impl DeleteExpressionRequestSerializer {
 }
 
 #[doc="<p>The result of a <code><a>DeleteExpression</a></code> request. Specifies the expression being deleted.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteExpressionResponse {
     #[doc="<p>The status of the expression being deleted.</p>"]
+    #[serde(rename="Expression")]
     pub expression: ExpressionStatus,
 }
 
@@ -1401,10 +1470,12 @@ impl DeleteExpressionResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DeleteIndexField</a></code> operation. Specifies the name of the domain you want to update and the name of the index field you want to delete.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIndexFieldRequest {
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>The name of the index field your want to remove from the domain's indexing options.</p>"]
+    #[serde(rename="IndexFieldName")]
     pub index_field_name: String,
 }
 
@@ -1427,9 +1498,10 @@ impl DeleteIndexFieldRequestSerializer {
 }
 
 #[doc="<p>The result of a <code><a>DeleteIndexField</a></code> request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIndexFieldResponse {
     #[doc="<p>The status of the index field being deleted.</p>"]
+    #[serde(rename="IndexField")]
     pub index_field: IndexFieldStatus,
 }
 
@@ -1477,10 +1549,12 @@ impl DeleteIndexFieldResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DeleteSuggester</a></code> operation. Specifies the name of the domain you want to update and name of the suggester you want to delete.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSuggesterRequest {
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>Specifies the name of the suggester you want to delete.</p>"]
+    #[serde(rename="SuggesterName")]
     pub suggester_name: String,
 }
 
@@ -1503,9 +1577,10 @@ impl DeleteSuggesterRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DeleteSuggester</code> request. Contains the status of the deleted suggester.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSuggesterResponse {
     #[doc="<p>The status of the suggester being deleted.</p>"]
+    #[serde(rename="Suggester")]
     pub suggester: SuggesterStatus,
 }
 
@@ -1552,13 +1627,18 @@ impl DeleteSuggesterResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DescribeAnalysisSchemes</a></code> operation. Specifies the name of the domain you want to describe. To limit the response to particular analysis schemes, specify the names of the analysis schemes you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAnalysisSchemesRequest {
     #[doc="<p>The analysis schemes you want to describe.</p>"]
+    #[serde(rename="AnalysisSchemeNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub analysis_scheme_names: Option<Vec<String>>,
     #[doc="<p>Whether to display the deployed configuration (<code>true</code>) or include any pending changes (<code>false</code>). Defaults to <code>false</code>.</p>"]
+    #[serde(rename="Deployed")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deployed: Option<bool>,
     #[doc="<p>The name of the domain you want to describe.</p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -1588,9 +1668,10 @@ impl DescribeAnalysisSchemesRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DescribeAnalysisSchemes</code> request. Contains the analysis schemes configured for the domain specified in the request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAnalysisSchemesResponse {
     #[doc="<p>The analysis scheme descriptions.</p>"]
+    #[serde(rename="AnalysisSchemes")]
     pub analysis_schemes: Vec<AnalysisSchemeStatus>,
 }
 
@@ -1639,11 +1720,14 @@ impl DescribeAnalysisSchemesResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DescribeAvailabilityOptions</a></code> operation. Specifies the name of the domain you want to describe. To show the active configuration and exclude any pending changes, set the Deployed option to <code>true</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAvailabilityOptionsRequest {
     #[doc="<p>Whether to display the deployed configuration (<code>true</code>) or include any pending changes (<code>false</code>). Defaults to <code>false</code>.</p>"]
+    #[serde(rename="Deployed")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deployed: Option<bool>,
     #[doc="<p>The name of the domain you want to describe.</p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -1668,9 +1752,11 @@ impl DescribeAvailabilityOptionsRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DescribeAvailabilityOptions</code> request. Indicates whether or not the Multi-AZ option is enabled for the domain specified in the request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAvailabilityOptionsResponse {
     #[doc="<p>The availability options configured for the domain. Indicates whether Multi-AZ is enabled for the domain. </p>"]
+    #[serde(rename="AvailabilityOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_options: Option<AvailabilityOptionsStatus>,
 }
 
@@ -1717,9 +1803,11 @@ impl DescribeAvailabilityOptionsResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DescribeDomains</a></code> operation. By default shows the status of all domains. To restrict the response to particular domains, specify the names of the domains you want to describe.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDomainsRequest {
     #[doc="<p>The names of the domains you want to include in the response.</p>"]
+    #[serde(rename="DomainNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain_names: Option<Vec<String>>,
 }
 
@@ -1743,8 +1831,9 @@ impl DescribeDomainsRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DescribeDomains</code> request. Contains the status of the domains specified in the request or all domains owned by the account.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDomainsResponse {
+    #[serde(rename="DomainStatusList")]
     pub domain_status_list: Vec<DomainStatus>,
 }
 
@@ -1792,13 +1881,18 @@ impl DescribeDomainsResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DescribeDomains</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular expressions, specify the names of the expressions you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExpressionsRequest {
     #[doc="<p>Whether to display the deployed configuration (<code>true</code>) or include any pending changes (<code>false</code>). Defaults to <code>false</code>.</p>"]
+    #[serde(rename="Deployed")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deployed: Option<bool>,
     #[doc="<p>The name of the domain you want to describe.</p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>Limits the <code><a>DescribeExpressions</a></code> response to the specified expressions. If not specified, all expressions are shown.</p>"]
+    #[serde(rename="ExpressionNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expression_names: Option<Vec<String>>,
 }
 
@@ -1828,9 +1922,10 @@ impl DescribeExpressionsRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DescribeExpressions</code> request. Contains the expressions configured for the domain specified in the request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExpressionsResponse {
     #[doc="<p>The expressions configured for the domain.</p>"]
+    #[serde(rename="Expressions")]
     pub expressions: Vec<ExpressionStatus>,
 }
 
@@ -1878,13 +1973,18 @@ impl DescribeExpressionsResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DescribeIndexFields</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular index fields, specify the names of the index fields you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIndexFieldsRequest {
     #[doc="<p>Whether to display the deployed configuration (<code>true</code>) or include any pending changes (<code>false</code>). Defaults to <code>false</code>.</p>"]
+    #[serde(rename="Deployed")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deployed: Option<bool>,
     #[doc="<p>The name of the domain you want to describe.</p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>A list of the index fields you want to describe. If not specified, information is returned for all configured index fields.</p>"]
+    #[serde(rename="FieldNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub field_names: Option<Vec<String>>,
 }
 
@@ -1914,9 +2014,10 @@ impl DescribeIndexFieldsRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DescribeIndexFields</code> request. Contains the index fields configured for the domain specified in the request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIndexFieldsResponse {
     #[doc="<p>The index fields configured for the domain.</p>"]
+    #[serde(rename="IndexFields")]
     pub index_fields: Vec<IndexFieldStatus>,
 }
 
@@ -1964,8 +2065,9 @@ impl DescribeIndexFieldsResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DescribeScalingParameters</a></code> operation. Specifies the name of the domain you want to describe. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScalingParametersRequest {
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -1986,8 +2088,9 @@ impl DescribeScalingParametersRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DescribeScalingParameters</code> request. Contains the scaling parameters configured for the domain specified in the request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScalingParametersResponse {
+    #[serde(rename="ScalingParameters")]
     pub scaling_parameters: ScalingParametersStatus,
 }
 
@@ -2036,11 +2139,14 @@ impl DescribeScalingParametersResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DescribeServiceAccessPolicies</a></code> operation. Specifies the name of the domain you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeServiceAccessPoliciesRequest {
     #[doc="<p>Whether to display the deployed configuration (<code>true</code>) or include any pending changes (<code>false</code>). Defaults to <code>false</code>.</p>"]
+    #[serde(rename="Deployed")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deployed: Option<bool>,
     #[doc="<p>The name of the domain you want to describe.</p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -2065,9 +2171,10 @@ impl DescribeServiceAccessPoliciesRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DescribeServiceAccessPolicies</code> request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeServiceAccessPoliciesResponse {
     #[doc="<p>The access rules configured for the domain specified in the request.</p>"]
+    #[serde(rename="AccessPolicies")]
     pub access_policies: AccessPoliciesStatus,
 }
 
@@ -2116,13 +2223,18 @@ impl DescribeServiceAccessPoliciesResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>DescribeSuggester</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular suggesters, specify the names of the suggesters you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSuggestersRequest {
     #[doc="<p>Whether to display the deployed configuration (<code>true</code>) or include any pending changes (<code>false</code>). Defaults to <code>false</code>.</p>"]
+    #[serde(rename="Deployed")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deployed: Option<bool>,
     #[doc="<p>The name of the domain you want to describe.</p>"]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>The suggesters you want to describe.</p>"]
+    #[serde(rename="SuggesterNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub suggester_names: Option<Vec<String>>,
 }
 
@@ -2152,9 +2264,10 @@ impl DescribeSuggestersRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>DescribeSuggesters</code> request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSuggestersResponse {
     #[doc="<p>The suggesters configured for the domain specified in the request.</p>"]
+    #[serde(rename="Suggesters")]
     pub suggesters: Vec<SuggesterStatus>,
 }
 
@@ -2202,13 +2315,18 @@ impl DescribeSuggestersResponseDeserializer {
     }
 }
 #[doc="<p>Options for a search suggester.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentSuggesterOptions {
     #[doc="<p>The level of fuzziness allowed when suggesting matches for a string: <code>none</code>, <code>low</code>, or <code>high</code>. With none, the specified string is treated as an exact prefix. With low, suggestions must differ from the specified string by no more than one character. With high, suggestions can differ by up to two characters. The default is none. </p>"]
+    #[serde(rename="FuzzyMatching")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fuzzy_matching: Option<String>,
     #[doc="<p>An expression that computes a score for each suggestion to control how they are sorted. The scores are rounded to the nearest integer, with a floor of 0 and a ceiling of 2^31-1. A document's relevance score is not computed for suggestions, so sort expressions cannot reference the <code>_score</code> value. To sort suggestions using a numeric field or existing expression, simply specify the name of the field or expression. If no expression is configured for the suggester, the suggestions are sorted with the closest matches listed first.</p>"]
+    #[serde(rename="SortExpression")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sort_expression: Option<String>,
     #[doc="<p>The name of the index field you want to use for suggestions. </p>"]
+    #[serde(rename="SourceField")]
     pub source_field: String,
 }
 
@@ -2353,29 +2471,52 @@ impl DomainNameMapDeserializer {
     }
 }
 #[doc="<p>The current status of the search domain.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainStatus {
+    #[serde(rename="ARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
     #[doc="<p>True if the search domain is created. It can take several minutes to initialize a domain when <a>CreateDomain</a> is called. Newly created search domains are returned from <a>DescribeDomains</a> with a false value for Created until domain creation is complete.</p>"]
+    #[serde(rename="Created")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub created: Option<bool>,
     #[doc="<p>True if the search domain has been deleted. The system must clean up resources dedicated to the search domain when <a>DeleteDomain</a> is called. Newly deleted search domains are returned from <a>DescribeDomains</a> with a true value for IsDeleted for several minutes until resource cleanup is complete.</p>"]
+    #[serde(rename="Deleted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deleted: Option<bool>,
     #[doc="<p>The service endpoint for updating documents in a search domain.</p>"]
+    #[serde(rename="DocService")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub doc_service: Option<ServiceEndpoint>,
+    #[serde(rename="DomainId")]
     pub domain_id: String,
+    #[serde(rename="DomainName")]
     pub domain_name: String,
+    #[serde(rename="Limits")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub limits: Option<Limits>,
     #[doc="<p>True if processing is being done to activate the current domain configuration.</p>"]
+    #[serde(rename="Processing")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub processing: Option<bool>,
     #[doc="<p>True if <a>IndexDocuments</a> needs to be called to activate the current domain configuration.</p>"]
+    #[serde(rename="RequiresIndexDocuments")]
     pub requires_index_documents: bool,
     #[doc="<p>The number of search instances that are available to process search requests.</p>"]
+    #[serde(rename="SearchInstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_instance_count: Option<i64>,
     #[doc="<p>The instance type that is being used to process search requests.</p>"]
+    #[serde(rename="SearchInstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_instance_type: Option<String>,
     #[doc="<p>The number of partitions across which the search index is spread.</p>"]
+    #[serde(rename="SearchPartitionCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_partition_count: Option<i64>,
     #[doc="<p>The service endpoint for requesting search results from a search domain.</p>"]
+    #[serde(rename="SearchService")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_service: Option<ServiceEndpoint>,
 }
 
@@ -2530,17 +2671,27 @@ impl DoubleDeserializer {
     }
 }
 #[doc="<p>Options for a field that contains an array of double-precision 64-bit floating point values. Present if <code>IndexFieldType</code> specifies the field is of type <code>double-array</code>. All options are enabled by default.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DoubleArrayOptions {
     #[doc="A value to use for the field if the field isn't specified for a document."]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<f64>,
     #[doc="<p>Whether facet information can be returned for the field.</p>"]
+    #[serde(rename="FacetEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub facet_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field can be returned in the search results.</p>"]
+    #[serde(rename="ReturnEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field are searchable.</p>"]
+    #[serde(rename="SearchEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_enabled: Option<bool>,
     #[doc="<p>A list of source fields to map to the field. </p>"]
+    #[serde(rename="SourceFields")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_fields: Option<String>,
 }
 
@@ -2640,19 +2791,31 @@ impl DoubleArrayOptionsSerializer {
 }
 
 #[doc="<p>Options for a double-precision 64-bit floating point field. Present if <code>IndexFieldType</code> specifies the field is of type <code>double</code>. All options are enabled by default.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DoubleOptions {
     #[doc="<p>A value to use for the field if the field isn't specified for a document. This can be important if you are using the field in an expression and that field is not present in every document.</p>"]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<f64>,
     #[doc="<p>Whether facet information can be returned for the field.</p>"]
+    #[serde(rename="FacetEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub facet_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field can be returned in the search results.</p>"]
+    #[serde(rename="ReturnEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field are searchable.</p>"]
+    #[serde(rename="SearchEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_enabled: Option<bool>,
     #[doc="<p>Whether the field can be used to sort the search results.</p>"]
+    #[serde(rename="SortEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sort_enabled: Option<bool>,
     #[doc="<p>The name of the source field to map to the field. </p>"]
+    #[serde(rename="SourceField")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_field: Option<String>,
 }
 
@@ -2786,9 +2949,11 @@ impl DynamicFieldNameListSerializer {
 }
 
 #[doc="<p>A named expression that can be evaluated at search time. Can be used to sort the search results, define other expressions, or return computed information in the search results. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Expression {
+    #[serde(rename="ExpressionName")]
     pub expression_name: String,
+    #[serde(rename="ExpressionValue")]
     pub expression_value: String,
 }
 
@@ -2859,10 +3024,12 @@ impl ExpressionSerializer {
 }
 
 #[doc="<p>The value of an <code>Expression</code> and its current status.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExpressionStatus {
     #[doc="<p>The expression that is evaluated for sorting while processing a search request.</p>"]
+    #[serde(rename="Options")]
     pub options: Expression,
+    #[serde(rename="Status")]
     pub status: OptionStatus,
 }
 
@@ -3051,8 +3218,9 @@ impl FieldValueDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>IndexDocuments</a></code> operation. Specifies the name of the domain you want to re-index.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IndexDocumentsRequest {
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -3073,9 +3241,11 @@ impl IndexDocumentsRequestSerializer {
 }
 
 #[doc="<p>The result of an <code>IndexDocuments</code> request. Contains the status of the indexing operation, including the fields being indexed.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IndexDocumentsResponse {
     #[doc="<p>The names of the fields that are currently being indexed.</p>"]
+    #[serde(rename="FieldNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub field_names: Option<Vec<String>>,
 }
 
@@ -3123,21 +3293,45 @@ impl IndexDocumentsResponseDeserializer {
     }
 }
 #[doc="<p>Configuration information for a field in the index, including its name, type, and options. The supported options depend on the <code><a>IndexFieldType</a></code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IndexField {
+    #[serde(rename="DateArrayOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_array_options: Option<DateArrayOptions>,
+    #[serde(rename="DateOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_options: Option<DateOptions>,
+    #[serde(rename="DoubleArrayOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub double_array_options: Option<DoubleArrayOptions>,
+    #[serde(rename="DoubleOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub double_options: Option<DoubleOptions>,
     #[doc="<p>A string that represents the name of an index field. CloudSearch supports regular index fields as well as dynamic fields. A dynamic field's name defines a pattern that begins or ends with a wildcard. Any document fields that don't map to a regular index field but do match a dynamic field's pattern are configured with the dynamic field's indexing options. </p> <p>Regular field names begin with a letter and can contain the following characters: a-z (lowercase), 0-9, and _ (underscore). Dynamic field names must begin or end with a wildcard (*). The wildcard can also be the only character in a dynamic field name. Multiple wildcards, and wildcards embedded within a string are not supported. </p> <p>The name <code>score</code> is reserved and cannot be used as a field name. To reference a document's ID, you can use the name <code>_id</code>. </p>"]
+    #[serde(rename="IndexFieldName")]
     pub index_field_name: String,
+    #[serde(rename="IndexFieldType")]
     pub index_field_type: String,
+    #[serde(rename="IntArrayOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub int_array_options: Option<IntArrayOptions>,
+    #[serde(rename="IntOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub int_options: Option<IntOptions>,
+    #[serde(rename="LatLonOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lat_lon_options: Option<LatLonOptions>,
+    #[serde(rename="LiteralArrayOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub literal_array_options: Option<LiteralArrayOptions>,
+    #[serde(rename="LiteralOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub literal_options: Option<LiteralOptions>,
+    #[serde(rename="TextArrayOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub text_array_options: Option<TextArrayOptions>,
+    #[serde(rename="TextOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub text_options: Option<TextOptions>,
 }
 
@@ -3320,9 +3514,11 @@ impl IndexFieldSerializer {
 }
 
 #[doc="<p>The value of an <code>IndexField</code> and its current status.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IndexFieldStatus {
+    #[serde(rename="Options")]
     pub options: IndexField,
+    #[serde(rename="Status")]
     pub status: OptionStatus,
 }
 
@@ -3442,17 +3638,27 @@ impl InstanceCountDeserializer {
     }
 }
 #[doc="<p>Options for a field that contains an array of 64-bit signed integers. Present if <code>IndexFieldType</code> specifies the field is of type <code>int-array</code>. All options are enabled by default.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IntArrayOptions {
     #[doc="A value to use for the field if the field isn't specified for a document."]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<i64>,
     #[doc="<p>Whether facet information can be returned for the field.</p>"]
+    #[serde(rename="FacetEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub facet_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field can be returned in the search results.</p>"]
+    #[serde(rename="ReturnEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field are searchable.</p>"]
+    #[serde(rename="SearchEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_enabled: Option<bool>,
     #[doc="<p>A list of source fields to map to the field. </p>"]
+    #[serde(rename="SourceFields")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_fields: Option<String>,
 }
 
@@ -3552,19 +3758,31 @@ impl IntArrayOptionsSerializer {
 }
 
 #[doc="<p>Options for a 64-bit signed integer field. Present if <code>IndexFieldType</code> specifies the field is of type <code>int</code>. All options are enabled by default.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IntOptions {
     #[doc="A value to use for the field if the field isn't specified for a document. This can be important if you are using the field in an expression and that field is not present in every document."]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<i64>,
     #[doc="<p>Whether facet information can be returned for the field.</p>"]
+    #[serde(rename="FacetEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub facet_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field can be returned in the search results.</p>"]
+    #[serde(rename="ReturnEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field are searchable.</p>"]
+    #[serde(rename="SearchEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_enabled: Option<bool>,
     #[doc="<p>Whether the field can be used to sort the search results.</p>"]
+    #[serde(rename="SortEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sort_enabled: Option<bool>,
     #[doc="<p>The name of the source field to map to the field. </p>"]
+    #[serde(rename="SourceField")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_field: Option<String>,
 }
 
@@ -3672,18 +3890,30 @@ impl IntOptionsSerializer {
 }
 
 #[doc="<p>Options for a latlon field. A latlon field contains a location stored as a latitude and longitude value pair. Present if <code>IndexFieldType</code> specifies the field is of type <code>latlon</code>. All options are enabled by default.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LatLonOptions {
     #[doc="A value to use for the field if the field isn't specified for a document."]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>Whether facet information can be returned for the field.</p>"]
+    #[serde(rename="FacetEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub facet_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field can be returned in the search results.</p>"]
+    #[serde(rename="ReturnEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field are searchable.</p>"]
+    #[serde(rename="SearchEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_enabled: Option<bool>,
     #[doc="<p>Whether the field can be used to sort the search results.</p>"]
+    #[serde(rename="SortEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sort_enabled: Option<bool>,
+    #[serde(rename="SourceField")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_field: Option<String>,
 }
 
@@ -3791,9 +4021,11 @@ impl LatLonOptionsSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Limits {
+    #[serde(rename="MaximumPartitionCount")]
     pub maximum_partition_count: i64,
+    #[serde(rename="MaximumReplicationCount")]
     pub maximum_replication_count: i64,
 }
 
@@ -3846,9 +4078,11 @@ impl LimitsDeserializer {
     }
 }
 #[doc="<p>The result of a <code>ListDomainNames</code> request. Contains a list of the domains owned by an account.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDomainNamesResponse {
     #[doc="<p>The names of the search domains owned by an account.</p>"]
+    #[serde(rename="DomainNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain_names: Option<::std::collections::HashMap<String, String>>,
 }
 
@@ -3896,17 +4130,27 @@ impl ListDomainNamesResponseDeserializer {
     }
 }
 #[doc="<p>Options for a field that contains an array of literal strings. Present if <code>IndexFieldType</code> specifies the field is of type <code>literal-array</code>. All options are enabled by default.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LiteralArrayOptions {
     #[doc="A value to use for the field if the field isn't specified for a document."]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>Whether facet information can be returned for the field.</p>"]
+    #[serde(rename="FacetEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub facet_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field can be returned in the search results.</p>"]
+    #[serde(rename="ReturnEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field are searchable.</p>"]
+    #[serde(rename="SearchEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_enabled: Option<bool>,
     #[doc="<p>A list of source fields to map to the field. </p>"]
+    #[serde(rename="SourceFields")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_fields: Option<String>,
 }
 
@@ -4007,18 +4251,30 @@ impl LiteralArrayOptionsSerializer {
 }
 
 #[doc="<p>Options for literal field. Present if <code>IndexFieldType</code> specifies the field is of type <code>literal</code>. All options are enabled by default.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LiteralOptions {
     #[doc="A value to use for the field if the field isn't specified for a document."]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>Whether facet information can be returned for the field.</p>"]
+    #[serde(rename="FacetEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub facet_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field can be returned in the search results.</p>"]
+    #[serde(rename="ReturnEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field are searchable.</p>"]
+    #[serde(rename="SearchEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_enabled: Option<bool>,
     #[doc="<p>Whether the field can be used to sort the search results.</p>"]
+    #[serde(rename="SortEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sort_enabled: Option<bool>,
+    #[serde(rename="SourceField")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_field: Option<String>,
 }
 
@@ -4197,17 +4453,24 @@ impl OptionStateDeserializer {
     }
 }
 #[doc="<p>The status of domain configuration option.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionStatus {
     #[doc="<p>A timestamp for when this option was created.</p>"]
+    #[serde(rename="CreationDate")]
     pub creation_date: String,
     #[doc="<p>Indicates that the option will be deleted once processing is complete.</p>"]
+    #[serde(rename="PendingDeletion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pending_deletion: Option<bool>,
     #[doc="<p>The state of processing a change to an option. Possible values:</p> <ul> <li> <code>RequiresIndexDocuments</code>: the option's latest value will not be deployed until <a>IndexDocuments</a> has been called and indexing is complete.</li> <li> <code>Processing</code>: the option's latest value is in the process of being activated. </li> <li> <code>Active</code>: the option's latest value is completely deployed.</li> <li> <code>FailedToValidate</code>: the option value is not compatible with the domain's data and cannot be used to index the data. You must either modify the option value or update or remove the incompatible documents.</li> </ul>"]
+    #[serde(rename="State")]
     pub state: String,
     #[doc="<p>A timestamp for when this option was last updated.</p>"]
+    #[serde(rename="UpdateDate")]
     pub update_date: String,
     #[doc="<p>A unique integer that indicates when this option was last updated.</p>"]
+    #[serde(rename="UpdateVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub update_version: Option<i64>,
 }
 
@@ -4314,13 +4577,19 @@ impl PolicyDocumentDeserializer {
     }
 }
 #[doc="<p>The desired instance type and desired number of replicas of each index partition.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScalingParameters {
     #[doc="<p>The instance type that you want to preconfigure for your domain. For example, <code>search.m1.small</code>.</p>"]
+    #[serde(rename="DesiredInstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub desired_instance_type: Option<String>,
     #[doc="<p>The number of partitions you want to preconfigure for your domain. Only valid when you select <code>m2.2xlarge</code> as the desired instance type.</p>"]
+    #[serde(rename="DesiredPartitionCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub desired_partition_count: Option<i64>,
     #[doc="<p>The number of replicas you want to preconfigure for each index partition.</p>"]
+    #[serde(rename="DesiredReplicationCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub desired_replication_count: Option<i64>,
 }
 
@@ -4404,9 +4673,11 @@ impl ScalingParametersSerializer {
 }
 
 #[doc="<p>The status and configuration of a search domain's scaling parameters. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScalingParametersStatus {
+    #[serde(rename="Options")]
     pub options: ScalingParameters,
+    #[serde(rename="Status")]
     pub status: OptionStatus,
 }
 
@@ -4471,8 +4742,10 @@ impl SearchInstanceTypeDeserializer {
     }
 }
 #[doc="<p>The endpoint to which service requests can be submitted.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ServiceEndpoint {
+    #[serde(rename="Endpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoint: Option<String>,
 }
 
@@ -4573,9 +4846,11 @@ impl StringDeserializer {
     }
 }
 #[doc="<p>Configuration information for a search suggester. Each suggester has a unique name and specifies the text field you want to use for suggestions. The following options can be configured for a suggester: <code>FuzzyMatching</code>, <code>SortExpression</code>. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Suggester {
+    #[serde(rename="DocumentSuggesterOptions")]
     pub document_suggester_options: DocumentSuggesterOptions,
+    #[serde(rename="SuggesterName")]
     pub suggester_name: String,
 }
 
@@ -4662,9 +4937,11 @@ impl SuggesterFuzzyMatchingDeserializer {
     }
 }
 #[doc="<p>The value of a <code>Suggester</code> and its current status.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SuggesterStatus {
+    #[serde(rename="Options")]
     pub options: Suggester,
+    #[serde(rename="Status")]
     pub status: OptionStatus,
 }
 
@@ -4756,17 +5033,27 @@ impl SuggesterStatusListDeserializer {
     }
 }
 #[doc="<p>Options for a field that contains an array of text strings. Present if <code>IndexFieldType</code> specifies the field is of type <code>text-array</code>. A <code>text-array</code> field is always searchable. All options are enabled by default.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TextArrayOptions {
     #[doc="<p>The name of an analysis scheme for a <code>text-array</code> field.</p>"]
+    #[serde(rename="AnalysisScheme")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub analysis_scheme: Option<String>,
     #[doc="A value to use for the field if the field isn't specified for a document."]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>Whether highlights can be returned for the field.</p>"]
+    #[serde(rename="HighlightEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub highlight_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field can be returned in the search results.</p>"]
+    #[serde(rename="ReturnEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_enabled: Option<bool>,
     #[doc="<p>A list of source fields to map to the field. </p>"]
+    #[serde(rename="SourceFields")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_fields: Option<String>,
 }
 
@@ -4867,18 +5154,30 @@ impl TextArrayOptionsSerializer {
 }
 
 #[doc="<p>Options for text field. Present if <code>IndexFieldType</code> specifies the field is of type <code>text</code>. A <code>text</code> field is always searchable. All options are enabled by default.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TextOptions {
     #[doc="<p>The name of an analysis scheme for a <code>text</code> field.</p>"]
+    #[serde(rename="AnalysisScheme")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub analysis_scheme: Option<String>,
     #[doc="A value to use for the field if the field isn't specified for a document."]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>Whether highlights can be returned for the field.</p>"]
+    #[serde(rename="HighlightEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub highlight_enabled: Option<bool>,
     #[doc="<p>Whether the contents of the field can be returned in the search results.</p>"]
+    #[serde(rename="ReturnEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_enabled: Option<bool>,
     #[doc="<p>Whether the field can be used to sort the search results.</p>"]
+    #[serde(rename="SortEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sort_enabled: Option<bool>,
+    #[serde(rename="SourceField")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_field: Option<String>,
 }
 
@@ -5001,10 +5300,12 @@ impl UIntValueDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>UpdateAvailabilityOptions</a></code> operation. Specifies the name of the domain you want to update and the Multi-AZ availability option.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAvailabilityOptionsRequest {
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="<p>You expand an existing search domain to a second Availability Zone by setting the Multi-AZ option to true. Similarly, you can turn off the Multi-AZ option to downgrade the domain to a single Availability Zone by setting the Multi-AZ option to <code>false</code>. </p>"]
+    #[serde(rename="MultiAZ")]
     pub multi_az: bool,
 }
 
@@ -5027,9 +5328,11 @@ impl UpdateAvailabilityOptionsRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>UpdateAvailabilityOptions</code> request. Contains the status of the domain's availability options. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAvailabilityOptionsResponse {
     #[doc="<p>The newly-configured availability options. Indicates whether Multi-AZ is enabled for the domain. </p>"]
+    #[serde(rename="AvailabilityOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_options: Option<AvailabilityOptionsStatus>,
 }
 
@@ -5076,9 +5379,11 @@ impl UpdateAvailabilityOptionsResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>UpdateScalingParameters</a></code> operation. Specifies the name of the domain you want to update and the scaling parameters you want to configure.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateScalingParametersRequest {
+    #[serde(rename="DomainName")]
     pub domain_name: String,
+    #[serde(rename="ScalingParameters")]
     pub scaling_parameters: ScalingParameters,
 }
 
@@ -5102,8 +5407,9 @@ impl UpdateScalingParametersRequestSerializer {
 }
 
 #[doc="<p>The result of a <code>UpdateScalingParameters</code> request. Contains the status of the newly-configured scaling parameters.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateScalingParametersResponse {
+    #[serde(rename="ScalingParameters")]
     pub scaling_parameters: ScalingParametersStatus,
 }
 
@@ -5152,10 +5458,12 @@ impl UpdateScalingParametersResponseDeserializer {
     }
 }
 #[doc="<p>Container for the parameters to the <code><a>UpdateServiceAccessPolicies</a></code> operation. Specifies the name of the domain you want to update and the access rules you want to configure.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateServiceAccessPoliciesRequest {
     #[doc="<p>The access rules you want to configure. These rules replace any existing rules. </p>"]
+    #[serde(rename="AccessPolicies")]
     pub access_policies: String,
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -5178,9 +5486,10 @@ impl UpdateServiceAccessPoliciesRequestSerializer {
 }
 
 #[doc="<p>The result of an <code>UpdateServiceAccessPolicies</code> request. Contains the new access policies.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateServiceAccessPoliciesResponse {
     #[doc="<p>The access rules configured for the domain.</p>"]
+    #[serde(rename="AccessPolicies")]
     pub access_policies: AccessPoliciesStatus,
 }
 

--- a/rusoto/services/cloudsearchdomain/src/generated.rs
+++ b/rusoto/services/cloudsearchdomain/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 #[doc="<p>A container for facet information. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Bucket {
     #[doc="<p>The number of hits that contain the facet value in the specified facet field.</p>"]
     #[serde(rename="count")]
@@ -43,7 +43,7 @@ pub struct Bucket {
 }
 
 #[doc="<p>A container for the calculated facet values and counts.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BucketInfo {
     #[doc="<p>A list of the calculated facet values and counts.</p>"]
     #[serde(rename="buckets")]
@@ -52,7 +52,7 @@ pub struct BucketInfo {
 }
 
 #[doc="<p>A warning returned by the document service when an issue is discovered while processing an upload request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentServiceWarning {
     #[doc="<p>The description for a warning returned by the document service.</p>"]
     #[serde(rename="message")]
@@ -61,7 +61,7 @@ pub struct DocumentServiceWarning {
 }
 
 #[doc="<p>The statistics for a field calculated in the request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FieldStats {
     #[doc="<p>The number of documents that contain a value in the specified field in the result set.</p>"]
     #[serde(rename="count")]
@@ -98,7 +98,7 @@ pub struct FieldStats {
 }
 
 #[doc="<p>Information about a document that matches the search request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Hit {
     #[doc="<p>The expressions returned from a document that matches the search request.</p>"]
     #[serde(rename="exprs")]
@@ -119,7 +119,7 @@ pub struct Hit {
 }
 
 #[doc="<p>The collection of documents that match the search request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Hits {
     #[doc="<p>A cursor that can be used to retrieve the next set of matching documents when you want to page through a large result set.</p>"]
     #[serde(rename="cursor")]
@@ -140,7 +140,7 @@ pub struct Hits {
 }
 
 #[doc="<p>Container for the parameters to the <code>Search</code> request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchRequest {
     #[doc="<p>Retrieves a cursor value you can use to page through large result sets. Use the <code>size</code> parameter to control the number of hits to include in each response. You can specify either the <code>cursor</code> or <code>start</code> parameter in a request; they are mutually exclusive. To get the first cursor, set the cursor value to <code>initial</code>. In subsequent requests, specify the cursor value returned in the hits section of the response. </p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/cloudsearch/latest/developerguide/paginating-results.html\">Paginating Results</a> in the <i>Amazon CloudSearch Developer Guide</i>.</p>"]
     #[serde(rename="cursor")]
@@ -200,7 +200,7 @@ pub struct SearchRequest {
 }
 
 #[doc="<p>The result of a <code>Search</code> request. Contains the documents that match the specified search criteria and any requested fields, highlights, and facet information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchResponse {
     #[doc="<p>The requested facet information.</p>"]
     #[serde(rename="facets")]
@@ -221,7 +221,7 @@ pub struct SearchResponse {
 }
 
 #[doc="<p>Contains the resource id (<code>rid</code>) and the time it took to process the request (<code>timems</code>).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchStatus {
     #[doc="<p>The encrypted resource ID for the request.</p>"]
     #[serde(rename="rid")]
@@ -234,7 +234,7 @@ pub struct SearchStatus {
 }
 
 #[doc="<p>Container for the suggestion information returned in a <code>SuggestResponse</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SuggestModel {
     #[doc="<p>The number of documents that were found to match the query string.</p>"]
     #[serde(rename="found")]
@@ -251,7 +251,7 @@ pub struct SuggestModel {
 }
 
 #[doc="<p>Container for the parameters to the <code>Suggest</code> request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SuggestRequest {
     #[doc="<p>Specifies the string for which you want to get suggestions.</p>"]
     #[serde(rename="query")]
@@ -266,7 +266,7 @@ pub struct SuggestRequest {
 }
 
 #[doc="<p>Contains the response to a <code>Suggest</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SuggestResponse {
     #[doc="<p>The status of a <code>SuggestRequest</code>. Contains the resource ID (<code>rid</code>) and how long it took to process the request (<code>timems</code>).</p>"]
     #[serde(rename="status")]
@@ -279,7 +279,7 @@ pub struct SuggestResponse {
 }
 
 #[doc="<p>Contains the resource id (<code>rid</code>) and the time it took to process the request (<code>timems</code>).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SuggestStatus {
     #[doc="<p>The encrypted resource ID for the request.</p>"]
     #[serde(rename="rid")]
@@ -292,7 +292,7 @@ pub struct SuggestStatus {
 }
 
 #[doc="<p>An autocomplete suggestion that matches the query string specified in a <code>SuggestRequest</code>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SuggestionMatch {
     #[doc="<p>The document ID of the suggested document.</p>"]
     #[serde(rename="id")]
@@ -309,7 +309,7 @@ pub struct SuggestionMatch {
 }
 
 #[doc="<p>Container for the parameters to the <code>UploadDocuments</code> request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadDocumentsRequest {
     #[doc="<p>The format of the batch you are uploading. Amazon CloudSearch supports two document batch formats:</p> <ul> <li>application/json</li> <li>application/xml</li> </ul>"]
     #[serde(rename="contentType")]
@@ -325,7 +325,7 @@ pub struct UploadDocumentsRequest {
 }
 
 #[doc="<p>Contains the response to an <code>UploadDocuments</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadDocumentsResponse {
     #[doc="<p>The number of documents that were added to the search domain.</p>"]
     #[serde(rename="adds")]

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Specifies the tags to add to a trail.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsRequest {
     #[doc="<p>Specifies the ARN of the trail to which one or more tags will be added. The format of a trail ARN is:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>"]
     #[serde(rename="ResourceId")]
@@ -41,11 +41,11 @@ pub struct AddTagsRequest {
 }
 
 #[doc="<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsResponse;
 
 #[doc="<p>Specifies the settings for each trail.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTrailRequest {
     #[doc="<p>Specifies a log group name using an Amazon Resource Name (ARN), a unique identifier that represents the log group to which CloudTrail logs will be delivered. Not required unless you specify CloudWatchLogsRoleArn.</p>"]
     #[serde(rename="CloudWatchLogsLogGroupArn")]
@@ -88,7 +88,7 @@ pub struct CreateTrailRequest {
 }
 
 #[doc="<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTrailResponse {
     #[doc="<p>Specifies the Amazon Resource Name (ARN) of the log group to which CloudTrail logs will be delivered.</p>"]
     #[serde(rename="CloudWatchLogsLogGroupArn")]
@@ -150,7 +150,7 @@ pub struct DataResource {
 }
 
 #[doc="<p>The request that specifies the name of a trail to delete.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTrailRequest {
     #[doc="<p>Specifies the name or the CloudTrail ARN of the trail to be deleted. The format of a trail ARN is: <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>"]
     #[serde(rename="Name")]
@@ -158,11 +158,11 @@ pub struct DeleteTrailRequest {
 }
 
 #[doc="<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTrailResponse;
 
 #[doc="<p>Returns information about the trail.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrailsRequest {
     #[doc="<p>Specifies whether to include shadow trails in the response. A shadow trail is the replication in a region of a trail that was created in a different region. The default is true.</p>"]
     #[serde(rename="includeShadowTrails")]
@@ -175,7 +175,7 @@ pub struct DescribeTrailsRequest {
 }
 
 #[doc="<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrailsResponse {
     #[doc="<p>The list of trail objects.</p>"]
     #[serde(rename="trailList")]
@@ -184,7 +184,7 @@ pub struct DescribeTrailsResponse {
 }
 
 #[doc="<p>Contains information about an event that was returned by a lookup request. The result includes a representation of a CloudTrail event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Event {
     #[doc="<p>A JSON string that contains a representation of the event returned.</p>"]
     #[serde(rename="CloudTrailEvent")]
@@ -233,14 +233,14 @@ pub struct EventSelector {
     pub read_write_type: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetEventSelectorsRequest {
     #[doc="<p>Specifies the name of the trail or trail ARN. If you specify a trail name, the string must meet the following requirements:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores (_), or dashes (-)</p> </li> <li> <p>Start with a letter or number, and end with a letter or number</p> </li> <li> <p>Be between 3 and 128 characters</p> </li> <li> <p>Have no adjacent periods, underscores or dashes. Names like <code>my-_namespace</code> and <code>my--namespace</code> are invalid.</p> </li> <li> <p>Not be in IP address format (for example, 192.168.5.4)</p> </li> </ul> <p>If you specify a trail ARN, it must be in the format:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>"]
     #[serde(rename="TrailName")]
     pub trail_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetEventSelectorsResponse {
     #[doc="<p>The event selectors that are configured for the trail.</p>"]
     #[serde(rename="EventSelectors")]
@@ -253,7 +253,7 @@ pub struct GetEventSelectorsResponse {
 }
 
 #[doc="<p>The name of a trail about which you want the current status.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTrailStatusRequest {
     #[doc="<p>Specifies the name or the CloudTrail ARN of the trail for which you are requesting status. To get the status of a shadow trail (a replication of the trail in another region), you must specify its ARN. The format of a trail ARN is:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>"]
     #[serde(rename="Name")]
@@ -261,7 +261,7 @@ pub struct GetTrailStatusRequest {
 }
 
 #[doc="<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTrailStatusResponse {
     #[doc="<p>Whether the CloudTrail is currently logging AWS API calls.</p>"]
     #[serde(rename="IsLogging")]
@@ -334,7 +334,7 @@ pub struct GetTrailStatusResponse {
 }
 
 #[doc="<p>Requests the public keys for a specified time range.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPublicKeysRequest {
     #[doc="<p>Optionally specifies, in UTC, the end of the time range to look up public keys for CloudTrail digest files. If not specified, the current time is used.</p>"]
     #[serde(rename="EndTime")]
@@ -351,7 +351,7 @@ pub struct ListPublicKeysRequest {
 }
 
 #[doc="<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPublicKeysResponse {
     #[doc="<p>Reserved for future use.</p>"]
     #[serde(rename="NextToken")]
@@ -364,7 +364,7 @@ pub struct ListPublicKeysResponse {
 }
 
 #[doc="<p>Specifies a list of trail tags to return.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsRequest {
     #[doc="<p>Reserved for future use.</p>"]
     #[serde(rename="NextToken")]
@@ -376,7 +376,7 @@ pub struct ListTagsRequest {
 }
 
 #[doc="<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsResponse {
     #[doc="<p>Reserved for future use.</p>"]
     #[serde(rename="NextToken")]
@@ -389,7 +389,7 @@ pub struct ListTagsResponse {
 }
 
 #[doc="<p>Specifies an attribute and value that filter the events returned.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LookupAttribute {
     #[doc="<p>Specifies an attribute on which to filter the events returned.</p>"]
     #[serde(rename="AttributeKey")]
@@ -400,7 +400,7 @@ pub struct LookupAttribute {
 }
 
 #[doc="<p>Contains a request for LookupEvents.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LookupEventsRequest {
     #[doc="<p>Specifies that only events that occur before or at the specified time are returned. If the specified end time is before the specified start time, an error is returned.</p>"]
     #[serde(rename="EndTime")]
@@ -425,7 +425,7 @@ pub struct LookupEventsRequest {
 }
 
 #[doc="<p>Contains a response to a LookupEvents action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LookupEventsResponse {
     #[doc="<p>A list of events returned based on the lookup attributes specified and the CloudTrail event. The events list is sorted by time. The most recent event is listed first.</p>"]
     #[serde(rename="Events")]
@@ -438,7 +438,7 @@ pub struct LookupEventsResponse {
 }
 
 #[doc="<p>Contains information about a returned public key.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PublicKey {
     #[doc="<p>The fingerprint of the public key.</p>"]
     #[serde(rename="Fingerprint")]
@@ -462,7 +462,7 @@ pub struct PublicKey {
     pub value: Option<Vec<u8>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutEventSelectorsRequest {
     #[doc="<p>Specifies the settings for your event selectors. You can configure up to five event selectors for a trail.</p>"]
     #[serde(rename="EventSelectors")]
@@ -472,7 +472,7 @@ pub struct PutEventSelectorsRequest {
     pub trail_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutEventSelectorsResponse {
     #[doc="<p>Specifies the event selectors configured for your trail.</p>"]
     #[serde(rename="EventSelectors")]
@@ -485,7 +485,7 @@ pub struct PutEventSelectorsResponse {
 }
 
 #[doc="<p>Specifies the tags to remove from a trail.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsRequest {
     #[doc="<p>Specifies the ARN of the trail from which tags should be removed. The format of a trail ARN is:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>"]
     #[serde(rename="ResourceId")]
@@ -497,11 +497,11 @@ pub struct RemoveTagsRequest {
 }
 
 #[doc="<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsResponse;
 
 #[doc="<p>Specifies the type and name of a resource referenced by an event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Resource {
     #[doc="<p>The name of the resource referenced by the event returned. These are user-created names whose values will depend on the environment. For example, the resource name might be \"auto-scaling-test-group\" for an Auto Scaling Group or \"i-1234567\" for an EC2 Instance.</p>"]
     #[serde(rename="ResourceName")]
@@ -514,7 +514,7 @@ pub struct Resource {
 }
 
 #[doc="<p>A resource tag.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceTag {
     #[doc="<p>Specifies the ARN of the resource.</p>"]
     #[serde(rename="ResourceId")]
@@ -527,7 +527,7 @@ pub struct ResourceTag {
 }
 
 #[doc="<p>The request to CloudTrail to start logging AWS API calls for an account.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartLoggingRequest {
     #[doc="<p>Specifies the name or the CloudTrail ARN of the trail for which CloudTrail logs AWS API calls. The format of a trail ARN is:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>"]
     #[serde(rename="Name")]
@@ -535,11 +535,11 @@ pub struct StartLoggingRequest {
 }
 
 #[doc="<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartLoggingResponse;
 
 #[doc="<p>Passes the request to CloudTrail to stop logging AWS API calls for the specified account.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopLoggingRequest {
     #[doc="<p>Specifies the name or the CloudTrail ARN of the trail for which CloudTrail will stop logging AWS API calls. The format of a trail ARN is:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>"]
     #[serde(rename="Name")]
@@ -547,7 +547,7 @@ pub struct StopLoggingRequest {
 }
 
 #[doc="<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopLoggingResponse;
 
 #[doc="<p>A custom key-value pair associated with a resource such as a CloudTrail trail.</p>"]
@@ -563,7 +563,7 @@ pub struct Tag {
 }
 
 #[doc="<p>The settings for a trail.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Trail {
     #[doc="<p>Specifies an Amazon Resource Name (ARN), a unique identifier that represents the log group to which CloudTrail logs will be delivered.</p>"]
     #[serde(rename="CloudWatchLogsLogGroupArn")]
@@ -620,7 +620,7 @@ pub struct Trail {
 }
 
 #[doc="<p>Specifies settings to update for the trail.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTrailRequest {
     #[doc="<p>Specifies a log group name using an Amazon Resource Name (ARN), a unique identifier that represents the log group to which CloudTrail logs will be delivered. Not required unless you specify CloudWatchLogsRoleArn.</p>"]
     #[serde(rename="CloudWatchLogsLogGroupArn")]
@@ -664,7 +664,7 @@ pub struct UpdateTrailRequest {
 }
 
 #[doc="<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTrailResponse {
     #[doc="<p>Specifies the Amazon Resource Name (ARN) of the log group to which CloudTrail logs will be delivered.</p>"]
     #[serde(rename="CloudWatchLogsLogGroupArn")]

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -82,17 +82,27 @@ impl AlarmDescriptionDeserializer {
     }
 }
 #[doc="<p>Represents the history of a specific alarm.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AlarmHistoryItem {
     #[doc="<p>The descriptive name for the alarm.</p>"]
+    #[serde(rename="AlarmName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_name: Option<String>,
     #[doc="<p>Data about the alarm, in JSON format.</p>"]
+    #[serde(rename="HistoryData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub history_data: Option<String>,
     #[doc="<p>The type of alarm history item.</p>"]
+    #[serde(rename="HistoryItemType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub history_item_type: Option<String>,
     #[doc="<p>A summary of the alarm history, in text format.</p>"]
+    #[serde(rename="HistorySummary")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub history_summary: Option<String>,
     #[doc="<p>The time stamp for the alarm history item.</p>"]
+    #[serde(rename="Timestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timestamp: Option<String>,
 }
 
@@ -308,15 +318,23 @@ impl DashboardEntriesDeserializer {
     }
 }
 #[doc="<p>Represents a specific dashboard.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DashboardEntry {
     #[doc="<p>The Amazon Resource Name (ARN) of the dashboard.</p>"]
+    #[serde(rename="DashboardArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_arn: Option<String>,
     #[doc="<p>The name of the dashboard.</p>"]
+    #[serde(rename="DashboardName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_name: Option<String>,
     #[doc="<p>The time stamp of when the dashboard was last modified, either by an API call or through the console. This number is expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC.</p>"]
+    #[serde(rename="LastModified")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_modified: Option<String>,
     #[doc="<p>The size of the dashboard, in bytes.</p>"]
+    #[serde(rename="Size")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub size: Option<i64>,
 }
 
@@ -403,11 +421,15 @@ impl DashboardNamesSerializer {
 }
 
 #[doc="<p>An error or warning for the operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DashboardValidationMessage {
     #[doc="<p>The data path related to the message.</p>"]
+    #[serde(rename="DataPath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub data_path: Option<String>,
     #[doc="<p>A message describing the error or warning.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
 }
 
@@ -515,23 +537,39 @@ impl DataPathDeserializer {
     }
 }
 #[doc="<p>Encapsulates the statistical data that CloudWatch computes from metric data.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Datapoint {
     #[doc="<p>The average of the metric values that correspond to the data point.</p>"]
+    #[serde(rename="Average")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub average: Option<f64>,
     #[doc="<p>The percentile statistic for the data point.</p>"]
+    #[serde(rename="ExtendedStatistics")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub extended_statistics: Option<::std::collections::HashMap<String, f64>>,
     #[doc="<p>The maximum metric value for the data point.</p>"]
+    #[serde(rename="Maximum")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub maximum: Option<f64>,
     #[doc="<p>The minimum metric value for the data point.</p>"]
+    #[serde(rename="Minimum")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub minimum: Option<f64>,
     #[doc="<p>The number of metric values that contributed to the aggregate value of this data point.</p>"]
+    #[serde(rename="SampleCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sample_count: Option<f64>,
     #[doc="<p>The sum of the metric values for the data point.</p>"]
+    #[serde(rename="Sum")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sum: Option<f64>,
     #[doc="<p>The time stamp used for the data point.</p>"]
+    #[serde(rename="Timestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timestamp: Option<String>,
     #[doc="<p>The standard unit for the data point.</p>"]
+    #[serde(rename="Unit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unit: Option<String>,
 }
 
@@ -689,9 +727,10 @@ impl DatapointsDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAlarmsInput {
     #[doc="<p>The alarms to be deleted.</p>"]
+    #[serde(rename="AlarmNames")]
     pub alarm_names: Vec<String>,
 }
 
@@ -712,9 +751,11 @@ impl DeleteAlarmsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDashboardsInput {
     #[doc="<p>The dashboards to be deleted.</p>"]
+    #[serde(rename="DashboardNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_names: Option<Vec<String>>,
 }
 
@@ -737,7 +778,7 @@ impl DeleteDashboardsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDashboardsOutput;
 
 struct DeleteDashboardsOutputDeserializer;
@@ -756,19 +797,31 @@ impl DeleteDashboardsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAlarmHistoryInput {
     #[doc="<p>The name of the alarm.</p>"]
+    #[serde(rename="AlarmName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_name: Option<String>,
     #[doc="<p>The ending date to retrieve alarm history.</p>"]
+    #[serde(rename="EndDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_date: Option<String>,
     #[doc="<p>The type of alarm histories to retrieve.</p>"]
+    #[serde(rename="HistoryItemType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub history_item_type: Option<String>,
     #[doc="<p>The maximum number of alarm history records to retrieve.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token returned by a previous call to indicate that there is more data available.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The starting date to retrieve alarm history.</p>"]
+    #[serde(rename="StartDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_date: Option<String>,
 }
 
@@ -810,11 +863,15 @@ impl DescribeAlarmHistoryInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAlarmHistoryOutput {
     #[doc="<p>The alarm histories, in JSON format.</p>"]
+    #[serde(rename="AlarmHistoryItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_history_items: Option<Vec<AlarmHistoryItem>>,
     #[doc="<p>The token that marks the start of the next batch of returned results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -865,21 +922,33 @@ impl DescribeAlarmHistoryOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAlarmsForMetricInput {
     #[doc="<p>The dimensions associated with the metric. If the metric has any associated dimensions, you must specify them in order for the call to succeed.</p>"]
+    #[serde(rename="Dimensions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dimensions: Option<Vec<Dimension>>,
     #[doc="<p>The percentile statistic for the metric. Specify a value between p0.0 and p100.</p>"]
+    #[serde(rename="ExtendedStatistic")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub extended_statistic: Option<String>,
     #[doc="<p>The name of the metric.</p>"]
+    #[serde(rename="MetricName")]
     pub metric_name: String,
     #[doc="<p>The namespace of the metric.</p>"]
+    #[serde(rename="Namespace")]
     pub namespace: String,
     #[doc="<p>The period, in seconds, over which the statistic is applied.</p>"]
+    #[serde(rename="Period")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub period: Option<i64>,
     #[doc="<p>The statistic for the metric, other than percentiles. For percentile statistics, use <code>ExtendedStatistics</code>.</p>"]
+    #[serde(rename="Statistic")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub statistic: Option<String>,
     #[doc="<p>The unit for the metric.</p>"]
+    #[serde(rename="Unit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unit: Option<String>,
 }
 
@@ -922,9 +991,11 @@ impl DescribeAlarmsForMetricInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAlarmsForMetricOutput {
     #[doc="<p>The information for each alarm with the specified metric.</p>"]
+    #[serde(rename="MetricAlarms")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric_alarms: Option<Vec<MetricAlarm>>,
 }
 
@@ -971,19 +1042,31 @@ impl DescribeAlarmsForMetricOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAlarmsInput {
     #[doc="<p>The action name prefix.</p>"]
+    #[serde(rename="ActionPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action_prefix: Option<String>,
     #[doc="<p>The alarm name prefix. If this parameter is specified, you cannot specify <code>AlarmNames</code>.</p>"]
+    #[serde(rename="AlarmNamePrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_name_prefix: Option<String>,
     #[doc="<p>The names of the alarms.</p>"]
+    #[serde(rename="AlarmNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_names: Option<Vec<String>>,
     #[doc="<p>The maximum number of alarm descriptions to retrieve.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The token returned by a previous call to indicate that there is more data available.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The state value to be used in matching alarms.</p>"]
+    #[serde(rename="StateValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state_value: Option<String>,
 }
 
@@ -1026,11 +1109,15 @@ impl DescribeAlarmsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAlarmsOutput {
     #[doc="<p>The information for the specified alarms.</p>"]
+    #[serde(rename="MetricAlarms")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric_alarms: Option<Vec<MetricAlarm>>,
     #[doc="<p>The token that marks the start of the next batch of returned results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1082,11 +1169,13 @@ impl DescribeAlarmsOutputDeserializer {
     }
 }
 #[doc="<p>Expands the identity of a metric.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Dimension {
     #[doc="<p>The name of the dimension.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The value representing the dimension measurement.</p>"]
+    #[serde(rename="Value")]
     pub value: String,
 }
 
@@ -1154,11 +1243,14 @@ impl DimensionSerializer {
 }
 
 #[doc="<p>Represents filters for a dimension.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DimensionFilter {
     #[doc="<p>The dimension name to be matched.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The value of the dimension to be matched.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -1275,9 +1367,10 @@ impl DimensionsSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableAlarmActionsInput {
     #[doc="<p>The names of the alarms.</p>"]
+    #[serde(rename="AlarmNames")]
     pub alarm_names: Vec<String>,
 }
 
@@ -1298,9 +1391,10 @@ impl DisableAlarmActionsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableAlarmActionsInput {
     #[doc="<p>The names of the alarms.</p>"]
+    #[serde(rename="AlarmNames")]
     pub alarm_names: Vec<String>,
 }
 
@@ -1375,9 +1469,11 @@ impl ExtendedStatisticsSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDashboardInput {
     #[doc="<p>The name of the dashboard to be described.</p>"]
+    #[serde(rename="DashboardName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_name: Option<String>,
 }
 
@@ -1399,13 +1495,19 @@ impl GetDashboardInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDashboardOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the dashboard.</p>"]
+    #[serde(rename="DashboardArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_arn: Option<String>,
     #[doc="<p>The detailed information about the dashboard, including what widgets are included and their location on the dashboard. For more information about the <code>DashboardBody</code> syntax, see <a>CloudWatch-Dashboard-Body-Structure</a>. </p>"]
+    #[serde(rename="DashboardBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_body: Option<String>,
     #[doc="<p>The name of the dashboard.</p>"]
+    #[serde(rename="DashboardName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_name: Option<String>,
 }
 
@@ -1462,25 +1564,38 @@ impl GetDashboardOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMetricStatisticsInput {
     #[doc="<p>The dimensions. If the metric contains multiple dimensions, you must include a value for each dimension. CloudWatch treats each unique combination of dimensions as a separate metric. If a specific combination of dimensions was not published, you can't retrieve statistics for it. You must specify the same dimensions that were used when the metrics were created. For an example, see <a href=\"http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#dimension-combinations\">Dimension Combinations</a> in the <i>Amazon CloudWatch User Guide</i>. For more information about specifying dimensions, see <a href=\"http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html\">Publishing Metrics</a> in the <i>Amazon CloudWatch User Guide</i>.</p>"]
+    #[serde(rename="Dimensions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dimensions: Option<Vec<Dimension>>,
     #[doc="<p>The time stamp that determines the last data point to return.</p> <p>The value specified is exclusive; results include data points up to the specified time stamp. The time stamp must be in ISO 8601 UTC format (for example, 2016-10-10T23:00:00Z).</p>"]
+    #[serde(rename="EndTime")]
     pub end_time: String,
     #[doc="<p>The percentile statistics. Specify values between p0.0 and p100. When calling <code>GetMetricStatistics</code>, you must specify either <code>Statistics</code> or <code>ExtendedStatistics</code>, but not both.</p>"]
+    #[serde(rename="ExtendedStatistics")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub extended_statistics: Option<Vec<String>>,
     #[doc="<p>The name of the metric, with or without spaces.</p>"]
+    #[serde(rename="MetricName")]
     pub metric_name: String,
     #[doc="<p>The namespace of the metric, with or without spaces.</p>"]
+    #[serde(rename="Namespace")]
     pub namespace: String,
     #[doc="<p>The granularity, in seconds, of the returned data points. For metrics with regular resolution, a period can be as short as one minute (60 seconds) and must be a multiple of 60. For high-resolution metrics that are collected at intervals of less than one minute, the period can be 1, 5, 10, 30, 60, or any multiple of 60. High-resolution metrics are those metrics stored by a <code>PutMetricData</code> call that includes a <code>StorageResolution</code> of 1 second.</p> <p>If the <code>StartTime</code> parameter specifies a time stamp that is greater than 3 hours ago, you must specify the period as follows or no data points in that time range is returned:</p> <ul> <li> <p>Start time between 3 hours and 15 days ago - Use a multiple of 60 seconds (1 minute).</p> </li> <li> <p>Start time between 15 and 63 days ago - Use a multiple of 300 seconds (5 minutes).</p> </li> <li> <p>Start time greater than 63 days ago - Use a multiple of 3600 seconds (1 hour).</p> </li> </ul>"]
+    #[serde(rename="Period")]
     pub period: i64,
     #[doc="<p>The time stamp that determines the first data point to return. Start times are evaluated relative to the time that CloudWatch receives the request.</p> <p>The value specified is inclusive; results include data points with the specified time stamp. The time stamp must be in ISO 8601 UTC format (for example, 2016-10-03T23:00:00Z).</p> <p>CloudWatch rounds the specified time stamp as follows:</p> <ul> <li> <p>Start time less than 15 days ago - Round down to the nearest whole minute. For example, 12:32:34 is rounded down to 12:32:00.</p> </li> <li> <p>Start time between 15 and 63 days ago - Round down to the nearest 5-minute clock interval. For example, 12:32:34 is rounded down to 12:30:00.</p> </li> <li> <p>Start time greater than 63 days ago - Round down to the nearest 1-hour clock interval. For example, 12:32:34 is rounded down to 12:00:00.</p> </li> </ul> <p>If you set <code>Period</code> to 5, 10, or 30, the start time of your request is rounded down to the nearest time that corresponds to even 5-, 10-, or 30-second divisions of a minute. For example, if you make a query at (HH:mm:ss) 01:05:23 for the previous 10-second period, the start time of your request is rounded down and you receive data from 01:05:10 to 01:05:20. If you make a query at 15:07:17 for the previous 5 minutes of data, using a period of 5 seconds, you receive data timestamped between 15:02:15 and 15:07:15. </p>"]
+    #[serde(rename="StartTime")]
     pub start_time: String,
     #[doc="<p>The metric statistics, other than percentile. For percentile statistics, use <code>ExtendedStatistics</code>. When calling <code>GetMetricStatistics</code>, you must specify either <code>Statistics</code> or <code>ExtendedStatistics</code>, but not both.</p>"]
+    #[serde(rename="Statistics")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub statistics: Option<Vec<String>>,
     #[doc="<p>The unit for a given metric. Metrics may be reported in multiple units. Not supplying a unit results in all units being returned. If the metric only ever reports one unit, specifying a unit has no effect.</p>"]
+    #[serde(rename="Unit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unit: Option<String>,
 }
 
@@ -1527,11 +1642,15 @@ impl GetMetricStatisticsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMetricStatisticsOutput {
     #[doc="<p>The data points for the specified metric.</p>"]
+    #[serde(rename="Datapoints")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub datapoints: Option<Vec<Datapoint>>,
     #[doc="<p>A label for the specified metric.</p>"]
+    #[serde(rename="Label")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub label: Option<String>,
 }
 
@@ -1637,11 +1756,15 @@ impl LastModifiedDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDashboardsInput {
     #[doc="<p>If you specify this parameter, only the dashboards with names starting with the specified string are listed. The maximum length is 255, and valid characters are A-Z, a-z, 0-9, \".\", \"-\", and \"_\". </p>"]
+    #[serde(rename="DashboardNamePrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_name_prefix: Option<String>,
     #[doc="<p>The token returned by a previous call to indicate that there is more data available.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1667,11 +1790,15 @@ impl ListDashboardsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDashboardsOutput {
     #[doc="<p>The list of matching dashboards.</p>"]
+    #[serde(rename="DashboardEntries")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_entries: Option<Vec<DashboardEntry>>,
     #[doc="<p>The token that marks the start of the next batch of returned results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1722,15 +1849,23 @@ impl ListDashboardsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListMetricsInput {
     #[doc="<p>The dimensions to filter against.</p>"]
+    #[serde(rename="Dimensions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dimensions: Option<Vec<DimensionFilter>>,
     #[doc="<p>The name of the metric to filter against.</p>"]
+    #[serde(rename="MetricName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric_name: Option<String>,
     #[doc="<p>The namespace to filter against.</p>"]
+    #[serde(rename="Namespace")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub namespace: Option<String>,
     #[doc="<p>The token returned by a previous call to indicate that there is more data available.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1765,11 +1900,15 @@ impl ListMetricsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListMetricsOutput {
     #[doc="<p>The metrics.</p>"]
+    #[serde(rename="Metrics")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metrics: Option<Vec<Metric>>,
     #[doc="<p>The token that marks the start of the next batch of returned results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1834,13 +1973,19 @@ impl MessageDeserializer {
     }
 }
 #[doc="<p>Represents a specific metric.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Metric {
     #[doc="<p>The dimensions for the metric.</p>"]
+    #[serde(rename="Dimensions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dimensions: Option<Vec<Dimension>>,
     #[doc="<p>The name of the metric.</p>"]
+    #[serde(rename="MetricName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric_name: Option<String>,
     #[doc="<p>The namespace of the metric.</p>"]
+    #[serde(rename="Namespace")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub namespace: Option<String>,
 }
 
@@ -1896,55 +2041,103 @@ impl MetricDeserializer {
     }
 }
 #[doc="<p>Represents an alarm.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MetricAlarm {
     #[doc="<p>Indicates whether actions should be executed during any changes to the alarm state.</p>"]
+    #[serde(rename="ActionsEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub actions_enabled: Option<bool>,
     #[doc="<p>The actions to execute when this alarm transitions to the <code>ALARM</code> state from any other state. Each action is specified as an Amazon Resource Name (ARN).</p>"]
+    #[serde(rename="AlarmActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_actions: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) of the alarm.</p>"]
+    #[serde(rename="AlarmArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_arn: Option<String>,
     #[doc="<p>The time stamp of the last update to the alarm configuration.</p>"]
+    #[serde(rename="AlarmConfigurationUpdatedTimestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_configuration_updated_timestamp: Option<String>,
     #[doc="<p>The description of the alarm.</p>"]
+    #[serde(rename="AlarmDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_description: Option<String>,
     #[doc="<p>The name of the alarm.</p>"]
+    #[serde(rename="AlarmName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_name: Option<String>,
     #[doc="<p>The arithmetic operation to use when comparing the specified statistic and threshold. The specified statistic value is used as the first operand.</p>"]
+    #[serde(rename="ComparisonOperator")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub comparison_operator: Option<String>,
     #[doc="<p>The dimensions for the metric associated with the alarm.</p>"]
+    #[serde(rename="Dimensions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dimensions: Option<Vec<Dimension>>,
     #[doc="<p>Used only for alarms based on percentiles. If <code>ignore</code>, the alarm state does not change during periods with too few data points to be statistically significant. If <code>evaluate</code> or this parameter is not used, the alarm is always evaluated and possibly changes state no matter how many data points are available.</p>"]
+    #[serde(rename="EvaluateLowSampleCountPercentile")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub evaluate_low_sample_count_percentile: Option<String>,
     #[doc="<p>The number of periods over which data is compared to the specified threshold.</p>"]
+    #[serde(rename="EvaluationPeriods")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub evaluation_periods: Option<i64>,
     #[doc="<p>The percentile statistic for the metric associated with the alarm. Specify a value between p0.0 and p100.</p>"]
+    #[serde(rename="ExtendedStatistic")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub extended_statistic: Option<String>,
     #[doc="<p>The actions to execute when this alarm transitions to the <code>INSUFFICIENT_DATA</code> state from any other state. Each action is specified as an Amazon Resource Name (ARN).</p>"]
+    #[serde(rename="InsufficientDataActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub insufficient_data_actions: Option<Vec<String>>,
     #[doc="<p>The name of the metric associated with the alarm.</p>"]
+    #[serde(rename="MetricName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metric_name: Option<String>,
     #[doc="<p>The namespace of the metric associated with the alarm.</p>"]
+    #[serde(rename="Namespace")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub namespace: Option<String>,
     #[doc="<p>The actions to execute when this alarm transitions to the <code>OK</code> state from any other state. Each action is specified as an Amazon Resource Name (ARN).</p>"]
+    #[serde(rename="OKActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ok_actions: Option<Vec<String>>,
     #[doc="<p>The period, in seconds, over which the statistic is applied.</p>"]
+    #[serde(rename="Period")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub period: Option<i64>,
     #[doc="<p>An explanation for the alarm state, in text format.</p>"]
+    #[serde(rename="StateReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state_reason: Option<String>,
     #[doc="<p>An explanation for the alarm state, in JSON format.</p>"]
+    #[serde(rename="StateReasonData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state_reason_data: Option<String>,
     #[doc="<p>The time stamp of the last update to the alarm state.</p>"]
+    #[serde(rename="StateUpdatedTimestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state_updated_timestamp: Option<String>,
     #[doc="<p>The state value for the alarm.</p>"]
+    #[serde(rename="StateValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state_value: Option<String>,
     #[doc="<p>The statistic for the metric associated with the alarm, other than percentile. For percentile statistics, use <code>ExtendedStatistic</code>.</p>"]
+    #[serde(rename="Statistic")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub statistic: Option<String>,
     #[doc="<p>The value to compare with the specified statistic.</p>"]
+    #[serde(rename="Threshold")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub threshold: Option<f64>,
     #[doc="<p>Sets how this alarm is to handle missing data points. If this parameter is omitted, the default behavior of <code>missing</code> is used.</p>"]
+    #[serde(rename="TreatMissingData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub treat_missing_data: Option<String>,
     #[doc="<p>The unit of the metric associated with the alarm.</p>"]
+    #[serde(rename="Unit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unit: Option<String>,
 }
 
@@ -2150,21 +2343,34 @@ impl MetricDataSerializer {
 }
 
 #[doc="<p>Encapsulates the information sent to either create a metric or add new values to be aggregated into an existing metric.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MetricDatum {
     #[doc="<p>The dimensions associated with the metric.</p>"]
+    #[serde(rename="Dimensions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dimensions: Option<Vec<Dimension>>,
     #[doc="<p>The name of the metric.</p>"]
+    #[serde(rename="MetricName")]
     pub metric_name: String,
     #[doc="<p>The statistical values for the metric.</p>"]
+    #[serde(rename="StatisticValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub statistic_values: Option<StatisticSet>,
     #[doc="<p>Valid values are 1 and 60. Setting this to 1 specifies this metric as a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second. Setting this to 60 specifies this metric as a regular-resolution metric, which CloudWatch stores at 1-minute resolution. Currently, high resolution is available only for custom metrics. For more information about high-resolution metrics, see <a href=\"http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics\">High-Resolution Metrics</a> in the <i>Amazon CloudWatch User Guide</i>. </p> <p>This field is optional, if you do not specify it the default of 60 is used.</p>"]
+    #[serde(rename="StorageResolution")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_resolution: Option<i64>,
     #[doc="<p>The time the metric data was received, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC.</p>"]
+    #[serde(rename="Timestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timestamp: Option<String>,
     #[doc="<p>The unit of the metric.</p>"]
+    #[serde(rename="Unit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unit: Option<String>,
     #[doc="<p>The value for the metric.</p> <p>Although the parameter accepts numbers of type Double, CloudWatch rejects values that are either too small or too large. Values must be in the range of 8.515920e-109 to 1.174271e+108 (Base 10) or 2e-360 to 2e360 (Base 2). In addition, special values (for example, NaN, +Infinity, -Infinity) are not supported.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<f64>,
 }
 
@@ -2321,11 +2527,15 @@ impl PeriodDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutDashboardInput {
     #[doc="<p>The detailed information about the dashboard in JSON format, including the widgets to include and their location on the dashboard.</p> <p>For more information about the syntax, see <a>CloudWatch-Dashboard-Body-Structure</a>.</p>"]
+    #[serde(rename="DashboardBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_body: Option<String>,
     #[doc="<p>The name of the dashboard. If a dashboard with this name already exists, this call modifies that dashboard, replacing its current contents. Otherwise, a new dashboard is created. The maximum length is 255, and valid characters are A-Z, a-z, 0-9, \"-\", and \"_\".</p>"]
+    #[serde(rename="DashboardName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_name: Option<String>,
 }
 
@@ -2351,9 +2561,11 @@ impl PutDashboardInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutDashboardOutput {
     #[doc="<p>If the input for <code>PutDashboard</code> was correct and the dashboard was successfully created or modified, this result is empty.</p> <p>If this result includes only warning messages, then the input was valid enough for the dashboard to be created or modified, but some elements of the dashboard may not render.</p> <p>If this result includes error messages, the input was not valid and the operation failed.</p>"]
+    #[serde(rename="DashboardValidationMessages")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dashboard_validation_messages: Option<Vec<DashboardValidationMessage>>,
 }
 
@@ -2398,43 +2610,72 @@ impl PutDashboardOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutMetricAlarmInput {
     #[doc="<p>Indicates whether actions should be executed during any changes to the alarm state.</p>"]
+    #[serde(rename="ActionsEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub actions_enabled: Option<bool>,
     #[doc="<p>The actions to execute when this alarm transitions to the <code>ALARM</code> state from any other state. Each action is specified as an Amazon Resource Name (ARN).</p> <p>Valid Values: arn:aws:automate:<i>region</i>:ec2:stop | arn:aws:automate:<i>region</i>:ec2:terminate | arn:aws:automate:<i>region</i>:ec2:recover</p> <p>Valid Values (for use with IAM roles): arn:aws:swf:us-east-1:{<i>customer-account</i>}:action/actions/AWS_EC2.InstanceId.Stop/1.0 | arn:aws:swf:us-east-1:{<i>customer-account</i>}:action/actions/AWS_EC2.InstanceId.Terminate/1.0 | arn:aws:swf:us-east-1:{<i>customer-account</i>}:action/actions/AWS_EC2.InstanceId.Reboot/1.0</p>"]
+    #[serde(rename="AlarmActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_actions: Option<Vec<String>>,
     #[doc="<p>The description for the alarm.</p>"]
+    #[serde(rename="AlarmDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_description: Option<String>,
     #[doc="<p>The name for the alarm. This name must be unique within the AWS account.</p>"]
+    #[serde(rename="AlarmName")]
     pub alarm_name: String,
     #[doc="<p> The arithmetic operation to use when comparing the specified statistic and threshold. The specified statistic value is used as the first operand.</p>"]
+    #[serde(rename="ComparisonOperator")]
     pub comparison_operator: String,
     #[doc="<p>The dimensions for the metric associated with the alarm.</p>"]
+    #[serde(rename="Dimensions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dimensions: Option<Vec<Dimension>>,
     #[doc="<p> Used only for alarms based on percentiles. If you specify <code>ignore</code>, the alarm state does not change during periods with too few data points to be statistically significant. If you specify <code>evaluate</code> or omit this parameter, the alarm is always evaluated and possibly changes state no matter how many data points are available. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#percentiles-with-low-samples\">Percentile-Based CloudWatch Alarms and Low Data Samples</a>.</p> <p>Valid Values: <code>evaluate | ignore</code> </p>"]
+    #[serde(rename="EvaluateLowSampleCountPercentile")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub evaluate_low_sample_count_percentile: Option<String>,
     #[doc="<p>The number of periods over which data is compared to the specified threshold. An alarm's total current evaluation period can be no longer than one day, so this number multiplied by <code>Period</code> cannot be more than 86,400 seconds.</p>"]
+    #[serde(rename="EvaluationPeriods")]
     pub evaluation_periods: i64,
     #[doc="<p>The percentile statistic for the metric associated with the alarm. Specify a value between p0.0 and p100.</p>"]
+    #[serde(rename="ExtendedStatistic")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub extended_statistic: Option<String>,
     #[doc="<p>The actions to execute when this alarm transitions to the <code>INSUFFICIENT_DATA</code> state from any other state. Each action is specified as an Amazon Resource Name (ARN).</p> <p>Valid Values: arn:aws:automate:<i>region</i>:ec2:stop | arn:aws:automate:<i>region</i>:ec2:terminate | arn:aws:automate:<i>region</i>:ec2:recover</p> <p>Valid Values (for use with IAM roles): arn:aws:swf:us-east-1:{<i>customer-account</i>}:action/actions/AWS_EC2.InstanceId.Stop/1.0 | arn:aws:swf:us-east-1:{<i>customer-account</i>}:action/actions/AWS_EC2.InstanceId.Terminate/1.0 | arn:aws:swf:us-east-1:{<i>customer-account</i>}:action/actions/AWS_EC2.InstanceId.Reboot/1.0</p>"]
+    #[serde(rename="InsufficientDataActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub insufficient_data_actions: Option<Vec<String>>,
     #[doc="<p>The name for the metric associated with the alarm.</p>"]
+    #[serde(rename="MetricName")]
     pub metric_name: String,
     #[doc="<p>The namespace for the metric associated with the alarm.</p>"]
+    #[serde(rename="Namespace")]
     pub namespace: String,
     #[doc="<p>The actions to execute when this alarm transitions to an <code>OK</code> state from any other state. Each action is specified as an Amazon Resource Name (ARN).</p> <p>Valid Values: arn:aws:automate:<i>region</i>:ec2:stop | arn:aws:automate:<i>region</i>:ec2:terminate | arn:aws:automate:<i>region</i>:ec2:recover</p> <p>Valid Values (for use with IAM roles): arn:aws:swf:us-east-1:{<i>customer-account</i>}:action/actions/AWS_EC2.InstanceId.Stop/1.0 | arn:aws:swf:us-east-1:{<i>customer-account</i>}:action/actions/AWS_EC2.InstanceId.Terminate/1.0 | arn:aws:swf:us-east-1:{<i>customer-account</i>}:action/actions/AWS_EC2.InstanceId.Reboot/1.0</p>"]
+    #[serde(rename="OKActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ok_actions: Option<Vec<String>>,
     #[doc="<p>The period, in seconds, over which the specified statistic is applied. Valid values are 10, 30, and any multiple of 60.</p> <p>Be sure to specify 10 or 30 only for metrics that are stored by a <code>PutMetricData</code> call with a <code>StorageResolution</code> of 1. If you specify a Period of 10 or 30 for a metric that does not have sub-minute resolution, the alarm still attempts to gather data at the period rate that you specify. In this case, it does not receive data for the attempts that do not correspond to a one-minute data resolution, and the alarm may often lapse into INSUFFICENT_DATA status. Specifying 10 or 30 also sets this alarm as a high-resolution alarm, which has a higher charge than other alarms. For more information about pricing, see <a href=\"https://aws.amazon.com/cloudwatch/pricing/\">Amazon CloudWatch Pricing</a>.</p> <p>An alarm's total current evaluation period can be no longer than one day, so <code>Period</code> multiplied by <code>EvaluationPeriods</code> cannot be more than 86,400 seconds.</p>"]
+    #[serde(rename="Period")]
     pub period: i64,
     #[doc="<p>The statistic for the metric associated with the alarm, other than percentile. For percentile statistics, use <code>ExtendedStatistic</code>.</p>"]
+    #[serde(rename="Statistic")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub statistic: Option<String>,
     #[doc="<p>The value against which the specified statistic is compared.</p>"]
+    #[serde(rename="Threshold")]
     pub threshold: f64,
     #[doc="<p> Sets how this alarm is to handle missing data points. If <code>TreatMissingData</code> is omitted, the default behavior of <code>missing</code> is used. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data\">Configuring How CloudWatch Alarms Treats Missing Data</a>.</p> <p>Valid Values: <code>breaching | notBreaching | ignore | missing</code> </p>"]
+    #[serde(rename="TreatMissingData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub treat_missing_data: Option<String>,
     #[doc="<p>The unit of measure for the statistic. For example, the units for the Amazon EC2 NetworkIn metric are Bytes because NetworkIn tracks the number of bytes that an instance receives on all network interfaces. You can also specify a unit when you create a custom metric. Units help provide conceptual meaning to your data. Metric data points that specify a unit of measure, such as Percent, are aggregated separately.</p> <p>If you specify a unit, you must use a unit that is appropriate for the metric. Otherwise, the CloudWatch alarm can get stuck in the <code>INSUFFICIENT DATA</code> state. </p>"]
+    #[serde(rename="Unit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unit: Option<String>,
 }
 
@@ -2514,11 +2755,13 @@ impl PutMetricAlarmInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutMetricDataInput {
     #[doc="<p>The data for the metric.</p>"]
+    #[serde(rename="MetricData")]
     pub metric_data: Vec<MetricDatum>,
     #[doc="<p>The namespace for the metric data.</p> <p>You cannot specify a namespace that begins with \"AWS/\". Namespaces that begin with \"AWS/\" are reserved for use by Amazon Web Services products.</p>"]
+    #[serde(rename="Namespace")]
     pub namespace: String,
 }
 
@@ -2608,15 +2851,20 @@ impl ResourceNameDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetAlarmStateInput {
     #[doc="<p>The name for the alarm. This name must be unique within the AWS account. The maximum length is 255 characters.</p>"]
+    #[serde(rename="AlarmName")]
     pub alarm_name: String,
     #[doc="<p>The reason that this alarm is set to this specific state, in text format.</p>"]
+    #[serde(rename="StateReason")]
     pub state_reason: String,
     #[doc="<p>The reason that this alarm is set to this specific state, in JSON format.</p>"]
+    #[serde(rename="StateReasonData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state_reason_data: Option<String>,
     #[doc="<p>The value of the state.</p>"]
+    #[serde(rename="StateValue")]
     pub state_value: String,
 }
 
@@ -2729,15 +2977,19 @@ impl StatisticDeserializer {
     }
 }
 #[doc="<p>Represents a set of statistics that describes a specific metric. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StatisticSet {
     #[doc="<p>The maximum value of the sample set.</p>"]
+    #[serde(rename="Maximum")]
     pub maximum: f64,
     #[doc="<p>The minimum value of the sample set.</p>"]
+    #[serde(rename="Minimum")]
     pub minimum: f64,
     #[doc="<p>The number of samples used for the statistic set.</p>"]
+    #[serde(rename="SampleCount")]
     pub sample_count: f64,
     #[doc="<p>The sum of values for the sample set.</p>"]
+    #[serde(rename="Sum")]
     pub sum: f64,
 }
 

--- a/rusoto/services/codebuild/src/generated.rs
+++ b/rusoto/services/codebuild/src/generated.rs
@@ -28,14 +28,14 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetBuildsInput {
     #[doc="<p>The IDs of the builds.</p>"]
     #[serde(rename="ids")]
     pub ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetBuildsOutput {
     #[doc="<p>Information about the requested builds.</p>"]
     #[serde(rename="builds")]
@@ -47,14 +47,14 @@ pub struct BatchGetBuildsOutput {
     pub builds_not_found: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetProjectsInput {
     #[doc="<p>The names of the build projects.</p>"]
     #[serde(rename="names")]
     pub names: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetProjectsOutput {
     #[doc="<p>Information about the requested build projects.</p>"]
     #[serde(rename="projects")]
@@ -67,7 +67,7 @@ pub struct BatchGetProjectsOutput {
 }
 
 #[doc="<p>Information about a build.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Build {
     #[doc="<p>The Amazon Resource Name (ARN) of the build.</p>"]
     #[serde(rename="arn")]
@@ -136,7 +136,7 @@ pub struct Build {
 }
 
 #[doc="<p>Information about build output artifacts.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BuildArtifacts {
     #[doc="<p>Information about the location of the build artifacts.</p>"]
     #[serde(rename="location")]
@@ -153,7 +153,7 @@ pub struct BuildArtifacts {
 }
 
 #[doc="<p>Information about a stage for a build.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BuildPhase {
     #[doc="<p>Additional information about a build phase, especially to help troubleshoot a failed build.</p>"]
     #[serde(rename="contexts")]
@@ -181,7 +181,7 @@ pub struct BuildPhase {
     pub start_time: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProjectInput {
     #[doc="<p>Information about the build output artifacts for the build project.</p>"]
     #[serde(rename="artifacts")]
@@ -217,7 +217,7 @@ pub struct CreateProjectInput {
     pub timeout_in_minutes: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProjectOutput {
     #[doc="<p>Information about the build project that was created.</p>"]
     #[serde(rename="project")]
@@ -225,18 +225,18 @@ pub struct CreateProjectOutput {
     pub project: Option<Project>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProjectInput {
     #[doc="<p>The name of the build project.</p>"]
     #[serde(rename="name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProjectOutput;
 
 #[doc="<p>Information about a Docker image that is managed by AWS CodeBuild.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentImage {
     #[doc="<p>The description of the Docker image.</p>"]
     #[serde(rename="description")]
@@ -249,7 +249,7 @@ pub struct EnvironmentImage {
 }
 
 #[doc="<p>A set of Docker images that are related by programming language and are managed by AWS CodeBuild.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentLanguage {
     #[doc="<p>The list of Docker images that are related by the specified programming language.</p>"]
     #[serde(rename="images")]
@@ -262,7 +262,7 @@ pub struct EnvironmentLanguage {
 }
 
 #[doc="<p>A set of Docker images that are related by platform and are managed by AWS CodeBuild.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentPlatform {
     #[doc="<p>The list of programming languages that are available for the specified platform.</p>"]
     #[serde(rename="languages")]
@@ -285,7 +285,7 @@ pub struct EnvironmentVariable {
     pub value: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBuildsForProjectInput {
     #[doc="<p>During a previous call, if there are more than 100 items in the list, only the first 100 items are returned, along with a unique string called a <i>next token</i>. To get the next batch of items in the list, call this operation again, adding the next token to the call. To get all of the items in the list, keep calling this operation with each subsequent next token that is returned, until no more next tokens are returned.</p>"]
     #[serde(rename="nextToken")]
@@ -300,7 +300,7 @@ pub struct ListBuildsForProjectInput {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBuildsForProjectOutput {
     #[doc="<p>A list of build IDs for the specified build project, with each build ID representing a single build.</p>"]
     #[serde(rename="ids")]
@@ -312,7 +312,7 @@ pub struct ListBuildsForProjectOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBuildsInput {
     #[doc="<p>During a previous call, if there are more than 100 items in the list, only the first 100 items are returned, along with a unique string called a <i>next token</i>. To get the next batch of items in the list, call this operation again, adding the next token to the call. To get all of the items in the list, keep calling this operation with each subsequent next token that is returned, until no more next tokens are returned.</p>"]
     #[serde(rename="nextToken")]
@@ -324,7 +324,7 @@ pub struct ListBuildsInput {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBuildsOutput {
     #[doc="<p>A list of build IDs, with each build ID representing a single build.</p>"]
     #[serde(rename="ids")]
@@ -336,10 +336,10 @@ pub struct ListBuildsOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCuratedEnvironmentImagesInput;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCuratedEnvironmentImagesOutput {
     #[doc="<p>Information about supported platforms for Docker images that are managed by AWS CodeBuild.</p>"]
     #[serde(rename="platforms")]
@@ -347,7 +347,7 @@ pub struct ListCuratedEnvironmentImagesOutput {
     pub platforms: Option<Vec<EnvironmentPlatform>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProjectsInput {
     #[doc="<p>During a previous call, if there are more than 100 items in the list, only the first 100 items are returned, along with a unique string called a <i>next token</i>. To get the next batch of items in the list, call this operation again, adding the next token to the call. To get all of the items in the list, keep calling this operation with each subsequent next token that is returned, until no more next tokens are returned.</p>"]
     #[serde(rename="nextToken")]
@@ -363,7 +363,7 @@ pub struct ListProjectsInput {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProjectsOutput {
     #[doc="<p>If there are more than 100 items in the list, only the first 100 items are returned, along with a unique string called a <i>next token</i>. To get the next batch of items in the list, call this operation again, adding the next token to the call.</p>"]
     #[serde(rename="nextToken")]
@@ -376,7 +376,7 @@ pub struct ListProjectsOutput {
 }
 
 #[doc="<p>Information about build logs in Amazon CloudWatch Logs.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LogsLocation {
     #[doc="<p>The URL to an individual build log in Amazon CloudWatch Logs.</p>"]
     #[serde(rename="deepLink")]
@@ -393,7 +393,7 @@ pub struct LogsLocation {
 }
 
 #[doc="<p>Additional information about a build phase that has an error. You can use this information to help troubleshoot a failed build.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PhaseContext {
     #[doc="<p>An explanation of the build phase's context. This explanation might include a command ID and an exit code.</p>"]
     #[serde(rename="message")]
@@ -406,7 +406,7 @@ pub struct PhaseContext {
 }
 
 #[doc="<p>Information about a build project.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Project {
     #[doc="<p>The Amazon Resource Name (ARN) of the build project.</p>"]
     #[serde(rename="arn")]
@@ -540,7 +540,7 @@ pub struct SourceAuth {
     pub type_: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartBuildInput {
     #[doc="<p>Build output artifact settings that override, for this build only, the latest ones already defined in the build project.</p>"]
     #[serde(rename="artifactsOverride")]
@@ -567,7 +567,7 @@ pub struct StartBuildInput {
     pub timeout_in_minutes_override: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartBuildOutput {
     #[doc="<p>Information about the build to be run.</p>"]
     #[serde(rename="build")]
@@ -575,14 +575,14 @@ pub struct StartBuildOutput {
     pub build: Option<Build>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopBuildInput {
     #[doc="<p>The ID of the build.</p>"]
     #[serde(rename="id")]
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopBuildOutput {
     #[doc="<p>Information about the build.</p>"]
     #[serde(rename="build")]
@@ -603,7 +603,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProjectInput {
     #[doc="<p>Information to be changed about the build output artifacts for the build project.</p>"]
     #[serde(rename="artifacts")]
@@ -642,7 +642,7 @@ pub struct UpdateProjectInput {
     pub timeout_in_minutes: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProjectOutput {
     #[doc="<p>Information about the build project that was changed.</p>"]
     #[serde(rename="project")]

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Represents the input of a batch get repositories operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetRepositoriesInput {
     #[doc="<p>The names of the repositories to get information about.</p>"]
     #[serde(rename="repositoryNames")]
@@ -37,7 +37,7 @@ pub struct BatchGetRepositoriesInput {
 }
 
 #[doc="<p>Represents the output of a batch get repositories operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetRepositoriesOutput {
     #[doc="<p>A list of repositories returned by the batch get repositories operation.</p>"]
     #[serde(rename="repositories")]
@@ -50,7 +50,7 @@ pub struct BatchGetRepositoriesOutput {
 }
 
 #[doc="<p>Returns information about a specific Git blob object.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BlobMetadata {
     #[doc="<p>The full ID of the blob.</p>"]
     #[serde(rename="blobId")]
@@ -67,7 +67,7 @@ pub struct BlobMetadata {
 }
 
 #[doc="<p>Returns information about a branch.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BranchInfo {
     #[doc="<p>The name of the branch.</p>"]
     #[serde(rename="branchName")]
@@ -80,7 +80,7 @@ pub struct BranchInfo {
 }
 
 #[doc="<p>Returns information about a specific commit.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Commit {
     #[doc="<p>Any additional data associated with the specified commit.</p>"]
     #[serde(rename="additionalData")]
@@ -109,7 +109,7 @@ pub struct Commit {
 }
 
 #[doc="<p>Represents the input of a create branch operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBranchInput {
     #[doc="<p>The name of the new branch to create.</p>"]
     #[serde(rename="branchName")]
@@ -123,7 +123,7 @@ pub struct CreateBranchInput {
 }
 
 #[doc="<p>Represents the input of a create repository operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRepositoryInput {
     #[doc="<p>A comment or description about the new repository.</p> <note> <p>The description field for a repository accepts all HTML characters and all valid Unicode characters. Applications that do not HTML-encode the description and display it in a web page could expose users to potentially malicious code. Make sure that you HTML-encode the description field in any application that uses this API to display the repository description on a web page.</p> </note>"]
     #[serde(rename="repositoryDescription")]
@@ -135,7 +135,7 @@ pub struct CreateRepositoryInput {
 }
 
 #[doc="<p>Represents the output of a create repository operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRepositoryOutput {
     #[doc="<p>Information about the newly created repository.</p>"]
     #[serde(rename="repositoryMetadata")]
@@ -144,7 +144,7 @@ pub struct CreateRepositoryOutput {
 }
 
 #[doc="<p>Represents the input of a delete repository operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRepositoryInput {
     #[doc="<p>The name of the repository to delete.</p>"]
     #[serde(rename="repositoryName")]
@@ -152,7 +152,7 @@ pub struct DeleteRepositoryInput {
 }
 
 #[doc="<p>Represents the output of a delete repository operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRepositoryOutput {
     #[doc="<p>The ID of the repository that was deleted.</p>"]
     #[serde(rename="repositoryId")]
@@ -161,7 +161,7 @@ pub struct DeleteRepositoryOutput {
 }
 
 #[doc="<p>Returns information about a set of differences for a commit specifier.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Difference {
     #[doc="<p>Information about an <code>afterBlob</code> data type object, including the ID, the file mode permission code, and the path.</p>"]
     #[serde(rename="afterBlob")]
@@ -178,7 +178,7 @@ pub struct Difference {
 }
 
 #[doc="<p>Represents the input of a get blob operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBlobInput {
     #[doc="<p>The ID of the blob, which is its SHA-1 pointer.</p>"]
     #[serde(rename="blobId")]
@@ -189,7 +189,7 @@ pub struct GetBlobInput {
 }
 
 #[doc="<p>Represents the output of a get blob operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBlobOutput {
     #[doc="<p>The content of the blob, usually a file.</p>"]
     #[serde(rename="content")]
@@ -202,7 +202,7 @@ pub struct GetBlobOutput {
 }
 
 #[doc="<p>Represents the input of a get branch operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBranchInput {
     #[doc="<p>The name of the branch for which you want to retrieve information.</p>"]
     #[serde(rename="branchName")]
@@ -215,7 +215,7 @@ pub struct GetBranchInput {
 }
 
 #[doc="<p>Represents the output of a get branch operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBranchOutput {
     #[doc="<p>The name of the branch.</p>"]
     #[serde(rename="branch")]
@@ -224,7 +224,7 @@ pub struct GetBranchOutput {
 }
 
 #[doc="<p>Represents the input of a get commit operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCommitInput {
     #[doc="<p>The commit ID.</p>"]
     #[serde(rename="commitId")]
@@ -235,14 +235,14 @@ pub struct GetCommitInput {
 }
 
 #[doc="<p>Represents the output of a get commit operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCommitOutput {
     #[doc="<p>A commit data type object that contains information about the specified commit.</p>"]
     #[serde(rename="commit")]
     pub commit: Commit,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDifferencesInput {
     #[doc="<p>A non-negative integer used to limit the number of returned results.</p>"]
     #[serde(rename="MaxResults")]
@@ -272,7 +272,7 @@ pub struct GetDifferencesInput {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDifferencesOutput {
     #[doc="<p>An enumeration token that can be used in a request to return the next batch of the results.</p>"]
     #[serde(rename="NextToken")]
@@ -285,7 +285,7 @@ pub struct GetDifferencesOutput {
 }
 
 #[doc="<p>Represents the input of a get repository operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRepositoryInput {
     #[doc="<p>The name of the repository to get information about.</p>"]
     #[serde(rename="repositoryName")]
@@ -293,7 +293,7 @@ pub struct GetRepositoryInput {
 }
 
 #[doc="<p>Represents the output of a get repository operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRepositoryOutput {
     #[doc="<p>Information about the repository.</p>"]
     #[serde(rename="repositoryMetadata")]
@@ -302,7 +302,7 @@ pub struct GetRepositoryOutput {
 }
 
 #[doc="<p>Represents the input of a get repository triggers operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRepositoryTriggersInput {
     #[doc="<p>The name of the repository for which the trigger is configured.</p>"]
     #[serde(rename="repositoryName")]
@@ -310,7 +310,7 @@ pub struct GetRepositoryTriggersInput {
 }
 
 #[doc="<p>Represents the output of a get repository triggers operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRepositoryTriggersOutput {
     #[doc="<p>The system-generated unique ID for the trigger.</p>"]
     #[serde(rename="configurationId")]
@@ -323,7 +323,7 @@ pub struct GetRepositoryTriggersOutput {
 }
 
 #[doc="<p>Represents the input of a list branches operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBranchesInput {
     #[doc="<p>An enumeration token that allows the operation to batch the results.</p>"]
     #[serde(rename="nextToken")]
@@ -335,7 +335,7 @@ pub struct ListBranchesInput {
 }
 
 #[doc="<p>Represents the output of a list branches operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBranchesOutput {
     #[doc="<p>The list of branch names.</p>"]
     #[serde(rename="branches")]
@@ -348,7 +348,7 @@ pub struct ListBranchesOutput {
 }
 
 #[doc="<p>Represents the input of a list repositories operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRepositoriesInput {
     #[doc="<p>An enumeration token that allows the operation to batch the results of the operation. Batch sizes are 1,000 for list repository operations. When the client sends the token back to AWS CodeCommit, another page of 1,000 records is retrieved.</p>"]
     #[serde(rename="nextToken")]
@@ -365,7 +365,7 @@ pub struct ListRepositoriesInput {
 }
 
 #[doc="<p>Represents the output of a list repositories operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRepositoriesOutput {
     #[doc="<p>An enumeration token that allows the operation to batch the results of the operation. Batch sizes are 1,000 for list repository operations. When the client sends the token back to AWS CodeCommit, another page of 1,000 records is retrieved.</p>"]
     #[serde(rename="nextToken")]
@@ -378,7 +378,7 @@ pub struct ListRepositoriesOutput {
 }
 
 #[doc="<p>Represents the input ofa put repository triggers operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRepositoryTriggersInput {
     #[doc="<p>The name of the repository where you want to create or update the trigger.</p>"]
     #[serde(rename="repositoryName")]
@@ -389,7 +389,7 @@ pub struct PutRepositoryTriggersInput {
 }
 
 #[doc="<p>Represents the output of a put repository triggers operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRepositoryTriggersOutput {
     #[doc="<p>The system-generated unique ID for the create or update operation.</p>"]
     #[serde(rename="configurationId")]
@@ -398,7 +398,7 @@ pub struct PutRepositoryTriggersOutput {
 }
 
 #[doc="<p>Information about a repository.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RepositoryMetadata {
     #[doc="<p>The Amazon Resource Name (ARN) of the repository.</p>"]
     #[serde(rename="Arn")]
@@ -443,7 +443,7 @@ pub struct RepositoryMetadata {
 }
 
 #[doc="<p>Information about a repository name and ID.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RepositoryNameIdPair {
     #[doc="<p>The ID associated with the repository.</p>"]
     #[serde(rename="repositoryId")]
@@ -478,7 +478,7 @@ pub struct RepositoryTrigger {
 }
 
 #[doc="<p>A trigger failed to run.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RepositoryTriggerExecutionFailure {
     #[doc="<p>Additional message information about the trigger that did not run.</p>"]
     #[serde(rename="failureMessage")]
@@ -491,7 +491,7 @@ pub struct RepositoryTriggerExecutionFailure {
 }
 
 #[doc="<p>Represents the input of a test repository triggers operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestRepositoryTriggersInput {
     #[doc="<p>The name of the repository in which to test the triggers.</p>"]
     #[serde(rename="repositoryName")]
@@ -502,7 +502,7 @@ pub struct TestRepositoryTriggersInput {
 }
 
 #[doc="<p>Represents the output of a test repository triggers operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestRepositoryTriggersOutput {
     #[doc="<p>The list of triggers that were not able to be tested. This list provides the names of the triggers that could not be tested, separated by commas.</p>"]
     #[serde(rename="failedExecutions")]
@@ -515,7 +515,7 @@ pub struct TestRepositoryTriggersOutput {
 }
 
 #[doc="<p>Represents the input of an update default branch operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDefaultBranchInput {
     #[doc="<p>The name of the branch to set as the default.</p>"]
     #[serde(rename="defaultBranchName")]
@@ -526,7 +526,7 @@ pub struct UpdateDefaultBranchInput {
 }
 
 #[doc="<p>Represents the input of an update repository description operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRepositoryDescriptionInput {
     #[doc="<p>The new comment or description for the specified repository. Repository descriptions are limited to 1,000 characters.</p>"]
     #[serde(rename="repositoryDescription")]
@@ -538,7 +538,7 @@ pub struct UpdateRepositoryDescriptionInput {
 }
 
 #[doc="<p>Represents the input of an update repository description operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRepositoryNameInput {
     #[doc="<p>The new name for the repository.</p>"]
     #[serde(rename="newName")]
@@ -549,7 +549,7 @@ pub struct UpdateRepositoryNameInput {
 }
 
 #[doc="<p>Information about the user who made a specified commit.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserInfo {
     #[doc="<p>The date when the specified commit was pushed to the repository.</p>"]
     #[serde(rename="date")]

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Represents the input of, and adds tags to, an on-premises instance operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToOnPremisesInstancesInput {
     #[doc="<p>The names of the on-premises instances to which to add tags.</p>"]
     #[serde(rename="instanceNames")]
@@ -66,7 +66,7 @@ pub struct AlarmConfiguration {
 }
 
 #[doc="<p>Information about an application.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationInfo {
     #[doc="<p>The application ID.</p>"]
     #[serde(rename="applicationId")]
@@ -104,7 +104,7 @@ pub struct AutoRollbackConfiguration {
 }
 
 #[doc="<p>Information about an Auto Scaling group.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoScalingGroup {
     #[doc="<p>An Auto Scaling lifecycle event hook name.</p>"]
     #[serde(rename="hook")]
@@ -117,7 +117,7 @@ pub struct AutoScalingGroup {
 }
 
 #[doc="<p>Represents the input of a BatchGetApplicationRevisions operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetApplicationRevisionsInput {
     #[doc="<p>The name of an AWS CodeDeploy application about which to get revision information.</p>"]
     #[serde(rename="applicationName")]
@@ -128,7 +128,7 @@ pub struct BatchGetApplicationRevisionsInput {
 }
 
 #[doc="<p>Represents the output of a BatchGetApplicationRevisions operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetApplicationRevisionsOutput {
     #[doc="<p>The name of the application that corresponds to the revisions.</p>"]
     #[serde(rename="applicationName")]
@@ -145,7 +145,7 @@ pub struct BatchGetApplicationRevisionsOutput {
 }
 
 #[doc="<p>Represents the input of a BatchGetApplications operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetApplicationsInput {
     #[doc="<p>A list of application names separated by spaces.</p>"]
     #[serde(rename="applicationNames")]
@@ -154,7 +154,7 @@ pub struct BatchGetApplicationsInput {
 }
 
 #[doc="<p>Represents the output of a BatchGetApplications operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetApplicationsOutput {
     #[doc="<p>Information about the applications.</p>"]
     #[serde(rename="applicationsInfo")]
@@ -163,7 +163,7 @@ pub struct BatchGetApplicationsOutput {
 }
 
 #[doc="<p>Represents the input of a BatchGetDeploymentGroups operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetDeploymentGroupsInput {
     #[doc="<p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="applicationName")]
@@ -174,7 +174,7 @@ pub struct BatchGetDeploymentGroupsInput {
 }
 
 #[doc="<p>Represents the output of a BatchGetDeploymentGroups operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetDeploymentGroupsOutput {
     #[doc="<p>Information about the deployment groups.</p>"]
     #[serde(rename="deploymentGroupsInfo")]
@@ -187,7 +187,7 @@ pub struct BatchGetDeploymentGroupsOutput {
 }
 
 #[doc="<p>Represents the input of a BatchGetDeploymentInstances operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetDeploymentInstancesInput {
     #[doc="<p>The unique ID of a deployment.</p>"]
     #[serde(rename="deploymentId")]
@@ -198,7 +198,7 @@ pub struct BatchGetDeploymentInstancesInput {
 }
 
 #[doc="<p>Represents the output of a BatchGetDeploymentInstances operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetDeploymentInstancesOutput {
     #[doc="<p>Information about errors that may have occurred during the API call.</p>"]
     #[serde(rename="errorMessage")]
@@ -211,7 +211,7 @@ pub struct BatchGetDeploymentInstancesOutput {
 }
 
 #[doc="<p>Represents the input of a BatchGetDeployments operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetDeploymentsInput {
     #[doc="<p>A list of deployment IDs, separated by spaces.</p>"]
     #[serde(rename="deploymentIds")]
@@ -220,7 +220,7 @@ pub struct BatchGetDeploymentsInput {
 }
 
 #[doc="<p>Represents the output of a BatchGetDeployments operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetDeploymentsOutput {
     #[doc="<p>Information about the deployments.</p>"]
     #[serde(rename="deploymentsInfo")]
@@ -229,7 +229,7 @@ pub struct BatchGetDeploymentsOutput {
 }
 
 #[doc="<p>Represents the input of a BatchGetOnPremisesInstances operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetOnPremisesInstancesInput {
     #[doc="<p>The names of the on-premises instances about which to get information.</p>"]
     #[serde(rename="instanceNames")]
@@ -238,7 +238,7 @@ pub struct BatchGetOnPremisesInstancesInput {
 }
 
 #[doc="<p>Represents the output of a BatchGetOnPremisesInstances operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetOnPremisesInstancesOutput {
     #[doc="<p>Information about the on-premises instances.</p>"]
     #[serde(rename="instanceInfos")]
@@ -276,7 +276,7 @@ pub struct BlueInstanceTerminationOption {
     pub termination_wait_time_in_minutes: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ContinueDeploymentInput {
     #[doc="<p>The deployment ID of the blue/green deployment for which you want to start rerouting traffic to the replacement environment.</p>"]
     #[serde(rename="deploymentId")]
@@ -285,7 +285,7 @@ pub struct ContinueDeploymentInput {
 }
 
 #[doc="<p>Represents the input of a CreateApplication operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateApplicationInput {
     #[doc="<p>The name of the application. This name must be unique with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="applicationName")]
@@ -293,7 +293,7 @@ pub struct CreateApplicationInput {
 }
 
 #[doc="<p>Represents the output of a CreateApplication operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateApplicationOutput {
     #[doc="<p>A unique application ID.</p>"]
     #[serde(rename="applicationId")]
@@ -302,7 +302,7 @@ pub struct CreateApplicationOutput {
 }
 
 #[doc="<p>Represents the input of a CreateDeploymentConfig operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeploymentConfigInput {
     #[doc="<p>The name of the deployment configuration to create.</p>"]
     #[serde(rename="deploymentConfigName")]
@@ -313,7 +313,7 @@ pub struct CreateDeploymentConfigInput {
 }
 
 #[doc="<p>Represents the output of a CreateDeploymentConfig operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeploymentConfigOutput {
     #[doc="<p>A unique deployment configuration ID.</p>"]
     #[serde(rename="deploymentConfigId")]
@@ -322,7 +322,7 @@ pub struct CreateDeploymentConfigOutput {
 }
 
 #[doc="<p>Represents the input of a CreateDeploymentGroup operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeploymentGroupInput {
     #[doc="<p>Information to add about Amazon CloudWatch alarms when the deployment group is created.</p>"]
     #[serde(rename="alarmConfiguration")]
@@ -384,7 +384,7 @@ pub struct CreateDeploymentGroupInput {
 }
 
 #[doc="<p>Represents the output of a CreateDeploymentGroup operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeploymentGroupOutput {
     #[doc="<p>A unique deployment group ID.</p>"]
     #[serde(rename="deploymentGroupId")]
@@ -393,7 +393,7 @@ pub struct CreateDeploymentGroupOutput {
 }
 
 #[doc="<p>Represents the input of a CreateDeployment operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeploymentInput {
     #[doc="<p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="applicationName")]
@@ -437,7 +437,7 @@ pub struct CreateDeploymentInput {
 }
 
 #[doc="<p>Represents the output of a CreateDeployment operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeploymentOutput {
     #[doc="<p>A unique deployment ID.</p>"]
     #[serde(rename="deploymentId")]
@@ -446,7 +446,7 @@ pub struct CreateDeploymentOutput {
 }
 
 #[doc="<p>Represents the input of a DeleteApplication operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationInput {
     #[doc="<p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="applicationName")]
@@ -454,7 +454,7 @@ pub struct DeleteApplicationInput {
 }
 
 #[doc="<p>Represents the input of a DeleteDeploymentConfig operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDeploymentConfigInput {
     #[doc="<p>The name of a deployment configuration associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="deploymentConfigName")]
@@ -462,7 +462,7 @@ pub struct DeleteDeploymentConfigInput {
 }
 
 #[doc="<p>Represents the input of a DeleteDeploymentGroup operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDeploymentGroupInput {
     #[doc="<p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="applicationName")]
@@ -473,7 +473,7 @@ pub struct DeleteDeploymentGroupInput {
 }
 
 #[doc="<p>Represents the output of a DeleteDeploymentGroup operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDeploymentGroupOutput {
     #[doc="<p>If the output contains no data, and the corresponding deployment group contained at least one Auto Scaling group, AWS CodeDeploy successfully removed all corresponding Auto Scaling lifecycle event hooks from the Amazon EC2 instances in the Auto Scaling group. If the output contains data, AWS CodeDeploy could not remove some Auto Scaling lifecycle event hooks from the Amazon EC2 instances in the Auto Scaling group.</p>"]
     #[serde(rename="hooksNotCleanedUp")]
@@ -482,7 +482,7 @@ pub struct DeleteDeploymentGroupOutput {
 }
 
 #[doc="<p>Information about a deployment configuration.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeploymentConfigInfo {
     #[doc="<p>The time at which the deployment configuration was created.</p>"]
     #[serde(rename="createTime")]
@@ -503,7 +503,7 @@ pub struct DeploymentConfigInfo {
 }
 
 #[doc="<p>Information about a deployment group.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeploymentGroupInfo {
     #[doc="<p>A list of alarms associated with the deployment group.</p>"]
     #[serde(rename="alarmConfiguration")]
@@ -584,7 +584,7 @@ pub struct DeploymentGroupInfo {
 }
 
 #[doc="<p>Information about a deployment.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeploymentInfo {
     #[doc="<p>Provides information about the results of a deployment, such as whether instances in the original environment in a blue/green deployment were not terminated.</p>"]
     #[serde(rename="additionalDeploymentStatusInfo")]
@@ -689,7 +689,7 @@ pub struct DeploymentInfo {
 }
 
 #[doc="<p>Information about the deployment status of the instances in the deployment.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeploymentOverview {
     #[doc="<p>The number of instances in the deployment in a failed state.</p>"]
     #[serde(rename="Failed")]
@@ -744,7 +744,7 @@ pub struct DeploymentStyle {
 }
 
 #[doc="<p>Represents the input of a DeregisterOnPremisesInstance operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterOnPremisesInstanceInput {
     #[doc="<p>The name of the on-premises instance to deregister.</p>"]
     #[serde(rename="instanceName")]
@@ -752,7 +752,7 @@ pub struct DeregisterOnPremisesInstanceInput {
 }
 
 #[doc="<p>Diagnostic information about executable scripts that are part of a deployment.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Diagnostics {
     #[doc="<p>The associated error code:</p> <ul> <li> <p>Success: The specified script ran.</p> </li> <li> <p>ScriptMissing: The specified script was not found in the specified location.</p> </li> <li> <p>ScriptNotExecutable: The specified script is not a recognized executable file type.</p> </li> <li> <p>ScriptTimedOut: The specified script did not finish running in the specified time period.</p> </li> <li> <p>ScriptFailed: The specified script failed to run as expected.</p> </li> <li> <p>UnknownError: The specified script did not run for an unknown reason.</p> </li> </ul>"]
     #[serde(rename="errorCode")]
@@ -808,7 +808,7 @@ pub struct ELBInfo {
 }
 
 #[doc="<p>Information about a deployment error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ErrorInformation {
     #[doc="<p>For information about additional error codes, see <a href=\"http://docs.aws.amazon.com/codedeploy/latest/userguide/error-codes.html\">Error Codes for AWS CodeDeploy</a> in the <a href=\"http://docs.aws.amazon.com/codedeploy/latest/userguide\">AWS CodeDeploy User Guide</a>.</p> <p>The error code:</p> <ul> <li> <p>APPLICATION_MISSING: The application was missing. This error code will most likely be raised if the application is deleted after the deployment is created but before it is started.</p> </li> <li> <p>DEPLOYMENT_GROUP_MISSING: The deployment group was missing. This error code will most likely be raised if the deployment group is deleted after the deployment is created but before it is started.</p> </li> <li> <p>HEALTH_CONSTRAINTS: The deployment failed on too many instances to be successfully deployed within the instance health constraints specified.</p> </li> <li> <p>HEALTH_CONSTRAINTS_INVALID: The revision cannot be successfully deployed within the instance health constraints specified.</p> </li> <li> <p>IAM_ROLE_MISSING: The service role cannot be accessed.</p> </li> <li> <p>IAM_ROLE_PERMISSIONS: The service role does not have the correct permissions.</p> </li> <li> <p>INTERNAL_ERROR: There was an internal error.</p> </li> <li> <p>NO_EC2_SUBSCRIPTION: The calling account is not subscribed to the Amazon EC2 service.</p> </li> <li> <p>NO_INSTANCES: No instance were specified, or no instance can be found.</p> </li> <li> <p>OVER_MAX_INSTANCES: The maximum number of instance was exceeded.</p> </li> <li> <p>THROTTLED: The operation was throttled because the calling account exceeded the throttling limits of one or more AWS services.</p> </li> <li> <p>TIMEOUT: The deployment has timed out.</p> </li> <li> <p>REVISION_MISSING: The revision ID was missing. This error code will most likely be raised if the revision is deleted after the deployment is created but before it is started.</p> </li> </ul>"]
     #[serde(rename="code")]
@@ -821,7 +821,7 @@ pub struct ErrorInformation {
 }
 
 #[doc="<p>Information about an application revision.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenericRevisionInfo {
     #[doc="<p>The deployment groups for which this is the current target revision.</p>"]
     #[serde(rename="deploymentGroups")]
@@ -846,7 +846,7 @@ pub struct GenericRevisionInfo {
 }
 
 #[doc="<p>Represents the input of a GetApplication operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetApplicationInput {
     #[doc="<p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="applicationName")]
@@ -854,7 +854,7 @@ pub struct GetApplicationInput {
 }
 
 #[doc="<p>Represents the output of a GetApplication operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetApplicationOutput {
     #[doc="<p>Information about the application.</p>"]
     #[serde(rename="application")]
@@ -863,7 +863,7 @@ pub struct GetApplicationOutput {
 }
 
 #[doc="<p>Represents the input of a GetApplicationRevision operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetApplicationRevisionInput {
     #[doc="<p>The name of the application that corresponds to the revision.</p>"]
     #[serde(rename="applicationName")]
@@ -874,7 +874,7 @@ pub struct GetApplicationRevisionInput {
 }
 
 #[doc="<p>Represents the output of a GetApplicationRevision operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetApplicationRevisionOutput {
     #[doc="<p>The name of the application that corresponds to the revision.</p>"]
     #[serde(rename="applicationName")]
@@ -891,7 +891,7 @@ pub struct GetApplicationRevisionOutput {
 }
 
 #[doc="<p>Represents the input of a GetDeploymentConfig operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentConfigInput {
     #[doc="<p>The name of a deployment configuration associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="deploymentConfigName")]
@@ -899,7 +899,7 @@ pub struct GetDeploymentConfigInput {
 }
 
 #[doc="<p>Represents the output of a GetDeploymentConfig operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentConfigOutput {
     #[doc="<p>Information about the deployment configuration.</p>"]
     #[serde(rename="deploymentConfigInfo")]
@@ -908,7 +908,7 @@ pub struct GetDeploymentConfigOutput {
 }
 
 #[doc="<p>Represents the input of a GetDeploymentGroup operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentGroupInput {
     #[doc="<p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="applicationName")]
@@ -919,7 +919,7 @@ pub struct GetDeploymentGroupInput {
 }
 
 #[doc="<p>Represents the output of a GetDeploymentGroup operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentGroupOutput {
     #[doc="<p>Information about the deployment group.</p>"]
     #[serde(rename="deploymentGroupInfo")]
@@ -928,7 +928,7 @@ pub struct GetDeploymentGroupOutput {
 }
 
 #[doc="<p>Represents the input of a GetDeployment operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentInput {
     #[doc="<p>A deployment ID associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="deploymentId")]
@@ -936,7 +936,7 @@ pub struct GetDeploymentInput {
 }
 
 #[doc="<p>Represents the input of a GetDeploymentInstance operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentInstanceInput {
     #[doc="<p>The unique ID of a deployment.</p>"]
     #[serde(rename="deploymentId")]
@@ -947,7 +947,7 @@ pub struct GetDeploymentInstanceInput {
 }
 
 #[doc="<p>Represents the output of a GetDeploymentInstance operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentInstanceOutput {
     #[doc="<p>Information about the instance.</p>"]
     #[serde(rename="instanceSummary")]
@@ -956,7 +956,7 @@ pub struct GetDeploymentInstanceOutput {
 }
 
 #[doc="<p>Represents the output of a GetDeployment operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentOutput {
     #[doc="<p>Information about the deployment.</p>"]
     #[serde(rename="deploymentInfo")]
@@ -965,7 +965,7 @@ pub struct GetDeploymentOutput {
 }
 
 #[doc="<p>Represents the input of a GetOnPremisesInstance operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOnPremisesInstanceInput {
     #[doc="<p>The name of the on-premises instance about which to get information.</p>"]
     #[serde(rename="instanceName")]
@@ -973,7 +973,7 @@ pub struct GetOnPremisesInstanceInput {
 }
 
 #[doc="<p>Represents the output of a GetOnPremisesInstance operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOnPremisesInstanceOutput {
     #[doc="<p>Information about the on-premises instance.</p>"]
     #[serde(rename="instanceInfo")]
@@ -1004,7 +1004,7 @@ pub struct GreenFleetProvisioningOption {
 }
 
 #[doc="<p>Information about an on-premises instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceInfo {
     #[doc="<p>If the on-premises instance was deregistered, the time at which the on-premises instance was deregistered.</p>"]
     #[serde(rename="deregisterTime")]
@@ -1037,7 +1037,7 @@ pub struct InstanceInfo {
 }
 
 #[doc="<p>Information about an instance in a deployment.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceSummary {
     #[doc="<p>The deployment ID.</p>"]
     #[serde(rename="deploymentId")]
@@ -1066,7 +1066,7 @@ pub struct InstanceSummary {
 }
 
 #[doc="<p>Information about the most recent attempted or successful deployment to a deployment group.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LastDeploymentInfo {
     #[doc="<p>A timestamp indicating when the most recent deployment to the deployment group started.</p>"]
     #[serde(rename="createTime")]
@@ -1087,7 +1087,7 @@ pub struct LastDeploymentInfo {
 }
 
 #[doc="<p>Information about a deployment lifecycle event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LifecycleEvent {
     #[doc="<p>Diagnostic information about the deployment lifecycle event.</p>"]
     #[serde(rename="diagnostics")]
@@ -1112,7 +1112,7 @@ pub struct LifecycleEvent {
 }
 
 #[doc="<p>Represents the input of a ListApplicationRevisions operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListApplicationRevisionsInput {
     #[doc="<p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="applicationName")]
@@ -1144,7 +1144,7 @@ pub struct ListApplicationRevisionsInput {
 }
 
 #[doc="<p>Represents the output of a ListApplicationRevisions operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListApplicationRevisionsOutput {
     #[doc="<p>If a large amount of information is returned, an identifier will also be returned. It can be used in a subsequent list application revisions call to return the next set of application revisions in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1157,7 +1157,7 @@ pub struct ListApplicationRevisionsOutput {
 }
 
 #[doc="<p>Represents the input of a ListApplications operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListApplicationsInput {
     #[doc="<p>An identifier returned from the previous list applications call. It can be used to return the next set of applications in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1166,7 +1166,7 @@ pub struct ListApplicationsInput {
 }
 
 #[doc="<p>Represents the output of a ListApplications operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListApplicationsOutput {
     #[doc="<p>A list of application names.</p>"]
     #[serde(rename="applications")]
@@ -1179,7 +1179,7 @@ pub struct ListApplicationsOutput {
 }
 
 #[doc="<p>Represents the input of a ListDeploymentConfigs operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeploymentConfigsInput {
     #[doc="<p>An identifier returned from the previous list deployment configurations call. It can be used to return the next set of deployment configurations in the list. </p>"]
     #[serde(rename="nextToken")]
@@ -1188,7 +1188,7 @@ pub struct ListDeploymentConfigsInput {
 }
 
 #[doc="<p>Represents the output of a ListDeploymentConfigs operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeploymentConfigsOutput {
     #[doc="<p>A list of deployment configurations, including built-in configurations such as CodeDeployDefault.OneAtATime.</p>"]
     #[serde(rename="deploymentConfigsList")]
@@ -1201,7 +1201,7 @@ pub struct ListDeploymentConfigsOutput {
 }
 
 #[doc="<p>Represents the input of a ListDeploymentGroups operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeploymentGroupsInput {
     #[doc="<p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="applicationName")]
@@ -1213,7 +1213,7 @@ pub struct ListDeploymentGroupsInput {
 }
 
 #[doc="<p>Represents the output of a ListDeploymentGroups operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeploymentGroupsOutput {
     #[doc="<p>The application name.</p>"]
     #[serde(rename="applicationName")]
@@ -1230,7 +1230,7 @@ pub struct ListDeploymentGroupsOutput {
 }
 
 #[doc="<p>Represents the input of a ListDeploymentInstances operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeploymentInstancesInput {
     #[doc="<p>The unique ID of a deployment.</p>"]
     #[serde(rename="deploymentId")]
@@ -1250,7 +1250,7 @@ pub struct ListDeploymentInstancesInput {
 }
 
 #[doc="<p>Represents the output of a ListDeploymentInstances operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeploymentInstancesOutput {
     #[doc="<p>A list of instance IDs.</p>"]
     #[serde(rename="instancesList")]
@@ -1263,7 +1263,7 @@ pub struct ListDeploymentInstancesOutput {
 }
 
 #[doc="<p>Represents the input of a ListDeployments operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeploymentsInput {
     #[doc="<p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="applicationName")]
@@ -1288,7 +1288,7 @@ pub struct ListDeploymentsInput {
 }
 
 #[doc="<p>Represents the output of a ListDeployments operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeploymentsOutput {
     #[doc="<p>A list of deployment IDs.</p>"]
     #[serde(rename="deployments")]
@@ -1301,7 +1301,7 @@ pub struct ListDeploymentsOutput {
 }
 
 #[doc="<p>Represents the input of a ListGitHubAccountTokenNames operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGitHubAccountTokenNamesInput {
     #[doc="<p>An identifier returned from the previous ListGitHubAccountTokenNames call. It can be used to return the next set of names in the list. </p>"]
     #[serde(rename="nextToken")]
@@ -1310,7 +1310,7 @@ pub struct ListGitHubAccountTokenNamesInput {
 }
 
 #[doc="<p>Represents the output of a ListGitHubAccountTokenNames operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGitHubAccountTokenNamesOutput {
     #[doc="<p>If a large amount of information is returned, an identifier is also returned. It can be used in a subsequent ListGitHubAccountTokenNames call to return the next set of names in the list. </p>"]
     #[serde(rename="nextToken")]
@@ -1323,7 +1323,7 @@ pub struct ListGitHubAccountTokenNamesOutput {
 }
 
 #[doc="<p>Represents the input of a ListOnPremisesInstances operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOnPremisesInstancesInput {
     #[doc="<p>An identifier returned from the previous list on-premises instances call. It can be used to return the next set of on-premises instances in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1340,7 +1340,7 @@ pub struct ListOnPremisesInstancesInput {
 }
 
 #[doc="<p>Represents the output of list on-premises instances operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOnPremisesInstancesOutput {
     #[doc="<p>The list of matching on-premises instance names.</p>"]
     #[serde(rename="instanceNames")]
@@ -1388,7 +1388,7 @@ pub struct OnPremisesTagSet {
 }
 
 #[doc="<p>Represents the input of a RegisterApplicationRevision operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterApplicationRevisionInput {
     #[doc="<p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>"]
     #[serde(rename="applicationName")]
@@ -1403,7 +1403,7 @@ pub struct RegisterApplicationRevisionInput {
 }
 
 #[doc="<p>Represents the input of the register on-premises instance operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterOnPremisesInstanceInput {
     #[doc="<p>The ARN of the IAM session to associate with the on-premises instance.</p>"]
     #[serde(rename="iamSessionArn")]
@@ -1419,7 +1419,7 @@ pub struct RegisterOnPremisesInstanceInput {
 }
 
 #[doc="<p>Represents the input of a RemoveTagsFromOnPremisesInstances operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromOnPremisesInstancesInput {
     #[doc="<p>The names of the on-premises instances from which to remove tags.</p>"]
     #[serde(rename="instanceNames")]
@@ -1430,7 +1430,7 @@ pub struct RemoveTagsFromOnPremisesInstancesInput {
 }
 
 #[doc="<p>Information about an application revision.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevisionInfo {
     #[doc="<p>Information about an application revision, including usage details and associated deployment groups.</p>"]
     #[serde(rename="genericRevisionInfo")]
@@ -1460,7 +1460,7 @@ pub struct RevisionLocation {
 }
 
 #[doc="<p>Information about a deployment rollback.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RollbackInfo {
     #[doc="<p>The ID of the deployment rollback.</p>"]
     #[serde(rename="rollbackDeploymentId")]
@@ -1501,7 +1501,7 @@ pub struct S3Location {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SkipWaitTimeForInstanceTerminationInput {
     #[doc="<p>The ID of the blue/green deployment for which you want to skip the instance termination wait time.</p>"]
     #[serde(rename="deploymentId")]
@@ -1510,7 +1510,7 @@ pub struct SkipWaitTimeForInstanceTerminationInput {
 }
 
 #[doc="<p>Represents the input of a StopDeployment operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopDeploymentInput {
     #[doc="<p>Indicates, when a deployment is stopped, whether instances that have been updated should be rolled back to the previous version of the application revision.</p>"]
     #[serde(rename="autoRollbackEnabled")]
@@ -1522,7 +1522,7 @@ pub struct StopDeploymentInput {
 }
 
 #[doc="<p>Represents the output of a StopDeployment operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopDeploymentOutput {
     #[doc="<p>The status of the stop deployment operation:</p> <ul> <li> <p>Pending: The stop operation is pending.</p> </li> <li> <p>Succeeded: The stop operation was successful.</p> </li> </ul>"]
     #[serde(rename="status")]
@@ -1591,7 +1591,7 @@ pub struct TargetInstances {
 }
 
 #[doc="<p>Information about a time range.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TimeRange {
     #[doc="<p>The end time of the time range.</p> <note> <p>Specify null to leave the end time open-ended.</p> </note>"]
     #[serde(rename="end")]
@@ -1621,7 +1621,7 @@ pub struct TriggerConfig {
 }
 
 #[doc="<p>Represents the input of an UpdateApplication operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateApplicationInput {
     #[doc="<p>The current name of the application you want to change.</p>"]
     #[serde(rename="applicationName")]
@@ -1634,7 +1634,7 @@ pub struct UpdateApplicationInput {
 }
 
 #[doc="<p>Represents the input of an UpdateDeploymentGroup operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDeploymentGroupInput {
     #[doc="<p>Information to add or change about Amazon CloudWatch alarms when the deployment group is updated.</p>"]
     #[serde(rename="alarmConfiguration")]
@@ -1701,7 +1701,7 @@ pub struct UpdateDeploymentGroupInput {
 }
 
 #[doc="<p>Represents the output of an UpdateDeploymentGroup operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDeploymentGroupOutput {
     #[doc="<p>If the output contains no data, and the corresponding deployment group contained at least one Auto Scaling group, AWS CodeDeploy successfully removed all corresponding Auto Scaling lifecycle event hooks from the AWS account. If the output contains data, AWS CodeDeploy could not remove some Auto Scaling lifecycle event hooks from the AWS account.</p>"]
     #[serde(rename="hooksNotCleanedUp")]

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Represents an AWS session credentials object. These credentials are temporary credentials that are issued by AWS Secure Token Service (STS). They can be used to access input and output artifacts in the Amazon S3 bucket used to store artifact for the pipeline in AWS CodePipeline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AWSSessionCredentials {
     #[doc="<p>The access key for the session.</p>"]
     #[serde(rename="accessKeyId")]
@@ -43,7 +43,7 @@ pub struct AWSSessionCredentials {
 }
 
 #[doc="<p>Represents the input of an acknowledge job action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcknowledgeJobInput {
     #[doc="<p>The unique system-generated ID of the job for which you want to confirm receipt.</p>"]
     #[serde(rename="jobId")]
@@ -54,7 +54,7 @@ pub struct AcknowledgeJobInput {
 }
 
 #[doc="<p>Represents the output of an acknowledge job action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcknowledgeJobOutput {
     #[doc="<p>Whether the job worker has received the specified job.</p>"]
     #[serde(rename="status")]
@@ -63,7 +63,7 @@ pub struct AcknowledgeJobOutput {
 }
 
 #[doc="<p>Represents the input of an acknowledge third party job action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcknowledgeThirdPartyJobInput {
     #[doc="<p>The clientToken portion of the clientId and clientToken pair used to verify that the calling entity is allowed access to the job and its details.</p>"]
     #[serde(rename="clientToken")]
@@ -77,7 +77,7 @@ pub struct AcknowledgeThirdPartyJobInput {
 }
 
 #[doc="<p>Represents the output of an acknowledge third party job action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcknowledgeThirdPartyJobOutput {
     #[doc="<p>The status information for the third party job, if any.</p>"]
     #[serde(rename="status")]
@@ -86,7 +86,7 @@ pub struct AcknowledgeThirdPartyJobOutput {
 }
 
 #[doc="<p>Represents information about an action configuration.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActionConfiguration {
     #[doc="<p>The configuration data for the action.</p>"]
     #[serde(rename="configuration")]
@@ -124,7 +124,7 @@ pub struct ActionConfigurationProperty {
 }
 
 #[doc="<p>Represents the context of an action within the stage of a pipeline to a job worker.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActionContext {
     #[doc="<p>The name of the action within the context of a job.</p>"]
     #[serde(rename="name")]
@@ -164,7 +164,7 @@ pub struct ActionDeclaration {
 }
 
 #[doc="<p>Represents information about the run of an action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActionExecution {
     #[doc="<p>The details of an error returned by a URL external to AWS.</p>"]
     #[serde(rename="errorDetails")]
@@ -219,7 +219,7 @@ pub struct ActionRevision {
 }
 
 #[doc="<p>Represents information about the state of an action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActionState {
     #[doc="<p>The name of the action.</p>"]
     #[serde(rename="actionName")]
@@ -244,7 +244,7 @@ pub struct ActionState {
 }
 
 #[doc="<p>Returns information about the details of an action type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActionType {
     #[doc="<p>The configuration properties for the action type.</p>"]
     #[serde(rename="actionConfigurationProperties")]
@@ -304,7 +304,7 @@ pub struct ActionTypeSettings {
 }
 
 #[doc="<p>Represents information about the result of an approval request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApprovalResult {
     #[doc="<p>The response submitted by a reviewer assigned to an approval action request.</p>"]
     #[serde(rename="status")]
@@ -315,7 +315,7 @@ pub struct ApprovalResult {
 }
 
 #[doc="<p>Represents information about an artifact that will be worked upon by actions in the pipeline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Artifact {
     #[doc="<p>The location of an artifact.</p>"]
     #[serde(rename="location")]
@@ -343,7 +343,7 @@ pub struct ArtifactDetails {
 }
 
 #[doc="<p>Represents information about the location of an artifact.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ArtifactLocation {
     #[doc="<p>The Amazon S3 bucket that contains the artifact.</p>"]
     #[serde(rename="s3Location")]
@@ -356,7 +356,7 @@ pub struct ArtifactLocation {
 }
 
 #[doc="<p>Represents revision details of an artifact. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ArtifactRevision {
     #[doc="<p>The date and time when the most recent revision of the artifact was created, in timestamp format.</p>"]
     #[serde(rename="created")]
@@ -411,7 +411,7 @@ pub struct BlockerDeclaration {
 }
 
 #[doc="<p>Represents the input of a create custom action operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCustomActionTypeInput {
     #[doc="<p>The category of the custom action, such as a build action or a test action.</p> <note> <p>Although Source and Approval are listed as valid values, they are not currently functional. These values are reserved for future use.</p> </note>"]
     #[serde(rename="category")]
@@ -439,7 +439,7 @@ pub struct CreateCustomActionTypeInput {
 }
 
 #[doc="<p>Represents the output of a create custom action operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCustomActionTypeOutput {
     #[doc="<p>Returns information about the details of an action type.</p>"]
     #[serde(rename="actionType")]
@@ -447,7 +447,7 @@ pub struct CreateCustomActionTypeOutput {
 }
 
 #[doc="<p>Represents the input of a create pipeline action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePipelineInput {
     #[doc="<p>Represents the structure of actions and stages to be performed in the pipeline. </p>"]
     #[serde(rename="pipeline")]
@@ -455,7 +455,7 @@ pub struct CreatePipelineInput {
 }
 
 #[doc="<p>Represents the output of a create pipeline action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePipelineOutput {
     #[doc="<p>Represents the structure of actions and stages to be performed in the pipeline. </p>"]
     #[serde(rename="pipeline")]
@@ -464,7 +464,7 @@ pub struct CreatePipelineOutput {
 }
 
 #[doc="<p>Represents information about a current revision.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CurrentRevision {
     #[doc="<p>The change identifier for the current revision.</p>"]
     #[serde(rename="changeIdentifier")]
@@ -483,7 +483,7 @@ pub struct CurrentRevision {
 }
 
 #[doc="<p>Represents the input of a delete custom action operation. The custom action will be marked as deleted.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCustomActionTypeInput {
     #[doc="<p>The category of the custom action that you want to delete, such as source or deploy.</p>"]
     #[serde(rename="category")]
@@ -497,7 +497,7 @@ pub struct DeleteCustomActionTypeInput {
 }
 
 #[doc="<p>Represents the input of a delete pipeline action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePipelineInput {
     #[doc="<p>The name of the pipeline to be deleted.</p>"]
     #[serde(rename="name")]
@@ -505,7 +505,7 @@ pub struct DeletePipelineInput {
 }
 
 #[doc="<p>Represents the input of a disable stage transition input action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableStageTransitionInput {
     #[doc="<p>The name of the pipeline in which you want to disable the flow of artifacts from one stage to another.</p>"]
     #[serde(rename="pipelineName")]
@@ -522,7 +522,7 @@ pub struct DisableStageTransitionInput {
 }
 
 #[doc="<p>Represents the input of an enable stage transition action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableStageTransitionInput {
     #[doc="<p>The name of the pipeline in which you want to enable the flow of artifacts from one stage to another.</p>"]
     #[serde(rename="pipelineName")]
@@ -547,7 +547,7 @@ pub struct EncryptionKey {
 }
 
 #[doc="<p>Represents information about an error in AWS CodePipeline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ErrorDetails {
     #[doc="<p>The system ID or error number code of the error.</p>"]
     #[serde(rename="code")]
@@ -560,7 +560,7 @@ pub struct ErrorDetails {
 }
 
 #[doc="<p>The details of the actions taken and results produced on an artifact as it passes through stages in the pipeline.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecutionDetails {
     #[doc="<p>The system-generated unique ID of this action used to identify this job worker in any external systems, such as AWS CodeDeploy.</p>"]
     #[serde(rename="externalExecutionId")]
@@ -577,7 +577,7 @@ pub struct ExecutionDetails {
 }
 
 #[doc="<p>Represents information about failure details.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailureDetails {
     #[doc="<p>The external ID of the run of the action that failed.</p>"]
     #[serde(rename="externalExecutionId")]
@@ -592,7 +592,7 @@ pub struct FailureDetails {
 }
 
 #[doc="<p>Represents the input of a get job details action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobDetailsInput {
     #[doc="<p>The unique system-generated ID for the job.</p>"]
     #[serde(rename="jobId")]
@@ -600,7 +600,7 @@ pub struct GetJobDetailsInput {
 }
 
 #[doc="<p>Represents the output of a get job details action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobDetailsOutput {
     #[doc="<p>The details of the job.</p> <note> <p>If AWSSessionCredentials is used, a long-running job can call GetJobDetails again to obtain new credentials.</p> </note>"]
     #[serde(rename="jobDetails")]
@@ -609,7 +609,7 @@ pub struct GetJobDetailsOutput {
 }
 
 #[doc="<p>Represents the input of a get pipeline execution action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPipelineExecutionInput {
     #[doc="<p>The ID of the pipeline execution about which you want to get execution details.</p>"]
     #[serde(rename="pipelineExecutionId")]
@@ -620,7 +620,7 @@ pub struct GetPipelineExecutionInput {
 }
 
 #[doc="<p>Represents the output of a get pipeline execution action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPipelineExecutionOutput {
     #[doc="<p>Represents information about the execution of a pipeline.</p>"]
     #[serde(rename="pipelineExecution")]
@@ -629,7 +629,7 @@ pub struct GetPipelineExecutionOutput {
 }
 
 #[doc="<p>Represents the input of a get pipeline action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPipelineInput {
     #[doc="<p>The name of the pipeline for which you want to get information. Pipeline names must be unique under an Amazon Web Services (AWS) user account.</p>"]
     #[serde(rename="name")]
@@ -641,7 +641,7 @@ pub struct GetPipelineInput {
 }
 
 #[doc="<p>Represents the output of a get pipeline action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPipelineOutput {
     #[doc="<p>Represents the structure of actions and stages to be performed in the pipeline. </p>"]
     #[serde(rename="pipeline")]
@@ -650,7 +650,7 @@ pub struct GetPipelineOutput {
 }
 
 #[doc="<p>Represents the input of a get pipeline state action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPipelineStateInput {
     #[doc="<p>The name of the pipeline about which you want to get information.</p>"]
     #[serde(rename="name")]
@@ -658,7 +658,7 @@ pub struct GetPipelineStateInput {
 }
 
 #[doc="<p>Represents the output of a get pipeline state action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPipelineStateOutput {
     #[doc="<p>The date and time the pipeline was created, in timestamp format.</p>"]
     #[serde(rename="created")]
@@ -683,7 +683,7 @@ pub struct GetPipelineStateOutput {
 }
 
 #[doc="<p>Represents the input of a get third party job details action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetThirdPartyJobDetailsInput {
     #[doc="<p>The clientToken portion of the clientId and clientToken pair used to verify that the calling entity is allowed access to the job and its details.</p>"]
     #[serde(rename="clientToken")]
@@ -694,7 +694,7 @@ pub struct GetThirdPartyJobDetailsInput {
 }
 
 #[doc="<p>Represents the output of a get third party job details action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetThirdPartyJobDetailsOutput {
     #[doc="<p>The details of the job, including any protected values defined for the job.</p>"]
     #[serde(rename="jobDetails")]
@@ -711,7 +711,7 @@ pub struct InputArtifact {
 }
 
 #[doc="<p>Represents information about a job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Job {
     #[doc="<p>The ID of the AWS account to use when performing the job.</p>"]
     #[serde(rename="accountId")]
@@ -732,7 +732,7 @@ pub struct Job {
 }
 
 #[doc="<p>Represents additional information about a job required for a job worker to complete the job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobData {
     #[doc="<p>Represents information about an action configuration.</p>"]
     #[serde(rename="actionConfiguration")]
@@ -769,7 +769,7 @@ pub struct JobData {
 }
 
 #[doc="<p>Represents information about the details of a job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobDetails {
     #[doc="<p>The AWS account ID associated with the job.</p>"]
     #[serde(rename="accountId")]
@@ -786,7 +786,7 @@ pub struct JobDetails {
 }
 
 #[doc="<p>Represents the input of a list action types action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListActionTypesInput {
     #[doc="<p>Filters the list of action types to those created by a specified entity.</p>"]
     #[serde(rename="actionOwnerFilter")]
@@ -799,7 +799,7 @@ pub struct ListActionTypesInput {
 }
 
 #[doc="<p>Represents the output of a list action types action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListActionTypesOutput {
     #[doc="<p>Provides details of the action types.</p>"]
     #[serde(rename="actionTypes")]
@@ -811,7 +811,7 @@ pub struct ListActionTypesOutput {
 }
 
 #[doc="<p>Represents the input of a list pipeline executions action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPipelineExecutionsInput {
     #[doc="<p>The maximum number of results to return in a single call. To retrieve the remaining results, make another call with the returned nextToken value. The available pipeline execution history is limited to the most recent 12 months, based on pipeline execution start times. Default value is 100.</p>"]
     #[serde(rename="maxResults")]
@@ -827,7 +827,7 @@ pub struct ListPipelineExecutionsInput {
 }
 
 #[doc="<p>Represents the output of a list pipeline executions action. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPipelineExecutionsOutput {
     #[doc="<p>A token that can be used in the next list pipeline executions call to return the next set of pipeline executions. To view all items in the list, continue to call this operation with each subsequent token until no more nextToken values are returned.</p>"]
     #[serde(rename="nextToken")]
@@ -840,7 +840,7 @@ pub struct ListPipelineExecutionsOutput {
 }
 
 #[doc="<p>Represents the input of a list pipelines action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPipelinesInput {
     #[doc="<p>An identifier that was returned from the previous list pipelines call, which can be used to return the next set of pipelines in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -849,7 +849,7 @@ pub struct ListPipelinesInput {
 }
 
 #[doc="<p>Represents the output of a list pipelines action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPipelinesOutput {
     #[doc="<p>If the amount of returned information is significantly large, an identifier is also returned which can be used in a subsequent list pipelines call to return the next set of pipelines in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -870,7 +870,7 @@ pub struct OutputArtifact {
 }
 
 #[doc="<p>Represents information about a pipeline to a job worker.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PipelineContext {
     #[doc="<p/>"]
     #[serde(rename="action")]
@@ -908,7 +908,7 @@ pub struct PipelineDeclaration {
 }
 
 #[doc="<p>Represents information about an execution of a pipeline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PipelineExecution {
     #[doc="<p>A list of ArtifactRevision objects included in a pipeline execution.</p>"]
     #[serde(rename="artifactRevisions")]
@@ -933,7 +933,7 @@ pub struct PipelineExecution {
 }
 
 #[doc="<p>Summary information about a pipeline execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PipelineExecutionSummary {
     #[doc="<p>The date and time of the last change to the pipeline execution, in timestamp format.</p>"]
     #[serde(rename="lastUpdateTime")]
@@ -954,7 +954,7 @@ pub struct PipelineExecutionSummary {
 }
 
 #[doc="<p>Returns a summary of a pipeline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PipelineSummary {
     #[doc="<p>The date and time the pipeline was created, in timestamp format.</p>"]
     #[serde(rename="created")]
@@ -975,7 +975,7 @@ pub struct PipelineSummary {
 }
 
 #[doc="<p>Represents the input of a poll for jobs action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PollForJobsInput {
     #[doc="<p>Represents information about an action type.</p>"]
     #[serde(rename="actionTypeId")]
@@ -991,7 +991,7 @@ pub struct PollForJobsInput {
 }
 
 #[doc="<p>Represents the output of a poll for jobs action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PollForJobsOutput {
     #[doc="<p>Information about the jobs to take action on.</p>"]
     #[serde(rename="jobs")]
@@ -1000,7 +1000,7 @@ pub struct PollForJobsOutput {
 }
 
 #[doc="<p>Represents the input of a poll for third party jobs action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PollForThirdPartyJobsInput {
     #[doc="<p>Represents information about an action type.</p>"]
     #[serde(rename="actionTypeId")]
@@ -1012,7 +1012,7 @@ pub struct PollForThirdPartyJobsInput {
 }
 
 #[doc="<p>Represents the output of a poll for third party jobs action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PollForThirdPartyJobsOutput {
     #[doc="<p>Information about the jobs to take action on.</p>"]
     #[serde(rename="jobs")]
@@ -1021,7 +1021,7 @@ pub struct PollForThirdPartyJobsOutput {
 }
 
 #[doc="<p>Represents the input of a put action revision action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutActionRevisionInput {
     #[doc="<p>The name of the action that will process the revision.</p>"]
     #[serde(rename="actionName")]
@@ -1038,7 +1038,7 @@ pub struct PutActionRevisionInput {
 }
 
 #[doc="<p>Represents the output of a put action revision action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutActionRevisionOutput {
     #[doc="<p>Indicates whether the artifact revision was previously used in an execution of the specified pipeline.</p>"]
     #[serde(rename="newRevision")]
@@ -1051,7 +1051,7 @@ pub struct PutActionRevisionOutput {
 }
 
 #[doc="<p>Represents the input of a put approval result action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutApprovalResultInput {
     #[doc="<p>The name of the action for which approval is requested.</p>"]
     #[serde(rename="actionName")]
@@ -1071,7 +1071,7 @@ pub struct PutApprovalResultInput {
 }
 
 #[doc="<p>Represents the output of a put approval result action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutApprovalResultOutput {
     #[doc="<p>The timestamp showing when the approval or rejection was submitted.</p>"]
     #[serde(rename="approvedAt")]
@@ -1080,7 +1080,7 @@ pub struct PutApprovalResultOutput {
 }
 
 #[doc="<p>Represents the input of a put job failure result action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutJobFailureResultInput {
     #[doc="<p>The details about the failure of a job.</p>"]
     #[serde(rename="failureDetails")]
@@ -1091,7 +1091,7 @@ pub struct PutJobFailureResultInput {
 }
 
 #[doc="<p>Represents the input of a put job success result action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutJobSuccessResultInput {
     #[doc="<p>A token generated by a job worker, such as an AWS CodeDeploy deployment ID, that a successful job provides to identify a custom action in progress. Future jobs will use this token in order to identify the running instance of the action. It can be reused to return additional information about the progress of the custom action. When the action is complete, no continuation token should be supplied.</p>"]
     #[serde(rename="continuationToken")]
@@ -1111,7 +1111,7 @@ pub struct PutJobSuccessResultInput {
 }
 
 #[doc="<p>Represents the input of a third party job failure result action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutThirdPartyJobFailureResultInput {
     #[doc="<p>The clientToken portion of the clientId and clientToken pair used to verify that the calling entity is allowed access to the job and its details.</p>"]
     #[serde(rename="clientToken")]
@@ -1125,7 +1125,7 @@ pub struct PutThirdPartyJobFailureResultInput {
 }
 
 #[doc="<p>Represents the input of a put third party job success result action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutThirdPartyJobSuccessResultInput {
     #[doc="<p>The clientToken portion of the clientId and clientToken pair used to verify that the calling entity is allowed access to the job and its details.</p>"]
     #[serde(rename="clientToken")]
@@ -1148,7 +1148,7 @@ pub struct PutThirdPartyJobSuccessResultInput {
 }
 
 #[doc="<p>Represents the input of a retry stage execution action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RetryStageExecutionInput {
     #[doc="<p>The ID of the pipeline execution in the failed stage to be retried. Use the <a>GetPipelineState</a> action to retrieve the current pipelineExecutionId of the failed stage</p>"]
     #[serde(rename="pipelineExecutionId")]
@@ -1165,7 +1165,7 @@ pub struct RetryStageExecutionInput {
 }
 
 #[doc="<p>Represents the output of a retry stage execution action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RetryStageExecutionOutput {
     #[doc="<p>The ID of the current workflow execution in the failed stage.</p>"]
     #[serde(rename="pipelineExecutionId")]
@@ -1174,7 +1174,7 @@ pub struct RetryStageExecutionOutput {
 }
 
 #[doc="<p>The location of the Amazon S3 bucket that contains a revision.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3ArtifactLocation {
     #[doc="<p>The name of the Amazon S3 bucket.</p>"]
     #[serde(rename="bucketName")]
@@ -1185,7 +1185,7 @@ pub struct S3ArtifactLocation {
 }
 
 #[doc="<p>Represents information about a stage to a job worker.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StageContext {
     #[doc="<p>The name of the stage.</p>"]
     #[serde(rename="name")]
@@ -1209,7 +1209,7 @@ pub struct StageDeclaration {
 }
 
 #[doc="<p>Represents information about the run of a stage.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StageExecution {
     #[doc="<p>The ID of the pipeline execution associated with the stage.</p>"]
     #[serde(rename="pipelineExecutionId")]
@@ -1220,7 +1220,7 @@ pub struct StageExecution {
 }
 
 #[doc="<p>Represents information about the state of the stage.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StageState {
     #[doc="<p>The state of the stage.</p>"]
     #[serde(rename="actionStates")]
@@ -1241,7 +1241,7 @@ pub struct StageState {
 }
 
 #[doc="<p>Represents the input of a start pipeline execution action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartPipelineExecutionInput {
     #[doc="<p>The name of the pipeline to start.</p>"]
     #[serde(rename="name")]
@@ -1249,7 +1249,7 @@ pub struct StartPipelineExecutionInput {
 }
 
 #[doc="<p>Represents the output of a start pipeline execution action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartPipelineExecutionOutput {
     #[doc="<p>The unique system-generated ID of the pipeline execution that was started.</p>"]
     #[serde(rename="pipelineExecutionId")]
@@ -1258,7 +1258,7 @@ pub struct StartPipelineExecutionOutput {
 }
 
 #[doc="<p>A response to a PollForThirdPartyJobs request returned by AWS CodePipeline when there is a job to be worked upon by a partner action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ThirdPartyJob {
     #[doc="<p>The clientToken portion of the clientId and clientToken pair used to verify that the calling entity is allowed access to the job and its details.</p>"]
     #[serde(rename="clientId")]
@@ -1271,7 +1271,7 @@ pub struct ThirdPartyJob {
 }
 
 #[doc="<p>Represents information about the job data for a partner action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ThirdPartyJobData {
     #[doc="<p>Represents information about an action configuration.</p>"]
     #[serde(rename="actionConfiguration")]
@@ -1308,7 +1308,7 @@ pub struct ThirdPartyJobData {
 }
 
 #[doc="<p>The details of a job sent in response to a GetThirdPartyJobDetails request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ThirdPartyJobDetails {
     #[doc="<p>The data to be returned by the third party job worker.</p>"]
     #[serde(rename="data")]
@@ -1325,7 +1325,7 @@ pub struct ThirdPartyJobDetails {
 }
 
 #[doc="<p>Represents information about the state of transitions between one stage and another stage.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TransitionState {
     #[doc="<p>The user-specified reason why the transition between two stages of a pipeline was disabled.</p>"]
     #[serde(rename="disabledReason")]
@@ -1346,7 +1346,7 @@ pub struct TransitionState {
 }
 
 #[doc="<p>Represents the input of an update pipeline action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePipelineInput {
     #[doc="<p>The name of the pipeline to be updated.</p>"]
     #[serde(rename="pipeline")]
@@ -1354,7 +1354,7 @@ pub struct UpdatePipelineInput {
 }
 
 #[doc="<p>Represents the output of an update pipeline action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePipelineOutput {
     #[doc="<p>The structure of the updated pipeline.</p>"]
     #[serde(rename="pipeline")]

--- a/rusoto/services/codestar/src/generated.rs
+++ b/rusoto/services/codestar/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateTeamMemberRequest {
     #[doc="<p>A user- or system-generated token that identifies the entity that requested the team member association to the project. This token can be used to repeat the request. </p>"]
     #[serde(rename="clientRequestToken")]
@@ -49,7 +49,7 @@ pub struct AssociateTeamMemberRequest {
     pub user_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateTeamMemberResult {
     #[doc="<p>The user- or system-generated token from the initial request that can be used to repeat the request. </p>"]
     #[serde(rename="clientRequestToken")]
@@ -57,7 +57,7 @@ pub struct AssociateTeamMemberResult {
     pub client_request_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProjectRequest {
     #[doc="<p>Reserved for future use.</p>"]
     #[serde(rename="clientRequestToken")]
@@ -75,7 +75,7 @@ pub struct CreateProjectRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProjectResult {
     #[doc="<p>Reserved for future use.</p>"]
     #[serde(rename="arn")]
@@ -93,7 +93,7 @@ pub struct CreateProjectResult {
     pub project_template_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserProfileRequest {
     #[doc="<p>The name that will be displayed as the friendly name for the user in AWS CodeStar. </p>"]
     #[serde(rename="displayName")]
@@ -110,7 +110,7 @@ pub struct CreateUserProfileRequest {
     pub user_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserProfileResult {
     #[doc="<p>The date the user profile was created, in timestamp format.</p>"]
     #[serde(rename="createdTimestamp")]
@@ -137,7 +137,7 @@ pub struct CreateUserProfileResult {
     pub user_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProjectRequest {
     #[doc="<p>A user- or system-generated token that identifies the entity that requested project deletion. This token can be used to repeat the request. </p>"]
     #[serde(rename="clientRequestToken")]
@@ -152,7 +152,7 @@ pub struct DeleteProjectRequest {
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProjectResult {
     #[doc="<p>The Amazon Resource Name (ARN) of the deleted project.</p>"]
     #[serde(rename="projectArn")]
@@ -164,28 +164,28 @@ pub struct DeleteProjectResult {
     pub stack_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserProfileRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the user to delete from AWS CodeStar.</p>"]
     #[serde(rename="userArn")]
     pub user_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserProfileResult {
     #[doc="<p>The Amazon Resource Name (ARN) of the user deleted from AWS CodeStar.</p>"]
     #[serde(rename="userArn")]
     pub user_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProjectRequest {
     #[doc="<p>The ID of the project.</p>"]
     #[serde(rename="id")]
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProjectResult {
     #[doc="<p>The Amazon Resource Name (ARN) for the project.</p>"]
     #[serde(rename="arn")]
@@ -221,14 +221,14 @@ pub struct DescribeProjectResult {
     pub stack_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserProfileRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the user.</p>"]
     #[serde(rename="userArn")]
     pub user_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserProfileResult {
     #[doc="<p>The date and time when the user profile was created in AWS CodeStar, in timestamp format.</p>"]
     #[serde(rename="createdTimestamp")]
@@ -253,7 +253,7 @@ pub struct DescribeUserProfileResult {
     pub user_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateTeamMemberRequest {
     #[doc="<p>The ID of the AWS CodeStar project from which you want to remove a team member.</p>"]
     #[serde(rename="projectId")]
@@ -263,10 +263,10 @@ pub struct DisassociateTeamMemberRequest {
     pub user_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateTeamMemberResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProjectsRequest {
     #[doc="<p>The maximum amount of data that can be contained in a single set of results.</p>"]
     #[serde(rename="maxResults")]
@@ -278,7 +278,7 @@ pub struct ListProjectsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProjectsResult {
     #[doc="<p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>"]
     #[serde(rename="nextToken")]
@@ -289,7 +289,7 @@ pub struct ListProjectsResult {
     pub projects: Vec<ProjectSummary>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourcesRequest {
     #[doc="<p>he maximum amount of data that can be contained in a single set of results.</p>"]
     #[serde(rename="maxResults")]
@@ -304,7 +304,7 @@ pub struct ListResourcesRequest {
     pub project_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourcesResult {
     #[doc="<p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>"]
     #[serde(rename="nextToken")]
@@ -316,7 +316,7 @@ pub struct ListResourcesResult {
     pub resources: Option<Vec<Resource>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTeamMembersRequest {
     #[doc="<p>The maximum number of team members you want returned in a response.</p>"]
     #[serde(rename="maxResults")]
@@ -331,7 +331,7 @@ pub struct ListTeamMembersRequest {
     pub project_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTeamMembersResult {
     #[doc="<p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>"]
     #[serde(rename="nextToken")]
@@ -342,7 +342,7 @@ pub struct ListTeamMembersResult {
     pub team_members: Vec<TeamMember>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUserProfilesRequest {
     #[doc="<p>The maximum number of results to return in a response.</p>"]
     #[serde(rename="maxResults")]
@@ -354,7 +354,7 @@ pub struct ListUserProfilesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUserProfilesResult {
     #[doc="<p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>"]
     #[serde(rename="nextToken")]
@@ -366,7 +366,7 @@ pub struct ListUserProfilesResult {
 }
 
 #[doc="<p>Information about the metadata for a project.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProjectSummary {
     #[doc="<p>The Amazon Resource Name (ARN) of the project.</p>"]
     #[serde(rename="projectArn")]
@@ -379,7 +379,7 @@ pub struct ProjectSummary {
 }
 
 #[doc="<p>Information about a resource for a project.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Resource {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource.</p>"]
     #[serde(rename="id")]
@@ -387,7 +387,7 @@ pub struct Resource {
 }
 
 #[doc="<p>Information about a team member in a project.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TeamMember {
     #[doc="<p>The role assigned to the user in the project. Project roles have different levels of access. For more information, see <a href=\"http://docs.aws.amazon.com/codestar/latest/userguide/working-with-teams.html\">Working with Teams</a> in the AWS CodeStar User Guide. </p>"]
     #[serde(rename="projectRole")]
@@ -401,7 +401,7 @@ pub struct TeamMember {
     pub user_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProjectRequest {
     #[doc="<p>The description of the project, if any.</p>"]
     #[serde(rename="description")]
@@ -416,10 +416,10 @@ pub struct UpdateProjectRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProjectResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTeamMemberRequest {
     #[doc="<p>The ID of the project.</p>"]
     #[serde(rename="projectId")]
@@ -437,7 +437,7 @@ pub struct UpdateTeamMemberRequest {
     pub user_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTeamMemberResult {
     #[doc="<p>The project role granted to the user.</p>"]
     #[serde(rename="projectRole")]
@@ -453,7 +453,7 @@ pub struct UpdateTeamMemberResult {
     pub user_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserProfileRequest {
     #[doc="<p>The name that is displayed as the friendly name for the user in AWS CodeStar.</p>"]
     #[serde(rename="displayName")]
@@ -472,7 +472,7 @@ pub struct UpdateUserProfileRequest {
     pub user_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserProfileResult {
     #[doc="<p>The date the user profile was created, in timestamp format.</p>"]
     #[serde(rename="createdTimestamp")]
@@ -500,7 +500,7 @@ pub struct UpdateUserProfileResult {
 }
 
 #[doc="<p>Information about a user's profile in AWS CodeStar.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserProfileSummary {
     #[doc="<p>The display name of a user in AWS CodeStar. For example, this could be set to both first and last name (\"Mary Major\") or a single name (\"Mary\"). The display name is also used to generate the initial icon associated with the user in AWS CodeStar projects. If spaces are included in the display name, the first character that appears after the space will be used as the second character in the user initial icon. The initial icon displays a maximum of two characters, so a display name with more than one space (for example \"Mary Jane Major\") would generate an initial icon using the first character and the first character after the space (\"MJ\", not \"MM\").</p>"]
     #[serde(rename="displayName")]

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -46,7 +46,7 @@ pub struct CognitoIdentityProvider {
 }
 
 #[doc="<p>Input to the CreateIdentityPool action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateIdentityPoolInput {
     #[doc="<p>TRUE if the identity pool supports unauthenticated logins.</p>"]
     #[serde(rename="AllowUnauthenticatedIdentities")]
@@ -77,7 +77,7 @@ pub struct CreateIdentityPoolInput {
 }
 
 #[doc="<p>Credentials for the provided identity ID.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Credentials {
     #[doc="<p>The Access Key portion of the credentials.</p>"]
     #[serde(rename="AccessKeyId")]
@@ -98,7 +98,7 @@ pub struct Credentials {
 }
 
 #[doc="<p>Input to the <code>DeleteIdentities</code> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIdentitiesInput {
     #[doc="<p>A list of 1-60 identities that you want to delete.</p>"]
     #[serde(rename="IdentityIdsToDelete")]
@@ -106,7 +106,7 @@ pub struct DeleteIdentitiesInput {
 }
 
 #[doc="<p>Returned in response to a successful <code>DeleteIdentities</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIdentitiesResponse {
     #[doc="<p>An array of UnprocessedIdentityId objects, each of which contains an ErrorCode and IdentityId.</p>"]
     #[serde(rename="UnprocessedIdentityIds")]
@@ -115,7 +115,7 @@ pub struct DeleteIdentitiesResponse {
 }
 
 #[doc="<p>Input to the DeleteIdentityPool action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIdentityPoolInput {
     #[doc="<p>An identity pool ID in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityPoolId")]
@@ -123,7 +123,7 @@ pub struct DeleteIdentityPoolInput {
 }
 
 #[doc="<p>Input to the <code>DescribeIdentity</code> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdentityInput {
     #[doc="<p>A unique identifier in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityId")]
@@ -131,7 +131,7 @@ pub struct DescribeIdentityInput {
 }
 
 #[doc="<p>Input to the DescribeIdentityPool action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdentityPoolInput {
     #[doc="<p>An identity pool ID in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityPoolId")]
@@ -139,7 +139,7 @@ pub struct DescribeIdentityPoolInput {
 }
 
 #[doc="<p>Input to the <code>GetCredentialsForIdentity</code> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCredentialsForIdentityInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the role to be assumed when multiple roles were received in the token from the identity provider. For example, a SAML-based identity provider. This parameter is optional for identity providers that do not support role customization.</p>"]
     #[serde(rename="CustomRoleArn")]
@@ -155,7 +155,7 @@ pub struct GetCredentialsForIdentityInput {
 }
 
 #[doc="<p>Returned in response to a successful <code>GetCredentialsForIdentity</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCredentialsForIdentityResponse {
     #[doc="<p>Credentials for the provided identity ID.</p>"]
     #[serde(rename="Credentials")]
@@ -168,7 +168,7 @@ pub struct GetCredentialsForIdentityResponse {
 }
 
 #[doc="<p>Input to the GetId action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdInput {
     #[doc="<p>A standard AWS account ID (9+ digits).</p>"]
     #[serde(rename="AccountId")]
@@ -184,7 +184,7 @@ pub struct GetIdInput {
 }
 
 #[doc="<p>Returned in response to a GetId request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdResponse {
     #[doc="<p>A unique identifier in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityId")]
@@ -193,7 +193,7 @@ pub struct GetIdResponse {
 }
 
 #[doc="<p>Input to the <code>GetIdentityPoolRoles</code> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityPoolRolesInput {
     #[doc="<p>An identity pool ID in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityPoolId")]
@@ -201,7 +201,7 @@ pub struct GetIdentityPoolRolesInput {
 }
 
 #[doc="<p>Returned in response to a successful <code>GetIdentityPoolRoles</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityPoolRolesResponse {
     #[doc="<p>An identity pool ID in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityPoolId")]
@@ -218,7 +218,7 @@ pub struct GetIdentityPoolRolesResponse {
 }
 
 #[doc="<p>Input to the <code>GetOpenIdTokenForDeveloperIdentity</code> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOpenIdTokenForDeveloperIdentityInput {
     #[doc="<p>A unique identifier in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityId")]
@@ -237,7 +237,7 @@ pub struct GetOpenIdTokenForDeveloperIdentityInput {
 }
 
 #[doc="<p>Returned in response to a successful <code>GetOpenIdTokenForDeveloperIdentity</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOpenIdTokenForDeveloperIdentityResponse {
     #[doc="<p>A unique identifier in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityId")]
@@ -250,7 +250,7 @@ pub struct GetOpenIdTokenForDeveloperIdentityResponse {
 }
 
 #[doc="<p>Input to the GetOpenIdToken action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOpenIdTokenInput {
     #[doc="<p>A unique identifier in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityId")]
@@ -262,7 +262,7 @@ pub struct GetOpenIdTokenInput {
 }
 
 #[doc="<p>Returned in response to a successful GetOpenIdToken request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOpenIdTokenResponse {
     #[doc="<p>A unique identifier in the format REGION:GUID. Note that the IdentityId returned may not match the one passed on input.</p>"]
     #[serde(rename="IdentityId")]
@@ -275,7 +275,7 @@ pub struct GetOpenIdTokenResponse {
 }
 
 #[doc="<p>A description of the identity.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IdentityDescription {
     #[doc="<p>Date on which the identity was created.</p>"]
     #[serde(rename="CreationDate")]
@@ -330,7 +330,7 @@ pub struct IdentityPool {
 }
 
 #[doc="<p>A description of the identity pool.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IdentityPoolShortDescription {
     #[doc="<p>An identity pool ID in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityPoolId")]
@@ -343,7 +343,7 @@ pub struct IdentityPoolShortDescription {
 }
 
 #[doc="<p>Input to the ListIdentities action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentitiesInput {
     #[doc="<p>An optional boolean parameter that allows you to hide disabled identities. If omitted, the ListIdentities API will include disabled identities in the response.</p>"]
     #[serde(rename="HideDisabled")]
@@ -362,7 +362,7 @@ pub struct ListIdentitiesInput {
 }
 
 #[doc="<p>The response to a ListIdentities request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentitiesResponse {
     #[doc="<p>An object containing a set of identities and associated mappings.</p>"]
     #[serde(rename="Identities")]
@@ -379,7 +379,7 @@ pub struct ListIdentitiesResponse {
 }
 
 #[doc="<p>Input to the ListIdentityPools action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentityPoolsInput {
     #[doc="<p>The maximum number of identities to return.</p>"]
     #[serde(rename="MaxResults")]
@@ -391,7 +391,7 @@ pub struct ListIdentityPoolsInput {
 }
 
 #[doc="<p>The result of a successful ListIdentityPools action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentityPoolsResponse {
     #[doc="<p>The identity pools returned by the ListIdentityPools action.</p>"]
     #[serde(rename="IdentityPools")]
@@ -404,7 +404,7 @@ pub struct ListIdentityPoolsResponse {
 }
 
 #[doc="<p>Input to the <code>LookupDeveloperIdentityInput</code> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LookupDeveloperIdentityInput {
     #[doc="<p>A unique ID used by your backend authentication process to identify a user. Typically, a developer identity provider would issue many developer user identifiers, in keeping with the number of users.</p>"]
     #[serde(rename="DeveloperUserIdentifier")]
@@ -428,7 +428,7 @@ pub struct LookupDeveloperIdentityInput {
 }
 
 #[doc="<p>Returned in response to a successful <code>LookupDeveloperIdentity</code> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LookupDeveloperIdentityResponse {
     #[doc="<p>This is the list of developer user identifiers associated with an identity ID. Cognito supports the association of multiple developer user identifiers with an identity ID.</p>"]
     #[serde(rename="DeveloperUserIdentifierList")]
@@ -462,7 +462,7 @@ pub struct MappingRule {
 }
 
 #[doc="<p>Input to the <code>MergeDeveloperIdentities</code> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MergeDeveloperIdentitiesInput {
     #[doc="<p>User identifier for the destination user. The value should be a <code>DeveloperUserIdentifier</code>.</p>"]
     #[serde(rename="DestinationUserIdentifier")]
@@ -479,7 +479,7 @@ pub struct MergeDeveloperIdentitiesInput {
 }
 
 #[doc="<p>Returned in response to a successful <code>MergeDeveloperIdentities</code> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MergeDeveloperIdentitiesResponse {
     #[doc="<p>A unique identifier in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityId")]
@@ -512,7 +512,7 @@ pub struct RulesConfigurationType {
 }
 
 #[doc="<p>Input to the <code>SetIdentityPoolRoles</code> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityPoolRolesInput {
     #[doc="<p>An identity pool ID in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityPoolId")]
@@ -527,7 +527,7 @@ pub struct SetIdentityPoolRolesInput {
 }
 
 #[doc="<p>Input to the <code>UnlinkDeveloperIdentity</code> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnlinkDeveloperIdentityInput {
     #[doc="<p>The \"domain\" by which Cognito will refer to your users.</p>"]
     #[serde(rename="DeveloperProviderName")]
@@ -544,7 +544,7 @@ pub struct UnlinkDeveloperIdentityInput {
 }
 
 #[doc="<p>Input to the UnlinkIdentity action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnlinkIdentityInput {
     #[doc="<p>A unique identifier in the format REGION:GUID.</p>"]
     #[serde(rename="IdentityId")]
@@ -558,7 +558,7 @@ pub struct UnlinkIdentityInput {
 }
 
 #[doc="<p>An array of UnprocessedIdentityId objects, each of which contains an ErrorCode and IdentityId.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnprocessedIdentityId {
     #[doc="<p>The error code indicating the type of error that occurred.</p>"]
     #[serde(rename="ErrorCode")]

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Represents the request to add custom attributes.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddCustomAttributesRequest {
     #[doc="<p>An array of custom attributes, such as Mutable and Name.</p>"]
     #[serde(rename="CustomAttributes")]
@@ -40,10 +40,10 @@ pub struct AddCustomAttributesRequest {
 }
 
 #[doc="<p>Represents the response from the server for the request to add custom attributes.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddCustomAttributesResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminAddUserToGroupRequest {
     #[doc="<p>The group name.</p>"]
     #[serde(rename="GroupName")]
@@ -57,7 +57,7 @@ pub struct AdminAddUserToGroupRequest {
 }
 
 #[doc="<p>Represents the request to confirm user registration.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminConfirmSignUpRequest {
     #[doc="<p>The user pool ID for which you want to confirm user registration.</p>"]
     #[serde(rename="UserPoolId")]
@@ -68,7 +68,7 @@ pub struct AdminConfirmSignUpRequest {
 }
 
 #[doc="<p>Represents the response from the server for the request to confirm registration.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminConfirmSignUpResponse;
 
 #[doc="<p>The type of configuration for creating a new user profile.</p>"]
@@ -89,7 +89,7 @@ pub struct AdminCreateUserConfigType {
 }
 
 #[doc="<p>Represents the request to create a user in the specified user pool.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminCreateUserRequest {
     #[doc="<p>Specify <code>\"EMAIL\"</code> if email will be used to send the welcome message. Specify <code>\"SMS\"</code> if the phone number will be used. The default value is <code>\"SMS\"</code>. More than one value can be specified.</p>"]
     #[serde(rename="DesiredDeliveryMediums")]
@@ -124,7 +124,7 @@ pub struct AdminCreateUserRequest {
 }
 
 #[doc="<p>Represents the response from the server to the request to create the user.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminCreateUserResponse {
     #[doc="<p>The newly created user.</p>"]
     #[serde(rename="User")]
@@ -133,7 +133,7 @@ pub struct AdminCreateUserResponse {
 }
 
 #[doc="<p>Represents the request to delete user attributes as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminDeleteUserAttributesRequest {
     #[doc="<p>An array of strings representing the user attribute names you wish to delete.</p> <p>For custom attributes, you must prepend the <code>custom:</code> prefix to the attribute name.</p>"]
     #[serde(rename="UserAttributeNames")]
@@ -147,11 +147,11 @@ pub struct AdminDeleteUserAttributesRequest {
 }
 
 #[doc="<p>Represents the response received from the server for a request to delete user attributes.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminDeleteUserAttributesResponse;
 
 #[doc="<p>Represents the request to delete a user as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminDeleteUserRequest {
     #[doc="<p>The user pool ID for the user pool where you want to delete the user.</p>"]
     #[serde(rename="UserPoolId")]
@@ -161,7 +161,7 @@ pub struct AdminDeleteUserRequest {
     pub username: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminDisableProviderForUserRequest {
     #[doc="<p>The user to be disabled.</p>"]
     #[serde(rename="User")]
@@ -171,11 +171,11 @@ pub struct AdminDisableProviderForUserRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminDisableProviderForUserResponse;
 
 #[doc="<p>Represents the request to disable any user as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminDisableUserRequest {
     #[doc="<p>The user pool ID for the user pool where you want to disable the user.</p>"]
     #[serde(rename="UserPoolId")]
@@ -186,11 +186,11 @@ pub struct AdminDisableUserRequest {
 }
 
 #[doc="<p>Represents the response received from the server to disable the user as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminDisableUserResponse;
 
 #[doc="<p>Represents the request that enables the user as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminEnableUserRequest {
     #[doc="<p>The user pool ID for the user pool where you want to enable the user.</p>"]
     #[serde(rename="UserPoolId")]
@@ -201,11 +201,11 @@ pub struct AdminEnableUserRequest {
 }
 
 #[doc="<p>Represents the response from the server for the request to enable a user as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminEnableUserResponse;
 
 #[doc="<p>Sends the forgot device request, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminForgetDeviceRequest {
     #[doc="<p>The device key.</p>"]
     #[serde(rename="DeviceKey")]
@@ -219,7 +219,7 @@ pub struct AdminForgetDeviceRequest {
 }
 
 #[doc="<p>Represents the request to get the device, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminGetDeviceRequest {
     #[doc="<p>The device key.</p>"]
     #[serde(rename="DeviceKey")]
@@ -233,7 +233,7 @@ pub struct AdminGetDeviceRequest {
 }
 
 #[doc="<p>Gets the device response, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminGetDeviceResponse {
     #[doc="<p>The device.</p>"]
     #[serde(rename="Device")]
@@ -241,7 +241,7 @@ pub struct AdminGetDeviceResponse {
 }
 
 #[doc="<p>Represents the request to get the specified user as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminGetUserRequest {
     #[doc="<p>The user pool ID for the user pool where you want to get information about the user.</p>"]
     #[serde(rename="UserPoolId")]
@@ -252,7 +252,7 @@ pub struct AdminGetUserRequest {
 }
 
 #[doc="<p>Represents the response from the server from the request to get the specified user as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminGetUserResponse {
     #[doc="<p>Indicates that the status is enabled.</p>"]
     #[serde(rename="Enabled")]
@@ -284,7 +284,7 @@ pub struct AdminGetUserResponse {
 }
 
 #[doc="<p>Initiates the authorization request, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminInitiateAuthRequest {
     #[doc="<p>The authentication flow for this call to execute. The API action will depend on this value. For example:</p> <ul> <li> <p> <code>REFRESH_TOKEN_AUTH</code> will take in a valid refresh token and return new tokens.</p> </li> <li> <p> <code>USER_SRP_AUTH</code> will take in <code>USERNAME</code> and <code>SRP_A</code> and return the SRP variables to be used for next challenge execution.</p> </li> </ul> <p>Valid values include:</p> <ul> <li> <p> <code>USER_SRP_AUTH</code>: Authentication flow for the Secure Remote Password (SRP) protocol.</p> </li> <li> <p> <code>REFRESH_TOKEN_AUTH</code>/<code>REFRESH_TOKEN</code>: Authentication flow for refreshing the access token and ID token by supplying a valid refresh token.</p> </li> <li> <p> <code>CUSTOM_AUTH</code>: Custom authentication flow.</p> </li> <li> <p> <code>ADMIN_NO_SRP_AUTH</code>: Non-SRP authentication flow; you can pass in the USERNAME and PASSWORD directly if the flow is enabled for calling the app client.</p> </li> </ul>"]
     #[serde(rename="AuthFlow")]
@@ -306,7 +306,7 @@ pub struct AdminInitiateAuthRequest {
 }
 
 #[doc="<p>Initiates the authentication response, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminInitiateAuthResponse {
     #[doc="<p>The result of the authentication response. This is only returned if the caller does not need to pass another challenge. If the caller does need to pass another challenge before it gets tokens, <code>ChallengeName</code>, <code>ChallengeParameters</code>, and <code>Session</code> are returned.</p>"]
     #[serde(rename="AuthenticationResult")]
@@ -326,7 +326,7 @@ pub struct AdminInitiateAuthResponse {
     pub session: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminLinkProviderForUserRequest {
     #[doc="<p>The existing user in the user pool to be linked to the external identity provider user account. Can be a native (Username + Password) Cognito User Pools user or a federated user (for example, a SAML or Facebook user). If the user doesn't exist, an exception is thrown. This is the user that is returned when the new user (with the linked identity provider attribute) signs in.</p> <p>The <code>ProviderAttributeValue</code> for the <code>DestinationUser</code> must match the username for the user in the user pool. The <code>ProviderAttributeName</code> will always be ignored.</p>"]
     #[serde(rename="DestinationUser")]
@@ -339,11 +339,11 @@ pub struct AdminLinkProviderForUserRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminLinkProviderForUserResponse;
 
 #[doc="<p>Represents the request to list devices, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminListDevicesRequest {
     #[doc="<p>The limit of the devices request.</p>"]
     #[serde(rename="Limit")]
@@ -362,7 +362,7 @@ pub struct AdminListDevicesRequest {
 }
 
 #[doc="<p>Lists the device's response, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminListDevicesResponse {
     #[doc="<p>The devices in the list of devices response.</p>"]
     #[serde(rename="Devices")]
@@ -374,7 +374,7 @@ pub struct AdminListDevicesResponse {
     pub pagination_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminListGroupsForUserRequest {
     #[doc="<p>The limit of the request to list groups.</p>"]
     #[serde(rename="Limit")]
@@ -392,7 +392,7 @@ pub struct AdminListGroupsForUserRequest {
     pub username: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminListGroupsForUserResponse {
     #[doc="<p>The groups that the user belongs to.</p>"]
     #[serde(rename="Groups")]
@@ -404,7 +404,7 @@ pub struct AdminListGroupsForUserResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminRemoveUserFromGroupRequest {
     #[doc="<p>The group name.</p>"]
     #[serde(rename="GroupName")]
@@ -418,7 +418,7 @@ pub struct AdminRemoveUserFromGroupRequest {
 }
 
 #[doc="<p>Represents the request to reset a user's password as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminResetUserPasswordRequest {
     #[doc="<p>The user pool ID for the user pool where you want to reset the user's password.</p>"]
     #[serde(rename="UserPoolId")]
@@ -429,11 +429,11 @@ pub struct AdminResetUserPasswordRequest {
 }
 
 #[doc="<p>Represents the response from the server to reset a user password as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminResetUserPasswordResponse;
 
 #[doc="<p>The request to respond to the authentication challenge, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminRespondToAuthChallengeRequest {
     #[doc="<p>The challenge name. For more information, see <a href=\"API_AdminInitiateAuth.html\">AdminInitiateAuth</a>.</p>"]
     #[serde(rename="ChallengeName")]
@@ -455,7 +455,7 @@ pub struct AdminRespondToAuthChallengeRequest {
 }
 
 #[doc="<p>Responds to the authentication challenge, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminRespondToAuthChallengeResponse {
     #[doc="<p>The result returned by the server in response to the authentication request.</p>"]
     #[serde(rename="AuthenticationResult")]
@@ -476,7 +476,7 @@ pub struct AdminRespondToAuthChallengeResponse {
 }
 
 #[doc="<p>Represents the request to set user settings as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminSetUserSettingsRequest {
     #[doc="<p>Specifies the options for MFA (e.g., email or phone number).</p>"]
     #[serde(rename="MFAOptions")]
@@ -490,11 +490,11 @@ pub struct AdminSetUserSettingsRequest {
 }
 
 #[doc="<p>Represents the response from the server to set user settings as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminSetUserSettingsResponse;
 
 #[doc="<p>The request to update the device status, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminUpdateDeviceStatusRequest {
     #[doc="<p>The device key.</p>"]
     #[serde(rename="DeviceKey")]
@@ -512,11 +512,11 @@ pub struct AdminUpdateDeviceStatusRequest {
 }
 
 #[doc="<p>The status response from the request to update the device, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminUpdateDeviceStatusResponse;
 
 #[doc="<p>Represents the request to update the user's attributes as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminUpdateUserAttributesRequest {
     #[doc="<p>An array of name-value pairs representing user attributes.</p> <p>For custom attributes, you must prepend the <code>custom:</code> prefix to the attribute name.</p>"]
     #[serde(rename="UserAttributes")]
@@ -530,11 +530,11 @@ pub struct AdminUpdateUserAttributesRequest {
 }
 
 #[doc="<p>Represents the response from the server for the request to update user attributes as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminUpdateUserAttributesResponse;
 
 #[doc="<p>The request to sign out of all devices, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminUserGlobalSignOutRequest {
     #[doc="<p>The user pool ID.</p>"]
     #[serde(rename="UserPoolId")]
@@ -545,7 +545,7 @@ pub struct AdminUserGlobalSignOutRequest {
 }
 
 #[doc="<p>The global sign-out response, as an administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdminUserGlobalSignOutResponse;
 
 #[doc="<p>Specifies whether the attribute is standard or custom.</p>"]
@@ -561,7 +561,7 @@ pub struct AttributeType {
 }
 
 #[doc="<p>The result type of the authentication result.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthenticationResultType {
     #[doc="<p>The access token of the authentication result.</p>"]
     #[serde(rename="AccessToken")]
@@ -590,7 +590,7 @@ pub struct AuthenticationResultType {
 }
 
 #[doc="<p>Represents the request to change a user password.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChangePasswordRequest {
     #[doc="<p>The access token in the change password request.</p>"]
     #[serde(rename="AccessToken")]
@@ -604,11 +604,11 @@ pub struct ChangePasswordRequest {
 }
 
 #[doc="<p>The response from the server to the change password request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChangePasswordResponse;
 
 #[doc="<p>The type of code delivery details being returned from the server.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CodeDeliveryDetailsType {
     #[doc="<p>The name of the attribute in the code delivery details type.</p>"]
     #[serde(rename="AttributeName")]
@@ -625,7 +625,7 @@ pub struct CodeDeliveryDetailsType {
 }
 
 #[doc="<p>Confirms the device request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmDeviceRequest {
     #[doc="<p>The access token.</p>"]
     #[serde(rename="AccessToken")]
@@ -644,7 +644,7 @@ pub struct ConfirmDeviceRequest {
 }
 
 #[doc="<p>Confirms the device response.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmDeviceResponse {
     #[doc="<p>Indicates whether the user confirmation is necessary to confirm the device response.</p>"]
     #[serde(rename="UserConfirmationNecessary")]
@@ -653,7 +653,7 @@ pub struct ConfirmDeviceResponse {
 }
 
 #[doc="<p>The request representing the confirmation for a password reset.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmForgotPasswordRequest {
     #[doc="<p>The app client ID of the app associated with the user pool.</p>"]
     #[serde(rename="ClientId")]
@@ -674,11 +674,11 @@ pub struct ConfirmForgotPasswordRequest {
 }
 
 #[doc="<p>The response from the server that results from a user's request to retrieve a forgotten password.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmForgotPasswordResponse;
 
 #[doc="<p>Represents the request to confirm registration of a user.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmSignUpRequest {
     #[doc="<p>The ID of the app client associated with the user pool.</p>"]
     #[serde(rename="ClientId")]
@@ -700,10 +700,10 @@ pub struct ConfirmSignUpRequest {
 }
 
 #[doc="<p>Represents the response from the server for the registration confirmation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmSignUpResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGroupRequest {
     #[doc="<p>A string containing the description of the group.</p>"]
     #[serde(rename="Description")]
@@ -725,7 +725,7 @@ pub struct CreateGroupRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGroupResponse {
     #[doc="<p>The group object for the group.</p>"]
     #[serde(rename="Group")]
@@ -733,7 +733,7 @@ pub struct CreateGroupResponse {
     pub group: Option<GroupType>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateIdentityProviderRequest {
     #[doc="<p>A mapping of identity provider attributes to standard and custom user pool attributes.</p>"]
     #[serde(rename="AttributeMapping")]
@@ -757,14 +757,14 @@ pub struct CreateIdentityProviderRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateIdentityProviderResponse {
     #[doc="<p>The newly created identity provider object.</p>"]
     #[serde(rename="IdentityProvider")]
     pub identity_provider: IdentityProviderType,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateResourceServerRequest {
     #[doc="<p>A unique resource server identifier for the resource server. This could be an HTTPS endpoint where the resource server is located. For example, <code>https://my-weather-api.example.com</code>.</p>"]
     #[serde(rename="Identifier")]
@@ -781,7 +781,7 @@ pub struct CreateResourceServerRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateResourceServerResponse {
     #[doc="<p>The newly created resource server.</p>"]
     #[serde(rename="ResourceServer")]
@@ -789,7 +789,7 @@ pub struct CreateResourceServerResponse {
 }
 
 #[doc="<p>Represents the request to create the user import job.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserImportJobRequest {
     #[doc="<p>The role ARN for the Amazon CloudWatch Logging role for the user import job.</p>"]
     #[serde(rename="CloudWatchLogsRoleArn")]
@@ -803,7 +803,7 @@ pub struct CreateUserImportJobRequest {
 }
 
 #[doc="<p>Represents the response from the server to the request to create the user import job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserImportJobResponse {
     #[doc="<p>The job object that represents the user import job.</p>"]
     #[serde(rename="UserImportJob")]
@@ -812,7 +812,7 @@ pub struct CreateUserImportJobResponse {
 }
 
 #[doc="<p>Represents the request to create a user pool client.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserPoolClientRequest {
     #[doc="<p>Set to <code>code</code> to initiate a code grant flow, which provides an authorization code as the response. This code can be exchanged for access tokens with the token endpoint.</p> <p>Set to <code>token</code> to specify that the client should get the access token (and, optionally, ID token, based on scopes) directly.</p>"]
     #[serde(rename="AllowedOAuthFlows")]
@@ -871,7 +871,7 @@ pub struct CreateUserPoolClientRequest {
 }
 
 #[doc="<p>Represents the response from the server to create a user pool client.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserPoolClientResponse {
     #[doc="<p>The user pool client that was just created.</p>"]
     #[serde(rename="UserPoolClient")]
@@ -879,7 +879,7 @@ pub struct CreateUserPoolClientResponse {
     pub user_pool_client: Option<UserPoolClientType>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserPoolDomainRequest {
     #[doc="<p>The domain string.</p>"]
     #[serde(rename="Domain")]
@@ -889,11 +889,11 @@ pub struct CreateUserPoolDomainRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserPoolDomainResponse;
 
 #[doc="<p>Represents the request to create a user pool.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserPoolRequest {
     #[doc="<p>The configuration for <code>AdminCreateUser</code> requests.</p>"]
     #[serde(rename="AdminCreateUserConfig")]
@@ -969,7 +969,7 @@ pub struct CreateUserPoolRequest {
 }
 
 #[doc="<p>Represents the response from the server for the request to create a user pool.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserPoolResponse {
     #[doc="<p>A container for the user pool details.</p>"]
     #[serde(rename="UserPool")]
@@ -977,7 +977,7 @@ pub struct CreateUserPoolResponse {
     pub user_pool: Option<UserPoolType>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteGroupRequest {
     #[doc="<p>The name of the group.</p>"]
     #[serde(rename="GroupName")]
@@ -987,7 +987,7 @@ pub struct DeleteGroupRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIdentityProviderRequest {
     #[doc="<p>The identity provider name.</p>"]
     #[serde(rename="ProviderName")]
@@ -997,7 +997,7 @@ pub struct DeleteIdentityProviderRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteResourceServerRequest {
     #[doc="<p>The identifier for the resource server.</p>"]
     #[serde(rename="Identifier")]
@@ -1008,7 +1008,7 @@ pub struct DeleteResourceServerRequest {
 }
 
 #[doc="<p>Represents the request to delete user attributes.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserAttributesRequest {
     #[doc="<p>The access token used in the request to delete user attributes.</p>"]
     #[serde(rename="AccessToken")]
@@ -1019,11 +1019,11 @@ pub struct DeleteUserAttributesRequest {
 }
 
 #[doc="<p>Represents the response from the server to delete user attributes.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserAttributesResponse;
 
 #[doc="<p>Represents the request to delete a user pool client.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserPoolClientRequest {
     #[doc="<p>The app client ID of the app associated with the user pool.</p>"]
     #[serde(rename="ClientId")]
@@ -1033,7 +1033,7 @@ pub struct DeleteUserPoolClientRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserPoolDomainRequest {
     #[doc="<p>The domain string.</p>"]
     #[serde(rename="Domain")]
@@ -1043,11 +1043,11 @@ pub struct DeleteUserPoolDomainRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserPoolDomainResponse;
 
 #[doc="<p>Represents the request to delete a user pool.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserPoolRequest {
     #[doc="<p>The user pool ID for the user pool you want to delete.</p>"]
     #[serde(rename="UserPoolId")]
@@ -1055,14 +1055,14 @@ pub struct DeleteUserPoolRequest {
 }
 
 #[doc="<p>Represents the request to delete a user.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserRequest {
     #[doc="<p>The access token from a request to delete a user.</p>"]
     #[serde(rename="AccessToken")]
     pub access_token: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdentityProviderRequest {
     #[doc="<p>The identity provider name.</p>"]
     #[serde(rename="ProviderName")]
@@ -1072,14 +1072,14 @@ pub struct DescribeIdentityProviderRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdentityProviderResponse {
     #[doc="<p>The identity provider that was deleted.</p>"]
     #[serde(rename="IdentityProvider")]
     pub identity_provider: IdentityProviderType,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeResourceServerRequest {
     #[doc="<p>The identifier for the resource server</p>"]
     #[serde(rename="Identifier")]
@@ -1089,7 +1089,7 @@ pub struct DescribeResourceServerRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeResourceServerResponse {
     #[doc="<p>The resource server.</p>"]
     #[serde(rename="ResourceServer")]
@@ -1097,7 +1097,7 @@ pub struct DescribeResourceServerResponse {
 }
 
 #[doc="<p>Represents the request to describe the user import job.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserImportJobRequest {
     #[doc="<p>The job ID for the user import job.</p>"]
     #[serde(rename="JobId")]
@@ -1108,7 +1108,7 @@ pub struct DescribeUserImportJobRequest {
 }
 
 #[doc="<p>Represents the response from the server to the request to describe the user import job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserImportJobResponse {
     #[doc="<p>The job object that represents the user import job.</p>"]
     #[serde(rename="UserImportJob")]
@@ -1117,7 +1117,7 @@ pub struct DescribeUserImportJobResponse {
 }
 
 #[doc="<p>Represents the request to describe a user pool client.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserPoolClientRequest {
     #[doc="<p>The app client ID of the app associated with the user pool.</p>"]
     #[serde(rename="ClientId")]
@@ -1128,7 +1128,7 @@ pub struct DescribeUserPoolClientRequest {
 }
 
 #[doc="<p>Represents the response from the server from a request to describe the user pool client.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserPoolClientResponse {
     #[doc="<p>The user pool client from a server response to describe the user pool client.</p>"]
     #[serde(rename="UserPoolClient")]
@@ -1136,14 +1136,14 @@ pub struct DescribeUserPoolClientResponse {
     pub user_pool_client: Option<UserPoolClientType>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserPoolDomainRequest {
     #[doc="<p>The domain string.</p>"]
     #[serde(rename="Domain")]
     pub domain: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserPoolDomainResponse {
     #[doc="<p>A domain description object containing information about the domain.</p>"]
     #[serde(rename="DomainDescription")]
@@ -1152,7 +1152,7 @@ pub struct DescribeUserPoolDomainResponse {
 }
 
 #[doc="<p>Represents the request to describe the user pool.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserPoolRequest {
     #[doc="<p>The user pool ID for the user pool you want to describe.</p>"]
     #[serde(rename="UserPoolId")]
@@ -1160,7 +1160,7 @@ pub struct DescribeUserPoolRequest {
 }
 
 #[doc="<p>Represents the response to describe the user pool.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserPoolResponse {
     #[doc="<p>The container of metadata returned by the server to describe the pool.</p>"]
     #[serde(rename="UserPool")]
@@ -1182,7 +1182,7 @@ pub struct DeviceConfigurationType {
 }
 
 #[doc="<p>The device verifier against which it will be authenticated.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeviceSecretVerifierConfigType {
     #[doc="<p>The password verifier.</p>"]
     #[serde(rename="PasswordVerifier")]
@@ -1195,7 +1195,7 @@ pub struct DeviceSecretVerifierConfigType {
 }
 
 #[doc="<p>The device type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeviceType {
     #[doc="<p>The device attributes.</p>"]
     #[serde(rename="DeviceAttributes")]
@@ -1220,7 +1220,7 @@ pub struct DeviceType {
 }
 
 #[doc="<p>A container for information about a domain.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainDescriptionType {
     #[doc="<p>The AWS account ID for the user pool owner.</p>"]
     #[serde(rename="AWSAccountId")]
@@ -1266,7 +1266,7 @@ pub struct EmailConfigurationType {
 }
 
 #[doc="<p>Represents the request to forget the device.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ForgetDeviceRequest {
     #[doc="<p>The access token for the forgotten device request.</p>"]
     #[serde(rename="AccessToken")]
@@ -1278,7 +1278,7 @@ pub struct ForgetDeviceRequest {
 }
 
 #[doc="<p>Represents the request to reset a user's password.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ForgotPasswordRequest {
     #[doc="<p>The ID of the client associated with the user pool.</p>"]
     #[serde(rename="ClientId")]
@@ -1293,7 +1293,7 @@ pub struct ForgotPasswordRequest {
 }
 
 #[doc="<p>Respresents the response from the server regarding the request to reset a password.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ForgotPasswordResponse {
     #[doc="<p>The code delivery details returned by the server in response to the request to reset a password.</p>"]
     #[serde(rename="CodeDeliveryDetails")]
@@ -1302,7 +1302,7 @@ pub struct ForgotPasswordResponse {
 }
 
 #[doc="<p>Represents the request to get the header information for the .csv file for the user import job.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCSVHeaderRequest {
     #[doc="<p>The user pool ID for the user pool that the users are to be imported into.</p>"]
     #[serde(rename="UserPoolId")]
@@ -1310,7 +1310,7 @@ pub struct GetCSVHeaderRequest {
 }
 
 #[doc="<p>Represents the response from the server to the request to get the header information for the .csv file for the user import job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCSVHeaderResponse {
     #[doc="<p>The header information for the .csv file for the user import job.</p>"]
     #[serde(rename="CSVHeader")]
@@ -1323,7 +1323,7 @@ pub struct GetCSVHeaderResponse {
 }
 
 #[doc="<p>Represents the request to get the device.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeviceRequest {
     #[doc="<p>The access token.</p>"]
     #[serde(rename="AccessToken")]
@@ -1335,14 +1335,14 @@ pub struct GetDeviceRequest {
 }
 
 #[doc="<p>Gets the device response.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeviceResponse {
     #[doc="<p>The device.</p>"]
     #[serde(rename="Device")]
     pub device: DeviceType,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupRequest {
     #[doc="<p>The name of the group.</p>"]
     #[serde(rename="GroupName")]
@@ -1352,7 +1352,7 @@ pub struct GetGroupRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupResponse {
     #[doc="<p>The group object for the group.</p>"]
     #[serde(rename="Group")]
@@ -1360,7 +1360,7 @@ pub struct GetGroupResponse {
     pub group: Option<GroupType>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityProviderByIdentifierRequest {
     #[doc="<p>The identity provider ID.</p>"]
     #[serde(rename="IdpIdentifier")]
@@ -1370,14 +1370,14 @@ pub struct GetIdentityProviderByIdentifierRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityProviderByIdentifierResponse {
     #[doc="<p>The identity provider object.</p>"]
     #[serde(rename="IdentityProvider")]
     pub identity_provider: IdentityProviderType,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUICustomizationRequest {
     #[doc="<p>The client ID for the client app.</p>"]
     #[serde(rename="ClientId")]
@@ -1388,7 +1388,7 @@ pub struct GetUICustomizationRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUICustomizationResponse {
     #[doc="<p>The UI customization information.</p>"]
     #[serde(rename="UICustomization")]
@@ -1396,7 +1396,7 @@ pub struct GetUICustomizationResponse {
 }
 
 #[doc="<p>Represents the request to get user attribute verification.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserAttributeVerificationCodeRequest {
     #[doc="<p>The access token returned by the server response to get the user attribute verification code.</p>"]
     #[serde(rename="AccessToken")]
@@ -1407,7 +1407,7 @@ pub struct GetUserAttributeVerificationCodeRequest {
 }
 
 #[doc="<p>The verification code response returned by the server response to get the user attribute verification code.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserAttributeVerificationCodeResponse {
     #[doc="<p>The code delivery details returned by the server in response to the request to get the user attribute verification code.</p>"]
     #[serde(rename="CodeDeliveryDetails")]
@@ -1416,7 +1416,7 @@ pub struct GetUserAttributeVerificationCodeResponse {
 }
 
 #[doc="<p>Represents the request to get information about the user.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserRequest {
     #[doc="<p>The access token returned by the server response to get information about the user.</p>"]
     #[serde(rename="AccessToken")]
@@ -1424,7 +1424,7 @@ pub struct GetUserRequest {
 }
 
 #[doc="<p>Represents the response from the server from the request to get information about the user.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserResponse {
     #[doc="<p>Specifies the options for MFA (e.g., email or phone number).</p>"]
     #[serde(rename="MFAOptions")]
@@ -1439,7 +1439,7 @@ pub struct GetUserResponse {
 }
 
 #[doc="<p>Represents the request to sign out all devices.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GlobalSignOutRequest {
     #[doc="<p>The access token.</p>"]
     #[serde(rename="AccessToken")]
@@ -1447,11 +1447,11 @@ pub struct GlobalSignOutRequest {
 }
 
 #[doc="<p>The response to the request to sign out all devices.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GlobalSignOutResponse;
 
 #[doc="<p>The group type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GroupType {
     #[doc="<p>The date the group was created.</p>"]
     #[serde(rename="CreationDate")]
@@ -1484,7 +1484,7 @@ pub struct GroupType {
 }
 
 #[doc="<p>A container for information about an identity provider.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IdentityProviderType {
     #[doc="<p>A mapping of identity provider attributes to standard and custom user pool attributes.</p>"]
     #[serde(rename="AttributeMapping")]
@@ -1521,7 +1521,7 @@ pub struct IdentityProviderType {
 }
 
 #[doc="<p>Initiates the authentication request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateAuthRequest {
     #[doc="<p>The authentication flow for this call to execute. The API action will depend on this value. For example: </p> <ul> <li> <p> <code>REFRESH_TOKEN_AUTH</code> will take in a valid refresh token and return new tokens.</p> </li> <li> <p> <code>USER_SRP_AUTH</code> will take in <code>USERNAME</code> and <code>SRP_A</code> and return the SRP variables to be used for next challenge execution.</p> </li> </ul> <p>Valid values include:</p> <ul> <li> <p> <code>USER_SRP_AUTH</code>: Authentication flow for the Secure Remote Password (SRP) protocol.</p> </li> <li> <p> <code>REFRESH_TOKEN_AUTH</code>/<code>REFRESH_TOKEN</code>: Authentication flow for refreshing the access token and ID token by supplying a valid refresh token.</p> </li> <li> <p> <code>CUSTOM_AUTH</code>: Custom authentication flow.</p> </li> </ul> <p> <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.</p>"]
     #[serde(rename="AuthFlow")]
@@ -1540,7 +1540,7 @@ pub struct InitiateAuthRequest {
 }
 
 #[doc="<p>Initiates the authentication response.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateAuthResponse {
     #[doc="<p>The result of the authentication response. This is only returned if the caller does not need to pass another challenge. If the caller does need to pass another challenge before it gets tokens, <code>ChallengeName</code>, <code>ChallengeParameters</code>, and <code>Session</code> are returned.</p>"]
     #[serde(rename="AuthenticationResult")]
@@ -1598,7 +1598,7 @@ pub struct LambdaConfigType {
 }
 
 #[doc="<p>Represents the request to list the devices.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDevicesRequest {
     #[doc="<p>The access tokens for the request to list devices.</p>"]
     #[serde(rename="AccessToken")]
@@ -1614,7 +1614,7 @@ pub struct ListDevicesRequest {
 }
 
 #[doc="<p>Represents the response to list devices.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDevicesResponse {
     #[doc="<p>The devices returned in the list devices response.</p>"]
     #[serde(rename="Devices")]
@@ -1626,7 +1626,7 @@ pub struct ListDevicesResponse {
     pub pagination_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupsRequest {
     #[doc="<p>The limit of the request to list groups.</p>"]
     #[serde(rename="Limit")]
@@ -1641,7 +1641,7 @@ pub struct ListGroupsRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupsResponse {
     #[doc="<p>The group objects for the groups.</p>"]
     #[serde(rename="Groups")]
@@ -1653,7 +1653,7 @@ pub struct ListGroupsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentityProvidersRequest {
     #[doc="<p>The maximum number of identity providers to return.</p>"]
     #[serde(rename="MaxResults")]
@@ -1668,7 +1668,7 @@ pub struct ListIdentityProvidersRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentityProvidersResponse {
     #[doc="<p>A pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -1679,7 +1679,7 @@ pub struct ListIdentityProvidersResponse {
     pub providers: Vec<ProviderDescription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourceServersRequest {
     #[doc="<p>The maximum number of resource servers to return.</p>"]
     #[serde(rename="MaxResults")]
@@ -1694,7 +1694,7 @@ pub struct ListResourceServersRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourceServersResponse {
     #[doc="<p>A pagination token.</p>"]
     #[serde(rename="NextToken")]
@@ -1706,7 +1706,7 @@ pub struct ListResourceServersResponse {
 }
 
 #[doc="<p>Represents the request to list the user import jobs.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUserImportJobsRequest {
     #[doc="<p>The maximum number of import jobs you want the request to return.</p>"]
     #[serde(rename="MaxResults")]
@@ -1721,7 +1721,7 @@ pub struct ListUserImportJobsRequest {
 }
 
 #[doc="<p>Represents the response from the server to the request to list the user import jobs.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUserImportJobsResponse {
     #[doc="<p>An identifier that can be used to return the next set of user import jobs in the list.</p>"]
     #[serde(rename="PaginationToken")]
@@ -1734,7 +1734,7 @@ pub struct ListUserImportJobsResponse {
 }
 
 #[doc="<p>Represents the request to list the user pool clients.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUserPoolClientsRequest {
     #[doc="<p>The maximum number of results you want the request to return when listing the user pool clients.</p>"]
     #[serde(rename="MaxResults")]
@@ -1750,7 +1750,7 @@ pub struct ListUserPoolClientsRequest {
 }
 
 #[doc="<p>Represents the response from the server that lists user pool clients.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUserPoolClientsResponse {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="NextToken")]
@@ -1763,7 +1763,7 @@ pub struct ListUserPoolClientsResponse {
 }
 
 #[doc="<p>Represents the request to list user pools.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUserPoolsRequest {
     #[doc="<p>The maximum number of results you want the request to return when listing the user pools.</p>"]
     #[serde(rename="MaxResults")]
@@ -1775,7 +1775,7 @@ pub struct ListUserPoolsRequest {
 }
 
 #[doc="<p>Represents the response to list user pools.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUserPoolsResponse {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="NextToken")]
@@ -1787,7 +1787,7 @@ pub struct ListUserPoolsResponse {
     pub user_pools: Option<Vec<UserPoolDescriptionType>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUsersInGroupRequest {
     #[doc="<p>The name of the group.</p>"]
     #[serde(rename="GroupName")]
@@ -1805,7 +1805,7 @@ pub struct ListUsersInGroupRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUsersInGroupResponse {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="NextToken")]
@@ -1818,7 +1818,7 @@ pub struct ListUsersInGroupResponse {
 }
 
 #[doc="<p>Represents the request to list users.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUsersRequest {
     #[doc="<p>An array of strings, where each string is the name of a user attribute to be returned for each user in the search results. If the array is empty, all attributes are returned.</p>"]
     #[serde(rename="AttributesToGet")]
@@ -1842,7 +1842,7 @@ pub struct ListUsersRequest {
 }
 
 #[doc="<p>The response from the request to list users.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUsersResponse {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="PaginationToken")]
@@ -1885,7 +1885,7 @@ pub struct MessageTemplateType {
 }
 
 #[doc="<p>The new device metadata type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NewDeviceMetadataType {
     #[doc="<p>The device group key.</p>"]
     #[serde(rename="DeviceGroupKey")]
@@ -1936,7 +1936,7 @@ pub struct PasswordPolicyType {
 }
 
 #[doc="<p>A container for identity provider details.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProviderDescription {
     #[doc="<p>The date the provider was added to the user pool.</p>"]
     #[serde(rename="CreationDate")]
@@ -1957,7 +1957,7 @@ pub struct ProviderDescription {
 }
 
 #[doc="<p>A container for information about an identity provider for a user pool.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProviderUserIdentifierType {
     #[doc="<p>The name of the provider attribute to link to, for example, <code>NameID</code>.</p>"]
     #[serde(rename="ProviderAttributeName")]
@@ -1974,7 +1974,7 @@ pub struct ProviderUserIdentifierType {
 }
 
 #[doc="<p>Represents the request to resend the confirmation code.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResendConfirmationCodeRequest {
     #[doc="<p>The ID of the client associated with the user pool.</p>"]
     #[serde(rename="ClientId")]
@@ -1989,7 +1989,7 @@ pub struct ResendConfirmationCodeRequest {
 }
 
 #[doc="<p>The response from the server when the Amazon Cognito Your User Pools service makes the request to resend a confirmation code.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResendConfirmationCodeResponse {
     #[doc="<p>The code delivery details returned by the server in response to the request to resend the confirmation code.</p>"]
     #[serde(rename="CodeDeliveryDetails")]
@@ -2009,7 +2009,7 @@ pub struct ResourceServerScopeType {
 }
 
 #[doc="<p>A container for information about a resource server for a user pool.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceServerType {
     #[doc="<p>The identifier for the resource server.</p>"]
     #[serde(rename="Identifier")]
@@ -2030,7 +2030,7 @@ pub struct ResourceServerType {
 }
 
 #[doc="<p>The request to respond to an authentication challenge.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RespondToAuthChallengeRequest {
     #[doc="<p>The challenge name. For more information, see <a href=\"API_InitiateAuth.html\">InitiateAuth</a>.</p> <p> <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.</p>"]
     #[serde(rename="ChallengeName")]
@@ -2049,7 +2049,7 @@ pub struct RespondToAuthChallengeRequest {
 }
 
 #[doc="<p>The response to respond to the authentication challenge.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RespondToAuthChallengeResponse {
     #[doc="<p>The result returned by the server in response to the request to respond to the authentication challenge.</p>"]
     #[serde(rename="AuthenticationResult")]
@@ -2102,7 +2102,7 @@ pub struct SchemaAttributeType {
     pub string_attribute_constraints: Option<StringAttributeConstraintsType>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetUICustomizationRequest {
     #[doc="<p>The CSS values in the UI customization.</p>"]
     #[serde(rename="CSS")]
@@ -2125,7 +2125,7 @@ pub struct SetUICustomizationRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetUICustomizationResponse {
     #[doc="<p>The UI customization information.</p>"]
     #[serde(rename="UICustomization")]
@@ -2133,7 +2133,7 @@ pub struct SetUICustomizationResponse {
 }
 
 #[doc="<p>Represents the request to set user settings.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetUserSettingsRequest {
     #[doc="<p>The access token for the set user settings request.</p>"]
     #[serde(rename="AccessToken")]
@@ -2144,11 +2144,11 @@ pub struct SetUserSettingsRequest {
 }
 
 #[doc="<p>The response from the server for a set user settings request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetUserSettingsResponse;
 
 #[doc="<p>Represents the request to register a user.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SignUpRequest {
     #[doc="<p>The ID of the client associated with the user pool.</p>"]
     #[serde(rename="ClientId")]
@@ -2174,7 +2174,7 @@ pub struct SignUpRequest {
 }
 
 #[doc="<p>The response from the server for a registration request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SignUpResponse {
     #[doc="<p>The code delivery details returned by the server response to the user registration request.</p>"]
     #[serde(rename="CodeDeliveryDetails")]
@@ -2201,7 +2201,7 @@ pub struct SmsConfigurationType {
 }
 
 #[doc="<p>Represents the request to start the user import job.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartUserImportJobRequest {
     #[doc="<p>The job ID for the user import job.</p>"]
     #[serde(rename="JobId")]
@@ -2212,7 +2212,7 @@ pub struct StartUserImportJobRequest {
 }
 
 #[doc="<p>Represents the response from the server to the request to start the user import job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartUserImportJobResponse {
     #[doc="<p>The job object that represents the user import job.</p>"]
     #[serde(rename="UserImportJob")]
@@ -2221,7 +2221,7 @@ pub struct StartUserImportJobResponse {
 }
 
 #[doc="<p>Represents the request to stop the user import job.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopUserImportJobRequest {
     #[doc="<p>The job ID for the user import job.</p>"]
     #[serde(rename="JobId")]
@@ -2232,7 +2232,7 @@ pub struct StopUserImportJobRequest {
 }
 
 #[doc="<p>Represents the response from the server to the request to stop the user import job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopUserImportJobResponse {
     #[doc="<p>The job object that represents the user import job.</p>"]
     #[serde(rename="UserImportJob")]
@@ -2254,7 +2254,7 @@ pub struct StringAttributeConstraintsType {
 }
 
 #[doc="<p>A container for the UI customization information for a user pool's built-in app UI.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UICustomizationType {
     #[doc="<p>The CSS values in the UI customization.</p>"]
     #[serde(rename="CSS")]
@@ -2287,7 +2287,7 @@ pub struct UICustomizationType {
 }
 
 #[doc="<p>Represents the request to update the device status.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDeviceStatusRequest {
     #[doc="<p>The access token.</p>"]
     #[serde(rename="AccessToken")]
@@ -2302,10 +2302,10 @@ pub struct UpdateDeviceStatusRequest {
 }
 
 #[doc="<p>The response to the request to update the device status.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDeviceStatusResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGroupRequest {
     #[doc="<p>A string containing the new description of the group.</p>"]
     #[serde(rename="Description")]
@@ -2327,7 +2327,7 @@ pub struct UpdateGroupRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGroupResponse {
     #[doc="<p>The group object for the group.</p>"]
     #[serde(rename="Group")]
@@ -2335,7 +2335,7 @@ pub struct UpdateGroupResponse {
     pub group: Option<GroupType>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateIdentityProviderRequest {
     #[doc="<p>The identity provider attribute mapping to be changed.</p>"]
     #[serde(rename="AttributeMapping")]
@@ -2357,14 +2357,14 @@ pub struct UpdateIdentityProviderRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateIdentityProviderResponse {
     #[doc="<p>The identity provider object.</p>"]
     #[serde(rename="IdentityProvider")]
     pub identity_provider: IdentityProviderType,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateResourceServerRequest {
     #[doc="<p>The identifier for the resource server.</p>"]
     #[serde(rename="Identifier")]
@@ -2381,7 +2381,7 @@ pub struct UpdateResourceServerRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateResourceServerResponse {
     #[doc="<p>The resource server.</p>"]
     #[serde(rename="ResourceServer")]
@@ -2389,7 +2389,7 @@ pub struct UpdateResourceServerResponse {
 }
 
 #[doc="<p>Represents the request to update user attributes.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserAttributesRequest {
     #[doc="<p>The access token for the request to update user attributes.</p>"]
     #[serde(rename="AccessToken")]
@@ -2400,7 +2400,7 @@ pub struct UpdateUserAttributesRequest {
 }
 
 #[doc="<p>Represents the response from the server for the request to update user attributes.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserAttributesResponse {
     #[doc="<p>The code delivery details list from the server for the request to update user attributes.</p>"]
     #[serde(rename="CodeDeliveryDetailsList")]
@@ -2409,7 +2409,7 @@ pub struct UpdateUserAttributesResponse {
 }
 
 #[doc="<p>Represents the request to update the user pool client.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserPoolClientRequest {
     #[doc="<p>Set to <code>code</code> to initiate a code grant flow, which provides an authorization code as the response. This code can be exchanged for access tokens with the token endpoint.</p> <p>Set to <code>token</code> to specify that the client should get the access token (and, optionally, ID token, based on scopes) directly.</p>"]
     #[serde(rename="AllowedOAuthFlows")]
@@ -2468,7 +2468,7 @@ pub struct UpdateUserPoolClientRequest {
 }
 
 #[doc="<p>Represents the response from the server to the request to update the user pool client.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserPoolClientResponse {
     #[doc="<p>The user pool client value from the response from the server when an update user pool client request is made.</p>"]
     #[serde(rename="UserPoolClient")]
@@ -2477,7 +2477,7 @@ pub struct UpdateUserPoolClientResponse {
 }
 
 #[doc="<p>Represents the request to update the user pool.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserPoolRequest {
     #[doc="<p>The configuration for <code>AdminCreateUser</code> requests.</p>"]
     #[serde(rename="AdminCreateUserConfig")]
@@ -2541,11 +2541,11 @@ pub struct UpdateUserPoolRequest {
 }
 
 #[doc="<p>Represents the response from the server when you make a request to update the user pool.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserPoolResponse;
 
 #[doc="<p>The user import job type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserImportJobType {
     #[doc="<p>The role ARN for the Amazon CloudWatch Logging role for the user import job. For more information, see \"Creating the CloudWatch Logs IAM Role\" in the Amazon Cognito Developer Guide.</p>"]
     #[serde(rename="CloudWatchLogsRoleArn")]
@@ -2602,7 +2602,7 @@ pub struct UserImportJobType {
 }
 
 #[doc="<p>The description of the user pool client.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserPoolClientDescription {
     #[doc="<p>The ID of the client associated with the user pool.</p>"]
     #[serde(rename="ClientId")]
@@ -2619,7 +2619,7 @@ pub struct UserPoolClientDescription {
 }
 
 #[doc="<p>Contains information about a user pool client.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserPoolClientType {
     #[doc="<p>Set to <code>code</code> to initiate a code grant flow, which provides an authorization code as the response. This code can be exchanged for access tokens with the token endpoint.</p> <p>Set to <code>token</code> to specify that the client should get the access token (and, optionally, ID token, based on scopes) directly.</p>"]
     #[serde(rename="AllowedOAuthFlows")]
@@ -2692,7 +2692,7 @@ pub struct UserPoolClientType {
 }
 
 #[doc="<p>A user pool description.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserPoolDescriptionType {
     #[doc="<p>The date the user pool description was created.</p>"]
     #[serde(rename="CreationDate")]
@@ -2730,7 +2730,7 @@ pub struct UserPoolPolicyType {
 }
 
 #[doc="<p>A container for information about the user pool type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserPoolType {
     #[doc="<p>The configuration for <code>AdminCreateUser</code> requests.</p>"]
     #[serde(rename="AdminCreateUserConfig")]
@@ -2835,7 +2835,7 @@ pub struct UserPoolType {
 }
 
 #[doc="<p>The user type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserType {
     #[doc="<p>A container with information about the user type attributes.</p>"]
     #[serde(rename="Attributes")]
@@ -2897,7 +2897,7 @@ pub struct VerificationMessageTemplateType {
 }
 
 #[doc="<p>Represents the request to verify user attributes.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerifyUserAttributeRequest {
     #[doc="<p>Represents the access token of the request to verify user attributes.</p>"]
     #[serde(rename="AccessToken")]
@@ -2911,7 +2911,7 @@ pub struct VerifyUserAttributeRequest {
 }
 
 #[doc="<p>A container representing the response from the server from the request to verify user attributes.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerifyUserAttributeResponse;
 
 /// Errors returned by AddCustomAttributes

--- a/rusoto/services/cognito-sync/src/generated.rs
+++ b/rusoto/services/cognito-sync/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 #[doc="The input for the BulkPublish operation."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BulkPublishRequest {
     #[doc="A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region."]
     #[serde(rename="IdentityPoolId")]
@@ -38,7 +38,7 @@ pub struct BulkPublishRequest {
 }
 
 #[doc="The output for the BulkPublish operation."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BulkPublishResponse {
     #[doc="A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region."]
     #[serde(rename="IdentityPoolId")]
@@ -64,7 +64,7 @@ pub struct CognitoStreams {
 }
 
 #[doc="A collection of data for an identity pool. An identity pool can have multiple datasets. A dataset is per identity and can be general or associated with a particular entity in an application (like a saved game). Datasets are automatically created if they don't exist. Data is synced by dataset, and a dataset can hold up to 1MB of key-value pairs."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Dataset {
     #[doc="Date on which the dataset was created."]
     #[serde(rename="CreationDate")]
@@ -97,7 +97,7 @@ pub struct Dataset {
 }
 
 #[doc="A request to delete the specific dataset."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDatasetRequest {
     #[doc="A string of up to 128 characters. Allowed characters are a-z, A-Z, 0-9, '_' (underscore), '-' (dash), and '.' (dot)."]
     #[serde(rename="DatasetName")]
@@ -111,7 +111,7 @@ pub struct DeleteDatasetRequest {
 }
 
 #[doc="Response to a successful DeleteDataset request."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDatasetResponse {
     #[doc="A collection of data for an identity pool. An identity pool can have multiple datasets. A dataset is per identity and can be general or associated with a particular entity in an application (like a saved game). Datasets are automatically created if they don't exist. Data is synced by dataset, and a dataset can hold up to 1MB of key-value pairs."]
     #[serde(rename="Dataset")]
@@ -120,7 +120,7 @@ pub struct DeleteDatasetResponse {
 }
 
 #[doc="A request for meta data about a dataset (creation date, number of records, size) by owner and dataset name."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDatasetRequest {
     #[doc="A string of up to 128 characters. Allowed characters are a-z, A-Z, 0-9, '_' (underscore), '-' (dash), and '.' (dot)."]
     #[serde(rename="DatasetName")]
@@ -134,7 +134,7 @@ pub struct DescribeDatasetRequest {
 }
 
 #[doc="Response to a successful DescribeDataset request."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDatasetResponse {
     #[doc="Meta data for a collection of data for an identity. An identity can have multiple datasets. A dataset can be general or associated with a particular entity in an application (like a saved game). Datasets are automatically created if they don't exist. Data is synced by dataset, and a dataset can hold up to 1MB of key-value pairs."]
     #[serde(rename="Dataset")]
@@ -143,7 +143,7 @@ pub struct DescribeDatasetResponse {
 }
 
 #[doc="A request for usage information about the identity pool."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdentityPoolUsageRequest {
     #[doc="A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region."]
     #[serde(rename="IdentityPoolId")]
@@ -151,7 +151,7 @@ pub struct DescribeIdentityPoolUsageRequest {
 }
 
 #[doc="Response to a successful DescribeIdentityPoolUsage request."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdentityPoolUsageResponse {
     #[doc="Information about the usage of the identity pool."]
     #[serde(rename="IdentityPoolUsage")]
@@ -160,7 +160,7 @@ pub struct DescribeIdentityPoolUsageResponse {
 }
 
 #[doc="A request for information about the usage of an identity pool."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdentityUsageRequest {
     #[doc="A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region."]
     #[serde(rename="IdentityId")]
@@ -171,7 +171,7 @@ pub struct DescribeIdentityUsageRequest {
 }
 
 #[doc="The response to a successful DescribeIdentityUsage request."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdentityUsageResponse {
     #[doc="Usage information for the identity."]
     #[serde(rename="IdentityUsage")]
@@ -180,7 +180,7 @@ pub struct DescribeIdentityUsageResponse {
 }
 
 #[doc="The input for the GetBulkPublishDetails operation."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBulkPublishDetailsRequest {
     #[doc="A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region."]
     #[serde(rename="IdentityPoolId")]
@@ -188,7 +188,7 @@ pub struct GetBulkPublishDetailsRequest {
 }
 
 #[doc="The output for the GetBulkPublishDetails operation."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBulkPublishDetailsResponse {
     #[doc="If BulkPublishStatus is SUCCEEDED, the time the last bulk publish operation completed."]
     #[serde(rename="BulkPublishCompleteTime")]
@@ -213,7 +213,7 @@ pub struct GetBulkPublishDetailsResponse {
 }
 
 #[doc="<p>A request for a list of the configured Cognito Events</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCognitoEventsRequest {
     #[doc="<p>The Cognito Identity Pool ID for the request</p>"]
     #[serde(rename="IdentityPoolId")]
@@ -221,7 +221,7 @@ pub struct GetCognitoEventsRequest {
 }
 
 #[doc="<p>The response from the GetCognitoEvents request</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCognitoEventsResponse {
     #[doc="<p>The Cognito Events returned from the GetCognitoEvents request</p>"]
     #[serde(rename="Events")]
@@ -230,7 +230,7 @@ pub struct GetCognitoEventsResponse {
 }
 
 #[doc="<p>The input for the GetIdentityPoolConfiguration operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityPoolConfigurationRequest {
     #[doc="<p>A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. This is the ID of the pool for which to return a configuration.</p>"]
     #[serde(rename="IdentityPoolId")]
@@ -238,7 +238,7 @@ pub struct GetIdentityPoolConfigurationRequest {
 }
 
 #[doc="<p>The output for the GetIdentityPoolConfiguration operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityPoolConfigurationResponse {
     #[doc="Options to apply to this identity pool for Amazon Cognito streams."]
     #[serde(rename="CognitoStreams")]
@@ -255,7 +255,7 @@ pub struct GetIdentityPoolConfigurationResponse {
 }
 
 #[doc="Usage information for the identity pool."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IdentityPoolUsage {
     #[doc="Data storage information for the identity pool."]
     #[serde(rename="DataStorage")]
@@ -276,7 +276,7 @@ pub struct IdentityPoolUsage {
 }
 
 #[doc="Usage information for the identity."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IdentityUsage {
     #[doc="Total data storage for this identity."]
     #[serde(rename="DataStorage")]
@@ -301,7 +301,7 @@ pub struct IdentityUsage {
 }
 
 #[doc="Request for a list of datasets for an identity."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDatasetsRequest {
     #[doc="A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region."]
     #[serde(rename="IdentityId")]
@@ -320,7 +320,7 @@ pub struct ListDatasetsRequest {
 }
 
 #[doc="Returned for a successful ListDatasets request."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDatasetsResponse {
     #[doc="Number of datasets returned."]
     #[serde(rename="Count")]
@@ -337,7 +337,7 @@ pub struct ListDatasetsResponse {
 }
 
 #[doc="A request for usage information on an identity pool."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentityPoolUsageRequest {
     #[doc="The maximum number of results to be returned."]
     #[serde(rename="MaxResults")]
@@ -350,7 +350,7 @@ pub struct ListIdentityPoolUsageRequest {
 }
 
 #[doc="Returned for a successful ListIdentityPoolUsage request."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentityPoolUsageResponse {
     #[doc="Total number of identities for the identity pool."]
     #[serde(rename="Count")]
@@ -371,7 +371,7 @@ pub struct ListIdentityPoolUsageResponse {
 }
 
 #[doc="A request for a list of records."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRecordsRequest {
     #[doc="A string of up to 128 characters. Allowed characters are a-z, A-Z, 0-9, '_' (underscore), '-' (dash), and '.' (dot)."]
     #[serde(rename="DatasetName")]
@@ -401,7 +401,7 @@ pub struct ListRecordsRequest {
 }
 
 #[doc="Returned for a successful ListRecordsRequest."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRecordsResponse {
     #[doc="Total number of records."]
     #[serde(rename="Count")]
@@ -455,7 +455,7 @@ pub struct PushSync {
 }
 
 #[doc="The basic data structure of a dataset."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Record {
     #[doc="The last modified date of the client device."]
     #[serde(rename="DeviceLastModifiedDate")]
@@ -484,7 +484,7 @@ pub struct Record {
 }
 
 #[doc="An update operation for a record."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecordPatch {
     #[doc="The last modified date of the client device."]
     #[serde(rename="DeviceLastModifiedDate")]
@@ -506,7 +506,7 @@ pub struct RecordPatch {
 }
 
 #[doc="<p>A request to RegisterDevice.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterDeviceRequest {
     #[doc="<p>The unique ID for this identity.</p>"]
     #[serde(rename="IdentityId")]
@@ -523,7 +523,7 @@ pub struct RegisterDeviceRequest {
 }
 
 #[doc="<p>Response to a RegisterDevice request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterDeviceResponse {
     #[doc="<p>The unique ID generated for this device by Cognito.</p>"]
     #[serde(rename="DeviceId")]
@@ -532,7 +532,7 @@ pub struct RegisterDeviceResponse {
 }
 
 #[doc="<p>A request to configure Cognito Events\"</p>\""]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetCognitoEventsRequest {
     #[doc="<p>The events to configure</p>"]
     #[serde(rename="Events")]
@@ -543,7 +543,7 @@ pub struct SetCognitoEventsRequest {
 }
 
 #[doc="<p>The input for the SetIdentityPoolConfiguration operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityPoolConfigurationRequest {
     #[doc="Options to apply to this identity pool for Amazon Cognito streams."]
     #[serde(rename="CognitoStreams")]
@@ -559,7 +559,7 @@ pub struct SetIdentityPoolConfigurationRequest {
 }
 
 #[doc="<p>The output for the SetIdentityPoolConfiguration operation</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityPoolConfigurationResponse {
     #[doc="Options to apply to this identity pool for Amazon Cognito streams."]
     #[serde(rename="CognitoStreams")]
@@ -576,7 +576,7 @@ pub struct SetIdentityPoolConfigurationResponse {
 }
 
 #[doc="<p>A request to SubscribeToDatasetRequest.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubscribeToDatasetRequest {
     #[doc="<p>The name of the dataset to subcribe to.</p>"]
     #[serde(rename="DatasetName")]
@@ -593,11 +593,11 @@ pub struct SubscribeToDatasetRequest {
 }
 
 #[doc="<p>Response to a SubscribeToDataset request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubscribeToDatasetResponse;
 
 #[doc="<p>A request to UnsubscribeFromDataset.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnsubscribeFromDatasetRequest {
     #[doc="<p>The name of the dataset from which to unsubcribe.</p>"]
     #[serde(rename="DatasetName")]
@@ -614,11 +614,11 @@ pub struct UnsubscribeFromDatasetRequest {
 }
 
 #[doc="<p>Response to an UnsubscribeFromDataset request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnsubscribeFromDatasetResponse;
 
 #[doc="A request to post updates to records or add and delete records for a dataset and user."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRecordsRequest {
     #[doc="Intended to supply a device ID that will populate the lastModifiedBy field referenced in other methods. The ClientContext field is not yet implemented."]
     #[serde(rename="ClientContext")]
@@ -647,7 +647,7 @@ pub struct UpdateRecordsRequest {
 }
 
 #[doc="Returned for a successful UpdateRecordsRequest."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRecordsResponse {
     #[doc="A list of records that have been updated."]
     #[serde(rename="Records")]

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Indicates whether an AWS resource or AWS Config rule is compliant and provides the number of contributors that affect the compliance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Compliance {
     #[doc="<p>The number of AWS resources or AWS Config rules that cause a result of <code>NON_COMPLIANT</code>, up to a maximum number.</p>"]
     #[serde(rename="ComplianceContributorCount")]
@@ -42,7 +42,7 @@ pub struct Compliance {
 }
 
 #[doc="<p>Indicates whether an AWS Config rule is compliant. A rule is compliant if all of the resources that the rule evaluated comply with it, and it is noncompliant if any of these resources do not comply.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComplianceByConfigRule {
     #[doc="<p>Indicates whether the AWS Config rule is compliant.</p>"]
     #[serde(rename="Compliance")]
@@ -55,7 +55,7 @@ pub struct ComplianceByConfigRule {
 }
 
 #[doc="<p>Indicates whether an AWS resource that is evaluated according to one or more AWS Config rules is compliant. A resource is compliant if it complies with all of the rules that evaluate it, and it is noncompliant if it does not comply with one or more of these rules.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComplianceByResource {
     #[doc="<p>Indicates whether the AWS resource complies with all of the AWS Config rules that evaluated it.</p>"]
     #[serde(rename="Compliance")]
@@ -72,7 +72,7 @@ pub struct ComplianceByResource {
 }
 
 #[doc="<p>The number of AWS resources or AWS Config rules responsible for the current compliance of the item, up to a maximum number.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComplianceContributorCount {
     #[doc="<p>Indicates whether the maximum count is reached.</p>"]
     #[serde(rename="CapExceeded")]
@@ -85,7 +85,7 @@ pub struct ComplianceContributorCount {
 }
 
 #[doc="<p>The number of AWS Config rules or AWS resources that are compliant and noncompliant.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComplianceSummary {
     #[doc="<p>The time that AWS Config created the compliance summary.</p>"]
     #[serde(rename="ComplianceSummaryTimestamp")]
@@ -102,7 +102,7 @@ pub struct ComplianceSummary {
 }
 
 #[doc="<p>The number of AWS resources of a specific type that are compliant or noncompliant, up to a maximum of 100 for each compliance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComplianceSummaryByResourceType {
     #[doc="<p>The number of AWS resources that are compliant or noncompliant, up to a maximum of 100 for each compliance.</p>"]
     #[serde(rename="ComplianceSummary")]
@@ -115,7 +115,7 @@ pub struct ComplianceSummaryByResourceType {
 }
 
 #[doc="<p>A list that contains the status of the delivery of either the snapshot or the configuration history to the specified Amazon S3 bucket.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigExportDeliveryInfo {
     #[doc="<p>The time of the last attempted delivery.</p>"]
     #[serde(rename="lastAttemptTime")]
@@ -184,7 +184,7 @@ pub struct ConfigRule {
 }
 
 #[doc="<p>Status information for your AWS managed Config rules. The status includes information such as the last time the rule ran, the last time it failed, and the related error for the last failure.</p> <p>This action does not return status information about custom Config rules.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigRuleEvaluationStatus {
     #[doc="<p>The Amazon Resource Name (ARN) of the AWS Config rule.</p>"]
     #[serde(rename="ConfigRuleArn")]
@@ -242,7 +242,7 @@ pub struct ConfigSnapshotDeliveryProperties {
 }
 
 #[doc="<p>A list that contains the status of the delivery of the configuration stream notification to the Amazon SNS topic.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigStreamDeliveryInfo {
     #[doc="<p>The error code from the last attempted delivery.</p>"]
     #[serde(rename="lastErrorCode")]
@@ -263,7 +263,7 @@ pub struct ConfigStreamDeliveryInfo {
 }
 
 #[doc="<p>A list that contains detailed configurations of a specified resource.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigurationItem {
     #[doc="<p>The 12 digit AWS account ID associated with the resource.</p>"]
     #[serde(rename="accountId")]
@@ -357,7 +357,7 @@ pub struct ConfigurationRecorder {
 }
 
 #[doc="<p>The current status of the configuration recorder.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigurationRecorderStatus {
     #[doc="<p>The error code indicating that the recording failed.</p>"]
     #[serde(rename="lastErrorCode")]
@@ -394,7 +394,7 @@ pub struct ConfigurationRecorderStatus {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConfigRuleRequest {
     #[doc="<p>The name of the AWS Config rule that you want to delete.</p>"]
     #[serde(rename="ConfigRuleName")]
@@ -402,7 +402,7 @@ pub struct DeleteConfigRuleRequest {
 }
 
 #[doc="<p>The request object for the <code>DeleteConfigurationRecorder</code> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConfigurationRecorderRequest {
     #[doc="<p>The name of the configuration recorder to be deleted. You can retrieve the name of your configuration recorder by using the <code>DescribeConfigurationRecorders</code> action.</p>"]
     #[serde(rename="ConfigurationRecorderName")]
@@ -410,7 +410,7 @@ pub struct DeleteConfigurationRecorderRequest {
 }
 
 #[doc="<p>The input for the <a>DeleteDeliveryChannel</a> action. The action accepts the following data in JSON format. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDeliveryChannelRequest {
     #[doc="<p>The name of the delivery channel to delete.</p>"]
     #[serde(rename="DeliveryChannelName")]
@@ -418,7 +418,7 @@ pub struct DeleteDeliveryChannelRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEvaluationResultsRequest {
     #[doc="<p>The name of the Config rule for which you want to delete the evaluation results.</p>"]
     #[serde(rename="ConfigRuleName")]
@@ -426,11 +426,11 @@ pub struct DeleteEvaluationResultsRequest {
 }
 
 #[doc="<p>The output when you delete the evaluation results for the specified Config rule.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEvaluationResultsResponse;
 
 #[doc="<p>The input for the <a>DeliverConfigSnapshot</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeliverConfigSnapshotRequest {
     #[doc="<p>The name of the delivery channel through which the snapshot is delivered.</p>"]
     #[serde(rename="deliveryChannelName")]
@@ -438,7 +438,7 @@ pub struct DeliverConfigSnapshotRequest {
 }
 
 #[doc="<p>The output for the <a>DeliverConfigSnapshot</a> action in JSON format.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeliverConfigSnapshotResponse {
     #[doc="<p>The ID of the snapshot that is being created.</p>"]
     #[serde(rename="configSnapshotId")]
@@ -472,7 +472,7 @@ pub struct DeliveryChannel {
 }
 
 #[doc="<p>The status of a specified delivery channel.</p> <p>Valid values: <code>Success</code> | <code>Failure</code> </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeliveryChannelStatus {
     #[doc="<p>A list that contains the status of the delivery of the configuration history to the specified Amazon S3 bucket.</p>"]
     #[serde(rename="configHistoryDeliveryInfo")]
@@ -493,7 +493,7 @@ pub struct DeliveryChannelStatus {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeComplianceByConfigRuleRequest {
     #[doc="<p>Filters the results by compliance.</p> <p>The allowed values are <code>COMPLIANT</code>, <code>NON_COMPLIANT</code>, and <code>INSUFFICIENT_DATA</code>.</p>"]
     #[serde(rename="ComplianceTypes")]
@@ -510,7 +510,7 @@ pub struct DescribeComplianceByConfigRuleRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeComplianceByConfigRuleResponse {
     #[doc="<p>Indicates whether each of the specified AWS Config rules is compliant.</p>"]
     #[serde(rename="ComplianceByConfigRules")]
@@ -523,7 +523,7 @@ pub struct DescribeComplianceByConfigRuleResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeComplianceByResourceRequest {
     #[doc="<p>Filters the results by compliance.</p> <p>The allowed values are <code>COMPLIANT</code>, <code>NON_COMPLIANT</code>, and <code>INSUFFICIENT_DATA</code>.</p>"]
     #[serde(rename="ComplianceTypes")]
@@ -548,7 +548,7 @@ pub struct DescribeComplianceByResourceRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeComplianceByResourceResponse {
     #[doc="<p>Indicates whether the specified AWS resource complies with all of the AWS Config rules that evaluate it.</p>"]
     #[serde(rename="ComplianceByResources")]
@@ -561,7 +561,7 @@ pub struct DescribeComplianceByResourceResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigRuleEvaluationStatusRequest {
     #[doc="<p>The name of the AWS managed Config rules for which you want status information. If you do not specify any names, AWS Config returns status information for all AWS managed Config rules that you use.</p>"]
     #[serde(rename="ConfigRuleNames")]
@@ -578,7 +578,7 @@ pub struct DescribeConfigRuleEvaluationStatusRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigRuleEvaluationStatusResponse {
     #[doc="<p>Status information about your AWS managed Config rules.</p>"]
     #[serde(rename="ConfigRulesEvaluationStatus")]
@@ -591,7 +591,7 @@ pub struct DescribeConfigRuleEvaluationStatusResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigRulesRequest {
     #[doc="<p>The names of the AWS Config rules for which you want details. If you do not specify any names, AWS Config returns details for all your rules.</p>"]
     #[serde(rename="ConfigRuleNames")]
@@ -604,7 +604,7 @@ pub struct DescribeConfigRulesRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigRulesResponse {
     #[doc="<p>The details about your AWS Config rules.</p>"]
     #[serde(rename="ConfigRules")]
@@ -617,7 +617,7 @@ pub struct DescribeConfigRulesResponse {
 }
 
 #[doc="<p>The input for the <a>DescribeConfigurationRecorderStatus</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigurationRecorderStatusRequest {
     #[doc="<p>The name(s) of the configuration recorder. If the name is not specified, the action returns the current status of all the configuration recorders associated with the account.</p>"]
     #[serde(rename="ConfigurationRecorderNames")]
@@ -626,7 +626,7 @@ pub struct DescribeConfigurationRecorderStatusRequest {
 }
 
 #[doc="<p>The output for the <a>DescribeConfigurationRecorderStatus</a> action in JSON format.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigurationRecorderStatusResponse {
     #[doc="<p>A list that contains status of the specified recorders.</p>"]
     #[serde(rename="ConfigurationRecordersStatus")]
@@ -635,7 +635,7 @@ pub struct DescribeConfigurationRecorderStatusResponse {
 }
 
 #[doc="<p>The input for the <a>DescribeConfigurationRecorders</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigurationRecordersRequest {
     #[doc="<p>A list of configuration recorder names.</p>"]
     #[serde(rename="ConfigurationRecorderNames")]
@@ -644,7 +644,7 @@ pub struct DescribeConfigurationRecordersRequest {
 }
 
 #[doc="<p>The output for the <a>DescribeConfigurationRecorders</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigurationRecordersResponse {
     #[doc="<p>A list that contains the descriptions of the specified configuration recorders.</p>"]
     #[serde(rename="ConfigurationRecorders")]
@@ -653,7 +653,7 @@ pub struct DescribeConfigurationRecordersResponse {
 }
 
 #[doc="<p>The input for the <a>DeliveryChannelStatus</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDeliveryChannelStatusRequest {
     #[doc="<p>A list of delivery channel names.</p>"]
     #[serde(rename="DeliveryChannelNames")]
@@ -662,7 +662,7 @@ pub struct DescribeDeliveryChannelStatusRequest {
 }
 
 #[doc="<p>The output for the <a>DescribeDeliveryChannelStatus</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDeliveryChannelStatusResponse {
     #[doc="<p>A list that contains the status of a specified delivery channel.</p>"]
     #[serde(rename="DeliveryChannelsStatus")]
@@ -671,7 +671,7 @@ pub struct DescribeDeliveryChannelStatusResponse {
 }
 
 #[doc="<p>The input for the <a>DescribeDeliveryChannels</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDeliveryChannelsRequest {
     #[doc="<p>A list of delivery channel names.</p>"]
     #[serde(rename="DeliveryChannelNames")]
@@ -680,7 +680,7 @@ pub struct DescribeDeliveryChannelsRequest {
 }
 
 #[doc="<p>The output for the <a>DescribeDeliveryChannels</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDeliveryChannelsResponse {
     #[doc="<p>A list that contains the descriptions of the specified delivery channel.</p>"]
     #[serde(rename="DeliveryChannels")]
@@ -710,7 +710,7 @@ pub struct Evaluation {
 }
 
 #[doc="<p>The details of an AWS Config evaluation. Provides the AWS resource that was evaluated, the compliance of the resource, related timestamps, and supplementary information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EvaluationResult {
     #[doc="<p>Supplementary information about how the evaluation determined the compliance.</p>"]
     #[serde(rename="Annotation")]
@@ -739,7 +739,7 @@ pub struct EvaluationResult {
 }
 
 #[doc="<p>Uniquely identifies an evaluation result.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EvaluationResultIdentifier {
     #[doc="<p>Identifies an AWS Config rule used to evaluate an AWS resource, and provides the type and ID of the evaluated resource.</p>"]
     #[serde(rename="EvaluationResultQualifier")]
@@ -752,7 +752,7 @@ pub struct EvaluationResultIdentifier {
 }
 
 #[doc="<p>Identifies an AWS Config rule that evaluated an AWS resource, and provides the type and ID of the resource that the rule evaluated.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EvaluationResultQualifier {
     #[doc="<p>The name of the AWS Config rule that was used in the evaluation.</p>"]
     #[serde(rename="ConfigRuleName")]
@@ -769,7 +769,7 @@ pub struct EvaluationResultQualifier {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetComplianceDetailsByConfigRuleRequest {
     #[doc="<p>Filters the results by compliance.</p> <p>The allowed values are <code>COMPLIANT</code>, <code>NON_COMPLIANT</code>, and <code>NOT_APPLICABLE</code>.</p>"]
     #[serde(rename="ComplianceTypes")]
@@ -789,7 +789,7 @@ pub struct GetComplianceDetailsByConfigRuleRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetComplianceDetailsByConfigRuleResponse {
     #[doc="<p>Indicates whether the AWS resource complies with the specified AWS Config rule.</p>"]
     #[serde(rename="EvaluationResults")]
@@ -802,7 +802,7 @@ pub struct GetComplianceDetailsByConfigRuleResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetComplianceDetailsByResourceRequest {
     #[doc="<p>Filters the results by compliance.</p> <p>The allowed values are <code>COMPLIANT</code>, <code>NON_COMPLIANT</code>, and <code>NOT_APPLICABLE</code>.</p>"]
     #[serde(rename="ComplianceTypes")]
@@ -821,7 +821,7 @@ pub struct GetComplianceDetailsByResourceRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetComplianceDetailsByResourceResponse {
     #[doc="<p>Indicates whether the specified AWS resource complies each AWS Config rule.</p>"]
     #[serde(rename="EvaluationResults")]
@@ -834,7 +834,7 @@ pub struct GetComplianceDetailsByResourceResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetComplianceSummaryByConfigRuleResponse {
     #[doc="<p>The number of AWS Config rules that are compliant and the number that are noncompliant, up to a maximum of 25 for each.</p>"]
     #[serde(rename="ComplianceSummary")]
@@ -843,7 +843,7 @@ pub struct GetComplianceSummaryByConfigRuleResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetComplianceSummaryByResourceTypeRequest {
     #[doc="<p>Specify one or more resource types to get the number of resources that are compliant and the number that are noncompliant for each resource type.</p> <p>For this request, you can specify an AWS resource type such as <code>AWS::EC2::Instance</code>, and you can specify that the resource type is an AWS account by specifying <code>AWS::::Account</code>.</p>"]
     #[serde(rename="ResourceTypes")]
@@ -852,7 +852,7 @@ pub struct GetComplianceSummaryByResourceTypeRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetComplianceSummaryByResourceTypeResponse {
     #[doc="<p>The number of resources that are compliant and the number that are noncompliant. If one or more resource types were provided with the request, the numbers are returned for each resource type. The maximum number returned is 100.</p>"]
     #[serde(rename="ComplianceSummariesByResourceType")]
@@ -860,7 +860,7 @@ pub struct GetComplianceSummaryByResourceTypeResponse {
     pub compliance_summaries_by_resource_type: Option<Vec<ComplianceSummaryByResourceType>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDiscoveredResourceCountsRequest {
     #[doc="<p>The maximum number of <a>ResourceCount</a> objects returned on each page. The default is 100. You cannot specify a limit greater than 100. If you specify 0, AWS Config uses the default.</p>"]
     #[serde(rename="limit")]
@@ -876,7 +876,7 @@ pub struct GetDiscoveredResourceCountsRequest {
     pub resource_types: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDiscoveredResourceCountsResponse {
     #[doc="<p>The string that you use in a subsequent request to get the next page of results in a paginated response.</p>"]
     #[serde(rename="nextToken")]
@@ -893,7 +893,7 @@ pub struct GetDiscoveredResourceCountsResponse {
 }
 
 #[doc="<p>The input for the <a>GetResourceConfigHistory</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetResourceConfigHistoryRequest {
     #[doc="<p>The chronological order for configuration items listed. By default the results are listed in reverse chronological order.</p>"]
     #[serde(rename="chronologicalOrder")]
@@ -924,7 +924,7 @@ pub struct GetResourceConfigHistoryRequest {
 }
 
 #[doc="<p>The output for the <a>GetResourceConfigHistory</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetResourceConfigHistoryResponse {
     #[doc="<p>A list that contains the configuration history of one or more resources.</p>"]
     #[serde(rename="configurationItems")]
@@ -937,7 +937,7 @@ pub struct GetResourceConfigHistoryResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDiscoveredResourcesRequest {
     #[doc="<p>Specifies whether AWS Config includes deleted resources in the results. By default, deleted resources are not included.</p>"]
     #[serde(rename="includeDeletedResources")]
@@ -965,7 +965,7 @@ pub struct ListDiscoveredResourcesRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDiscoveredResourcesResponse {
     #[doc="<p>The string that you use in a subsequent request to get the next page of results in a paginated response.</p>"]
     #[serde(rename="nextToken")]
@@ -977,7 +977,7 @@ pub struct ListDiscoveredResourcesResponse {
     pub resource_identifiers: Option<Vec<ResourceIdentifier>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutConfigRuleRequest {
     #[doc="<p>The rule that you want to add to your account.</p>"]
     #[serde(rename="ConfigRule")]
@@ -985,7 +985,7 @@ pub struct PutConfigRuleRequest {
 }
 
 #[doc="<p>The input for the <a>PutConfigurationRecorder</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutConfigurationRecorderRequest {
     #[doc="<p>The configuration recorder object that records each configuration change made to the resources.</p>"]
     #[serde(rename="ConfigurationRecorder")]
@@ -993,7 +993,7 @@ pub struct PutConfigurationRecorderRequest {
 }
 
 #[doc="<p>The input for the <a>PutDeliveryChannel</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutDeliveryChannelRequest {
     #[doc="<p>The configuration delivery channel object that delivers the configuration information to an Amazon S3 bucket, and to an Amazon SNS topic.</p>"]
     #[serde(rename="DeliveryChannel")]
@@ -1001,7 +1001,7 @@ pub struct PutDeliveryChannelRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutEvaluationsRequest {
     #[doc="<p>The assessments that the AWS Lambda function performs. Each evaluation identifies an AWS resource and indicates whether it complies with the AWS Config rule that invokes the AWS Lambda function.</p>"]
     #[serde(rename="Evaluations")]
@@ -1017,7 +1017,7 @@ pub struct PutEvaluationsRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutEvaluationsResponse {
     #[doc="<p>Requests that failed because of a client or server error.</p>"]
     #[serde(rename="FailedEvaluations")]
@@ -1043,7 +1043,7 @@ pub struct RecordingGroup {
 }
 
 #[doc="<p>The relationship of the related resource to the main resource.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Relationship {
     #[doc="<p>The type of relationship with the related resource.</p>"]
     #[serde(rename="relationshipName")]
@@ -1064,7 +1064,7 @@ pub struct Relationship {
 }
 
 #[doc="<p>An object that contains the resource type and the number of resources.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceCount {
     #[doc="<p>The number of resources.</p>"]
     #[serde(rename="count")]
@@ -1077,7 +1077,7 @@ pub struct ResourceCount {
 }
 
 #[doc="<p>The details that identify a resource that is discovered by AWS Config, including the resource type, ID, and (if available) the custom resource name.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceIdentifier {
     #[doc="<p>The time that the resource was deleted.</p>"]
     #[serde(rename="resourceDeletionTime")]
@@ -1151,7 +1151,7 @@ pub struct SourceDetail {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartConfigRulesEvaluationRequest {
     #[doc="<p>The list of names of Config rules that you want to run evaluations for.</p>"]
     #[serde(rename="ConfigRuleNames")]
@@ -1160,11 +1160,11 @@ pub struct StartConfigRulesEvaluationRequest {
 }
 
 #[doc="<p>The output when you start the evaluation for the specified Config rule.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartConfigRulesEvaluationResponse;
 
 #[doc="<p>The input for the <a>StartConfigurationRecorder</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartConfigurationRecorderRequest {
     #[doc="<p>The name of the recorder object that records each configuration change made to the resources.</p>"]
     #[serde(rename="ConfigurationRecorderName")]
@@ -1172,7 +1172,7 @@ pub struct StartConfigurationRecorderRequest {
 }
 
 #[doc="<p>The input for the <a>StopConfigurationRecorder</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopConfigurationRecorderRequest {
     #[doc="<p>The name of the recorder object that records each configuration change made to the resources.</p>"]
     #[serde(rename="ConfigurationRecorderName")]

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="Request of DeleteReportDefinition"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReportDefinitionRequest {
     #[serde(rename="ReportName")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -37,7 +37,7 @@ pub struct DeleteReportDefinitionRequest {
 }
 
 #[doc="Response of DeleteReportDefinition"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReportDefinitionResponse {
     #[serde(rename="ResponseMessage")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -45,7 +45,7 @@ pub struct DeleteReportDefinitionResponse {
 }
 
 #[doc="Request of DescribeReportDefinitions"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReportDefinitionsRequest {
     #[serde(rename="MaxResults")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -56,7 +56,7 @@ pub struct DescribeReportDefinitionsRequest {
 }
 
 #[doc="Response of DescribeReportDefinitions"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReportDefinitionsResponse {
     #[serde(rename="NextToken")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -67,14 +67,14 @@ pub struct DescribeReportDefinitionsResponse {
 }
 
 #[doc="Request of PutReportDefinition"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutReportDefinitionRequest {
     #[serde(rename="ReportDefinition")]
     pub report_definition: ReportDefinition,
 }
 
 #[doc="Response of PutReportDefinition"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutReportDefinitionResponse;
 
 #[doc="The definition of AWS Cost and Usage Report. Customer can specify the report name, time unit, report format, compression format, S3 bucket and additional artifacts and schema elements in the definition."]

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Contains the parameters for ActivatePipeline.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivatePipelineInput {
     #[doc="<p>A list of parameter values to pass to the pipeline at activation.</p>"]
     #[serde(rename="parameterValues")]
@@ -45,11 +45,11 @@ pub struct ActivatePipelineInput {
 }
 
 #[doc="<p>Contains the output of ActivatePipeline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivatePipelineOutput;
 
 #[doc="<p>Contains the parameters for AddTags.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsInput {
     #[doc="<p>The ID of the pipeline.</p>"]
     #[serde(rename="pipelineId")]
@@ -60,11 +60,11 @@ pub struct AddTagsInput {
 }
 
 #[doc="<p>Contains the output of AddTags.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsOutput;
 
 #[doc="<p>Contains the parameters for CreatePipeline.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePipelineInput {
     #[doc="<p>The description for the pipeline.</p>"]
     #[serde(rename="description")]
@@ -83,7 +83,7 @@ pub struct CreatePipelineInput {
 }
 
 #[doc="<p>Contains the output of CreatePipeline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePipelineOutput {
     #[doc="<p>The ID that AWS Data Pipeline assigns the newly created pipeline. For example, <code>df-06372391ZG65EXAMPLE</code>.</p>"]
     #[serde(rename="pipelineId")]
@@ -91,7 +91,7 @@ pub struct CreatePipelineOutput {
 }
 
 #[doc="<p>Contains the parameters for DeactivatePipeline.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeactivatePipelineInput {
     #[doc="<p>Indicates whether to cancel any running objects. The default is true, which sets the state of any running objects to <code>CANCELED</code>. If this value is false, the pipeline is deactivated after all running objects finish.</p>"]
     #[serde(rename="cancelActive")]
@@ -103,11 +103,11 @@ pub struct DeactivatePipelineInput {
 }
 
 #[doc="<p>Contains the output of DeactivatePipeline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeactivatePipelineOutput;
 
 #[doc="<p>Contains the parameters for DeletePipeline.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePipelineInput {
     #[doc="<p>The ID of the pipeline.</p>"]
     #[serde(rename="pipelineId")]
@@ -115,7 +115,7 @@ pub struct DeletePipelineInput {
 }
 
 #[doc="<p>Contains the parameters for DescribeObjects.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeObjectsInput {
     #[doc="<p>Indicates whether any expressions in the object should be evaluated when the object descriptions are returned.</p>"]
     #[serde(rename="evaluateExpressions")]
@@ -134,7 +134,7 @@ pub struct DescribeObjectsInput {
 }
 
 #[doc="<p>Contains the output of DescribeObjects.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeObjectsOutput {
     #[doc="<p>Indicates whether there are more results to return.</p>"]
     #[serde(rename="hasMoreResults")]
@@ -150,7 +150,7 @@ pub struct DescribeObjectsOutput {
 }
 
 #[doc="<p>Contains the parameters for DescribePipelines.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePipelinesInput {
     #[doc="<p>The IDs of the pipelines to describe. You can pass as many as 25 identifiers in a single call. To obtain pipeline IDs, call <a>ListPipelines</a>.</p>"]
     #[serde(rename="pipelineIds")]
@@ -158,7 +158,7 @@ pub struct DescribePipelinesInput {
 }
 
 #[doc="<p>Contains the output of DescribePipelines.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePipelinesOutput {
     #[doc="<p>An array of descriptions for the specified pipelines.</p>"]
     #[serde(rename="pipelineDescriptionList")]
@@ -166,7 +166,7 @@ pub struct DescribePipelinesOutput {
 }
 
 #[doc="<p>Contains the parameters for EvaluateExpression.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EvaluateExpressionInput {
     #[doc="<p>The expression to evaluate.</p>"]
     #[serde(rename="expression")]
@@ -180,7 +180,7 @@ pub struct EvaluateExpressionInput {
 }
 
 #[doc="<p>Contains the output of EvaluateExpression.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EvaluateExpressionOutput {
     #[doc="<p>The evaluated expression.</p>"]
     #[serde(rename="evaluatedExpression")]
@@ -204,7 +204,7 @@ pub struct Field {
 }
 
 #[doc="<p>Contains the parameters for GetPipelineDefinition.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPipelineDefinitionInput {
     #[doc="<p>The ID of the pipeline.</p>"]
     #[serde(rename="pipelineId")]
@@ -216,7 +216,7 @@ pub struct GetPipelineDefinitionInput {
 }
 
 #[doc="<p>Contains the output of GetPipelineDefinition.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPipelineDefinitionOutput {
     #[doc="<p>The parameter objects used in the pipeline definition.</p>"]
     #[serde(rename="parameterObjects")]
@@ -233,7 +233,7 @@ pub struct GetPipelineDefinitionOutput {
 }
 
 #[doc="<p><p>Identity information for the EC2 instance that is hosting the task runner. You can get this value by calling a metadata URI from the EC2 instance. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html\">Instance Metadata</a> in the <i>Amazon Elastic Compute Cloud User Guide.</i> Passing in this value proves that your task runner is running on an EC2 instance, and ensures the proper AWS Data Pipeline service charges are applied to your pipeline.</p></p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceIdentity {
     #[doc="<p>A description of an EC2 instance that is generated when the instance is launched and exposed to the instance via the instance metadata service in the form of a JSON representation of an object.</p>"]
     #[serde(rename="document")]
@@ -246,7 +246,7 @@ pub struct InstanceIdentity {
 }
 
 #[doc="<p>Contains the parameters for ListPipelines.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPipelinesInput {
     #[doc="<p>The starting point for the results to be returned. For the first call, this value should be empty. As long as there are more results, continue to call <code>ListPipelines</code> with the marker value from the previous call to retrieve the next set of results.</p>"]
     #[serde(rename="marker")]
@@ -255,7 +255,7 @@ pub struct ListPipelinesInput {
 }
 
 #[doc="<p>Contains the output of ListPipelines.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPipelinesOutput {
     #[doc="<p>Indicates whether there are more results that can be obtained by a subsequent call.</p>"]
     #[serde(rename="hasMoreResults")]
@@ -271,7 +271,7 @@ pub struct ListPipelinesOutput {
 }
 
 #[doc="<p>Contains a logical operation for comparing the value of a field with a specified value.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Operator {
     #[doc="<p> The logical operation to be performed: equal (<code>EQ</code>), equal reference (<code>REF_EQ</code>), less than or equal (<code>LE</code>), greater than or equal (<code>GE</code>), or between (<code>BETWEEN</code>). Equal reference (<code>REF_EQ</code>) can be used only with reference fields. The other comparison types can be used only with String fields. The comparison types you can use apply only to certain object fields, as detailed below. </p> <p> The comparison operators EQ and REF_EQ act on the following fields: </p> <ul> <li>name</li> <li>@sphere</li> <li>parent</li> <li>@componentParent</li> <li>@instanceParent</li> <li>@status</li> <li>@scheduledStartTime</li> <li>@scheduledEndTime</li> <li>@actualStartTime</li> <li>@actualEndTime</li> </ul> <p> The comparison operators <code>GE</code>, <code>LE</code>, and <code>BETWEEN</code> act on the following fields: </p> <ul> <li>@scheduledStartTime</li> <li>@scheduledEndTime</li> <li>@actualStartTime</li> <li>@actualEndTime</li> </ul> <p>Note that fields beginning with the at sign (@) are read-only and set by the web service. When you name fields, you should choose names containing only alpha-numeric values, as symbols may be reserved by AWS Data Pipeline. User-defined fields that you add to a pipeline should prefix their name with the string \"my\".</p>"]
     #[serde(rename="type")]
@@ -317,7 +317,7 @@ pub struct ParameterValue {
 }
 
 #[doc="<p>Contains pipeline metadata.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PipelineDescription {
     #[doc="<p>Description of the pipeline.</p>"]
     #[serde(rename="description")]
@@ -339,7 +339,7 @@ pub struct PipelineDescription {
 }
 
 #[doc="<p>Contains the name and identifier of a pipeline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PipelineIdName {
     #[doc="<p>The ID of the pipeline that was assigned by AWS Data Pipeline. This is a string of the form <code>df-297EG78HU43EEXAMPLE</code>.</p>"]
     #[serde(rename="id")]
@@ -366,7 +366,7 @@ pub struct PipelineObject {
 }
 
 #[doc="<p>Contains the parameters for PollForTask.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PollForTaskInput {
     #[doc="<p>The public DNS name of the calling task runner.</p>"]
     #[serde(rename="hostname")]
@@ -382,7 +382,7 @@ pub struct PollForTaskInput {
 }
 
 #[doc="<p>Contains the output of PollForTask.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PollForTaskOutput {
     #[doc="<p>The information needed to complete the task that is being assigned to the task runner. One of the fields returned in this object is <code>taskId</code>, which contains an identifier for the task being assigned. The calling task runner uses <code>taskId</code> in subsequent calls to <a>ReportTaskProgress</a> and <a>SetTaskStatus</a>.</p>"]
     #[serde(rename="taskObject")]
@@ -391,7 +391,7 @@ pub struct PollForTaskOutput {
 }
 
 #[doc="<p>Contains the parameters for PutPipelineDefinition.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutPipelineDefinitionInput {
     #[doc="<p>The parameter objects used with the pipeline.</p>"]
     #[serde(rename="parameterObjects")]
@@ -410,7 +410,7 @@ pub struct PutPipelineDefinitionInput {
 }
 
 #[doc="<p>Contains the output of PutPipelineDefinition.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutPipelineDefinitionOutput {
     #[doc="<p>Indicates whether there were validation errors, and the pipeline definition is stored but cannot be activated until you correct the pipeline and call <code>PutPipelineDefinition</code> to commit the corrected pipeline.</p>"]
     #[serde(rename="errored")]
@@ -426,7 +426,7 @@ pub struct PutPipelineDefinitionOutput {
 }
 
 #[doc="<p>Defines the query to run against an object.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Query {
     #[doc="<p>List of selectors that define the query. An object must satisfy all of the selectors to match the query.</p>"]
     #[serde(rename="selectors")]
@@ -435,7 +435,7 @@ pub struct Query {
 }
 
 #[doc="<p>Contains the parameters for QueryObjects.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct QueryObjectsInput {
     #[doc="<p>The maximum number of object names that <code>QueryObjects</code> will return in a single call. The default value is 100. </p>"]
     #[serde(rename="limit")]
@@ -458,7 +458,7 @@ pub struct QueryObjectsInput {
 }
 
 #[doc="<p>Contains the output of QueryObjects.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct QueryObjectsOutput {
     #[doc="<p>Indicates whether there are more results that can be obtained by a subsequent call.</p>"]
     #[serde(rename="hasMoreResults")]
@@ -475,7 +475,7 @@ pub struct QueryObjectsOutput {
 }
 
 #[doc="<p>Contains the parameters for RemoveTags.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsInput {
     #[doc="<p>The ID of the pipeline.</p>"]
     #[serde(rename="pipelineId")]
@@ -486,11 +486,11 @@ pub struct RemoveTagsInput {
 }
 
 #[doc="<p>Contains the output of RemoveTags.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsOutput;
 
 #[doc="<p>Contains the parameters for ReportTaskProgress.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReportTaskProgressInput {
     #[doc="<p>Key-value pairs that define the properties of the ReportTaskProgressInput object.</p>"]
     #[serde(rename="fields")]
@@ -502,7 +502,7 @@ pub struct ReportTaskProgressInput {
 }
 
 #[doc="<p>Contains the output of ReportTaskProgress.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReportTaskProgressOutput {
     #[doc="<p>If true, the calling task runner should cancel processing of the task. The task runner does not need to call <a>SetTaskStatus</a> for canceled tasks.</p>"]
     #[serde(rename="canceled")]
@@ -510,7 +510,7 @@ pub struct ReportTaskProgressOutput {
 }
 
 #[doc="<p>Contains the parameters for ReportTaskRunnerHeartbeat.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReportTaskRunnerHeartbeatInput {
     #[doc="<p>The public DNS name of the task runner.</p>"]
     #[serde(rename="hostname")]
@@ -526,7 +526,7 @@ pub struct ReportTaskRunnerHeartbeatInput {
 }
 
 #[doc="<p>Contains the output of ReportTaskRunnerHeartbeat.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReportTaskRunnerHeartbeatOutput {
     #[doc="<p>Indicates whether the calling task runner should terminate.</p>"]
     #[serde(rename="terminate")]
@@ -534,7 +534,7 @@ pub struct ReportTaskRunnerHeartbeatOutput {
 }
 
 #[doc="<p>A comparision that is used to determine whether a query should return this object.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Selector {
     #[doc="<p>The name of the field that the operator will be applied to. The field name is the \"key\" portion of the field definition in the pipeline definition syntax that is used by the AWS Data Pipeline API. If the field is not set on the object, the condition fails.</p>"]
     #[serde(rename="fieldName")]
@@ -546,7 +546,7 @@ pub struct Selector {
 }
 
 #[doc="<p>Contains the parameters for SetStatus.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetStatusInput {
     #[doc="<p>The IDs of the objects. The corresponding objects can be either physical or components, but not a mix of both types.</p>"]
     #[serde(rename="objectIds")]
@@ -560,7 +560,7 @@ pub struct SetStatusInput {
 }
 
 #[doc="<p>Contains the parameters for SetTaskStatus.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetTaskStatusInput {
     #[doc="<p>If an error occurred during the task, this value specifies the error code. This value is set on the physical attempt object. It is used to display error information to the user. It should not start with string \"Service_\" which is reserved by the system.</p>"]
     #[serde(rename="errorId")]
@@ -583,7 +583,7 @@ pub struct SetTaskStatusInput {
 }
 
 #[doc="<p>Contains the output of SetTaskStatus.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetTaskStatusOutput;
 
 #[doc="<p>Tags are key/value pairs defined by a user and associated with a pipeline to control access. AWS Data Pipeline allows you to associate ten tags per pipeline. For more information, see <a href=\"http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-control-access.html\">Controlling User Access to Pipelines</a> in the <i>AWS Data Pipeline Developer Guide</i>.</p>"]
@@ -598,7 +598,7 @@ pub struct Tag {
 }
 
 #[doc="<p>Contains information about a pipeline task that is assigned to a task runner.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TaskObject {
     #[doc="<p>The ID of the pipeline task attempt object. AWS Data Pipeline uses this value to track how many times a task is attempted.</p>"]
     #[serde(rename="attemptId")]
@@ -619,7 +619,7 @@ pub struct TaskObject {
 }
 
 #[doc="<p>Contains the parameters for ValidatePipelineDefinition.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ValidatePipelineDefinitionInput {
     #[doc="<p>The parameter objects used with the pipeline.</p>"]
     #[serde(rename="parameterObjects")]
@@ -638,7 +638,7 @@ pub struct ValidatePipelineDefinitionInput {
 }
 
 #[doc="<p>Contains the output of ValidatePipelineDefinition.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ValidatePipelineDefinitionOutput {
     #[doc="<p>Indicates whether there were validation errors.</p>"]
     #[serde(rename="errored")]
@@ -654,7 +654,7 @@ pub struct ValidatePipelineDefinitionOutput {
 }
 
 #[doc="<p>Defines a validation error. Validation errors prevent pipeline activation. The set of validation errors that can be returned are defined by AWS Data Pipeline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ValidationError {
     #[doc="<p>A description of the validation error.</p>"]
     #[serde(rename="errors")]
@@ -667,7 +667,7 @@ pub struct ValidationError {
 }
 
 #[doc="<p>Defines a validation warning. Validation warnings do not prevent pipeline activation. The set of validation warnings that can be returned are defined by AWS Data Pipeline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ValidationWarning {
     #[doc="<p>The identifier of the object that contains the validation warning.</p>"]
     #[serde(rename="id")]

--- a/rusoto/services/dax/src/generated.rs
+++ b/rusoto/services/dax/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Contains all of the attributes of a specific DAX cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Cluster {
     #[doc="<p>The number of nodes in the cluster that are active (i.e., capable of serving requests).</p>"]
     #[serde(rename="ActiveNodes")]
@@ -97,7 +97,7 @@ pub struct Cluster {
     pub total_nodes: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterRequest {
     #[doc="<p>The Availability Zones (AZs) in which the cluster nodes will be created. All nodes belonging to the cluster are placed in these Availability Zones. Use this parameter if you want to distribute the nodes across multiple AZs.</p>"]
     #[serde(rename="AvailabilityZones")]
@@ -145,7 +145,7 @@ pub struct CreateClusterRequest {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterResponse {
     #[doc="<p>A description of the DAX cluster that you have created.</p>"]
     #[serde(rename="Cluster")]
@@ -153,7 +153,7 @@ pub struct CreateClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateParameterGroupRequest {
     #[doc="<p>A description of the parameter group.</p>"]
     #[serde(rename="Description")]
@@ -164,7 +164,7 @@ pub struct CreateParameterGroupRequest {
     pub parameter_group_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateParameterGroupResponse {
     #[doc="<p>Represents the output of a <i>CreateParameterGroup</i> action.</p>"]
     #[serde(rename="ParameterGroup")]
@@ -172,7 +172,7 @@ pub struct CreateParameterGroupResponse {
     pub parameter_group: Option<ParameterGroup>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubnetGroupRequest {
     #[doc="<p>A description for the subnet group</p>"]
     #[serde(rename="Description")]
@@ -186,7 +186,7 @@ pub struct CreateSubnetGroupRequest {
     pub subnet_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubnetGroupResponse {
     #[doc="<p>Represents the output of a <i>CreateSubnetGroup</i> operation.</p>"]
     #[serde(rename="SubnetGroup")]
@@ -194,7 +194,7 @@ pub struct CreateSubnetGroupResponse {
     pub subnet_group: Option<SubnetGroup>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecreaseReplicationFactorRequest {
     #[doc="<p>The Availability Zone(s) from which to remove nodes.</p>"]
     #[serde(rename="AvailabilityZones")]
@@ -212,7 +212,7 @@ pub struct DecreaseReplicationFactorRequest {
     pub node_ids_to_remove: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecreaseReplicationFactorResponse {
     #[doc="<p>A description of the DAX cluster, after you have decreased its replication factor.</p>"]
     #[serde(rename="Cluster")]
@@ -220,14 +220,14 @@ pub struct DecreaseReplicationFactorResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterRequest {
     #[doc="<p>The name of the cluster to be deleted.</p>"]
     #[serde(rename="ClusterName")]
     pub cluster_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterResponse {
     #[doc="<p>A description of the DAX cluster that is being deleted.</p>"]
     #[serde(rename="Cluster")]
@@ -235,14 +235,14 @@ pub struct DeleteClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteParameterGroupRequest {
     #[doc="<p>The name of the parameter group to delete.</p>"]
     #[serde(rename="ParameterGroupName")]
     pub parameter_group_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteParameterGroupResponse {
     #[doc="<p>A user-specified message for this action (i.e., a reason for deleting the parameter group).</p>"]
     #[serde(rename="DeletionMessage")]
@@ -250,14 +250,14 @@ pub struct DeleteParameterGroupResponse {
     pub deletion_message: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSubnetGroupRequest {
     #[doc="<p>The name of the subnet group to delete.</p>"]
     #[serde(rename="SubnetGroupName")]
     pub subnet_group_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSubnetGroupResponse {
     #[doc="<p>A user-specified message for this action (i.e., a reason for deleting the subnet group).</p>"]
     #[serde(rename="DeletionMessage")]
@@ -265,7 +265,7 @@ pub struct DeleteSubnetGroupResponse {
     pub deletion_message: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClustersRequest {
     #[doc="<p>The names of the DAX clusters being described.</p>"]
     #[serde(rename="ClusterNames")]
@@ -281,7 +281,7 @@ pub struct DescribeClustersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClustersResponse {
     #[doc="<p>The descriptions of your DAX clusters, in response to a <i>DescribeClusters</i> request.</p>"]
     #[serde(rename="Clusters")]
@@ -293,7 +293,7 @@ pub struct DescribeClustersResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDefaultParametersRequest {
     #[doc="<p>The maximum number of results to include in the response. If more results exist than the specified <code>MaxResults</code> value, a token is included in the response so that the remaining results can be retrieved.</p> <p>The value for <code>MaxResults</code> must be between 20 and 100.</p>"]
     #[serde(rename="MaxResults")]
@@ -305,7 +305,7 @@ pub struct DescribeDefaultParametersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDefaultParametersResponse {
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
     #[serde(rename="NextToken")]
@@ -317,7 +317,7 @@ pub struct DescribeDefaultParametersResponse {
     pub parameters: Option<Vec<Parameter>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsRequest {
     #[doc="<p>The number of minutes' worth of events to retrieve.</p>"]
     #[serde(rename="Duration")]
@@ -349,7 +349,7 @@ pub struct DescribeEventsRequest {
     pub start_time: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsResponse {
     #[doc="<p>An array of events. Each element in the array represents one event.</p>"]
     #[serde(rename="Events")]
@@ -361,7 +361,7 @@ pub struct DescribeEventsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeParameterGroupsRequest {
     #[doc="<p>The maximum number of results to include in the response. If more results exist than the specified <code>MaxResults</code> value, a token is included in the response so that the remaining results can be retrieved.</p> <p>The value for <code>MaxResults</code> must be between 20 and 100.</p>"]
     #[serde(rename="MaxResults")]
@@ -377,7 +377,7 @@ pub struct DescribeParameterGroupsRequest {
     pub parameter_group_names: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeParameterGroupsResponse {
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
     #[serde(rename="NextToken")]
@@ -389,7 +389,7 @@ pub struct DescribeParameterGroupsResponse {
     pub parameter_groups: Option<Vec<ParameterGroup>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeParametersRequest {
     #[doc="<p>The maximum number of results to include in the response. If more results exist than the specified <code>MaxResults</code> value, a token is included in the response so that the remaining results can be retrieved.</p> <p>The value for <code>MaxResults</code> must be between 20 and 100.</p>"]
     #[serde(rename="MaxResults")]
@@ -408,7 +408,7 @@ pub struct DescribeParametersRequest {
     pub source: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeParametersResponse {
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
     #[serde(rename="NextToken")]
@@ -420,7 +420,7 @@ pub struct DescribeParametersResponse {
     pub parameters: Option<Vec<Parameter>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSubnetGroupsRequest {
     #[doc="<p>The maximum number of results to include in the response. If more results exist than the specified <code>MaxResults</code> value, a token is included in the response so that the remaining results can be retrieved.</p> <p>The value for <code>MaxResults</code> must be between 20 and 100.</p>"]
     #[serde(rename="MaxResults")]
@@ -436,7 +436,7 @@ pub struct DescribeSubnetGroupsRequest {
     pub subnet_group_names: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSubnetGroupsResponse {
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
     #[serde(rename="NextToken")]
@@ -449,7 +449,7 @@ pub struct DescribeSubnetGroupsResponse {
 }
 
 #[doc="<p>Represents the information required for client programs to connect to the configuration endpoint for a DAX cluster, or to an individual node within the cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Endpoint {
     #[doc="<p>The DNS hostname of the endpoint.</p>"]
     #[serde(rename="Address")]
@@ -462,7 +462,7 @@ pub struct Endpoint {
 }
 
 #[doc="<p>Represents a single occurrence of something interesting within the system. Some examples of events are creating a DAX cluster, adding or removing a node, or rebooting a node.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Event {
     #[doc="<p>The date and time when the event occurred.</p>"]
     #[serde(rename="Date")]
@@ -482,7 +482,7 @@ pub struct Event {
     pub source_type: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IncreaseReplicationFactorRequest {
     #[doc="<p>The Availability Zones (AZs) in which the cluster nodes will be created. All nodes belonging to the cluster are placed in these Availability Zones. Use this parameter if you want to distribute the nodes across multiple AZs.</p>"]
     #[serde(rename="AvailabilityZones")]
@@ -496,7 +496,7 @@ pub struct IncreaseReplicationFactorRequest {
     pub new_replication_factor: i64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IncreaseReplicationFactorResponse {
     #[doc="<p>A description of the DAX cluster. with its new replication factor.</p>"]
     #[serde(rename="Cluster")]
@@ -504,7 +504,7 @@ pub struct IncreaseReplicationFactorResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsRequest {
     #[doc="<p>An optional token returned from a prior request. Use this token for pagination of results from this action. If this parameter is specified, the response includes only results beyond the token.</p>"]
     #[serde(rename="NextToken")]
@@ -515,7 +515,7 @@ pub struct ListTagsRequest {
     pub resource_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsResponse {
     #[doc="<p>If this value is present, there are additional results to be displayed. To retrieve them, call <code>ListTags</code> again, with <code>NextToken</code> set to this value.</p>"]
     #[serde(rename="NextToken")]
@@ -528,7 +528,7 @@ pub struct ListTagsResponse {
 }
 
 #[doc="<p>Represents an individual node within a DAX cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Node {
     #[doc="<p>The Availability Zone (AZ) in which the node has been deployed.</p>"]
     #[serde(rename="AvailabilityZone")]
@@ -557,7 +557,7 @@ pub struct Node {
 }
 
 #[doc="<p>Represents a parameter value that is applicable to a particular node type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NodeTypeSpecificValue {
     #[doc="<p>A node type to which the parameter value applies.</p>"]
     #[serde(rename="NodeType")]
@@ -570,7 +570,7 @@ pub struct NodeTypeSpecificValue {
 }
 
 #[doc="<p>Describes a notification topic and its status. Notification topics are used for publishing DAX events to subscribers using Amazon Simple Notification Service (SNS).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotificationConfiguration {
     #[doc="<p>The Amazon Resource Name (ARN) that identifies the topic. </p>"]
     #[serde(rename="TopicArn")]
@@ -583,7 +583,7 @@ pub struct NotificationConfiguration {
 }
 
 #[doc="<p>Describes an individual setting that controls some aspect of DAX behavior.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Parameter {
     #[doc="<p>A range of values within which the parameter can be set.</p>"]
     #[serde(rename="AllowedValues")]
@@ -628,7 +628,7 @@ pub struct Parameter {
 }
 
 #[doc="<p>A named set of parameters that are applied to all of the nodes in a DAX cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ParameterGroup {
     #[doc="<p>A description of the parameter group.</p>"]
     #[serde(rename="Description")]
@@ -641,7 +641,7 @@ pub struct ParameterGroup {
 }
 
 #[doc="<p>The status of a parameter group.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ParameterGroupStatus {
     #[doc="<p>The node IDs of one or more nodes to be rebooted.</p>"]
     #[serde(rename="NodeIdsToReboot")]
@@ -658,7 +658,7 @@ pub struct ParameterGroupStatus {
 }
 
 #[doc="<p>An individual DAX parameter.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ParameterNameValue {
     #[doc="<p>The name of the parameter.</p>"]
     #[serde(rename="ParameterName")]
@@ -670,7 +670,7 @@ pub struct ParameterNameValue {
     pub parameter_value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootNodeRequest {
     #[doc="<p>The name of the DAX cluster containing the node to be rebooted.</p>"]
     #[serde(rename="ClusterName")]
@@ -680,7 +680,7 @@ pub struct RebootNodeRequest {
     pub node_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootNodeResponse {
     #[doc="<p>A description of the DAX cluster after a node has been rebooted.</p>"]
     #[serde(rename="Cluster")]
@@ -689,7 +689,7 @@ pub struct RebootNodeResponse {
 }
 
 #[doc="<p>An individual VPC security group and its status.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SecurityGroupMembership {
     #[doc="<p>The unique ID for this security group.</p>"]
     #[serde(rename="SecurityGroupIdentifier")]
@@ -702,7 +702,7 @@ pub struct SecurityGroupMembership {
 }
 
 #[doc="<p>Represents the subnet associated with a DAX cluster. This parameter refers to subnets defined in Amazon Virtual Private Cloud (Amazon VPC) and used with DAX.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Subnet {
     #[doc="<p>The Availability Zone (AZ) for subnet subnet.</p>"]
     #[serde(rename="SubnetAvailabilityZone")]
@@ -715,7 +715,7 @@ pub struct Subnet {
 }
 
 #[doc="<p>Represents the output of one of the following actions:</p> <ul> <li> <p> <i>CreateSubnetGroup</i> </p> </li> <li> <p> <i>ModifySubnetGroup</i> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubnetGroup {
     #[doc="<p>The description of the subnet group.</p>"]
     #[serde(rename="Description")]
@@ -748,7 +748,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceRequest {
     #[doc="<p>The name of the DAX resource to which tags should be added.</p>"]
     #[serde(rename="ResourceName")]
@@ -758,7 +758,7 @@ pub struct TagResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceResponse {
     #[doc="<p>The list of tags that are associated with the DAX resource.</p>"]
     #[serde(rename="Tags")]
@@ -766,7 +766,7 @@ pub struct TagResourceResponse {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceRequest {
     #[doc="<p>The name of the DAX resource from which the tags should be removed.</p>"]
     #[serde(rename="ResourceName")]
@@ -776,7 +776,7 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceResponse {
     #[doc="<p>The tag keys that have been removed from the cluster.</p>"]
     #[serde(rename="Tags")]
@@ -784,7 +784,7 @@ pub struct UntagResourceResponse {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateClusterRequest {
     #[doc="<p>The name of the DAX cluster to be modified.</p>"]
     #[serde(rename="ClusterName")]
@@ -815,7 +815,7 @@ pub struct UpdateClusterRequest {
     pub security_group_ids: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateClusterResponse {
     #[doc="<p>A description of the DAX cluster, after it has been modified.</p>"]
     #[serde(rename="Cluster")]
@@ -823,7 +823,7 @@ pub struct UpdateClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateParameterGroupRequest {
     #[doc="<p>The name of the parameter group.</p>"]
     #[serde(rename="ParameterGroupName")]
@@ -833,7 +833,7 @@ pub struct UpdateParameterGroupRequest {
     pub parameter_name_values: Vec<ParameterNameValue>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateParameterGroupResponse {
     #[doc="<p>The parameter group that has been modified.</p>"]
     #[serde(rename="ParameterGroup")]
@@ -841,7 +841,7 @@ pub struct UpdateParameterGroupResponse {
     pub parameter_group: Option<ParameterGroup>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSubnetGroupRequest {
     #[doc="<p>A description of the subnet group.</p>"]
     #[serde(rename="Description")]
@@ -856,7 +856,7 @@ pub struct UpdateSubnetGroupRequest {
     pub subnet_ids: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSubnetGroupResponse {
     #[doc="<p>The subnet group that has been modified.</p>"]
     #[serde(rename="SubnetGroup")]

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>A container for account-level settings within AWS Device Farm.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountSettings {
     #[doc="<p>The AWS account number specified in the <code>AccountSettings</code> container.</p>"]
     #[serde(rename="awsAccountNumber")]
@@ -62,7 +62,7 @@ pub struct AccountSettings {
 }
 
 #[doc="<p>Represents the output of a test. Examples of artifacts include logs and screenshots.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Artifact {
     #[doc="<p>The artifact's ARN.</p>"]
     #[serde(rename="arn")]
@@ -87,7 +87,7 @@ pub struct Artifact {
 }
 
 #[doc="<p>Represents the amount of CPU that an app is using on a physical device.</p> <p>Note that this does not represent system-wide CPU usage.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CPU {
     #[doc="<p>The CPU's architecture, for example x86 or ARM.</p>"]
     #[serde(rename="architecture")]
@@ -104,7 +104,7 @@ pub struct CPU {
 }
 
 #[doc="<p>Represents entity counters.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Counters {
     #[doc="<p>The number of errored entities.</p>"]
     #[serde(rename="errored")]
@@ -137,7 +137,7 @@ pub struct Counters {
 }
 
 #[doc="<p>Represents a request to the create device pool operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDevicePoolRequest {
     #[doc="<p>The device pool's description.</p>"]
     #[serde(rename="description")]
@@ -155,7 +155,7 @@ pub struct CreateDevicePoolRequest {
 }
 
 #[doc="<p>Represents the result of a create device pool request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDevicePoolResult {
     #[doc="<p>The newly created device pool.</p>"]
     #[serde(rename="devicePool")]
@@ -163,7 +163,7 @@ pub struct CreateDevicePoolResult {
     pub device_pool: Option<DevicePool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNetworkProfileRequest {
     #[doc="<p>The description of the network profile.</p>"]
     #[serde(rename="description")]
@@ -213,7 +213,7 @@ pub struct CreateNetworkProfileRequest {
     pub uplink_loss_percent: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNetworkProfileResult {
     #[doc="<p>The network profile that is returned by the create network profile request.</p>"]
     #[serde(rename="networkProfile")]
@@ -222,7 +222,7 @@ pub struct CreateNetworkProfileResult {
 }
 
 #[doc="<p>Represents a request to the create project operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProjectRequest {
     #[doc="<p>Sets the execution timeout value (in minutes) for a project. All test runs in this project will use the specified execution timeout value unless overridden when scheduling a run.</p>"]
     #[serde(rename="defaultJobTimeoutMinutes")]
@@ -234,7 +234,7 @@ pub struct CreateProjectRequest {
 }
 
 #[doc="<p>Represents the result of a create project request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProjectResult {
     #[doc="<p>The newly created project.</p>"]
     #[serde(rename="project")]
@@ -243,7 +243,7 @@ pub struct CreateProjectResult {
 }
 
 #[doc="<p>Creates the configuration settings for a remote access session, including the device model and type.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRemoteAccessSessionConfiguration {
     #[doc="<p>Returns the billing method for purposes of configuring a remote access session.</p>"]
     #[serde(rename="billingMethod")]
@@ -252,7 +252,7 @@ pub struct CreateRemoteAccessSessionConfiguration {
 }
 
 #[doc="<p>Creates and submits a request to start a remote access session.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRemoteAccessSessionRequest {
     #[doc="<p>The configuration information for the remote access session request.</p>"]
     #[serde(rename="configuration")]
@@ -271,7 +271,7 @@ pub struct CreateRemoteAccessSessionRequest {
 }
 
 #[doc="<p>Represents the server response from a request to create a remote access session.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRemoteAccessSessionResult {
     #[doc="<p>A container that describes the remote access session when the request to create a remote access session is sent.</p>"]
     #[serde(rename="remoteAccessSession")]
@@ -280,7 +280,7 @@ pub struct CreateRemoteAccessSessionResult {
 }
 
 #[doc="<p>Represents a request to the create upload operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUploadRequest {
     #[doc="<p>The upload's content type (for example, \"application/octet-stream\").</p>"]
     #[serde(rename="contentType")]
@@ -298,7 +298,7 @@ pub struct CreateUploadRequest {
 }
 
 #[doc="<p>Represents the result of a create upload request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUploadResult {
     #[doc="<p>The newly created upload.</p>"]
     #[serde(rename="upload")]
@@ -307,7 +307,7 @@ pub struct CreateUploadResult {
 }
 
 #[doc="<p>Represents a request to the delete device pool operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDevicePoolRequest {
     #[doc="<p>Represents the Amazon Resource Name (ARN) of the Device Farm device pool you wish to delete.</p>"]
     #[serde(rename="arn")]
@@ -315,21 +315,21 @@ pub struct DeleteDevicePoolRequest {
 }
 
 #[doc="<p>Represents the result of a delete device pool request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDevicePoolResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNetworkProfileRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the network profile you want to delete.</p>"]
     #[serde(rename="arn")]
     pub arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNetworkProfileResult;
 
 #[doc="<p>Represents a request to the delete project operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProjectRequest {
     #[doc="<p>Represents the Amazon Resource Name (ARN) of the Device Farm project you wish to delete.</p>"]
     #[serde(rename="arn")]
@@ -337,11 +337,11 @@ pub struct DeleteProjectRequest {
 }
 
 #[doc="<p>Represents the result of a delete project request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProjectResult;
 
 #[doc="<p>Represents the request to delete the specified remote access session.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRemoteAccessSessionRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the sesssion for which you want to delete remote access.</p>"]
     #[serde(rename="arn")]
@@ -349,11 +349,11 @@ pub struct DeleteRemoteAccessSessionRequest {
 }
 
 #[doc="<p>The response from the server when a request is made to delete the remote access session.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRemoteAccessSessionResult;
 
 #[doc="<p>Represents a request to the delete run operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRunRequest {
     #[doc="<p>The Amazon Resource Name (ARN) for the run you wish to delete.</p>"]
     #[serde(rename="arn")]
@@ -361,11 +361,11 @@ pub struct DeleteRunRequest {
 }
 
 #[doc="<p>Represents the result of a delete run request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRunResult;
 
 #[doc="<p>Represents a request to the delete upload operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUploadRequest {
     #[doc="<p>Represents the Amazon Resource Name (ARN) of the Device Farm upload you wish to delete.</p>"]
     #[serde(rename="arn")]
@@ -373,11 +373,11 @@ pub struct DeleteUploadRequest {
 }
 
 #[doc="<p>Represents the result of a delete upload request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUploadResult;
 
 #[doc="<p>Represents a device type that an app is tested against.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Device {
     #[doc="<p>The device's ARN.</p>"]
     #[serde(rename="arn")]
@@ -450,7 +450,7 @@ pub struct Device {
 }
 
 #[doc="<p>Represents the total (metered or unmetered) minutes used by the resource to run tests. Contains the sum of minutes consumed by all children.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeviceMinutes {
     #[doc="<p>When specified, represents only the sum of metered minutes used by the resource to run tests.</p>"]
     #[serde(rename="metered")]
@@ -467,7 +467,7 @@ pub struct DeviceMinutes {
 }
 
 #[doc="<p>Represents a collection of device types.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DevicePool {
     #[doc="<p>The device pool's ARN.</p>"]
     #[serde(rename="arn")]
@@ -492,7 +492,7 @@ pub struct DevicePool {
 }
 
 #[doc="<p>Represents a device pool compatibility result.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DevicePoolCompatibilityResult {
     #[doc="<p>Whether the result was compatible with the device pool.</p>"]
     #[serde(rename="compatible")]
@@ -509,7 +509,7 @@ pub struct DevicePoolCompatibilityResult {
 }
 
 #[doc="<p>Represents configuration information about a test run, such as the execution timeout (in minutes).</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecutionConfiguration {
     #[doc="<p>True if account cleanup is enabled at the beginning of the test; otherwise, false.</p>"]
     #[serde(rename="accountsCleanup")]
@@ -526,11 +526,11 @@ pub struct ExecutionConfiguration {
 }
 
 #[doc="<p>Represents the request sent to retrieve the account settings.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccountSettingsRequest;
 
 #[doc="<p>Represents the account settings return values from the <code>GetAccountSettings</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccountSettingsResult {
     #[doc="<p>The account settings.</p>"]
     #[serde(rename="accountSettings")]
@@ -539,7 +539,7 @@ pub struct GetAccountSettingsResult {
 }
 
 #[doc="<p>Represents a request to the get device pool compatibility operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDevicePoolCompatibilityRequest {
     #[doc="<p>The ARN of the app that is associated with the specified device pool.</p>"]
     #[serde(rename="appArn")]
@@ -559,7 +559,7 @@ pub struct GetDevicePoolCompatibilityRequest {
 }
 
 #[doc="<p>Represents the result of describe device pool compatibility request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDevicePoolCompatibilityResult {
     #[doc="<p>Information about compatible devices.</p>"]
     #[serde(rename="compatibleDevices")]
@@ -572,7 +572,7 @@ pub struct GetDevicePoolCompatibilityResult {
 }
 
 #[doc="<p>Represents a request to the get device pool operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDevicePoolRequest {
     #[doc="<p>The device pool's ARN.</p>"]
     #[serde(rename="arn")]
@@ -580,7 +580,7 @@ pub struct GetDevicePoolRequest {
 }
 
 #[doc="<p>Represents the result of a get device pool request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDevicePoolResult {
     #[doc="<p>An object containing information about the requested device pool.</p>"]
     #[serde(rename="devicePool")]
@@ -589,7 +589,7 @@ pub struct GetDevicePoolResult {
 }
 
 #[doc="<p>Represents a request to the get device request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeviceRequest {
     #[doc="<p>The device type's ARN.</p>"]
     #[serde(rename="arn")]
@@ -597,7 +597,7 @@ pub struct GetDeviceRequest {
 }
 
 #[doc="<p>Represents the result of a get device request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeviceResult {
     #[doc="<p>An object containing information about the requested device.</p>"]
     #[serde(rename="device")]
@@ -606,7 +606,7 @@ pub struct GetDeviceResult {
 }
 
 #[doc="<p>Represents a request to the get job operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobRequest {
     #[doc="<p>The job's ARN.</p>"]
     #[serde(rename="arn")]
@@ -614,7 +614,7 @@ pub struct GetJobRequest {
 }
 
 #[doc="<p>Represents the result of a get job request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobResult {
     #[doc="<p>An object containing information about the requested job.</p>"]
     #[serde(rename="job")]
@@ -622,14 +622,14 @@ pub struct GetJobResult {
     pub job: Option<Job>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetNetworkProfileRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the network profile you want to return information about.</p>"]
     #[serde(rename="arn")]
     pub arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetNetworkProfileResult {
     #[doc="<p>The network profile.</p>"]
     #[serde(rename="networkProfile")]
@@ -638,7 +638,7 @@ pub struct GetNetworkProfileResult {
 }
 
 #[doc="<p>Represents the request to retrieve the offering status for the specified customer or account.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOfferingStatusRequest {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -647,7 +647,7 @@ pub struct GetOfferingStatusRequest {
 }
 
 #[doc="<p>Returns the status result for a device offering.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOfferingStatusResult {
     #[doc="<p>When specified, gets the offering status for the current period.</p>"]
     #[serde(rename="current")]
@@ -664,7 +664,7 @@ pub struct GetOfferingStatusResult {
 }
 
 #[doc="<p>Represents a request to the get project operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetProjectRequest {
     #[doc="<p>The project's ARN.</p>"]
     #[serde(rename="arn")]
@@ -672,7 +672,7 @@ pub struct GetProjectRequest {
 }
 
 #[doc="<p>Represents the result of a get project request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetProjectResult {
     #[doc="<p>The project you wish to get information about.</p>"]
     #[serde(rename="project")]
@@ -681,7 +681,7 @@ pub struct GetProjectResult {
 }
 
 #[doc="<p>Represents the request to get information about the specified remote access session.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRemoteAccessSessionRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the remote access session about which you want to get session information.</p>"]
     #[serde(rename="arn")]
@@ -689,7 +689,7 @@ pub struct GetRemoteAccessSessionRequest {
 }
 
 #[doc="<p>Represents the response from the server that lists detailed information about the remote access session.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRemoteAccessSessionResult {
     #[doc="<p>A container that lists detailed information about the remote access session.</p>"]
     #[serde(rename="remoteAccessSession")]
@@ -698,7 +698,7 @@ pub struct GetRemoteAccessSessionResult {
 }
 
 #[doc="<p>Represents a request to the get run operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRunRequest {
     #[doc="<p>The run's ARN.</p>"]
     #[serde(rename="arn")]
@@ -706,7 +706,7 @@ pub struct GetRunRequest {
 }
 
 #[doc="<p>Represents the result of a get run request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRunResult {
     #[doc="<p>The run you wish to get results from.</p>"]
     #[serde(rename="run")]
@@ -715,7 +715,7 @@ pub struct GetRunResult {
 }
 
 #[doc="<p>Represents a request to the get suite operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSuiteRequest {
     #[doc="<p>The suite's ARN.</p>"]
     #[serde(rename="arn")]
@@ -723,7 +723,7 @@ pub struct GetSuiteRequest {
 }
 
 #[doc="<p>Represents the result of a get suite request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSuiteResult {
     #[doc="<p>A collection of one or more tests.</p>"]
     #[serde(rename="suite")]
@@ -732,7 +732,7 @@ pub struct GetSuiteResult {
 }
 
 #[doc="<p>Represents a request to the get test operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTestRequest {
     #[doc="<p>The test's ARN.</p>"]
     #[serde(rename="arn")]
@@ -740,7 +740,7 @@ pub struct GetTestRequest {
 }
 
 #[doc="<p>Represents the result of a get test request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTestResult {
     #[doc="<p>A test condition that is evaluated.</p>"]
     #[serde(rename="test")]
@@ -749,7 +749,7 @@ pub struct GetTestResult {
 }
 
 #[doc="<p>Represents a request to the get upload operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUploadRequest {
     #[doc="<p>The upload's ARN.</p>"]
     #[serde(rename="arn")]
@@ -757,7 +757,7 @@ pub struct GetUploadRequest {
 }
 
 #[doc="<p>Represents the result of a get upload request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUploadResult {
     #[doc="<p>An app or a set of one or more tests to upload or that have been uploaded.</p>"]
     #[serde(rename="upload")]
@@ -766,7 +766,7 @@ pub struct GetUploadResult {
 }
 
 #[doc="<p>Represents information about incompatibility.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IncompatibilityMessage {
     #[doc="<p>A message about the incompatibility.</p>"]
     #[serde(rename="message")]
@@ -779,7 +779,7 @@ pub struct IncompatibilityMessage {
 }
 
 #[doc="<p>Represents the request to install an Android application (in .apk format) or an iOS application (in .ipa format) as part of a remote access session.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstallToRemoteAccessSessionRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the app about which you are requesting information.</p>"]
     #[serde(rename="appArn")]
@@ -790,7 +790,7 @@ pub struct InstallToRemoteAccessSessionRequest {
 }
 
 #[doc="<p>Represents the response from the server after AWS Device Farm makes a request to install to a remote access session.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstallToRemoteAccessSessionResult {
     #[doc="<p>An app to upload or that has been uploaded.</p>"]
     #[serde(rename="appUpload")]
@@ -799,7 +799,7 @@ pub struct InstallToRemoteAccessSessionResult {
 }
 
 #[doc="<p>Represents a device.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Job {
     #[doc="<p>The job's ARN.</p>"]
     #[serde(rename="arn")]
@@ -852,7 +852,7 @@ pub struct Job {
 }
 
 #[doc="<p>Represents a request to the list artifacts operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListArtifactsRequest {
     #[doc="<p>The Run, Job, Suite, or Test ARN.</p>"]
     #[serde(rename="arn")]
@@ -867,7 +867,7 @@ pub struct ListArtifactsRequest {
 }
 
 #[doc="<p>Represents the result of a list artifacts operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListArtifactsResult {
     #[doc="<p>Information about the artifacts.</p>"]
     #[serde(rename="artifacts")]
@@ -880,7 +880,7 @@ pub struct ListArtifactsResult {
 }
 
 #[doc="<p>Represents the result of a list device pools request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDevicePoolsRequest {
     #[doc="<p>The project ARN.</p>"]
     #[serde(rename="arn")]
@@ -896,7 +896,7 @@ pub struct ListDevicePoolsRequest {
 }
 
 #[doc="<p>Represents the result of a list device pools request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDevicePoolsResult {
     #[doc="<p>Information about the device pools.</p>"]
     #[serde(rename="devicePools")]
@@ -909,7 +909,7 @@ pub struct ListDevicePoolsResult {
 }
 
 #[doc="<p>Represents the result of a list devices request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDevicesRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the project.</p>"]
     #[serde(rename="arn")]
@@ -922,7 +922,7 @@ pub struct ListDevicesRequest {
 }
 
 #[doc="<p>Represents the result of a list devices operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDevicesResult {
     #[doc="<p>Information about the devices.</p>"]
     #[serde(rename="devices")]
@@ -935,7 +935,7 @@ pub struct ListDevicesResult {
 }
 
 #[doc="<p>Represents a request to the list jobs operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsRequest {
     #[doc="<p>The jobs' ARNs.</p>"]
     #[serde(rename="arn")]
@@ -947,7 +947,7 @@ pub struct ListJobsRequest {
 }
 
 #[doc="<p>Represents the result of a list jobs request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsResult {
     #[doc="<p>Information about the jobs.</p>"]
     #[serde(rename="jobs")]
@@ -959,7 +959,7 @@ pub struct ListJobsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListNetworkProfilesRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the project for which you want to list network profiles.</p>"]
     #[serde(rename="arn")]
@@ -974,7 +974,7 @@ pub struct ListNetworkProfilesRequest {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListNetworkProfilesResult {
     #[doc="<p>A list of the available network profiles.</p>"]
     #[serde(rename="networkProfiles")]
@@ -986,7 +986,7 @@ pub struct ListNetworkProfilesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOfferingPromotionsRequest {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -994,7 +994,7 @@ pub struct ListOfferingPromotionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOfferingPromotionsResult {
     #[doc="<p>An identifier to be used in the next call to this operation, to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1007,7 +1007,7 @@ pub struct ListOfferingPromotionsResult {
 }
 
 #[doc="<p>Represents the request to list the offering transaction history.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOfferingTransactionsRequest {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1016,7 +1016,7 @@ pub struct ListOfferingTransactionsRequest {
 }
 
 #[doc="<p>Returns the transaction log of the specified offerings.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOfferingTransactionsResult {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1029,7 +1029,7 @@ pub struct ListOfferingTransactionsResult {
 }
 
 #[doc="<p>Represents the request to list all offerings.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOfferingsRequest {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1038,7 +1038,7 @@ pub struct ListOfferingsRequest {
 }
 
 #[doc="<p>Represents the return values of the list of offerings.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOfferingsResult {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1051,7 +1051,7 @@ pub struct ListOfferingsResult {
 }
 
 #[doc="<p>Represents a request to the list projects operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProjectsRequest {
     #[doc="<p>Optional. If no Amazon Resource Name (ARN) is specified, then AWS Device Farm returns a list of all projects for the AWS account. You can also specify a project ARN.</p>"]
     #[serde(rename="arn")]
@@ -1064,7 +1064,7 @@ pub struct ListProjectsRequest {
 }
 
 #[doc="<p>Represents the result of a list projects request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProjectsResult {
     #[doc="<p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1077,7 +1077,7 @@ pub struct ListProjectsResult {
 }
 
 #[doc="<p>Represents the request to return information about the remote access session.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRemoteAccessSessionsRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the remote access session about which you are requesting information.</p>"]
     #[serde(rename="arn")]
@@ -1089,7 +1089,7 @@ pub struct ListRemoteAccessSessionsRequest {
 }
 
 #[doc="<p>Represents the response from the server after AWS Device Farm makes a request to return information about the remote access session.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRemoteAccessSessionsResult {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1102,7 +1102,7 @@ pub struct ListRemoteAccessSessionsResult {
 }
 
 #[doc="<p>Represents a request to the list runs operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRunsRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the project for which you want to list runs.</p>"]
     #[serde(rename="arn")]
@@ -1114,7 +1114,7 @@ pub struct ListRunsRequest {
 }
 
 #[doc="<p>Represents the result of a list runs request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRunsResult {
     #[doc="<p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1127,7 +1127,7 @@ pub struct ListRunsResult {
 }
 
 #[doc="<p>Represents a request to the list samples operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSamplesRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the project for which you want to list samples.</p>"]
     #[serde(rename="arn")]
@@ -1139,7 +1139,7 @@ pub struct ListSamplesRequest {
 }
 
 #[doc="<p>Represents the result of a list samples request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSamplesResult {
     #[doc="<p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1152,7 +1152,7 @@ pub struct ListSamplesResult {
 }
 
 #[doc="<p>Represents a request to the list suites operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSuitesRequest {
     #[doc="<p>The suites' ARNs.</p>"]
     #[serde(rename="arn")]
@@ -1164,7 +1164,7 @@ pub struct ListSuitesRequest {
 }
 
 #[doc="<p>Represents the result of a list suites request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSuitesResult {
     #[doc="<p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1177,7 +1177,7 @@ pub struct ListSuitesResult {
 }
 
 #[doc="<p>Represents a request to the list tests operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTestsRequest {
     #[doc="<p>The tests' ARNs.</p>"]
     #[serde(rename="arn")]
@@ -1189,7 +1189,7 @@ pub struct ListTestsRequest {
 }
 
 #[doc="<p>Represents the result of a list tests request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTestsResult {
     #[doc="<p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1202,7 +1202,7 @@ pub struct ListTestsResult {
 }
 
 #[doc="<p>Represents a request to the list unique problems operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUniqueProblemsRequest {
     #[doc="<p>The unique problems' ARNs.</p>"]
     #[serde(rename="arn")]
@@ -1214,7 +1214,7 @@ pub struct ListUniqueProblemsRequest {
 }
 
 #[doc="<p>Represents the result of a list unique problems request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUniqueProblemsResult {
     #[doc="<p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1227,7 +1227,7 @@ pub struct ListUniqueProblemsResult {
 }
 
 #[doc="<p>Represents a request to the list uploads operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUploadsRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the project for which you want to list uploads.</p>"]
     #[serde(rename="arn")]
@@ -1239,7 +1239,7 @@ pub struct ListUploadsRequest {
 }
 
 #[doc="<p>Represents the result of a list uploads request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUploadsResult {
     #[doc="<p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>"]
     #[serde(rename="nextToken")]
@@ -1252,7 +1252,7 @@ pub struct ListUploadsResult {
 }
 
 #[doc="<p>Represents a latitude and longitude pair, expressed in geographic coordinate system degrees (for example 47.6204, -122.3491).</p> <p>Elevation is currently not supported.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Location {
     #[doc="<p>The latitude.</p>"]
     #[serde(rename="latitude")]
@@ -1263,7 +1263,7 @@ pub struct Location {
 }
 
 #[doc="<p>A number representing the monetary amount for an offering or transaction.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MonetaryAmount {
     #[doc="<p>The numerical amount of an offering or transaction.</p>"]
     #[serde(rename="amount")]
@@ -1276,7 +1276,7 @@ pub struct MonetaryAmount {
 }
 
 #[doc="<p>An array of settings that describes characteristics of a network profile.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkProfile {
     #[doc="<p>The Amazon Resource Name (ARN) of the network profile.</p>"]
     #[serde(rename="arn")]
@@ -1329,7 +1329,7 @@ pub struct NetworkProfile {
 }
 
 #[doc="<p>Represents the metadata of a device offering.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Offering {
     #[doc="<p>A string describing the offering.</p>"]
     #[serde(rename="description")]
@@ -1354,7 +1354,7 @@ pub struct Offering {
 }
 
 #[doc="<p>Represents information about an offering promotion.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OfferingPromotion {
     #[doc="<p>A string describing the offering promotion.</p>"]
     #[serde(rename="description")]
@@ -1367,7 +1367,7 @@ pub struct OfferingPromotion {
 }
 
 #[doc="<p>The status of the offering.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OfferingStatus {
     #[doc="<p>The date on which the offering is effective.</p>"]
     #[serde(rename="effectiveOn")]
@@ -1388,7 +1388,7 @@ pub struct OfferingStatus {
 }
 
 #[doc="<p>Represents the metadata of an offering transaction.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OfferingTransaction {
     #[doc="<p>The cost of an offering transaction.</p>"]
     #[serde(rename="cost")]
@@ -1413,7 +1413,7 @@ pub struct OfferingTransaction {
 }
 
 #[doc="<p>Represents a specific warning or failure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Problem {
     #[doc="<p>Information about the associated device.</p>"]
     #[serde(rename="device")]
@@ -1446,7 +1446,7 @@ pub struct Problem {
 }
 
 #[doc="<p>Information about a problem detail.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProblemDetail {
     #[doc="<p>The problem detail's ARN.</p>"]
     #[serde(rename="arn")]
@@ -1459,7 +1459,7 @@ pub struct ProblemDetail {
 }
 
 #[doc="<p>Represents an operating-system neutral workspace for running and managing tests.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Project {
     #[doc="<p>The project's ARN.</p>"]
     #[serde(rename="arn")]
@@ -1480,7 +1480,7 @@ pub struct Project {
 }
 
 #[doc="<p>Represents a request for a purchase offering.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseOfferingRequest {
     #[doc="<p>The ID of the offering.</p>"]
     #[serde(rename="offeringId")]
@@ -1497,7 +1497,7 @@ pub struct PurchaseOfferingRequest {
 }
 
 #[doc="<p>The result of the purchase offering (e.g., success or failure).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseOfferingResult {
     #[doc="<p>Represents the offering transaction for the purchase result.</p>"]
     #[serde(rename="offeringTransaction")]
@@ -1506,7 +1506,7 @@ pub struct PurchaseOfferingResult {
 }
 
 #[doc="<p>Represents the set of radios and their states on a device. Examples of radios include Wi-Fi, GPS, Bluetooth, and NFC.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Radios {
     #[doc="<p>True if Bluetooth is enabled at the beginning of the test; otherwise, false.</p>"]
     #[serde(rename="bluetooth")]
@@ -1527,7 +1527,7 @@ pub struct Radios {
 }
 
 #[doc="<p>Specifies whether charges for devices will be recurring.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecurringCharge {
     #[doc="<p>The cost of the recurring charge.</p>"]
     #[serde(rename="cost")]
@@ -1540,7 +1540,7 @@ pub struct RecurringCharge {
 }
 
 #[doc="<p>Represents information about the remote access session.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoteAccessSession {
     #[doc="<p>The Amazon Resource Name (ARN) of the remote access session.</p>"]
     #[serde(rename="arn")]
@@ -1593,7 +1593,7 @@ pub struct RemoteAccessSession {
 }
 
 #[doc="<p>A request representing an offering renewal.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RenewOfferingRequest {
     #[doc="<p>The ID of a request to renew an offering.</p>"]
     #[serde(rename="offeringId")]
@@ -1606,7 +1606,7 @@ pub struct RenewOfferingRequest {
 }
 
 #[doc="<p>The result of a renewal offering.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RenewOfferingResult {
     #[doc="<p>Represents the status of the offering transaction for the renewal.</p>"]
     #[serde(rename="offeringTransaction")]
@@ -1615,7 +1615,7 @@ pub struct RenewOfferingResult {
 }
 
 #[doc="<p>Represents the screen resolution of a device in height and width, expressed in pixels.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Resolution {
     #[doc="<p>The screen resolution's height, expressed in pixels.</p>"]
     #[serde(rename="height")]
@@ -1645,7 +1645,7 @@ pub struct Rule {
 }
 
 #[doc="<p>Represents an app on a set of devices with a specific test and configuration.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Run {
     #[doc="<p>The run's ARN.</p>"]
     #[serde(rename="arn")]
@@ -1714,7 +1714,7 @@ pub struct Run {
 }
 
 #[doc="<p>Represents a sample of performance data.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Sample {
     #[doc="<p>The sample's ARN.</p>"]
     #[serde(rename="arn")]
@@ -1731,7 +1731,7 @@ pub struct Sample {
 }
 
 #[doc="<p>Represents the settings for a run. Includes things like location, radio states, auxiliary apps, and network profiles.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduleRunConfiguration {
     #[doc="<p>A list of auxiliary apps for the run.</p>"]
     #[serde(rename="auxiliaryApps")]
@@ -1764,7 +1764,7 @@ pub struct ScheduleRunConfiguration {
 }
 
 #[doc="<p>Represents a request to the schedule run operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduleRunRequest {
     #[doc="<p>The ARN of the app to schedule a run.</p>"]
     #[serde(rename="appArn")]
@@ -1794,7 +1794,7 @@ pub struct ScheduleRunRequest {
 }
 
 #[doc="<p>Represents the result of a schedule run request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduleRunResult {
     #[doc="<p>Information about the scheduled run.</p>"]
     #[serde(rename="run")]
@@ -1803,7 +1803,7 @@ pub struct ScheduleRunResult {
 }
 
 #[doc="<p>Represents additional test settings.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduleRunTest {
     #[doc="<p>The test's filter.</p>"]
     #[serde(rename="filter")]
@@ -1823,7 +1823,7 @@ pub struct ScheduleRunTest {
 }
 
 #[doc="<p>Represents the request to stop the remote access session.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopRemoteAccessSessionRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the remote access session you wish to stop.</p>"]
     #[serde(rename="arn")]
@@ -1831,7 +1831,7 @@ pub struct StopRemoteAccessSessionRequest {
 }
 
 #[doc="<p>Represents the response from the server that describes the remote access session when AWS Device Farm stops the session.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopRemoteAccessSessionResult {
     #[doc="<p>A container representing the metadata from the service about the remote access session you are stopping.</p>"]
     #[serde(rename="remoteAccessSession")]
@@ -1840,7 +1840,7 @@ pub struct StopRemoteAccessSessionResult {
 }
 
 #[doc="<p>Represents the request to stop a specific run.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopRunRequest {
     #[doc="<p>Represents the Amazon Resource Name (ARN) of the Device Farm run you wish to stop.</p>"]
     #[serde(rename="arn")]
@@ -1848,7 +1848,7 @@ pub struct StopRunRequest {
 }
 
 #[doc="<p>Represents the results of your stop run attempt.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopRunResult {
     #[doc="<p>The run that was stopped.</p>"]
     #[serde(rename="run")]
@@ -1857,7 +1857,7 @@ pub struct StopRunResult {
 }
 
 #[doc="<p>Represents a collection of one or more tests.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Suite {
     #[doc="<p>The suite's ARN.</p>"]
     #[serde(rename="arn")]
@@ -1906,7 +1906,7 @@ pub struct Suite {
 }
 
 #[doc="<p>Represents a condition that is evaluated.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Test {
     #[doc="<p>The test's ARN.</p>"]
     #[serde(rename="arn")]
@@ -1955,7 +1955,7 @@ pub struct Test {
 }
 
 #[doc="<p>Represents information about free trial device minutes for an AWS account.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TrialMinutes {
     #[doc="<p>The number of free trial minutes remaining in the account.</p>"]
     #[serde(rename="remaining")]
@@ -1968,7 +1968,7 @@ pub struct TrialMinutes {
 }
 
 #[doc="<p>A collection of one or more problems, grouped by their result.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UniqueProblem {
     #[doc="<p>A message about the unique problems' result.</p>"]
     #[serde(rename="message")]
@@ -1981,7 +1981,7 @@ pub struct UniqueProblem {
 }
 
 #[doc="<p>Represents a request to the update device pool operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDevicePoolRequest {
     #[doc="<p>The Amazon Resourc Name (ARN) of the Device Farm device pool you wish to update.</p>"]
     #[serde(rename="arn")]
@@ -2001,7 +2001,7 @@ pub struct UpdateDevicePoolRequest {
 }
 
 #[doc="<p>Represents the result of an update device pool request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDevicePoolResult {
     #[doc="<p>The device pool you just updated.</p>"]
     #[serde(rename="devicePool")]
@@ -2009,7 +2009,7 @@ pub struct UpdateDevicePoolResult {
     pub device_pool: Option<DevicePool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateNetworkProfileRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the project that you wish to update network profile settings.</p>"]
     #[serde(rename="arn")]
@@ -2060,7 +2060,7 @@ pub struct UpdateNetworkProfileRequest {
     pub uplink_loss_percent: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateNetworkProfileResult {
     #[doc="<p>A list of the available network profiles.</p>"]
     #[serde(rename="networkProfile")]
@@ -2069,7 +2069,7 @@ pub struct UpdateNetworkProfileResult {
 }
 
 #[doc="<p>Represents a request to the update project operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProjectRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the project whose name you wish to update.</p>"]
     #[serde(rename="arn")]
@@ -2085,7 +2085,7 @@ pub struct UpdateProjectRequest {
 }
 
 #[doc="<p>Represents the result of an update project request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProjectResult {
     #[doc="<p>The project you wish to update.</p>"]
     #[serde(rename="project")]
@@ -2094,7 +2094,7 @@ pub struct UpdateProjectResult {
 }
 
 #[doc="<p>An app or a set of one or more tests to upload or that have been uploaded.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Upload {
     #[doc="<p>The upload's ARN.</p>"]
     #[serde(rename="arn")]

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Container for the parameters to the AllocateConnectionOnInterconnect operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AllocateConnectionOnInterconnectRequest {
     #[doc="<p>Bandwidth of the connection.</p> <p>Example: \"<i>500Mbps</i>\"</p> <p>Default: None</p> <p>Values: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, or 500Mbps</p>"]
     #[serde(rename="bandwidth")]
@@ -49,7 +49,7 @@ pub struct AllocateConnectionOnInterconnectRequest {
 }
 
 #[doc="<p>Container for the parameters to theHostedConnection operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AllocateHostedConnectionRequest {
     #[doc="<p>The bandwidth of the connection.</p> <p>Example: <code>500Mbps</code> </p> <p>Default: None</p> <p>Values: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, or 500Mbps</p>"]
     #[serde(rename="bandwidth")]
@@ -69,7 +69,7 @@ pub struct AllocateHostedConnectionRequest {
 }
 
 #[doc="<p>Container for the parameters to the AllocatePrivateVirtualInterface operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AllocatePrivateVirtualInterfaceRequest {
     #[doc="<p>The connection ID on which the private virtual interface is provisioned.</p> <p>Default: None</p>"]
     #[serde(rename="connectionId")]
@@ -83,7 +83,7 @@ pub struct AllocatePrivateVirtualInterfaceRequest {
 }
 
 #[doc="<p>Container for the parameters to the AllocatePublicVirtualInterface operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AllocatePublicVirtualInterfaceRequest {
     #[doc="<p>The connection ID on which the public virtual interface is provisioned.</p> <p>Default: None</p>"]
     #[serde(rename="connectionId")]
@@ -97,7 +97,7 @@ pub struct AllocatePublicVirtualInterfaceRequest {
 }
 
 #[doc="<p>Container for the parameters to the AssociateConnectionWithLag operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateConnectionWithLagRequest {
     #[doc="<p>The ID of the connection.</p> <p>Example: dxcon-abc123</p> <p>Default: None</p>"]
     #[serde(rename="connectionId")]
@@ -108,7 +108,7 @@ pub struct AssociateConnectionWithLagRequest {
 }
 
 #[doc="<p>Container for the parameters to the AssociateHostedConnection operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateHostedConnectionRequest {
     #[doc="<p>The ID of the hosted connection.</p> <p>Example: dxcon-abc123</p> <p>Default: None</p>"]
     #[serde(rename="connectionId")]
@@ -119,7 +119,7 @@ pub struct AssociateHostedConnectionRequest {
 }
 
 #[doc="<p>Container for the parameters to the AssociateVirtualInterface operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateVirtualInterfaceRequest {
     #[doc="<p>The ID of the LAG or connection with which to associate the virtual interface.</p> <p>Example: dxlag-abc123 or dxcon-abc123</p> <p>Default: None</p>"]
     #[serde(rename="connectionId")]
@@ -130,7 +130,7 @@ pub struct AssociateVirtualInterfaceRequest {
 }
 
 #[doc="<p>A structure containing information about a BGP peer.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BGPPeer {
     #[serde(rename="addressFamily")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -156,14 +156,14 @@ pub struct BGPPeer {
 }
 
 #[doc="<p>Container for the parameters to the ConfirmConnection operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmConnectionRequest {
     #[serde(rename="connectionId")]
     pub connection_id: String,
 }
 
 #[doc="<p>The response received when ConfirmConnection is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmConnectionResponse {
     #[serde(rename="connectionState")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -171,7 +171,7 @@ pub struct ConfirmConnectionResponse {
 }
 
 #[doc="<p>Container for the parameters to the ConfirmPrivateVirtualInterface operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmPrivateVirtualInterfaceRequest {
     #[doc="<p>ID of the virtual private gateway that will be attached to the virtual interface.</p> <p> A virtual private gateway can be managed via the Amazon Virtual Private Cloud (VPC) console or the <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-CreateVpnGateway.html\">EC2 CreateVpnGateway</a> action.</p> <p>Default: None</p>"]
     #[serde(rename="virtualGatewayId")]
@@ -181,7 +181,7 @@ pub struct ConfirmPrivateVirtualInterfaceRequest {
 }
 
 #[doc="<p>The response received when ConfirmPrivateVirtualInterface is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmPrivateVirtualInterfaceResponse {
     #[serde(rename="virtualInterfaceState")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -189,14 +189,14 @@ pub struct ConfirmPrivateVirtualInterfaceResponse {
 }
 
 #[doc="<p>Container for the parameters to the ConfirmPublicVirtualInterface operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmPublicVirtualInterfaceRequest {
     #[serde(rename="virtualInterfaceId")]
     pub virtual_interface_id: String,
 }
 
 #[doc="<p>The response received when ConfirmPublicVirtualInterface is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmPublicVirtualInterfaceResponse {
     #[serde(rename="virtualInterfaceState")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -204,7 +204,7 @@ pub struct ConfirmPublicVirtualInterfaceResponse {
 }
 
 #[doc="<p>A connection represents the physical network connection between the AWS Direct Connect location and the customer.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Connection {
     #[doc="<p>The Direct Connection endpoint which the physical connection terminates on.</p>"]
     #[serde(rename="awsDevice")]
@@ -250,7 +250,7 @@ pub struct Connection {
 }
 
 #[doc="<p>A structure containing a list of connections.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Connections {
     #[doc="<p>A list of connections.</p>"]
     #[serde(rename="connections")]
@@ -259,7 +259,7 @@ pub struct Connections {
 }
 
 #[doc="<p>Container for the parameters to the CreateBGPPeer operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBGPPeerRequest {
     #[doc="<p>Detailed information for the BGP peer to be created.</p> <p>Default: None</p>"]
     #[serde(rename="newBGPPeer")]
@@ -272,7 +272,7 @@ pub struct CreateBGPPeerRequest {
 }
 
 #[doc="<p>The response received when CreateBGPPeer is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBGPPeerResponse {
     #[serde(rename="virtualInterface")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -280,7 +280,7 @@ pub struct CreateBGPPeerResponse {
 }
 
 #[doc="<p>Container for the parameters to the CreateConnection operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConnectionRequest {
     #[serde(rename="bandwidth")]
     pub bandwidth: String,
@@ -294,7 +294,7 @@ pub struct CreateConnectionRequest {
 }
 
 #[doc="<p>Container for the parameters to the CreateInterconnect operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInterconnectRequest {
     #[doc="<p>The port bandwidth</p> <p>Example: 1Gbps</p> <p>Default: None</p> <p>Available values: 1Gbps,10Gbps</p>"]
     #[serde(rename="bandwidth")]
@@ -311,7 +311,7 @@ pub struct CreateInterconnectRequest {
 }
 
 #[doc="<p>Container for the parameters to the CreateLag operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLagRequest {
     #[doc="<p>The ID of an existing connection to migrate to the LAG.</p> <p>Default: None</p>"]
     #[serde(rename="connectionId")]
@@ -332,7 +332,7 @@ pub struct CreateLagRequest {
 }
 
 #[doc="<p>Container for the parameters to the CreatePrivateVirtualInterface operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePrivateVirtualInterfaceRequest {
     #[serde(rename="connectionId")]
     pub connection_id: String,
@@ -342,7 +342,7 @@ pub struct CreatePrivateVirtualInterfaceRequest {
 }
 
 #[doc="<p>Container for the parameters to the CreatePublicVirtualInterface operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePublicVirtualInterfaceRequest {
     #[serde(rename="connectionId")]
     pub connection_id: String,
@@ -352,7 +352,7 @@ pub struct CreatePublicVirtualInterfaceRequest {
 }
 
 #[doc="<p>Container for the parameters to the DeleteBGPPeer operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBGPPeerRequest {
     #[serde(rename="asn")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -367,7 +367,7 @@ pub struct DeleteBGPPeerRequest {
 }
 
 #[doc="<p>The response received when DeleteBGPPeer is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBGPPeerResponse {
     #[serde(rename="virtualInterface")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -375,21 +375,21 @@ pub struct DeleteBGPPeerResponse {
 }
 
 #[doc="<p>Container for the parameters to the DeleteConnection operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConnectionRequest {
     #[serde(rename="connectionId")]
     pub connection_id: String,
 }
 
 #[doc="<p>Container for the parameters to the DeleteInterconnect operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteInterconnectRequest {
     #[serde(rename="interconnectId")]
     pub interconnect_id: String,
 }
 
 #[doc="<p>The response received when DeleteInterconnect is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteInterconnectResponse {
     #[serde(rename="interconnectState")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -397,7 +397,7 @@ pub struct DeleteInterconnectResponse {
 }
 
 #[doc="<p>Container for the parameters to the DeleteLag operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLagRequest {
     #[doc="<p>The ID of the LAG to delete.</p> <p>Example: dxlag-abc123</p> <p>Default: None</p>"]
     #[serde(rename="lagId")]
@@ -405,14 +405,14 @@ pub struct DeleteLagRequest {
 }
 
 #[doc="<p>Container for the parameters to the DeleteVirtualInterface operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVirtualInterfaceRequest {
     #[serde(rename="virtualInterfaceId")]
     pub virtual_interface_id: String,
 }
 
 #[doc="<p>The response received when DeleteVirtualInterface is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVirtualInterfaceResponse {
     #[serde(rename="virtualInterfaceState")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -420,7 +420,7 @@ pub struct DeleteVirtualInterfaceResponse {
 }
 
 #[doc="<p>Container for the parameters to the DescribeConnectionLoa operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConnectionLoaRequest {
     #[serde(rename="connectionId")]
     pub connection_id: String,
@@ -434,7 +434,7 @@ pub struct DescribeConnectionLoaRequest {
 }
 
 #[doc="<p>The response received when DescribeConnectionLoa is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConnectionLoaResponse {
     #[serde(rename="loa")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -442,7 +442,7 @@ pub struct DescribeConnectionLoaResponse {
 }
 
 #[doc="<p>Container for the parameters to the DescribeConnectionsOnInterconnect operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConnectionsOnInterconnectRequest {
     #[doc="<p>ID of the interconnect on which a list of connection is provisioned.</p> <p>Example: dxcon-abc123</p> <p>Default: None</p>"]
     #[serde(rename="interconnectId")]
@@ -450,7 +450,7 @@ pub struct DescribeConnectionsOnInterconnectRequest {
 }
 
 #[doc="<p>Container for the parameters to the DescribeConnections operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConnectionsRequest {
     #[serde(rename="connectionId")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -458,7 +458,7 @@ pub struct DescribeConnectionsRequest {
 }
 
 #[doc="<p>Container for the parameters to the DescribeHostedConnections operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHostedConnectionsRequest {
     #[doc="<p>The ID of the interconnect or LAG on which the hosted connections are provisioned.</p> <p>Example: dxcon-abc123 or dxlag-abc123</p> <p>Default: None</p>"]
     #[serde(rename="connectionId")]
@@ -466,7 +466,7 @@ pub struct DescribeHostedConnectionsRequest {
 }
 
 #[doc="<p>Container for the parameters to the DescribeInterconnectLoa operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInterconnectLoaRequest {
     #[serde(rename="interconnectId")]
     pub interconnect_id: String,
@@ -480,7 +480,7 @@ pub struct DescribeInterconnectLoaRequest {
 }
 
 #[doc="<p>The response received when DescribeInterconnectLoa is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInterconnectLoaResponse {
     #[serde(rename="loa")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -488,7 +488,7 @@ pub struct DescribeInterconnectLoaResponse {
 }
 
 #[doc="<p>Container for the parameters to the DescribeInterconnects operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInterconnectsRequest {
     #[serde(rename="interconnectId")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -496,7 +496,7 @@ pub struct DescribeInterconnectsRequest {
 }
 
 #[doc="<p>Container for the parameters to the DescribeLags operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLagsRequest {
     #[doc="<p>The ID of the LAG.</p> <p>Example: dxlag-abc123</p> <p>Default: None</p>"]
     #[serde(rename="lagId")]
@@ -505,7 +505,7 @@ pub struct DescribeLagsRequest {
 }
 
 #[doc="<p>Container for the parameters to the DescribeLoa operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoaRequest {
     #[doc="<p>The ID of a connection, LAG, or interconnect for which to get the LOA-CFA information.</p> <p>Example: dxcon-abc123 or dxlag-abc123</p> <p>Default: None</p>"]
     #[serde(rename="connectionId")]
@@ -521,7 +521,7 @@ pub struct DescribeLoaRequest {
 }
 
 #[doc="<p>Container for the parameters to the DescribeTags operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsRequest {
     #[doc="<p>The Amazon Resource Names (ARNs) of the Direct Connect resources.</p>"]
     #[serde(rename="resourceArns")]
@@ -529,7 +529,7 @@ pub struct DescribeTagsRequest {
 }
 
 #[doc="<p>The response received when DescribeTags is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsResponse {
     #[doc="<p>Information about the tags.</p>"]
     #[serde(rename="resourceTags")]
@@ -538,7 +538,7 @@ pub struct DescribeTagsResponse {
 }
 
 #[doc="<p>Container for the parameters to the DescribeVirtualInterfaces operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVirtualInterfacesRequest {
     #[serde(rename="connectionId")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -549,7 +549,7 @@ pub struct DescribeVirtualInterfacesRequest {
 }
 
 #[doc="<p>Container for the parameters to the DisassociateConnectionFromLag operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateConnectionFromLagRequest {
     #[doc="<p>The ID of the connection to disassociate from the LAG.</p> <p>Example: dxcon-abc123</p> <p>Default: None</p>"]
     #[serde(rename="connectionId")]
@@ -560,7 +560,7 @@ pub struct DisassociateConnectionFromLagRequest {
 }
 
 #[doc="<p>An interconnect is a connection that can host other connections.</p> <p>Like a standard AWS Direct Connect connection, an interconnect represents the physical connection between an AWS Direct Connect partner's network and a specific Direct Connect location. An AWS Direct Connect partner who owns an interconnect can provision hosted connections on the interconnect for their end customers, thereby providing the end customers with connectivity to AWS services.</p> <p>The resources of the interconnect, including bandwidth and VLAN numbers, are shared by all of the hosted connections on the interconnect, and the owner of the interconnect determines how these resources are assigned.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Interconnect {
     #[doc="<p>The Direct Connection endpoint which the physical connection terminates on.</p>"]
     #[serde(rename="awsDevice")]
@@ -594,7 +594,7 @@ pub struct Interconnect {
 }
 
 #[doc="<p>A structure containing a list of interconnects.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Interconnects {
     #[doc="<p>A list of interconnects.</p>"]
     #[serde(rename="interconnects")]
@@ -603,7 +603,7 @@ pub struct Interconnects {
 }
 
 #[doc="<p>Describes a link aggregation group (LAG). A LAG is a connection that uses the Link Aggregation Control Protocol (LACP) to logically aggregate a bundle of physical connections. Like an interconnect, it can host other connections. All connections in a LAG must terminate on the same physical AWS Direct Connect endpoint, and must be the same bandwidth.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Lag {
     #[doc="<p>Indicates whether the LAG can host other connections.</p> <note> <p>This is intended for use by AWS Direct Connect partners only.</p> </note>"]
     #[serde(rename="allowsHostedConnections")]
@@ -652,7 +652,7 @@ pub struct Lag {
 }
 
 #[doc="<p>A structure containing a list of LAGs.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Lags {
     #[doc="<p>A list of LAGs.</p>"]
     #[serde(rename="lags")]
@@ -661,7 +661,7 @@ pub struct Lags {
 }
 
 #[doc="<p>A structure containing the Letter of Authorization - Connecting Facility Assignment (LOA-CFA) for a connection.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Loa {
     #[serde(rename="loaContent")]
     #[serde(
@@ -676,7 +676,7 @@ pub struct Loa {
 }
 
 #[doc="<p>An AWS Direct Connect location where connections and interconnects can be requested.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Location {
     #[doc="<p>The code used to indicate the AWS Direct Connect location.</p>"]
     #[serde(rename="locationCode")]
@@ -689,7 +689,7 @@ pub struct Location {
 }
 
 #[doc="<p>A location is a network facility where AWS Direct Connect routers are available to be connected. Generally, these are colocation hubs where many network providers have equipment, and where cross connects can be delivered. Locations include a name and facility code, and must be provided when creating a connection.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Locations {
     #[doc="<p>A list of colocation hubs where network providers have equipment. Most regions have multiple locations available.</p>"]
     #[serde(rename="locations")]
@@ -698,7 +698,7 @@ pub struct Locations {
 }
 
 #[doc="<p>A structure containing information about a new BGP peer.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NewBGPPeer {
     #[serde(rename="addressFamily")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -718,7 +718,7 @@ pub struct NewBGPPeer {
 }
 
 #[doc="<p>A structure containing information about a new private virtual interface.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NewPrivateVirtualInterface {
     #[serde(rename="addressFamily")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -743,7 +743,7 @@ pub struct NewPrivateVirtualInterface {
 }
 
 #[doc="<p>A structure containing information about a private virtual interface that will be provisioned on a connection.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NewPrivateVirtualInterfaceAllocation {
     #[serde(rename="addressFamily")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -766,7 +766,7 @@ pub struct NewPrivateVirtualInterfaceAllocation {
 }
 
 #[doc="<p>A structure containing information about a new public virtual interface.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NewPublicVirtualInterface {
     #[serde(rename="addressFamily")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -792,7 +792,7 @@ pub struct NewPublicVirtualInterface {
 }
 
 #[doc="<p>A structure containing information about a public virtual interface that will be provisioned on a connection.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NewPublicVirtualInterfaceAllocation {
     #[serde(rename="addressFamily")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -818,7 +818,7 @@ pub struct NewPublicVirtualInterfaceAllocation {
 }
 
 #[doc="<p>The tags associated with a Direct Connect resource.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceTag {
     #[doc="<p>The Amazon Resource Name (ARN) of the Direct Connect resource.</p>"]
     #[serde(rename="resourceArn")]
@@ -852,7 +852,7 @@ pub struct Tag {
 }
 
 #[doc="<p>Container for the parameters to the TagResource operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the Direct Connect resource.</p> <p>Example: arn:aws:directconnect:us-east-1:123456789012:dxcon/dxcon-fg5678gh</p>"]
     #[serde(rename="resourceArn")]
@@ -863,11 +863,11 @@ pub struct TagResourceRequest {
 }
 
 #[doc="<p>The response received when TagResource is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceResponse;
 
 #[doc="<p>Container for the parameters to the UntagResource operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the Direct Connect resource.</p>"]
     #[serde(rename="resourceArn")]
@@ -878,11 +878,11 @@ pub struct UntagResourceRequest {
 }
 
 #[doc="<p>The response received when UntagResource is called.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceResponse;
 
 #[doc="<p>Container for the parameters to the UpdateLag operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateLagRequest {
     #[doc="<p>The ID of the LAG to update.</p> <p>Example: dxlag-abc123</p> <p>Default: None</p>"]
     #[serde(rename="lagId")]
@@ -898,7 +898,7 @@ pub struct UpdateLagRequest {
 }
 
 #[doc="<p>You can create one or more AWS Direct Connect private virtual interfaces linking to your virtual private gateway.</p> <p>Virtual private gateways can be managed using the Amazon Virtual Private Cloud (Amazon VPC) console or the <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-CreateVpnGateway.html\">Amazon EC2 CreateVpnGateway action</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VirtualGateway {
     #[serde(rename="virtualGatewayId")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -909,7 +909,7 @@ pub struct VirtualGateway {
 }
 
 #[doc="<p>A structure containing a list of virtual private gateways.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VirtualGateways {
     #[doc="<p>A list of virtual private gateways.</p>"]
     #[serde(rename="virtualGateways")]
@@ -918,7 +918,7 @@ pub struct VirtualGateways {
 }
 
 #[doc="<p>A virtual interface (VLAN) transmits the traffic between the AWS Direct Connect location and the customer.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VirtualInterface {
     #[serde(rename="addressFamily")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -976,7 +976,7 @@ pub struct VirtualInterface {
 }
 
 #[doc="<p>A structure containing a list of virtual interfaces.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VirtualInterfaces {
     #[doc="<p>A list of virtual interfaces.</p>"]
     #[serde(rename="virtualInterfaces")]

--- a/rusoto/services/discovery/src/generated.rs
+++ b/rusoto/services/discovery/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Information about agents or connectors that were instructed to start collecting data. Information includes the agent/connector ID, a description of the operation, and whether the agent/connector configuration was updated.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AgentConfigurationStatus {
     #[doc="<p>The agent/connector ID.</p>"]
     #[serde(rename="agentId")]
@@ -46,7 +46,7 @@ pub struct AgentConfigurationStatus {
 }
 
 #[doc="<p>Information about agents or connectors associated with the user’s AWS account. Information includes agent or connector IDs, IP addresses, media access control (MAC) addresses, agent or connector health, hostname where the agent or connector resides, and agent version for each agent.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AgentInfo {
     #[doc="<p>The agent or connector ID.</p>"]
     #[serde(rename="agentId")]
@@ -91,7 +91,7 @@ pub struct AgentInfo {
 }
 
 #[doc="<p>Network details about the host where the agent/connector resides.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AgentNetworkInfo {
     #[doc="<p>The IP address for the host where the agent/connector resides.</p>"]
     #[serde(rename="ipAddress")]
@@ -103,7 +103,7 @@ pub struct AgentNetworkInfo {
     pub mac_address: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateConfigurationItemsToApplicationRequest {
     #[doc="<p>The configuration ID of an application with which items are to be associated.</p>"]
     #[serde(rename="applicationConfigurationId")]
@@ -113,11 +113,11 @@ pub struct AssociateConfigurationItemsToApplicationRequest {
     pub configuration_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateConfigurationItemsToApplicationResponse;
 
 #[doc="<p>Tags for a configuration item. Tags are metadata that help you categorize IT assets.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigurationTag {
     #[doc="<p>The configuration ID for the item to tag. You can specify a list of keys and values.</p>"]
     #[serde(rename="configurationId")]
@@ -141,7 +141,7 @@ pub struct ConfigurationTag {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateApplicationRequest {
     #[doc="<p>Description of the application to be created.</p>"]
     #[serde(rename="description")]
@@ -152,7 +152,7 @@ pub struct CreateApplicationRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateApplicationResponse {
     #[doc="<p>Configuration ID of an application to be created.</p>"]
     #[serde(rename="configurationId")]
@@ -160,7 +160,7 @@ pub struct CreateApplicationResponse {
     pub configuration_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTagsRequest {
     #[doc="<p>A list of configuration items that you want to tag.</p>"]
     #[serde(rename="configurationIds")]
@@ -170,11 +170,11 @@ pub struct CreateTagsRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTagsResponse;
 
 #[doc="<p>Inventory data for installed discovery agents.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CustomerAgentInfo {
     #[doc="<p>Number of active discovery agents.</p>"]
     #[serde(rename="activeAgents")]
@@ -200,7 +200,7 @@ pub struct CustomerAgentInfo {
 }
 
 #[doc="<p>Inventory data for installed discovery connectors.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CustomerConnectorInfo {
     #[doc="<p>Number of active discovery connectors.</p>"]
     #[serde(rename="activeConnectors")]
@@ -225,17 +225,17 @@ pub struct CustomerConnectorInfo {
     pub unknown_connectors: i64,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationsRequest {
     #[doc="<p>Configuration ID of an application to be deleted.</p>"]
     #[serde(rename="configurationIds")]
     pub configuration_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationsResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsRequest {
     #[doc="<p>A list of configuration items with tags that you want to delete.</p>"]
     #[serde(rename="configurationIds")]
@@ -246,10 +246,10 @@ pub struct DeleteTagsRequest {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAgentsRequest {
     #[doc="<p>The agent or the Connector IDs for which you want information. If you specify no IDs, the system returns information about all agents/Connectors associated with your AWS user account.</p>"]
     #[serde(rename="agentIds")]
@@ -269,7 +269,7 @@ pub struct DescribeAgentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAgentsResponse {
     #[doc="<p>Lists agents or the Connector by ID or lists all agents/Connectors associated with your user account if you did not specify an agent/Connector ID. The output includes agent/Connector IDs, IP addresses, media access control (MAC) addresses, agent/Connector health, host name where the agent/Connector resides, and the version number of each agent/Connector.</p>"]
     #[serde(rename="agentsInfo")]
@@ -281,14 +281,14 @@ pub struct DescribeAgentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigurationsRequest {
     #[doc="<p>One or more configuration IDs.</p>"]
     #[serde(rename="configurationIds")]
     pub configuration_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigurationsResponse {
     #[doc="<p>A key in the response map. The value is an array of data.</p>"]
     #[serde(rename="configurations")]
@@ -296,7 +296,7 @@ pub struct DescribeConfigurationsResponse {
     pub configurations: Option<Vec<::std::collections::HashMap<String, String>>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExportConfigurationsRequest {
     #[doc="<p>A unique identifier that you can use to query the export status.</p>"]
     #[serde(rename="exportIds")]
@@ -312,7 +312,7 @@ pub struct DescribeExportConfigurationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExportConfigurationsResponse {
     #[doc="<p>Returns export details. When the status is complete, the response includes a URL for an Amazon S3 bucket where you can view the data in a CSV file.</p>"]
     #[serde(rename="exportsInfo")]
@@ -324,7 +324,7 @@ pub struct DescribeExportConfigurationsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExportTasksRequest {
     #[doc="<p>One or more unique identifiers used to query the status of an export request.</p>"]
     #[serde(rename="exportIds")]
@@ -344,7 +344,7 @@ pub struct DescribeExportTasksRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExportTasksResponse {
     #[doc="<p>Contains one or more sets of export request details. When the status of a request is <code>SUCCEEDED</code>, the response includes a URL for an Amazon S3 bucket where you can view the data in a CSV file.</p>"]
     #[serde(rename="exportsInfo")]
@@ -356,7 +356,7 @@ pub struct DescribeExportTasksResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsRequest {
     #[doc="<p>You can filter the list using a <i>key</i>-<i>value</i> format. You can separate these items by using logical operators. Allowed filters include <code>tagKey</code>, <code>tagValue</code>, and <code>configurationId</code>. </p>"]
     #[serde(rename="filters")]
@@ -372,7 +372,7 @@ pub struct DescribeTagsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsResponse {
     #[doc="<p>The call returns a token. Use this token to get the next set of results.</p>"]
     #[serde(rename="nextToken")]
@@ -384,7 +384,7 @@ pub struct DescribeTagsResponse {
     pub tags: Option<Vec<ConfigurationTag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateConfigurationItemsFromApplicationRequest {
     #[doc="<p>Configuration ID of an application from which each item is disassociated.</p>"]
     #[serde(rename="applicationConfigurationId")]
@@ -394,10 +394,10 @@ pub struct DisassociateConfigurationItemsFromApplicationRequest {
     pub configuration_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateConfigurationItemsFromApplicationResponse;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExportConfigurationsResponse {
     #[doc="<p>A unique identifier that you can use to query the export status.</p>"]
     #[serde(rename="exportId")]
@@ -406,7 +406,7 @@ pub struct ExportConfigurationsResponse {
 }
 
 #[doc="<p>Used to select which agent's data is to be exported. A single agent ID may be selected for export using the <a href=\"http://docs.aws.amazon.com/application-discovery/latest/APIReference/API_StartExportTask.html\">StartExportTask</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExportFilter {
     #[doc="<p>Supported condition: <code>EQUALS</code> </p>"]
     #[serde(rename="condition")]
@@ -420,7 +420,7 @@ pub struct ExportFilter {
 }
 
 #[doc="<p>Information regarding the export status of discovered data. The value is an array of objects.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExportInfo {
     #[doc="<p>A URL for an Amazon S3 bucket where you can review the exported data. The URL is displayed only if the export succeeded.</p>"]
     #[serde(rename="configurationsDownloadUrl")]
@@ -453,7 +453,7 @@ pub struct ExportInfo {
 }
 
 #[doc="<p>A filter that can use conditional operators.</p> <p>For more information about filters, see <a href=\"http://docs.aws.amazon.com/application-discovery/latest/APIReference/discovery-api-queries.html\">Querying Discovered Configuration Items</a>. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Filter {
     #[doc="<p>A conditional operator. The following operators are valid: EQUALS, NOT_EQUALS, CONTAINS, NOT_CONTAINS. If you specify multiple filters, the system utilizes all filters as though concatenated by <i>AND</i>. If you specify multiple values for a particular filter, the system differentiates the values using <i>OR</i>. Calling either <i>DescribeConfigurations</i> or <i>ListConfigurations</i> returns attributes of matching configuration items.</p>"]
     #[serde(rename="condition")]
@@ -466,10 +466,10 @@ pub struct Filter {
     pub values: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDiscoverySummaryRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDiscoverySummaryResponse {
     #[doc="<p>Details about discovered agents, including agent status and health.</p>"]
     #[serde(rename="agentSummary")]
@@ -497,7 +497,7 @@ pub struct GetDiscoverySummaryResponse {
     pub servers_mappedto_tags: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListConfigurationsRequest {
     #[doc="<p>A valid configuration identified by Application Discovery Service. </p>"]
     #[serde(rename="configurationType")]
@@ -520,7 +520,7 @@ pub struct ListConfigurationsRequest {
     pub order_by: Option<Vec<OrderByElement>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListConfigurationsResponse {
     #[doc="<p>Returns configuration details, including the configuration ID, attribute names, and attribute values.</p>"]
     #[serde(rename="configurations")]
@@ -532,7 +532,7 @@ pub struct ListConfigurationsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListServerNeighborsRequest {
     #[doc="<p>Configuration ID of the server for which neighbors are being listed.</p>"]
     #[serde(rename="configurationId")]
@@ -555,7 +555,7 @@ pub struct ListServerNeighborsRequest {
     pub port_information_needed: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListServerNeighborsResponse {
     #[doc="<p>Count of distinct servers that are one hop away from the given server.</p>"]
     #[serde(rename="knownDependencyCount")]
@@ -571,7 +571,7 @@ pub struct ListServerNeighborsResponse {
 }
 
 #[doc="<p>Details about neighboring servers.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NeighborConnectionDetail {
     #[doc="<p>The number of open network connections with the neighboring server.</p>"]
     #[serde(rename="connectionsCount")]
@@ -593,7 +593,7 @@ pub struct NeighborConnectionDetail {
 }
 
 #[doc="<p>A field and direction for ordered output.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OrderByElement {
     #[doc="<p>The field on which to order.</p>"]
     #[serde(rename="fieldName")]
@@ -604,14 +604,14 @@ pub struct OrderByElement {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartDataCollectionByAgentIdsRequest {
     #[doc="<p>The IDs of the agents or connectors from which to start collecting data. If you send a request to an agent/connector ID that you do not have permission to contact, according to your AWS account, the service does not throw an exception. Instead, it returns the error in the <i>Description</i> field. If you send a request to multiple agents/connectors and you do not have permission to contact some of those agents/connectors, the system does not throw an exception. Instead, the system shows <code>Failed</code> in the <i>Description</i> field.</p>"]
     #[serde(rename="agentIds")]
     pub agent_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartDataCollectionByAgentIdsResponse {
     #[doc="<p>Information about agents or the connector that were instructed to start collecting data. Information includes the agent/connector ID, a description of the operation performed, and whether the agent/connector configuration was updated.</p>"]
     #[serde(rename="agentsConfigurationStatus")]
@@ -619,7 +619,7 @@ pub struct StartDataCollectionByAgentIdsResponse {
     pub agents_configuration_status: Option<Vec<AgentConfigurationStatus>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartExportTaskRequest {
     #[doc="<p>The end timestamp for exported data from the single Application Discovery Agent selected in the filters. If no value is specified, exported data includes the most recent data collected by the agent.</p>"]
     #[serde(rename="endTime")]
@@ -639,7 +639,7 @@ pub struct StartExportTaskRequest {
     pub start_time: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartExportTaskResponse {
     #[doc="<p>A unique identifier used to query the status of an export request.</p>"]
     #[serde(rename="exportId")]
@@ -647,14 +647,14 @@ pub struct StartExportTaskResponse {
     pub export_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopDataCollectionByAgentIdsRequest {
     #[doc="<p>The IDs of the agents or connectors from which to stop collecting data.</p>"]
     #[serde(rename="agentIds")]
     pub agent_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopDataCollectionByAgentIdsResponse {
     #[doc="<p>Information about the agents or connector that were instructed to stop collecting data. Information includes the agent/connector ID, a description of the operation performed, and whether the agent/connector configuration was updated.</p>"]
     #[serde(rename="agentsConfigurationStatus")]
@@ -663,7 +663,7 @@ pub struct StopDataCollectionByAgentIdsResponse {
 }
 
 #[doc="<p>Metadata that help you categorize IT assets.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>The type of tag on which to filter.</p>"]
     #[serde(rename="key")]
@@ -674,7 +674,7 @@ pub struct Tag {
 }
 
 #[doc="<p>The tag filter. Valid names are: <code>tagKey</code>, <code>tagValue</code>, <code>configurationId</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagFilter {
     #[doc="<p>A name of the tag filter.</p>"]
     #[serde(rename="name")]
@@ -684,7 +684,7 @@ pub struct TagFilter {
     pub values: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateApplicationRequest {
     #[doc="<p>Configuration ID of the application to be updated.</p>"]
     #[serde(rename="configurationId")]
@@ -699,7 +699,7 @@ pub struct UpdateApplicationRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateApplicationResponse;
 
 /// Errors returned by AssociateConfigurationItemsToApplication

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Describes a quota for an AWS account, for example, the number of replication instances allowed.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountQuota {
     #[doc="<p>The name of the AWS DMS quota for this AWS account.</p>"]
     #[serde(rename="AccountQuotaName")]
@@ -46,7 +46,7 @@ pub struct AccountQuota {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceMessage {
     #[doc="<p>The Amazon Resource Name (ARN) of the AWS DMS resource the tag is to be added to. AWS DMS resources include a replication instance, endpoint, and a replication task.</p>"]
     #[serde(rename="ResourceArn")]
@@ -57,11 +57,11 @@ pub struct AddTagsToResourceMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceResponse;
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AvailabilityZone {
     #[doc="<p>The name of the availability zone.</p>"]
     #[serde(rename="Name")]
@@ -70,7 +70,7 @@ pub struct AvailabilityZone {
 }
 
 #[doc="<p>The SSL certificate that can be used to encrypt connections between the endpoints and the replication instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Certificate {
     #[doc="<p>The Amazon Resource Name (ARN) for the certificate.</p>"]
     #[serde(rename="CertificateArn")]
@@ -119,7 +119,7 @@ pub struct Certificate {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Connection {
     #[doc="<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>"]
     #[serde(rename="EndpointArn")]
@@ -148,7 +148,7 @@ pub struct Connection {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEndpointMessage {
     #[doc="<p>The Amazon Resource Number (ARN) for the certificate.</p>"]
     #[serde(rename="CertificateArn")]
@@ -214,7 +214,7 @@ pub struct CreateEndpointMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEndpointResponse {
     #[doc="<p>The endpoint that was created.</p>"]
     #[serde(rename="Endpoint")]
@@ -223,7 +223,7 @@ pub struct CreateEndpointResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEventSubscriptionMessage {
     #[doc="<p> A Boolean value; set to <b>true</b> to activate the subscription, or set to <b>false</b> to create the subscription but not activate it. </p>"]
     #[serde(rename="Enabled")]
@@ -254,7 +254,7 @@ pub struct CreateEventSubscriptionMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEventSubscriptionResponse {
     #[doc="<p>The event subscription that was created.</p>"]
     #[serde(rename="EventSubscription")]
@@ -263,7 +263,7 @@ pub struct CreateEventSubscriptionResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReplicationInstanceMessage {
     #[doc="<p>The amount of storage (in gigabytes) to be initially allocated for the replication instance.</p>"]
     #[serde(rename="AllocatedStorage")]
@@ -318,7 +318,7 @@ pub struct CreateReplicationInstanceMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReplicationInstanceResponse {
     #[doc="<p>The replication instance that was created.</p>"]
     #[serde(rename="ReplicationInstance")]
@@ -327,7 +327,7 @@ pub struct CreateReplicationInstanceResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReplicationSubnetGroupMessage {
     #[doc="<p>The description for the subnet group.</p>"]
     #[serde(rename="ReplicationSubnetGroupDescription")]
@@ -345,7 +345,7 @@ pub struct CreateReplicationSubnetGroupMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReplicationSubnetGroupResponse {
     #[doc="<p>The replication subnet group that was created.</p>"]
     #[serde(rename="ReplicationSubnetGroup")]
@@ -354,7 +354,7 @@ pub struct CreateReplicationSubnetGroupResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReplicationTaskMessage {
     #[doc="<p>The start time for the Change Data Capture (CDC) operation.</p>"]
     #[serde(rename="CdcStartTime")]
@@ -389,7 +389,7 @@ pub struct CreateReplicationTaskMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReplicationTaskResponse {
     #[doc="<p>The replication task that was created.</p>"]
     #[serde(rename="ReplicationTask")]
@@ -397,14 +397,14 @@ pub struct CreateReplicationTaskResponse {
     pub replication_task: Option<ReplicationTask>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCertificateMessage {
     #[doc="<p>The Amazon Resource Name (ARN) of the deleted certificate.</p>"]
     #[serde(rename="CertificateArn")]
     pub certificate_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCertificateResponse {
     #[doc="<p>The Secure Sockets Layer (SSL) certificate.</p>"]
     #[serde(rename="Certificate")]
@@ -413,7 +413,7 @@ pub struct DeleteCertificateResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEndpointMessage {
     #[doc="<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>"]
     #[serde(rename="EndpointArn")]
@@ -421,7 +421,7 @@ pub struct DeleteEndpointMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEndpointResponse {
     #[doc="<p>The endpoint that was deleted.</p>"]
     #[serde(rename="Endpoint")]
@@ -430,7 +430,7 @@ pub struct DeleteEndpointResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEventSubscriptionMessage {
     #[doc="<p>The name of the DMS event notification subscription to be deleted.</p>"]
     #[serde(rename="SubscriptionName")]
@@ -438,7 +438,7 @@ pub struct DeleteEventSubscriptionMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEventSubscriptionResponse {
     #[doc="<p>The event subscription that was deleted.</p>"]
     #[serde(rename="EventSubscription")]
@@ -447,7 +447,7 @@ pub struct DeleteEventSubscriptionResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReplicationInstanceMessage {
     #[doc="<p>The Amazon Resource Name (ARN) of the replication instance to be deleted.</p>"]
     #[serde(rename="ReplicationInstanceArn")]
@@ -455,7 +455,7 @@ pub struct DeleteReplicationInstanceMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReplicationInstanceResponse {
     #[doc="<p>The replication instance that was deleted.</p>"]
     #[serde(rename="ReplicationInstance")]
@@ -464,7 +464,7 @@ pub struct DeleteReplicationInstanceResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReplicationSubnetGroupMessage {
     #[doc="<p>The subnet group name of the replication instance.</p>"]
     #[serde(rename="ReplicationSubnetGroupIdentifier")]
@@ -472,11 +472,11 @@ pub struct DeleteReplicationSubnetGroupMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReplicationSubnetGroupResponse;
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReplicationTaskMessage {
     #[doc="<p>The Amazon Resource Name (ARN) of the replication task to be deleted.</p>"]
     #[serde(rename="ReplicationTaskArn")]
@@ -484,7 +484,7 @@ pub struct DeleteReplicationTaskMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReplicationTaskResponse {
     #[doc="<p>The deleted replication task.</p>"]
     #[serde(rename="ReplicationTask")]
@@ -493,11 +493,11 @@ pub struct DeleteReplicationTaskResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountAttributesMessage;
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountAttributesResponse {
     #[doc="<p>Account quota information.</p>"]
     #[serde(rename="AccountQuotas")]
@@ -505,7 +505,7 @@ pub struct DescribeAccountAttributesResponse {
     pub account_quotas: Option<Vec<AccountQuota>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCertificatesMessage {
     #[doc="<p>Filters applied to the certificate described in the form of key-value pairs.</p>"]
     #[serde(rename="Filters")]
@@ -521,7 +521,7 @@ pub struct DescribeCertificatesMessage {
     pub max_records: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCertificatesResponse {
     #[doc="<p>The Secure Sockets Layer (SSL) certificates associated with the replication instance.</p>"]
     #[serde(rename="Certificates")]
@@ -534,7 +534,7 @@ pub struct DescribeCertificatesResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConnectionsMessage {
     #[doc="<p>The filters applied to the connection.</p> <p>Valid filter names: endpoint-arn | replication-instance-arn</p>"]
     #[serde(rename="Filters")]
@@ -551,7 +551,7 @@ pub struct DescribeConnectionsMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConnectionsResponse {
     #[doc="<p>A description of the connections.</p>"]
     #[serde(rename="Connections")]
@@ -564,7 +564,7 @@ pub struct DescribeConnectionsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEndpointTypesMessage {
     #[doc="<p>Filters applied to the describe action.</p> <p>Valid filter names: engine-name | endpoint-type</p>"]
     #[serde(rename="Filters")]
@@ -581,7 +581,7 @@ pub struct DescribeEndpointTypesMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEndpointTypesResponse {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
     #[serde(rename="Marker")]
@@ -594,7 +594,7 @@ pub struct DescribeEndpointTypesResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEndpointsMessage {
     #[doc="<p>Filters applied to the describe action.</p> <p>Valid filter names: endpoint-arn | endpoint-type | endpoint-id | engine-name</p>"]
     #[serde(rename="Filters")]
@@ -611,7 +611,7 @@ pub struct DescribeEndpointsMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEndpointsResponse {
     #[doc="<p>Endpoint description.</p>"]
     #[serde(rename="Endpoints")]
@@ -624,7 +624,7 @@ pub struct DescribeEndpointsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventCategoriesMessage {
     #[doc="<p>Filters applied to the action.</p>"]
     #[serde(rename="Filters")]
@@ -637,7 +637,7 @@ pub struct DescribeEventCategoriesMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventCategoriesResponse {
     #[doc="<p>A list of event categories.</p>"]
     #[serde(rename="EventCategoryGroupList")]
@@ -646,7 +646,7 @@ pub struct DescribeEventCategoriesResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventSubscriptionsMessage {
     #[doc="<p>Filters applied to the action.</p>"]
     #[serde(rename="Filters")]
@@ -667,7 +667,7 @@ pub struct DescribeEventSubscriptionsMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventSubscriptionsResponse {
     #[doc="<p>A list of event subscriptions.</p>"]
     #[serde(rename="EventSubscriptionsList")]
@@ -680,7 +680,7 @@ pub struct DescribeEventSubscriptionsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsMessage {
     #[doc="<p>The duration of the events to be listed.</p>"]
     #[serde(rename="Duration")]
@@ -721,7 +721,7 @@ pub struct DescribeEventsMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsResponse {
     #[doc="<p>The events described.</p>"]
     #[serde(rename="Events")]
@@ -734,7 +734,7 @@ pub struct DescribeEventsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeOrderableReplicationInstancesMessage {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
     #[serde(rename="Marker")]
@@ -747,7 +747,7 @@ pub struct DescribeOrderableReplicationInstancesMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeOrderableReplicationInstancesResponse {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
     #[serde(rename="Marker")]
@@ -760,7 +760,7 @@ pub struct DescribeOrderableReplicationInstancesResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRefreshSchemasStatusMessage {
     #[doc="<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>"]
     #[serde(rename="EndpointArn")]
@@ -768,7 +768,7 @@ pub struct DescribeRefreshSchemasStatusMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRefreshSchemasStatusResponse {
     #[doc="<p>The status of the schema.</p>"]
     #[serde(rename="RefreshSchemasStatus")]
@@ -777,7 +777,7 @@ pub struct DescribeRefreshSchemasStatusResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReplicationInstancesMessage {
     #[doc="<p>Filters applied to the describe action.</p> <p>Valid filter names: replication-instance-arn | replication-instance-id | replication-instance-class | engine-version</p>"]
     #[serde(rename="Filters")]
@@ -794,7 +794,7 @@ pub struct DescribeReplicationInstancesMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReplicationInstancesResponse {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
     #[serde(rename="Marker")]
@@ -807,7 +807,7 @@ pub struct DescribeReplicationInstancesResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReplicationSubnetGroupsMessage {
     #[doc="<p>Filters applied to the describe action.</p>"]
     #[serde(rename="Filters")]
@@ -824,7 +824,7 @@ pub struct DescribeReplicationSubnetGroupsMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReplicationSubnetGroupsResponse {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
     #[serde(rename="Marker")]
@@ -837,7 +837,7 @@ pub struct DescribeReplicationSubnetGroupsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReplicationTasksMessage {
     #[doc="<p>Filters applied to the describe action.</p> <p>Valid filter names: replication-task-arn | replication-task-id | migration-type | endpoint-arn | replication-instance-arn</p>"]
     #[serde(rename="Filters")]
@@ -854,7 +854,7 @@ pub struct DescribeReplicationTasksMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReplicationTasksResponse {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
     #[serde(rename="Marker")]
@@ -867,7 +867,7 @@ pub struct DescribeReplicationTasksResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSchemasMessage {
     #[doc="<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>"]
     #[serde(rename="EndpointArn")]
@@ -883,7 +883,7 @@ pub struct DescribeSchemasMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSchemasResponse {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
     #[serde(rename="Marker")]
@@ -896,7 +896,7 @@ pub struct DescribeSchemasResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTableStatisticsMessage {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
     #[serde(rename="Marker")]
@@ -912,7 +912,7 @@ pub struct DescribeTableStatisticsMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTableStatisticsResponse {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
     #[serde(rename="Marker")]
@@ -937,7 +937,7 @@ pub struct DynamoDbSettings {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Endpoint {
     #[doc="<p>The Amazon Resource Name (ARN) used for SSL connection to the endpoint.</p>"]
     #[serde(rename="CertificateArn")]
@@ -1010,7 +1010,7 @@ pub struct Endpoint {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Event {
     #[doc="<p>The date of the event.</p>"]
     #[serde(rename="Date")]
@@ -1035,7 +1035,7 @@ pub struct Event {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventCategoryGroup {
     #[doc="<p> A list of event categories for a <code>SourceType</code> that you want to subscribe to. </p>"]
     #[serde(rename="EventCategories")]
@@ -1048,7 +1048,7 @@ pub struct EventCategoryGroup {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventSubscription {
     #[doc="<p>The AWS DMS event notification subscription Id.</p>"]
     #[serde(rename="CustSubscriptionId")]
@@ -1089,7 +1089,7 @@ pub struct EventSubscription {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Filter {
     #[doc="<p>The name of the filter.</p>"]
     #[serde(rename="Name")]
@@ -1099,7 +1099,7 @@ pub struct Filter {
     pub values: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportCertificateMessage {
     #[doc="<p>The customer-assigned name of the certificate. Valid characters are A-z and 0-9.</p>"]
     #[serde(rename="CertificateIdentifier")]
@@ -1122,7 +1122,7 @@ pub struct ImportCertificateMessage {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportCertificateResponse {
     #[doc="<p>The certificate to be uploaded.</p>"]
     #[serde(rename="Certificate")]
@@ -1131,7 +1131,7 @@ pub struct ImportCertificateResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceMessage {
     #[doc="<p>The Amazon Resource Name (ARN) string that uniquely identifies the AWS DMS resource.</p>"]
     #[serde(rename="ResourceArn")]
@@ -1139,7 +1139,7 @@ pub struct ListTagsForResourceMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceResponse {
     #[doc="<p>A list of tags for the resource.</p>"]
     #[serde(rename="TagList")]
@@ -1148,7 +1148,7 @@ pub struct ListTagsForResourceResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyEndpointMessage {
     #[doc="<p>The Amazon Resource Name (ARN) of the certificate used for SSL connection.</p>"]
     #[serde(rename="CertificateArn")]
@@ -1212,7 +1212,7 @@ pub struct ModifyEndpointMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyEndpointResponse {
     #[doc="<p>The modified endpoint.</p>"]
     #[serde(rename="Endpoint")]
@@ -1221,7 +1221,7 @@ pub struct ModifyEndpointResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyEventSubscriptionMessage {
     #[doc="<p> A Boolean value; set to <b>true</b> to activate the subscription. </p>"]
     #[serde(rename="Enabled")]
@@ -1245,7 +1245,7 @@ pub struct ModifyEventSubscriptionMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyEventSubscriptionResponse {
     #[doc="<p>The modified event subscription.</p>"]
     #[serde(rename="EventSubscription")]
@@ -1254,7 +1254,7 @@ pub struct ModifyEventSubscriptionResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyReplicationInstanceMessage {
     #[doc="<p>The amount of storage (in gigabytes) to be allocated for the replication instance.</p>"]
     #[serde(rename="AllocatedStorage")]
@@ -1302,7 +1302,7 @@ pub struct ModifyReplicationInstanceMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyReplicationInstanceResponse {
     #[doc="<p>The modified replication instance.</p>"]
     #[serde(rename="ReplicationInstance")]
@@ -1311,7 +1311,7 @@ pub struct ModifyReplicationInstanceResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyReplicationSubnetGroupMessage {
     #[doc="<p>The description of the replication instance subnet group.</p>"]
     #[serde(rename="ReplicationSubnetGroupDescription")]
@@ -1326,7 +1326,7 @@ pub struct ModifyReplicationSubnetGroupMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyReplicationSubnetGroupResponse {
     #[doc="<p>The modified replication subnet group.</p>"]
     #[serde(rename="ReplicationSubnetGroup")]
@@ -1335,7 +1335,7 @@ pub struct ModifyReplicationSubnetGroupResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyReplicationTaskMessage {
     #[doc="<p>The start time for the Change Data Capture (CDC) operation.</p>"]
     #[serde(rename="CdcStartTime")]
@@ -1363,7 +1363,7 @@ pub struct ModifyReplicationTaskMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyReplicationTaskResponse {
     #[doc="<p>The replication task that was modified.</p>"]
     #[serde(rename="ReplicationTask")]
@@ -1421,7 +1421,7 @@ pub struct MongoDbSettings {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OrderableReplicationInstance {
     #[doc="<p>The default amount of storage (in gigabytes) that is allocated for the replication instance.</p>"]
     #[serde(rename="DefaultAllocatedStorage")]
@@ -1454,7 +1454,7 @@ pub struct OrderableReplicationInstance {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RefreshSchemasMessage {
     #[doc="<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>"]
     #[serde(rename="EndpointArn")]
@@ -1465,7 +1465,7 @@ pub struct RefreshSchemasMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RefreshSchemasResponse {
     #[doc="<p>The status of the refreshed schema.</p>"]
     #[serde(rename="RefreshSchemasStatus")]
@@ -1474,7 +1474,7 @@ pub struct RefreshSchemasResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RefreshSchemasStatus {
     #[doc="<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>"]
     #[serde(rename="EndpointArn")]
@@ -1498,7 +1498,7 @@ pub struct RefreshSchemasStatus {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReloadTablesMessage {
     #[doc="<p>The Amazon Resource Name (ARN) of the replication instance. </p>"]
     #[serde(rename="ReplicationTaskArn")]
@@ -1508,7 +1508,7 @@ pub struct ReloadTablesMessage {
     pub tables_to_reload: Vec<TableToReload>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReloadTablesResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the replication task. </p>"]
     #[serde(rename="ReplicationTaskArn")]
@@ -1517,7 +1517,7 @@ pub struct ReloadTablesResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceMessage {
     #[doc="<p>&gt;The Amazon Resource Name (ARN) of the AWS DMS resource the tag is to be removed from.</p>"]
     #[serde(rename="ResourceArn")]
@@ -1528,11 +1528,11 @@ pub struct RemoveTagsFromResourceMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceResponse;
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplicationInstance {
     #[doc="<p>The amount of storage (in gigabytes) that is allocated for the replication instance.</p>"]
     #[serde(rename="AllocatedStorage")]
@@ -1613,7 +1613,7 @@ pub struct ReplicationInstance {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplicationPendingModifiedValues {
     #[doc="<p>The amount of storage (in gigabytes) that is allocated for the replication instance.</p>"]
     #[serde(rename="AllocatedStorage")]
@@ -1634,7 +1634,7 @@ pub struct ReplicationPendingModifiedValues {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplicationSubnetGroup {
     #[doc="<p>The description of the replication subnet group.</p>"]
     #[serde(rename="ReplicationSubnetGroupDescription")]
@@ -1659,7 +1659,7 @@ pub struct ReplicationSubnetGroup {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplicationTask {
     #[doc="<p>The last error (failure) message generated for the replication instance.</p>"]
     #[serde(rename="LastFailureMessage")]
@@ -1720,7 +1720,7 @@ pub struct ReplicationTask {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplicationTaskStats {
     #[doc="<p>The elapsed time of the task, in milliseconds.</p>"]
     #[serde(rename="ElapsedTimeMillis")]
@@ -1782,7 +1782,7 @@ pub struct S3Settings {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartReplicationTaskMessage {
     #[doc="<p>The start time for the Change Data Capture (CDC) operation.</p>"]
     #[serde(rename="CdcStartTime")]
@@ -1797,7 +1797,7 @@ pub struct StartReplicationTaskMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartReplicationTaskResponse {
     #[doc="<p>The replication task started.</p>"]
     #[serde(rename="ReplicationTask")]
@@ -1806,7 +1806,7 @@ pub struct StartReplicationTaskResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopReplicationTaskMessage {
     #[doc="<p>The Amazon Resource Number(ARN) of the replication task to be stopped.</p>"]
     #[serde(rename="ReplicationTaskArn")]
@@ -1814,7 +1814,7 @@ pub struct StopReplicationTaskMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopReplicationTaskResponse {
     #[doc="<p>The replication task stopped.</p>"]
     #[serde(rename="ReplicationTask")]
@@ -1823,7 +1823,7 @@ pub struct StopReplicationTaskResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Subnet {
     #[doc="<p>The Availability Zone of the subnet.</p>"]
     #[serde(rename="SubnetAvailabilityZone")]
@@ -1840,7 +1840,7 @@ pub struct Subnet {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SupportedEndpointType {
     #[doc="<p>The type of endpoint.</p>"]
     #[serde(rename="EndpointType")]
@@ -1857,7 +1857,7 @@ pub struct SupportedEndpointType {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TableStatistics {
     #[doc="<p>The Data Definition Language (DDL) used to build and modify the structure of your tables.</p>"]
     #[serde(rename="Ddls")]
@@ -1906,7 +1906,7 @@ pub struct TableStatistics {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TableToReload {
     #[doc="<p>The schema name of the table to be reloaded.</p>"]
     #[serde(rename="SchemaName")]
@@ -1932,7 +1932,7 @@ pub struct Tag {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestConnectionMessage {
     #[doc="<p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>"]
     #[serde(rename="EndpointArn")]
@@ -1943,7 +1943,7 @@ pub struct TestConnectionMessage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestConnectionResponse {
     #[doc="<p>The connection tested.</p>"]
     #[serde(rename="Connection")]
@@ -1952,7 +1952,7 @@ pub struct TestConnectionResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcSecurityGroupMembership {
     #[doc="<p>The status of the VPC security group.</p>"]
     #[serde(rename="Status")]

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddIpRoutesRequest {
     #[doc="<p>Identifier (ID) of the directory to which to add the address block.</p>"]
     #[serde(rename="DirectoryId")]
@@ -42,10 +42,10 @@ pub struct AddIpRoutesRequest {
     pub update_security_group_for_directory_controllers: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddIpRoutesResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceRequest {
     #[doc="<p>Identifier (ID) for the directory to which to add the tag.</p>"]
     #[serde(rename="ResourceId")]
@@ -55,7 +55,7 @@ pub struct AddTagsToResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceResult;
 
 #[doc="<p>Represents a named directory attribute.</p>"]
@@ -71,7 +71,7 @@ pub struct Attribute {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelSchemaExtensionRequest {
     #[doc="<p>The identifier of the directory whose schema extension will be canceled.</p>"]
     #[serde(rename="DirectoryId")]
@@ -81,11 +81,11 @@ pub struct CancelSchemaExtensionRequest {
     pub schema_extension_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelSchemaExtensionResult;
 
 #[doc="<p>Contains information about a computer account in a directory.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Computer {
     #[doc="<p>An array of <a>Attribute</a> objects containing the LDAP attributes that belong to the computer account.</p>"]
     #[serde(rename="ComputerAttributes")]
@@ -102,7 +102,7 @@ pub struct Computer {
 }
 
 #[doc="<p>Points to a remote domain with which you are setting up a trust relationship. Conditional forwarders are required in order to set up a trust relationship with another domain.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConditionalForwarder {
     #[doc="<p>The IP addresses of the remote DNS server associated with RemoteDomainName. This is the IP address of the DNS server that your conditional forwarder points to.</p>"]
     #[serde(rename="DnsIpAddrs")]
@@ -119,7 +119,7 @@ pub struct ConditionalForwarder {
 }
 
 #[doc="<p>Contains the inputs for the <a>ConnectDirectory</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConnectDirectoryRequest {
     #[doc="<p>A <a>DirectoryConnectSettings</a> object that contains additional information for the operation.</p>"]
     #[serde(rename="ConnectSettings")]
@@ -144,7 +144,7 @@ pub struct ConnectDirectoryRequest {
 }
 
 #[doc="<p>Contains the results of the <a>ConnectDirectory</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConnectDirectoryResult {
     #[doc="<p>The identifier of the new directory.</p>"]
     #[serde(rename="DirectoryId")]
@@ -153,7 +153,7 @@ pub struct ConnectDirectoryResult {
 }
 
 #[doc="<p>Contains the inputs for the <a>CreateAlias</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAliasRequest {
     #[doc="<p>The requested alias.</p> <p>The alias must be unique amongst all aliases in AWS. This operation throws an <code>EntityAlreadyExistsException</code> error if the alias already exists.</p>"]
     #[serde(rename="Alias")]
@@ -164,7 +164,7 @@ pub struct CreateAliasRequest {
 }
 
 #[doc="<p>Contains the results of the <a>CreateAlias</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAliasResult {
     #[doc="<p>The alias for the directory.</p>"]
     #[serde(rename="Alias")]
@@ -177,7 +177,7 @@ pub struct CreateAliasResult {
 }
 
 #[doc="<p>Contains the inputs for the <a>CreateComputer</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateComputerRequest {
     #[doc="<p>An array of <a>Attribute</a> objects that contain any LDAP attributes to apply to the computer account.</p>"]
     #[serde(rename="ComputerAttributes")]
@@ -199,7 +199,7 @@ pub struct CreateComputerRequest {
 }
 
 #[doc="<p>Contains the results for the <a>CreateComputer</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateComputerResult {
     #[doc="<p>A <a>Computer</a> object that represents the computer account.</p>"]
     #[serde(rename="Computer")]
@@ -208,7 +208,7 @@ pub struct CreateComputerResult {
 }
 
 #[doc="<p>Initiates the creation of a conditional forwarder for your AWS Directory Service for Microsoft Active Directory. Conditional forwarders are required in order to set up a trust relationship with another domain.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConditionalForwarderRequest {
     #[doc="<p>The directory ID of the AWS directory for which you are creating the conditional forwarder.</p>"]
     #[serde(rename="DirectoryId")]
@@ -222,11 +222,11 @@ pub struct CreateConditionalForwarderRequest {
 }
 
 #[doc="<p>The result of a CreateConditinalForwarder request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConditionalForwarderResult;
 
 #[doc="<p>Contains the inputs for the <a>CreateDirectory</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDirectoryRequest {
     #[doc="<p>A textual description for the directory.</p>"]
     #[serde(rename="Description")]
@@ -252,7 +252,7 @@ pub struct CreateDirectoryRequest {
 }
 
 #[doc="<p>Contains the results of the <a>CreateDirectory</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDirectoryResult {
     #[doc="<p>The identifier of the directory that was created.</p>"]
     #[serde(rename="DirectoryId")]
@@ -261,7 +261,7 @@ pub struct CreateDirectoryResult {
 }
 
 #[doc="<p>Creates a Microsoft AD in the AWS cloud.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateMicrosoftADRequest {
     #[doc="<p>A textual description for the directory. This label will appear on the AWS console <code>Directory Details</code> page after the directory is created.</p>"]
     #[serde(rename="Description")]
@@ -283,7 +283,7 @@ pub struct CreateMicrosoftADRequest {
 }
 
 #[doc="<p>Result of a CreateMicrosoftAD request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateMicrosoftADResult {
     #[doc="<p>The identifier of the directory that was created.</p>"]
     #[serde(rename="DirectoryId")]
@@ -292,7 +292,7 @@ pub struct CreateMicrosoftADResult {
 }
 
 #[doc="<p>Contains the inputs for the <a>CreateSnapshot</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSnapshotRequest {
     #[doc="<p>The identifier of the directory of which to take a snapshot.</p>"]
     #[serde(rename="DirectoryId")]
@@ -304,7 +304,7 @@ pub struct CreateSnapshotRequest {
 }
 
 #[doc="<p>Contains the results of the <a>CreateSnapshot</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSnapshotResult {
     #[doc="<p>The identifier of the snapshot that was created.</p>"]
     #[serde(rename="SnapshotId")]
@@ -313,7 +313,7 @@ pub struct CreateSnapshotResult {
 }
 
 #[doc="<p>AWS Directory Service for Microsoft Active Directory allows you to configure trust relationships. For example, you can establish a trust between your Microsoft AD in the AWS cloud, and your existing on-premises Microsoft Active Directory. This would allow you to provide users and groups access to resources in either domain, with a single set of credentials.</p> <p>This action initiates the creation of the AWS side of a trust relationship between a Microsoft AD in the AWS cloud and an external domain.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTrustRequest {
     #[doc="<p>The IP addresses of the remote DNS server associated with RemoteDomainName.</p>"]
     #[serde(rename="ConditionalForwarderIpAddrs")]
@@ -338,7 +338,7 @@ pub struct CreateTrustRequest {
 }
 
 #[doc="<p>The result of a CreateTrust request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTrustResult {
     #[doc="<p>A unique identifier for the trust relationship that was created.</p>"]
     #[serde(rename="TrustId")]
@@ -347,7 +347,7 @@ pub struct CreateTrustResult {
 }
 
 #[doc="<p>Deletes a conditional forwarder.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConditionalForwarderRequest {
     #[doc="<p>The directory ID for which you are deleting the conditional forwarder.</p>"]
     #[serde(rename="DirectoryId")]
@@ -358,11 +358,11 @@ pub struct DeleteConditionalForwarderRequest {
 }
 
 #[doc="<p>The result of a DeleteConditionalForwarder request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConditionalForwarderResult;
 
 #[doc="<p>Contains the inputs for the <a>DeleteDirectory</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDirectoryRequest {
     #[doc="<p>The identifier of the directory to delete.</p>"]
     #[serde(rename="DirectoryId")]
@@ -370,7 +370,7 @@ pub struct DeleteDirectoryRequest {
 }
 
 #[doc="<p>Contains the results of the <a>DeleteDirectory</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDirectoryResult {
     #[doc="<p>The directory identifier.</p>"]
     #[serde(rename="DirectoryId")]
@@ -379,7 +379,7 @@ pub struct DeleteDirectoryResult {
 }
 
 #[doc="<p>Contains the inputs for the <a>DeleteSnapshot</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSnapshotRequest {
     #[doc="<p>The identifier of the directory snapshot to be deleted.</p>"]
     #[serde(rename="SnapshotId")]
@@ -387,7 +387,7 @@ pub struct DeleteSnapshotRequest {
 }
 
 #[doc="<p>Contains the results of the <a>DeleteSnapshot</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSnapshotResult {
     #[doc="<p>The identifier of the directory snapshot that was deleted.</p>"]
     #[serde(rename="SnapshotId")]
@@ -396,7 +396,7 @@ pub struct DeleteSnapshotResult {
 }
 
 #[doc="<p>Deletes the local side of an existing trust relationship between the Microsoft AD in the AWS cloud and the external domain.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTrustRequest {
     #[doc="<p>Delete a conditional forwarder as part of a DeleteTrustRequest.</p>"]
     #[serde(rename="DeleteAssociatedConditionalForwarder")]
@@ -408,7 +408,7 @@ pub struct DeleteTrustRequest {
 }
 
 #[doc="<p>The result of a DeleteTrust request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTrustResult {
     #[doc="<p>The Trust ID of the trust relationship that was deleted.</p>"]
     #[serde(rename="TrustId")]
@@ -417,7 +417,7 @@ pub struct DeleteTrustResult {
 }
 
 #[doc="<p>Removes the specified directory as a publisher to the specified SNS topic.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterEventTopicRequest {
     #[doc="<p>The Directory ID to remove as a publisher. This directory will no longer send messages to the specified SNS topic.</p>"]
     #[serde(rename="DirectoryId")]
@@ -428,11 +428,11 @@ pub struct DeregisterEventTopicRequest {
 }
 
 #[doc="<p>The result of a DeregisterEventTopic request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterEventTopicResult;
 
 #[doc="<p>Describes a conditional forwarder.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConditionalForwardersRequest {
     #[doc="<p>The directory ID for which to get the list of associated conditional forwarders.</p>"]
     #[serde(rename="DirectoryId")]
@@ -444,7 +444,7 @@ pub struct DescribeConditionalForwardersRequest {
 }
 
 #[doc="<p>The result of a DescribeConditionalForwarder request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConditionalForwardersResult {
     #[doc="<p>The list of conditional forwarders that have been created.</p>"]
     #[serde(rename="ConditionalForwarders")]
@@ -453,7 +453,7 @@ pub struct DescribeConditionalForwardersResult {
 }
 
 #[doc="<p>Contains the inputs for the <a>DescribeDirectories</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDirectoriesRequest {
     #[doc="<p>A list of identifiers of the directories for which to obtain the information. If this member is null, all directories that belong to the current account are returned.</p> <p>An empty list results in an <code>InvalidParameterException</code> being thrown.</p>"]
     #[serde(rename="DirectoryIds")]
@@ -470,7 +470,7 @@ pub struct DescribeDirectoriesRequest {
 }
 
 #[doc="<p>Contains the results of the <a>DescribeDirectories</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDirectoriesResult {
     #[doc="<p>The list of <a>DirectoryDescription</a> objects that were retrieved.</p> <p>It is possible that this list contains less than the number of items specified in the <i>Limit</i> member of the request. This occurs if there are less than the requested number of items left to retrieve, or if the limitations of the operation have been exceeded.</p>"]
     #[serde(rename="DirectoryDescriptions")]
@@ -482,7 +482,7 @@ pub struct DescribeDirectoriesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDomainControllersRequest {
     #[doc="<p>Identifier of the directory for which to retrieve the domain controller information.</p>"]
     #[serde(rename="DirectoryId")]
@@ -501,7 +501,7 @@ pub struct DescribeDomainControllersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDomainControllersResult {
     #[doc="<p>List of the <a>DomainController</a> objects that were retrieved.</p>"]
     #[serde(rename="DomainControllers")]
@@ -514,7 +514,7 @@ pub struct DescribeDomainControllersResult {
 }
 
 #[doc="<p>Describes event topics.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventTopicsRequest {
     #[doc="<p>The Directory ID for which to get the list of associated SNS topics. If this member is null, associations for all Directory IDs are returned.</p>"]
     #[serde(rename="DirectoryId")]
@@ -527,7 +527,7 @@ pub struct DescribeEventTopicsRequest {
 }
 
 #[doc="<p>The result of a DescribeEventTopic request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventTopicsResult {
     #[doc="<p>A list of SNS topic names that receive status messages from the specified Directory ID.</p>"]
     #[serde(rename="EventTopics")]
@@ -536,7 +536,7 @@ pub struct DescribeEventTopicsResult {
 }
 
 #[doc="<p>Contains the inputs for the <a>DescribeSnapshots</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSnapshotsRequest {
     #[doc="<p>The identifier of the directory for which to retrieve snapshot information.</p>"]
     #[serde(rename="DirectoryId")]
@@ -557,7 +557,7 @@ pub struct DescribeSnapshotsRequest {
 }
 
 #[doc="<p>Contains the results of the <a>DescribeSnapshots</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSnapshotsResult {
     #[doc="<p>If not null, more results are available. Pass this value in the <i>NextToken</i> member of a subsequent call to <a>DescribeSnapshots</a>.</p>"]
     #[serde(rename="NextToken")]
@@ -570,7 +570,7 @@ pub struct DescribeSnapshotsResult {
 }
 
 #[doc="<p>Describes the trust relationships for a particular Microsoft AD in the AWS cloud. If no input parameters are are provided, such as directory ID or trust ID, this request describes all the trust relationships.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrustsRequest {
     #[doc="<p>The Directory ID of the AWS directory that is a part of the requested trust relationship.</p>"]
     #[serde(rename="DirectoryId")]
@@ -591,7 +591,7 @@ pub struct DescribeTrustsRequest {
 }
 
 #[doc="<p>The result of a DescribeTrust request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrustsResult {
     #[doc="<p>If not null, more results are available. Pass this value for the <i>NextToken</i> parameter in a subsequent call to <a>DescribeTrusts</a> to retrieve the next set of items.</p>"]
     #[serde(rename="NextToken")]
@@ -604,7 +604,7 @@ pub struct DescribeTrustsResult {
 }
 
 #[doc="<p>Contains information for the <a>ConnectDirectory</a> operation when an AD Connector directory is being created.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DirectoryConnectSettings {
     #[doc="<p>A list of one or more IP addresses of DNS servers or domain controllers in the on-premises directory.</p>"]
     #[serde(rename="CustomerDnsIps")]
@@ -621,7 +621,7 @@ pub struct DirectoryConnectSettings {
 }
 
 #[doc="<p>Contains information about an AD Connector directory.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DirectoryConnectSettingsDescription {
     #[doc="<p>A list of the Availability Zones that the directory is in.</p>"]
     #[serde(rename="AvailabilityZones")]
@@ -650,7 +650,7 @@ pub struct DirectoryConnectSettingsDescription {
 }
 
 #[doc="<p>Contains information about an AWS Directory Service directory.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DirectoryDescription {
     #[doc="<p>The access URL for the directory, such as <code>http://&lt;alias&gt;.awsapps.com</code>. If no alias has been created for the directory, <code>&lt;alias&gt;</code> is the directory identifier, such as <code>d-XXXXXXXXXX</code>.</p>"]
     #[serde(rename="AccessUrl")]
@@ -731,7 +731,7 @@ pub struct DirectoryDescription {
 }
 
 #[doc="<p>Contains directory limit information for a region.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DirectoryLimits {
     #[doc="<p>The current number of cloud directories in the region.</p>"]
     #[serde(rename="CloudOnlyDirectoriesCurrentCount")]
@@ -772,7 +772,7 @@ pub struct DirectoryLimits {
 }
 
 #[doc="<p>Contains VPC information for the <a>CreateDirectory</a> or <a>CreateMicrosoftAD</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DirectoryVpcSettings {
     #[doc="<p>The identifiers of the subnets for the directory servers. The two subnets must be in different Availability Zones. AWS Directory Service creates a directory server and a DNS server in each of these subnets.</p>"]
     #[serde(rename="SubnetIds")]
@@ -783,7 +783,7 @@ pub struct DirectoryVpcSettings {
 }
 
 #[doc="<p>Contains information about the directory.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DirectoryVpcSettingsDescription {
     #[doc="<p>The list of Availability Zones that the directory is in.</p>"]
     #[serde(rename="AvailabilityZones")]
@@ -804,7 +804,7 @@ pub struct DirectoryVpcSettingsDescription {
 }
 
 #[doc="<p>Contains the inputs for the <a>DisableRadius</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableRadiusRequest {
     #[doc="<p>The identifier of the directory for which to disable MFA.</p>"]
     #[serde(rename="DirectoryId")]
@@ -812,11 +812,11 @@ pub struct DisableRadiusRequest {
 }
 
 #[doc="<p>Contains the results of the <a>DisableRadius</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableRadiusResult;
 
 #[doc="<p>Contains the inputs for the <a>DisableSso</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableSsoRequest {
     #[doc="<p>The identifier of the directory for which to disable single-sign on.</p>"]
     #[serde(rename="DirectoryId")]
@@ -832,11 +832,11 @@ pub struct DisableSsoRequest {
 }
 
 #[doc="<p>Contains the results of the <a>DisableSso</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableSsoResult;
 
 #[doc="<p>Contains information about the domain controllers for a specified directory.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainController {
     #[doc="<p>The Availability Zone where the domain controller is located.</p>"]
     #[serde(rename="AvailabilityZone")]
@@ -881,7 +881,7 @@ pub struct DomainController {
 }
 
 #[doc="<p>Contains the inputs for the <a>EnableRadius</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableRadiusRequest {
     #[doc="<p>The identifier of the directory for which to enable MFA.</p>"]
     #[serde(rename="DirectoryId")]
@@ -892,11 +892,11 @@ pub struct EnableRadiusRequest {
 }
 
 #[doc="<p>Contains the results of the <a>EnableRadius</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableRadiusResult;
 
 #[doc="<p>Contains the inputs for the <a>EnableSso</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableSsoRequest {
     #[doc="<p>The identifier of the directory for which to enable single-sign on.</p>"]
     #[serde(rename="DirectoryId")]
@@ -912,11 +912,11 @@ pub struct EnableSsoRequest {
 }
 
 #[doc="<p>Contains the results of the <a>EnableSso</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableSsoResult;
 
 #[doc="<p>Information about SNS topic and AWS Directory Service directory associations.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventTopic {
     #[doc="<p>The date and time of when you associated your directory with the SNS topic.</p>"]
     #[serde(rename="CreatedDateTime")]
@@ -941,11 +941,11 @@ pub struct EventTopic {
 }
 
 #[doc="<p>Contains the inputs for the <a>GetDirectoryLimits</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDirectoryLimitsRequest;
 
 #[doc="<p>Contains the results of the <a>GetDirectoryLimits</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDirectoryLimitsResult {
     #[doc="<p>A <a>DirectoryLimits</a> object that contains the directory limits for the current region.</p>"]
     #[serde(rename="DirectoryLimits")]
@@ -954,7 +954,7 @@ pub struct GetDirectoryLimitsResult {
 }
 
 #[doc="<p>Contains the inputs for the <a>GetSnapshotLimits</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSnapshotLimitsRequest {
     #[doc="<p>Contains the identifier of the directory to obtain the limits for.</p>"]
     #[serde(rename="DirectoryId")]
@@ -962,7 +962,7 @@ pub struct GetSnapshotLimitsRequest {
 }
 
 #[doc="<p>Contains the results of the <a>GetSnapshotLimits</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSnapshotLimitsResult {
     #[doc="<p>A <a>SnapshotLimits</a> object that contains the manual snapshot limits for the specified directory.</p>"]
     #[serde(rename="SnapshotLimits")]
@@ -971,7 +971,7 @@ pub struct GetSnapshotLimitsResult {
 }
 
 #[doc="<p>IP address block. This is often the address block of the DNS server used for your on-premises domain. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IpRoute {
     #[doc="<p>IP address block using CIDR format, for example 10.0.0.0/24. This is often the address block of the DNS server used for your on-premises domain. For a single IP address use a CIDR address block with /32. For example 10.0.0.0/32.</p>"]
     #[serde(rename="CidrIp")]
@@ -984,7 +984,7 @@ pub struct IpRoute {
 }
 
 #[doc="<p>Information about one or more IP address blocks.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IpRouteInfo {
     #[doc="<p>The date and time the address block was added to the directory.</p>"]
     #[serde(rename="AddedDateTime")]
@@ -1012,7 +1012,7 @@ pub struct IpRouteInfo {
     pub ip_route_status_reason: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIpRoutesRequest {
     #[doc="<p>Identifier (ID) of the directory for which you want to retrieve the IP addresses.</p>"]
     #[serde(rename="DirectoryId")]
@@ -1027,7 +1027,7 @@ pub struct ListIpRoutesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIpRoutesResult {
     #[doc="<p>A list of <a>IpRoute</a>s.</p>"]
     #[serde(rename="IpRoutesInfo")]
@@ -1039,7 +1039,7 @@ pub struct ListIpRoutesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSchemaExtensionsRequest {
     #[doc="<p>The identifier of the directory from which to retrieve the schema extension information.</p>"]
     #[serde(rename="DirectoryId")]
@@ -1054,7 +1054,7 @@ pub struct ListSchemaExtensionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSchemaExtensionsResult {
     #[doc="<p>If not null, more results are available. Pass this value for the <code>NextToken</code> parameter in a subsequent call to <code>ListSchemaExtensions</code> to retrieve the next set of items.</p>"]
     #[serde(rename="NextToken")]
@@ -1066,7 +1066,7 @@ pub struct ListSchemaExtensionsResult {
     pub schema_extensions_info: Option<Vec<SchemaExtensionInfo>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceRequest {
     #[doc="<p>Reserved for future use.</p>"]
     #[serde(rename="Limit")]
@@ -1081,7 +1081,7 @@ pub struct ListTagsForResourceRequest {
     pub resource_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceResult {
     #[doc="<p>Reserved for future use.</p>"]
     #[serde(rename="NextToken")]
@@ -1131,7 +1131,7 @@ pub struct RadiusSettings {
 }
 
 #[doc="<p>Registers a new event topic.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterEventTopicRequest {
     #[doc="<p>The Directory ID that will publish status messages to the SNS topic.</p>"]
     #[serde(rename="DirectoryId")]
@@ -1142,10 +1142,10 @@ pub struct RegisterEventTopicRequest {
 }
 
 #[doc="<p>The result of a RegisterEventTopic request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterEventTopicResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveIpRoutesRequest {
     #[doc="<p>IP address blocks that you want to remove.</p>"]
     #[serde(rename="CidrIps")]
@@ -1155,10 +1155,10 @@ pub struct RemoveIpRoutesRequest {
     pub directory_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveIpRoutesResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceRequest {
     #[doc="<p>Identifier (ID) of the directory from which to remove the tag.</p>"]
     #[serde(rename="ResourceId")]
@@ -1168,11 +1168,11 @@ pub struct RemoveTagsFromResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceResult;
 
 #[doc="<p>An object representing the inputs for the <a>RestoreFromSnapshot</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreFromSnapshotRequest {
     #[doc="<p>The identifier of the snapshot to restore from.</p>"]
     #[serde(rename="SnapshotId")]
@@ -1180,11 +1180,11 @@ pub struct RestoreFromSnapshotRequest {
 }
 
 #[doc="<p>Contains the results of the <a>RestoreFromSnapshot</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreFromSnapshotResult;
 
 #[doc="<p>Information about a schema extension.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SchemaExtensionInfo {
     #[doc="<p>A description of the schema extension.</p>"]
     #[serde(rename="Description")]
@@ -1217,7 +1217,7 @@ pub struct SchemaExtensionInfo {
 }
 
 #[doc="<p>Describes a directory snapshot.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Snapshot {
     #[doc="<p>The directory identifier.</p>"]
     #[serde(rename="DirectoryId")]
@@ -1246,7 +1246,7 @@ pub struct Snapshot {
 }
 
 #[doc="<p>Contains manual snapshot limit information for a directory.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SnapshotLimits {
     #[doc="<p>The current number of manual snapshots of the directory.</p>"]
     #[serde(rename="ManualSnapshotsCurrentCount")]
@@ -1262,7 +1262,7 @@ pub struct SnapshotLimits {
     pub manual_snapshots_limit_reached: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartSchemaExtensionRequest {
     #[doc="<p>If true, creates a snapshot of the directory before applying the schema extension.</p>"]
     #[serde(rename="CreateSnapshotBeforeSchemaExtension")]
@@ -1278,7 +1278,7 @@ pub struct StartSchemaExtensionRequest {
     pub ldif_content: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartSchemaExtensionResult {
     #[doc="<p>The identifier of the schema extension that will be applied.</p>"]
     #[serde(rename="SchemaExtensionId")]
@@ -1298,7 +1298,7 @@ pub struct Tag {
 }
 
 #[doc="<p>Describes a trust relationship between an Microsoft AD in the AWS cloud and an external domain.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Trust {
     #[doc="<p>The date and time that the trust relationship was created.</p>"]
     #[serde(rename="CreatedDateTime")]
@@ -1343,7 +1343,7 @@ pub struct Trust {
 }
 
 #[doc="<p>Updates a conditional forwarder.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateConditionalForwarderRequest {
     #[doc="<p>The directory ID of the AWS directory for which to update the conditional forwarder.</p>"]
     #[serde(rename="DirectoryId")]
@@ -1357,10 +1357,10 @@ pub struct UpdateConditionalForwarderRequest {
 }
 
 #[doc="<p>The result of an UpdateConditionalForwarder request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateConditionalForwarderResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateNumberOfDomainControllersRequest {
     #[doc="<p>The number of domain controllers desired in the directory.</p>"]
     #[serde(rename="DesiredNumber")]
@@ -1370,11 +1370,11 @@ pub struct UpdateNumberOfDomainControllersRequest {
     pub directory_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateNumberOfDomainControllersResult;
 
 #[doc="<p>Contains the inputs for the <a>UpdateRadius</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRadiusRequest {
     #[doc="<p>The identifier of the directory for which to update the RADIUS server information.</p>"]
     #[serde(rename="DirectoryId")]
@@ -1385,11 +1385,11 @@ pub struct UpdateRadiusRequest {
 }
 
 #[doc="<p>Contains the results of the <a>UpdateRadius</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRadiusResult;
 
 #[doc="<p>Initiates the verification of an existing trust relationship between a Microsoft AD in the AWS cloud and an external domain.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerifyTrustRequest {
     #[doc="<p>The unique Trust ID of the trust relationship to verify.</p>"]
     #[serde(rename="TrustId")]
@@ -1397,7 +1397,7 @@ pub struct VerifyTrustRequest {
 }
 
 #[doc="<p>Result of a VerifyTrust request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerifyTrustResult {
     #[doc="<p>The unique Trust ID of the trust relationship that was verified.</p>"]
     #[serde(rename="TrustId")]

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -89,7 +89,7 @@ pub struct AttributeValue {
 }
 
 #[doc="<p>For the <code>UpdateItem</code> operation, represents the attributes to be modified, the action to perform on each, and the new value for each.</p> <note> <p>You cannot use <code>UpdateItem</code> to update any primary key attributes. Instead, you will need to delete the item, and then use <code>PutItem</code> to create a new item with new attributes.</p> </note> <p>Attribute values cannot be null; string and binary type attributes must have lengths greater than zero; and set type attributes must not be empty. Requests with empty values will be rejected with a <code>ValidationException</code> exception.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttributeValueUpdate {
     #[doc="<p>Specifies how to perform the update. Valid values are <code>PUT</code> (default), <code>DELETE</code>, and <code>ADD</code>. The behavior depends on whether the specified primary key already exists in the table.</p> <p> <b>If an item with the specified <i>Key</i> is found in the table:</b> </p> <ul> <li> <p> <code>PUT</code> - Adds the specified attribute to the item. If the attribute already exists, it is replaced by the new value. </p> </li> <li> <p> <code>DELETE</code> - If no value is specified, the attribute and its value are removed from the item. The data type of the specified value must match the existing value's data type.</p> <p>If a <i>set</i> of values is specified, then those values are subtracted from the old set. For example, if the attribute value was the set <code>[a,b,c]</code> and the <code>DELETE</code> action specified <code>[a,c]</code>, then the final attribute value would be <code>[b]</code>. Specifying an empty set is an error.</p> </li> <li> <p> <code>ADD</code> - If the attribute does not already exist, then the attribute and its values are added to the item. If the attribute does exist, then the behavior of <code>ADD</code> depends on the data type of the attribute:</p> <ul> <li> <p>If the existing attribute is a number, and if <code>Value</code> is also a number, then the <code>Value</code> is mathematically added to the existing attribute. If <code>Value</code> is a negative number, then it is subtracted from the existing attribute.</p> <note> <p> If you use <code>ADD</code> to increment or decrement a number value for an item that doesn't exist before the update, DynamoDB uses 0 as the initial value.</p> <p>In addition, if you use <code>ADD</code> to update an existing item, and intend to increment or decrement an attribute value which does not yet exist, DynamoDB uses <code>0</code> as the initial value. For example, suppose that the item you want to update does not yet have an attribute named <i>itemcount</i>, but you decide to <code>ADD</code> the number <code>3</code> to this attribute anyway, even though it currently does not exist. DynamoDB will create the <i>itemcount</i> attribute, set its initial value to <code>0</code>, and finally add <code>3</code> to it. The result will be a new <i>itemcount</i> attribute in the item, with a value of <code>3</code>.</p> </note> </li> <li> <p>If the existing data type is a set, and if the <code>Value</code> is also a set, then the <code>Value</code> is added to the existing set. (This is a <i>set</i> operation, not mathematical addition.) For example, if the attribute value was the set <code>[1,2]</code>, and the <code>ADD</code> action specified <code>[3]</code>, then the final attribute value would be <code>[1,2,3]</code>. An error occurs if an Add action is specified for a set attribute and the attribute type specified does not match the existing set type. </p> <p>Both sets must have the same primitive data type. For example, if the existing data type is a set of strings, the <code>Value</code> must also be a set of strings. The same holds true for number sets and binary sets.</p> </li> </ul> <p>This action is only valid for an existing attribute whose data type is number or is a set. Do not use <code>ADD</code> for any other data types.</p> </li> </ul> <p> <b>If no item with the specified <i>Key</i> is found:</b> </p> <ul> <li> <p> <code>PUT</code> - DynamoDB creates a new item with the specified primary key, and then adds the attribute. </p> </li> <li> <p> <code>DELETE</code> - Nothing happens; there is no attribute to delete.</p> </li> <li> <p> <code>ADD</code> - DynamoDB creates an item with the supplied primary key and number (or set of numbers) for the attribute value. The only data types allowed are number and number set; no other data types can be specified.</p> </li> </ul>"]
     #[serde(rename="Action")]
@@ -102,7 +102,7 @@ pub struct AttributeValueUpdate {
 }
 
 #[doc="<p>Represents the input of a <code>BatchGetItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetItemInput {
     #[doc="<p>A map of one or more table names and, for each table, a map that describes one or more items to retrieve from that table. Each table name can be used only once per <code>BatchGetItem</code> request.</p> <p>Each element in the map of items to retrieve consists of the following:</p> <ul> <li> <p> <code>ConsistentRead</code> - If <code>true</code>, a strongly consistent read is used; if <code>false</code> (the default), an eventually consistent read is used.</p> </li> <li> <p> <code>ExpressionAttributeNames</code> - One or more substitution tokens for attribute names in the <code>ProjectionExpression</code> parameter. The following are some use cases for using <code>ExpressionAttributeNames</code>:</p> <ul> <li> <p>To access an attribute whose name conflicts with a DynamoDB reserved word.</p> </li> <li> <p>To create a placeholder for repeating occurrences of an attribute name in an expression.</p> </li> <li> <p>To prevent special characters in an attribute name from being misinterpreted in an expression.</p> </li> </ul> <p>Use the <b>#</b> character in an expression to dereference an attribute name. For example, consider the following attribute name:</p> <ul> <li> <p> <code>Percentile</code> </p> </li> </ul> <p>The name of this attribute conflicts with a reserved word, so it cannot be used directly in an expression. (For the complete list of reserved words, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer Guide</i>). To work around this, you could specify the following for <code>ExpressionAttributeNames</code>:</p> <ul> <li> <p> <code>{\"#P\":\"Percentile\"}</code> </p> </li> </ul> <p>You could then use this substitution in an expression, as in this example:</p> <ul> <li> <p> <code>#P = :val</code> </p> </li> </ul> <note> <p>Tokens that begin with the <b>:</b> character are <i>expression attribute values</i>, which are placeholders for the actual value at runtime.</p> </note> <p>For more information on expression attribute names, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p> </li> <li> <p> <code>Keys</code> - An array of primary key attribute values that define specific items in the table. For each primary key, you must provide <i>all</i> of the key attributes. For example, with a simple primary key, you only need to provide the partition key value. For a composite key, you must provide <i>both</i> the partition key value and the sort key value.</p> </li> <li> <p> <code>ProjectionExpression</code> - A string that identifies one or more attributes to retrieve from the table. These attributes can include scalars, sets, or elements of a JSON document. The attributes in the expression must be separated by commas.</p> <p>If no attribute names are specified, then all attributes will be returned. If any of the requested attributes are not found, they will not appear in the result.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p> </li> <li> <p> <code>AttributesToGet</code> - This is a legacy parameter. Use <code>ProjectionExpression</code> instead. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html\">AttributesToGet</a> in the <i>Amazon DynamoDB Developer Guide</i>. </p> </li> </ul>"]
     #[serde(rename="RequestItems")]
@@ -113,7 +113,7 @@ pub struct BatchGetItemInput {
 }
 
 #[doc="<p>Represents the output of a <code>BatchGetItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetItemOutput {
     #[doc="<p>The read capacity units consumed by the entire <code>BatchGetItem</code> operation.</p> <p>Each element consists of:</p> <ul> <li> <p> <code>TableName</code> - The table that consumed the provisioned throughput.</p> </li> <li> <p> <code>CapacityUnits</code> - The total number of capacity units consumed.</p> </li> </ul>"]
     #[serde(rename="ConsumedCapacity")]
@@ -133,7 +133,7 @@ pub struct BatchGetItemOutput {
 }
 
 #[doc="<p>Represents the input of a <code>BatchWriteItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchWriteItemInput {
     #[doc="<p>A map of one or more table names and, for each table, a list of operations to be performed (<code>DeleteRequest</code> or <code>PutRequest</code>). Each element in the map consists of the following:</p> <ul> <li> <p> <code>DeleteRequest</code> - Perform a <code>DeleteItem</code> operation on the specified item. The item to be deleted is identified by a <code>Key</code> subelement:</p> <ul> <li> <p> <code>Key</code> - A map of primary key attribute values that uniquely identify the item. Each entry in this map consists of an attribute name and an attribute value. For each primary key, you must provide <i>all</i> of the key attributes. For example, with a simple primary key, you only need to provide a value for the partition key. For a composite primary key, you must provide values for <i>both</i> the partition key and the sort key.</p> </li> </ul> </li> <li> <p> <code>PutRequest</code> - Perform a <code>PutItem</code> operation on the specified item. The item to be put is identified by an <code>Item</code> subelement:</p> <ul> <li> <p> <code>Item</code> - A map of attributes and their values. Each entry in this map consists of an attribute name and an attribute value. Attribute values must not be null; string and binary type attributes must have lengths greater than zero; and set type attributes must not be empty. Requests that contain empty values will be rejected with a <code>ValidationException</code> exception.</p> <p>If you specify any attributes that are part of an index key, then the data types for those attributes must match those of the schema in the table's attribute definition.</p> </li> </ul> </li> </ul>"]
     #[serde(rename="RequestItems")]
@@ -148,7 +148,7 @@ pub struct BatchWriteItemInput {
 }
 
 #[doc="<p>Represents the output of a <code>BatchWriteItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchWriteItemOutput {
     #[doc="<p>The capacity units consumed by the entire <code>BatchWriteItem</code> operation.</p> <p>Each element consists of:</p> <ul> <li> <p> <code>TableName</code> - The table that consumed the provisioned throughput.</p> </li> <li> <p> <code>CapacityUnits</code> - The total number of capacity units consumed.</p> </li> </ul>"]
     #[serde(rename="ConsumedCapacity")]
@@ -166,7 +166,7 @@ pub struct BatchWriteItemOutput {
 }
 
 #[doc="<p>Represents the amount of provisioned throughput capacity consumed on a table or an index.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Capacity {
     #[doc="<p>The total number of capacity units consumed on a table or an index.</p>"]
     #[serde(rename="CapacityUnits")]
@@ -175,7 +175,7 @@ pub struct Capacity {
 }
 
 #[doc="<p>Represents the selection criteria for a <code>Query</code> or <code>Scan</code> operation:</p> <ul> <li> <p>For a <code>Query</code> operation, <code>Condition</code> is used for specifying the <code>KeyConditions</code> to use when querying a table or an index. For <code>KeyConditions</code>, only the following comparison operators are supported:</p> <p> <code>EQ | LE | LT | GE | GT | BEGINS_WITH | BETWEEN</code> </p> <p> <code>Condition</code> is also used in a <code>QueryFilter</code>, which evaluates the query results and returns only the desired values.</p> </li> <li> <p>For a <code>Scan</code> operation, <code>Condition</code> is used in a <code>ScanFilter</code>, which evaluates the scan results and returns only the desired values.</p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Condition {
     #[doc="<p>One or more values to evaluate against the supplied attribute. The number of values in the list depends on the <code>ComparisonOperator</code> being used.</p> <p>For type Number, value comparisons are numeric.</p> <p>String value comparisons for greater than, equals, or less than are based on ASCII character code values. For example, <code>a</code> is greater than <code>A</code>, and <code>a</code> is greater than <code>B</code>. For a list of code values, see <a href=\"http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters\">http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.</p> <p>For Binary, DynamoDB treats each byte of the binary data as unsigned when it compares binary values.</p>"]
     #[serde(rename="AttributeValueList")]
@@ -187,7 +187,7 @@ pub struct Condition {
 }
 
 #[doc="<p>The capacity units consumed by an operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the request asked for it. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConsumedCapacity {
     #[doc="<p>The total number of capacity units consumed by the operation.</p>"]
     #[serde(rename="CapacityUnits")]
@@ -212,7 +212,7 @@ pub struct ConsumedCapacity {
 }
 
 #[doc="<p>Represents a new global secondary index to be added to an existing table.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGlobalSecondaryIndexAction {
     #[doc="<p>The name of the global secondary index to be created.</p>"]
     #[serde(rename="IndexName")]
@@ -229,7 +229,7 @@ pub struct CreateGlobalSecondaryIndexAction {
 }
 
 #[doc="<p>Represents the input of a <code>CreateTable</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTableInput {
     #[doc="<p>An array of attributes that describe the key schema for the table and indexes.</p>"]
     #[serde(rename="AttributeDefinitions")]
@@ -258,7 +258,7 @@ pub struct CreateTableInput {
 }
 
 #[doc="<p>Represents the output of a <code>CreateTable</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTableOutput {
     #[doc="<p>Represents the properties of the table.</p>"]
     #[serde(rename="TableDescription")]
@@ -267,7 +267,7 @@ pub struct CreateTableOutput {
 }
 
 #[doc="<p>Represents a global secondary index to be deleted from an existing table.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteGlobalSecondaryIndexAction {
     #[doc="<p>The name of the global secondary index to be deleted.</p>"]
     #[serde(rename="IndexName")]
@@ -275,7 +275,7 @@ pub struct DeleteGlobalSecondaryIndexAction {
 }
 
 #[doc="<p>Represents the input of a <code>DeleteItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteItemInput {
     #[doc="<p>A condition that must be satisfied in order for a conditional <code>DeleteItem</code> to succeed.</p> <p>An expression can contain any of the following:</p> <ul> <li> <p>Functions: <code>attribute_exists | attribute_not_exists | attribute_type | contains | begins_with | size</code> </p> <p>These function names are case-sensitive.</p> </li> <li> <p>Comparison operators: <code>= | &lt;&gt; | &lt; | &gt; | &lt;= | &gt;= | BETWEEN | IN </code> </p> </li> <li> <p> Logical operators: <code>AND | OR | NOT</code> </p> </li> </ul> <p>For more information on condition expressions, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Specifying Conditions</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="ConditionExpression")]
@@ -318,7 +318,7 @@ pub struct DeleteItemInput {
 }
 
 #[doc="<p>Represents the output of a <code>DeleteItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteItemOutput {
     #[doc="<p>A map of attribute names to <code>AttributeValue</code> objects, representing the item as it appeared before the <code>DeleteItem</code> operation. This map appears in the response only if <code>ReturnValues</code> was specified as <code>ALL_OLD</code> in the request.</p>"]
     #[serde(rename="Attributes")]
@@ -343,7 +343,7 @@ pub struct DeleteRequest {
 }
 
 #[doc="<p>Represents the input of a <code>DeleteTable</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTableInput {
     #[doc="<p>The name of the table to delete.</p>"]
     #[serde(rename="TableName")]
@@ -351,7 +351,7 @@ pub struct DeleteTableInput {
 }
 
 #[doc="<p>Represents the output of a <code>DeleteTable</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTableOutput {
     #[doc="<p>Represents the properties of a table.</p>"]
     #[serde(rename="TableDescription")]
@@ -360,11 +360,11 @@ pub struct DeleteTableOutput {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeLimits</code> operation. Has no content.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLimitsInput;
 
 #[doc="<p>Represents the output of a <code>DescribeLimits</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLimitsOutput {
     #[doc="<p>The maximum total read capacity units that your account allows you to provision across all of your tables in this region.</p>"]
     #[serde(rename="AccountMaxReadCapacityUnits")]
@@ -385,7 +385,7 @@ pub struct DescribeLimitsOutput {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeTable</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTableInput {
     #[doc="<p>The name of the table to describe.</p>"]
     #[serde(rename="TableName")]
@@ -393,7 +393,7 @@ pub struct DescribeTableInput {
 }
 
 #[doc="<p>Represents the output of a <code>DescribeTable</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTableOutput {
     #[doc="<p>The properties of the table.</p>"]
     #[serde(rename="Table")]
@@ -401,14 +401,14 @@ pub struct DescribeTableOutput {
     pub table: Option<TableDescription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTimeToLiveInput {
     #[doc="<p>The name of the table to be described.</p>"]
     #[serde(rename="TableName")]
     pub table_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTimeToLiveOutput {
     #[doc="<p/>"]
     #[serde(rename="TimeToLiveDescription")]
@@ -417,7 +417,7 @@ pub struct DescribeTimeToLiveOutput {
 }
 
 #[doc="<p>Represents a condition to be compared with an attribute value. This condition can be used with <code>DeleteItem</code>, <code>PutItem</code> or <code>UpdateItem</code> operations; if the comparison evaluates to true, the operation succeeds; if not, the operation fails. You can use <code>ExpectedAttributeValue</code> in one of two different ways:</p> <ul> <li> <p>Use <code>AttributeValueList</code> to specify one or more values to compare against an attribute. Use <code>ComparisonOperator</code> to specify how you want to perform the comparison. If the comparison evaluates to true, then the conditional operation succeeds.</p> </li> <li> <p>Use <code>Value</code> to specify a value that DynamoDB will compare against an attribute. If the values match, then <code>ExpectedAttributeValue</code> evaluates to true and the conditional operation succeeds. Optionally, you can also set <code>Exists</code> to false, indicating that you <i>do not</i> expect to find the attribute value in the table. In this case, the conditional operation succeeds only if the comparison evaluates to false.</p> </li> </ul> <p> <code>Value</code> and <code>Exists</code> are incompatible with <code>AttributeValueList</code> and <code>ComparisonOperator</code>. Note that if you use both sets of parameters at once, DynamoDB will return a <code>ValidationException</code> exception.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExpectedAttributeValue {
     #[doc="<p>One or more values to evaluate against the supplied attribute. The number of values in the list depends on the <code>ComparisonOperator</code> being used.</p> <p>For type Number, value comparisons are numeric.</p> <p>String value comparisons for greater than, equals, or less than are based on ASCII character code values. For example, <code>a</code> is greater than <code>A</code>, and <code>a</code> is greater than <code>B</code>. For a list of code values, see <a href=\"http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters\">http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.</p> <p>For Binary, DynamoDB treats each byte of the binary data as unsigned when it compares binary values.</p> <p>For information on specifying data types in JSON, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataFormat.html\">JSON Data Format</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="AttributeValueList")]
@@ -438,7 +438,7 @@ pub struct ExpectedAttributeValue {
 }
 
 #[doc="<p>Represents the input of a <code>GetItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetItemInput {
     #[doc="<p>This is a legacy parameter. Use <code>ProjectionExpression</code> instead. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html\">AttributesToGet</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="AttributesToGet")]
@@ -468,7 +468,7 @@ pub struct GetItemInput {
 }
 
 #[doc="<p>Represents the output of a <code>GetItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetItemOutput {
     #[doc="<p>The capacity units consumed by the <code>GetItem</code> operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="ConsumedCapacity")]
@@ -481,7 +481,7 @@ pub struct GetItemOutput {
 }
 
 #[doc="<p>Represents the properties of a global secondary index.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GlobalSecondaryIndex {
     #[doc="<p>The name of the global secondary index. The name must be unique among all other indexes on this table.</p>"]
     #[serde(rename="IndexName")]
@@ -498,7 +498,7 @@ pub struct GlobalSecondaryIndex {
 }
 
 #[doc="<p>Represents the properties of a global secondary index.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GlobalSecondaryIndexDescription {
     #[doc="<p>Indicates whether the index is currently backfilling. <i>Backfilling</i> is the process of reading items from the table and determining whether they can be added to the index. (Not all items will qualify: For example, a partition key cannot have any duplicate values.) If an item can be added to the index, DynamoDB will do so. After all items have been processed, the backfilling operation is complete and <code>Backfilling</code> is false.</p> <note> <p>For indexes that were created during a <code>CreateTable</code> operation, the <code>Backfilling</code> attribute does not appear in the <code>DescribeTable</code> output.</p> </note>"]
     #[serde(rename="Backfilling")]
@@ -539,7 +539,7 @@ pub struct GlobalSecondaryIndexDescription {
 }
 
 #[doc="<p>Represents one of the following:</p> <ul> <li> <p>A new global secondary index to be added to an existing table.</p> </li> <li> <p>New provisioned throughput parameters for an existing global secondary index.</p> </li> <li> <p>An existing global secondary index to be removed from an existing table.</p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GlobalSecondaryIndexUpdate {
     #[doc="<p>The parameters required for creating a global secondary index on an existing table:</p> <ul> <li> <p> <code>IndexName </code> </p> </li> <li> <p> <code>KeySchema </code> </p> </li> <li> <p> <code>AttributeDefinitions </code> </p> </li> <li> <p> <code>Projection </code> </p> </li> <li> <p> <code>ProvisionedThroughput </code> </p> </li> </ul>"]
     #[serde(rename="Create")]
@@ -556,7 +556,7 @@ pub struct GlobalSecondaryIndexUpdate {
 }
 
 #[doc="<p>Information about item collections, if any, that were affected by the operation. <code>ItemCollectionMetrics</code> is only returned if the request asked for it. If the table does not have any local secondary indexes, this information is not returned in the response.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ItemCollectionMetrics {
     #[doc="<p>The partition key value of the item collection. This value is the same as the partition key value of the item.</p>"]
     #[serde(rename="ItemCollectionKey")]
@@ -604,7 +604,7 @@ pub struct KeysAndAttributes {
 }
 
 #[doc="<p>Represents the input of a <code>ListTables</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTablesInput {
     #[doc="<p>The first table name that this operation will evaluate. Use the value that was returned for <code>LastEvaluatedTableName</code> in a previous operation, so that you can obtain the next page of results.</p>"]
     #[serde(rename="ExclusiveStartTableName")]
@@ -617,7 +617,7 @@ pub struct ListTablesInput {
 }
 
 #[doc="<p>Represents the output of a <code>ListTables</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTablesOutput {
     #[doc="<p>The name of the last table in the current page of results. Use this value as the <code>ExclusiveStartTableName</code> in a new request to obtain the next page of results, until all the table names are returned.</p> <p>If you do not receive a <code>LastEvaluatedTableName</code> value in the response, this means that there are no more table names to be retrieved.</p>"]
     #[serde(rename="LastEvaluatedTableName")]
@@ -629,7 +629,7 @@ pub struct ListTablesOutput {
     pub table_names: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsOfResourceInput {
     #[doc="<p>An optional string that, if supplied, must be copied from the output of a previous call to ListTagOfResource. When provided in this manner, this API fetches the next page of results.</p>"]
     #[serde(rename="NextToken")]
@@ -640,7 +640,7 @@ pub struct ListTagsOfResourceInput {
     pub resource_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsOfResourceOutput {
     #[doc="<p>If this value is returned, there are additional results to be displayed. To retrieve them, call ListTagsOfResource again, with NextToken set to this value.</p>"]
     #[serde(rename="NextToken")]
@@ -653,7 +653,7 @@ pub struct ListTagsOfResourceOutput {
 }
 
 #[doc="<p>Represents the properties of a local secondary index.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LocalSecondaryIndex {
     #[doc="<p>The name of the local secondary index. The name must be unique among all other indexes on this table.</p>"]
     #[serde(rename="IndexName")]
@@ -667,7 +667,7 @@ pub struct LocalSecondaryIndex {
 }
 
 #[doc="<p>Represents the properties of a local secondary index.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LocalSecondaryIndexDescription {
     #[doc="<p>The Amazon Resource Name (ARN) that uniquely identifies the index.</p>"]
     #[serde(rename="IndexArn")]
@@ -709,7 +709,7 @@ pub struct Projection {
 }
 
 #[doc="<p>Represents the provisioned throughput settings for a specified table or index. The settings can be modified using the <code>UpdateTable</code> operation.</p> <p>For current minimum and maximum provisioned throughput values, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Limits</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisionedThroughput {
     #[doc="<p>The maximum number of strongly consistent reads consumed per second before DynamoDB returns a <code>ThrottlingException</code>. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#ProvisionedThroughput\">Specifying Read and Write Requirements</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="ReadCapacityUnits")]
@@ -720,7 +720,7 @@ pub struct ProvisionedThroughput {
 }
 
 #[doc="<p>Represents the provisioned throughput settings for the table, consisting of read and write capacity units, along with data about increases and decreases.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisionedThroughputDescription {
     #[doc="<p>The date and time of the last provisioned throughput decrease for this table.</p>"]
     #[serde(rename="LastDecreaseDateTime")]
@@ -745,7 +745,7 @@ pub struct ProvisionedThroughputDescription {
 }
 
 #[doc="<p>Represents the input of a <code>PutItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutItemInput {
     #[doc="<p>A condition that must be satisfied in order for a conditional <code>PutItem</code> operation to succeed.</p> <p>An expression can contain any of the following:</p> <ul> <li> <p>Functions: <code>attribute_exists | attribute_not_exists | attribute_type | contains | begins_with | size</code> </p> <p>These function names are case-sensitive.</p> </li> <li> <p>Comparison operators: <code>= | &lt;&gt; | &lt; | &gt; | &lt;= | &gt;= | BETWEEN | IN </code> </p> </li> <li> <p> Logical operators: <code>AND | OR | NOT</code> </p> </li> </ul> <p>For more information on condition expressions, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Specifying Conditions</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="ConditionExpression")]
@@ -788,7 +788,7 @@ pub struct PutItemInput {
 }
 
 #[doc="<p>Represents the output of a <code>PutItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutItemOutput {
     #[doc="<p>The attribute values as they appeared before the <code>PutItem</code> operation, but only if <code>ReturnValues</code> is specified as <code>ALL_OLD</code> in the request. Each element consists of an attribute name and an attribute value.</p>"]
     #[serde(rename="Attributes")]
@@ -813,7 +813,7 @@ pub struct PutRequest {
 }
 
 #[doc="<p>Represents the input of a <code>Query</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct QueryInput {
     #[doc="<p>This is a legacy parameter. Use <code>ProjectionExpression</code> instead. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html\">AttributesToGet</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="AttributesToGet")]
@@ -885,7 +885,7 @@ pub struct QueryInput {
 }
 
 #[doc="<p>Represents the output of a <code>Query</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct QueryOutput {
     #[doc="<p>The capacity units consumed by the <code>Query</code> operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the <code>ReturnConsumedCapacity</code> parameter was specified For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="ConsumedCapacity")]
@@ -910,7 +910,7 @@ pub struct QueryOutput {
 }
 
 #[doc="<p>Represents the input of a <code>Scan</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScanInput {
     #[doc="<p>This is a legacy parameter. Use <code>ProjectionExpression</code> instead. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html\">AttributesToGet</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="AttributesToGet")]
@@ -978,7 +978,7 @@ pub struct ScanInput {
 }
 
 #[doc="<p>Represents the output of a <code>Scan</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScanOutput {
     #[doc="<p>The capacity units consumed by the <code>Scan</code> operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="ConsumedCapacity")]
@@ -1016,7 +1016,7 @@ pub struct StreamSpecification {
 }
 
 #[doc="<p>Represents the properties of a table.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TableDescription {
     #[doc="<p>An array of <code>AttributeDefinition</code> objects. Each of these objects describes one attribute in the table and index key schema.</p> <p>Each <code>AttributeDefinition</code> object in this array is composed of:</p> <ul> <li> <p> <code>AttributeName</code> - The name of the attribute.</p> </li> <li> <p> <code>AttributeType</code> - The data type for the attribute.</p> </li> </ul>"]
     #[serde(rename="AttributeDefinitions")]
@@ -1087,7 +1087,7 @@ pub struct Tag {
     pub value: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceInput {
     #[doc="<p>Identifies the Amazon DynamoDB resource to which tags should be added. This value is an Amazon Resource Name (ARN).</p>"]
     #[serde(rename="ResourceArn")]
@@ -1098,7 +1098,7 @@ pub struct TagResourceInput {
 }
 
 #[doc="<p>The description of the Time to Live (TTL) status on the specified table. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TimeToLiveDescription {
     #[doc="<p> The name of the Time to Live attribute for items in the table.</p>"]
     #[serde(rename="AttributeName")]
@@ -1121,7 +1121,7 @@ pub struct TimeToLiveSpecification {
     pub enabled: bool,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceInput {
     #[doc="<p>The Amazon DyanamoDB resource the tags will be removed from. This value is an Amazon Resource Name (ARN).</p>"]
     #[serde(rename="ResourceArn")]
@@ -1132,7 +1132,7 @@ pub struct UntagResourceInput {
 }
 
 #[doc="<p>Represents the new provisioned throughput settings to be applied to a global secondary index.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGlobalSecondaryIndexAction {
     #[doc="<p>The name of the global secondary index to be updated.</p>"]
     #[serde(rename="IndexName")]
@@ -1143,7 +1143,7 @@ pub struct UpdateGlobalSecondaryIndexAction {
 }
 
 #[doc="<p>Represents the input of an <code>UpdateItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateItemInput {
     #[doc="<p>This is a legacy parameter. Use <code>UpdateExpression</code> instead. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributeUpdates.html\">AttributeUpdates</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"]
     #[serde(rename="AttributeUpdates")]
@@ -1194,7 +1194,7 @@ pub struct UpdateItemInput {
 }
 
 #[doc="<p>Represents the output of an <code>UpdateItem</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateItemOutput {
     #[doc="<p>A map of attribute values as they appear before or after the <code>UpdateItem</code> operation, as determined by the <code>ReturnValues</code> parameter.</p> <p>The <code>Attributes</code> map is only present if <code>ReturnValues</code> was specified as something other than <code>NONE</code> in the request. Each element represents one attribute.</p>"]
     #[serde(rename="Attributes")]
@@ -1211,7 +1211,7 @@ pub struct UpdateItemOutput {
 }
 
 #[doc="<p>Represents the input of an <code>UpdateTable</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTableInput {
     #[doc="<p>An array of attributes that describe the key schema for the table and indexes. If you are adding a new global secondary index to the table, <code>AttributeDefinitions</code> must include the key element(s) of the new index.</p>"]
     #[serde(rename="AttributeDefinitions")]
@@ -1235,7 +1235,7 @@ pub struct UpdateTableInput {
 }
 
 #[doc="<p>Represents the output of an <code>UpdateTable</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTableOutput {
     #[doc="<p>Represents the properties of the table.</p>"]
     #[serde(rename="TableDescription")]
@@ -1244,7 +1244,7 @@ pub struct UpdateTableOutput {
 }
 
 #[doc="<p>Represents the input of an <code>UpdateTimeToLive</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTimeToLiveInput {
     #[doc="<p>The name of the table to be configured.</p>"]
     #[serde(rename="TableName")]
@@ -1254,7 +1254,7 @@ pub struct UpdateTimeToLiveInput {
     pub time_to_live_specification: TimeToLiveSpecification,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTimeToLiveOutput {
     #[doc="<p>Represents the output of an <code>UpdateTimeToLive</code> operation.</p>"]
     #[serde(rename="TimeToLiveSpecification")]

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Represents the data for an attribute. You can set one, and only one, of the elements.</p> <p>Each attribute in an item is a name-value pair. An attribute can be single-valued or multi-valued set. For example, a book item can have title and authors attributes. Each book has one title but can have many authors. The multi-valued attribute is a set; duplicate values are not allowed.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttributeValue {
     #[doc="<p>A Binary data type.</p>"]
     #[serde(rename="B")]
@@ -78,7 +78,7 @@ pub struct AttributeValue {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeStream</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStreamInput {
     #[doc="<p>The shard ID of the first item that this operation will evaluate. Use the value that was returned for <code>LastEvaluatedShardId</code> in the previous operation. </p>"]
     #[serde(rename="ExclusiveStartShardId")]
@@ -94,7 +94,7 @@ pub struct DescribeStreamInput {
 }
 
 #[doc="<p>Represents the output of a <code>DescribeStream</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStreamOutput {
     #[doc="<p>A complete description of the stream, including its creation date and time, the DynamoDB table associated with the stream, the shard IDs within the stream, and the beginning and ending sequence numbers of stream records within the shards.</p>"]
     #[serde(rename="StreamDescription")]
@@ -103,7 +103,7 @@ pub struct DescribeStreamOutput {
 }
 
 #[doc="<p>Represents the input of a <code>GetRecords</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRecordsInput {
     #[doc="<p>The maximum number of records to return from the shard. The upper limit is 1000.</p>"]
     #[serde(rename="Limit")]
@@ -115,7 +115,7 @@ pub struct GetRecordsInput {
 }
 
 #[doc="<p>Represents the output of a <code>GetRecords</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRecordsOutput {
     #[doc="<p>The next position in the shard from which to start sequentially reading stream records. If set to <code>null</code>, the shard has been closed and the requested iterator will not return any more data.</p>"]
     #[serde(rename="NextShardIterator")]
@@ -128,7 +128,7 @@ pub struct GetRecordsOutput {
 }
 
 #[doc="<p>Represents the input of a <code>GetShardIterator</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetShardIteratorInput {
     #[doc="<p>The sequence number of a stream record in the shard from which to start reading.</p>"]
     #[serde(rename="SequenceNumber")]
@@ -146,7 +146,7 @@ pub struct GetShardIteratorInput {
 }
 
 #[doc="<p>Represents the output of a <code>GetShardIterator</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetShardIteratorOutput {
     #[doc="<p>The position in the shard from which to start reading stream records sequentially. A shard iterator specifies this position using the sequence number of a stream record in a shard.</p>"]
     #[serde(rename="ShardIterator")]
@@ -155,7 +155,7 @@ pub struct GetShardIteratorOutput {
 }
 
 #[doc="<p>Contains details about the type of identity that made the request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Identity {
     #[doc="<p>A unique identifier for the entity that made the call. For Time To Live, the principalId is \"dynamodb.amazonaws.com\".</p>"]
     #[serde(rename="PrincipalId")]
@@ -168,7 +168,7 @@ pub struct Identity {
 }
 
 #[doc="<p>Represents <i>a single element</i> of a key schema. A key schema specifies the attributes that make up the primary key of a table, or the key attributes of an index.</p> <p>A <code>KeySchemaElement</code> represents exactly one attribute of the primary key. For example, a simple primary key (partition key) would be represented by one <code>KeySchemaElement</code>. A composite primary key (partition key and sort key) would require one <code>KeySchemaElement</code> for the partition key, and another <code>KeySchemaElement</code> for the sort key.</p> <note> <p>The partition key of an item is also known as its <i>hash attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values.</p> <p>The sort key of an item is also known as its <i>range attribute</i>. The term \"range attribute\" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.</p> </note>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KeySchemaElement {
     #[doc="<p>The name of a key attribute.</p>"]
     #[serde(rename="AttributeName")]
@@ -179,7 +179,7 @@ pub struct KeySchemaElement {
 }
 
 #[doc="<p>Represents the input of a <code>ListStreams</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStreamsInput {
     #[doc="<p>The ARN (Amazon Resource Name) of the first item that this operation will evaluate. Use the value that was returned for <code>LastEvaluatedStreamArn</code> in the previous operation. </p>"]
     #[serde(rename="ExclusiveStartStreamArn")]
@@ -196,7 +196,7 @@ pub struct ListStreamsInput {
 }
 
 #[doc="<p>Represents the output of a <code>ListStreams</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStreamsOutput {
     #[doc="<p>The stream ARN of the item where the operation stopped, inclusive of the previous result set. Use this value to start a new operation, excluding this value in the new request.</p> <p>If <code>LastEvaluatedStreamArn</code> is empty, then the \"last page\" of results has been processed and there is no more data to be retrieved.</p> <p>If <code>LastEvaluatedStreamArn</code> is not empty, it does not necessarily mean that there is more data in the result set. The only way to know when you have reached the end of the result set is when <code>LastEvaluatedStreamArn</code> is empty.</p>"]
     #[serde(rename="LastEvaluatedStreamArn")]
@@ -209,7 +209,7 @@ pub struct ListStreamsOutput {
 }
 
 #[doc="<p>A description of a unique event within a stream.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Record {
     #[doc="<p>The region in which the <code>GetRecords</code> request was received.</p>"]
     #[serde(rename="awsRegion")]
@@ -242,7 +242,7 @@ pub struct Record {
 }
 
 #[doc="<p>The beginning and ending sequence numbers for the stream records contained within a shard.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SequenceNumberRange {
     #[doc="<p>The last sequence number.</p>"]
     #[serde(rename="EndingSequenceNumber")]
@@ -255,7 +255,7 @@ pub struct SequenceNumberRange {
 }
 
 #[doc="<p>A uniquely identified group of stream records within a stream.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Shard {
     #[doc="<p>The shard ID of the current shard's parent.</p>"]
     #[serde(rename="ParentShardId")]
@@ -272,7 +272,7 @@ pub struct Shard {
 }
 
 #[doc="<p>Represents all of the data describing a particular stream.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Stream {
     #[doc="<p>The Amazon Resource Name (ARN) for the stream.</p>"]
     #[serde(rename="StreamArn")]
@@ -289,7 +289,7 @@ pub struct Stream {
 }
 
 #[doc="<p>Represents all of the data describing a particular stream.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StreamDescription {
     #[doc="<p>The date and time when the request to create this stream was issued.</p>"]
     #[serde(rename="CreationRequestDateTime")]
@@ -330,7 +330,7 @@ pub struct StreamDescription {
 }
 
 #[doc="<p>A description of a single data modification that was performed on an item in a DynamoDB table.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StreamRecord {
     #[doc="<p>The approximate date and time when the stream record was created, in <a href=\"http://www.epochconverter.com/\">UNIX epoch time</a> format.</p>"]
     #[serde(rename="ApproximateCreationDateTime")]

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -40,13 +40,18 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>Contains the parameters for accepting the quote.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptReservedInstancesExchangeQuoteRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The IDs of the Convertible Reserved Instances to exchange for other Convertible Reserved Instances of the same or higher value.</p>"]
+    #[serde(rename="ReservedInstanceIds")]
     pub reserved_instance_ids: Vec<String>,
     #[doc="<p>The configurations of the Convertible Reserved Instance offerings that you are purchasing in this exchange.</p>"]
+    #[serde(rename="TargetConfigurations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_configurations: Option<Vec<TargetConfigurationRequest>>,
 }
 
@@ -81,9 +86,11 @@ impl AcceptReservedInstancesExchangeQuoteRequestSerializer {
 }
 
 #[doc="<p>The result of the exchange and whether it was <code>successful</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptReservedInstancesExchangeQuoteResult {
     #[doc="<p>The ID of the successful exchange.</p>"]
+    #[serde(rename="ExchangeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub exchange_id: Option<String>,
 }
 
@@ -131,11 +138,15 @@ impl AcceptReservedInstancesExchangeQuoteResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AcceptVpcPeeringConnection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptVpcPeeringConnectionRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC peering connection.</p>"]
+    #[serde(rename="VpcPeeringConnectionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_peering_connection_id: Option<String>,
 }
 
@@ -162,9 +173,11 @@ impl AcceptVpcPeeringConnectionRequestSerializer {
 }
 
 #[doc="<p>Contains the output of AcceptVpcPeeringConnection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptVpcPeeringConnectionResult {
     #[doc="<p>Information about the VPC peering connection.</p>"]
+    #[serde(rename="VpcPeeringConnection")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_peering_connection: Option<VpcPeeringConnection>,
 }
 
@@ -213,11 +226,15 @@ impl AcceptVpcPeeringConnectionResultDeserializer {
     }
 }
 #[doc="<p>Describes an account attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountAttribute {
     #[doc="<p>The name of the account attribute.</p>"]
+    #[serde(rename="AttributeName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_name: Option<String>,
     #[doc="<p>One or more values for the account attribute.</p>"]
+    #[serde(rename="AttributeValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_values: Option<Vec<AccountAttributeValue>>,
 }
 
@@ -320,9 +337,11 @@ impl AccountAttributeNameStringListSerializer {
 }
 
 #[doc="<p>Describes a value of an account attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountAttributeValue {
     #[doc="<p>The value of the attribute.</p>"]
+    #[serde(rename="AttributeValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_value: Option<String>,
 }
 
@@ -412,15 +431,23 @@ impl AccountAttributeValueListDeserializer {
     }
 }
 #[doc="<p>Describes a running instance in a Spot fleet.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActiveInstance {
     #[doc="<p>The health status of the instance. If the status of either the instance status check or the system status check is <code>impaired</code>, the health status of the instance is <code>unhealthy</code>. Otherwise, the health status is <code>healthy</code>.</p>"]
+    #[serde(rename="InstanceHealth")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_health: Option<String>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The instance type.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The ID of the Spot instance request.</p>"]
+    #[serde(rename="SpotInstanceRequestId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_instance_request_id: Option<String>,
 }
 
@@ -536,23 +563,39 @@ impl ActivityStatusDeserializer {
     }
 }
 #[doc="<p>Describes an Elastic IP address.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Address {
     #[doc="<p>The ID representing the allocation of the address for use with EC2-VPC.</p>"]
+    #[serde(rename="AllocationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocation_id: Option<String>,
     #[doc="<p>The ID representing the association of the address with an instance in a VPC.</p>"]
+    #[serde(rename="AssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association_id: Option<String>,
     #[doc="<p>Indicates whether this Elastic IP address is for use with instances in EC2-Classic (<code>standard</code>) or instances in a VPC (<code>vpc</code>).</p>"]
+    #[serde(rename="Domain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain: Option<String>,
     #[doc="<p>The ID of the instance that the address is associated with (if any).</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>The ID of the AWS account that owns the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_owner_id: Option<String>,
     #[doc="<p>The private IP address associated with the Elastic IP address.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
     #[doc="<p>The Elastic IP address.</p>"]
+    #[serde(rename="PublicIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip: Option<String>,
 }
 
@@ -671,13 +714,19 @@ impl AddressListDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AllocateAddress.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AllocateAddressRequest {
     #[doc="<p>[EC2-VPC] The Elastic IP address to recover.</p>"]
+    #[serde(rename="Address")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub address: Option<String>,
     #[doc="<p>Set to <code>vpc</code> to allocate the address for use with instances in a VPC.</p> <p>Default: The address is for use with instances in EC2-Classic.</p>"]
+    #[serde(rename="Domain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -708,13 +757,19 @@ impl AllocateAddressRequestSerializer {
 }
 
 #[doc="<p>Contains the output of AllocateAddress.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AllocateAddressResult {
     #[doc="<p>[EC2-VPC] The ID that AWS assigns to represent the allocation of the Elastic IP address for use with instances in a VPC.</p>"]
+    #[serde(rename="AllocationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocation_id: Option<String>,
     #[doc="<p>Indicates whether this Elastic IP address is for use with instances in EC2-Classic (<code>standard</code>) or instances in a VPC (<code>vpc</code>).</p>"]
+    #[serde(rename="Domain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain: Option<String>,
     #[doc="<p>The Elastic IP address.</p>"]
+    #[serde(rename="PublicIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip: Option<String>,
 }
 
@@ -769,17 +824,24 @@ impl AllocateAddressResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AllocateHosts.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AllocateHostsRequest {
     #[doc="<p>This is enabled by default. This property allows instances to be automatically placed onto available Dedicated Hosts, when you are launching instances without specifying a host ID.</p> <p>Default: Enabled</p>"]
+    #[serde(rename="AutoPlacement")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_placement: Option<String>,
     #[doc="<p>The Availability Zone for the Dedicated Hosts.</p>"]
+    #[serde(rename="AvailabilityZone")]
     pub availability_zone: String,
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html\">How to Ensure Idempotency</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>. </p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>Specify the instance type that you want your Dedicated Hosts to be configured for. When you specify the instance type, that is the only instance type that you can launch onto that host.</p>"]
+    #[serde(rename="InstanceType")]
     pub instance_type: String,
     #[doc="<p>The number of Dedicated Hosts you want to allocate to your account with these parameters.</p>"]
+    #[serde(rename="Quantity")]
     pub quantity: i64,
 }
 
@@ -812,9 +874,11 @@ impl AllocateHostsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of AllocateHosts.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AllocateHostsResult {
     #[doc="<p>The ID of the allocated Dedicated Host. This is used when you want to launch an instance onto a specific host.</p>"]
+    #[serde(rename="HostIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_ids: Option<Vec<String>>,
 }
 
@@ -915,13 +979,18 @@ impl ArchitectureValuesDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssignIpv6AddressesRequest {
     #[doc="<p>The number of IPv6 addresses to assign to the network interface. Amazon EC2 automatically selects the IPv6 addresses from the subnet range. You can't use this option if specifying specific IPv6 addresses.</p>"]
+    #[serde(rename="Ipv6AddressCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_address_count: Option<i64>,
     #[doc="<p>One or more specific IPv6 addresses to be assigned to the network interface. You can't use this option if you're specifying a number of IPv6 addresses.</p>"]
+    #[serde(rename="Ipv6Addresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_addresses: Option<Vec<String>>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
     pub network_interface_id: String,
 }
 
@@ -950,11 +1019,15 @@ impl AssignIpv6AddressesRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssignIpv6AddressesResult {
     #[doc="<p>The IPv6 addresses assigned to the network interface.</p>"]
+    #[serde(rename="AssignedIpv6Addresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub assigned_ipv_6_addresses: Option<Vec<String>>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
 }
 
@@ -1007,15 +1080,22 @@ impl AssignIpv6AddressesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AssignPrivateIpAddresses.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssignPrivateIpAddressesRequest {
     #[doc="<p>Indicates whether to allow an IP address that is already assigned to another network interface or instance to be reassigned to the specified network interface.</p>"]
+    #[serde(rename="AllowReassignment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_reassignment: Option<bool>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
     pub network_interface_id: String,
     #[doc="<p>One or more IP addresses to be assigned as a secondary private IP address to the network interface. You can't specify this parameter when also specifying a number of secondary IP addresses.</p> <p>If you don't specify an IP address, Amazon EC2 automatically selects an IP address within the subnet range.</p>"]
+    #[serde(rename="PrivateIpAddresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_addresses: Option<Vec<String>>,
     #[doc="<p>The number of secondary IP addresses to assign to the network interface. You can't specify this parameter when also specifying private IP addresses.</p>"]
+    #[serde(rename="SecondaryPrivateIpAddressCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub secondary_private_ip_address_count: Option<i64>,
 }
 
@@ -1051,21 +1131,35 @@ impl AssignPrivateIpAddressesRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for AssociateAddress.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateAddressRequest {
     #[doc="<p>[EC2-VPC] The allocation ID. This is required for EC2-VPC.</p>"]
+    #[serde(rename="AllocationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocation_id: Option<String>,
     #[doc="<p>[EC2-VPC] For a VPC in an EC2-Classic account, specify true to allow an Elastic IP address that is already associated with an instance or network interface to be reassociated with the specified instance or network interface. Otherwise, the operation fails. In a VPC in an EC2-VPC-only account, reassociation is automatic, therefore you can specify false to ensure the operation fails if the Elastic IP address is already associated with another resource.</p>"]
+    #[serde(rename="AllowReassociation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_reassociation: Option<bool>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the instance. This is required for EC2-Classic. For EC2-VPC, you can specify either the instance ID or the network interface ID, but not both. The operation fails if you specify an instance ID unless exactly one network interface is attached.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>[EC2-VPC] The ID of the network interface. If the instance has more than one network interface, you must specify a network interface ID.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>[EC2-VPC] The primary or secondary private IP address to associate with the Elastic IP address. If no private IP address is specified, the Elastic IP address is associated with the primary private IP address.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
     #[doc="<p>The Elastic IP address. This is required for EC2-Classic.</p>"]
+    #[serde(rename="PublicIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip: Option<String>,
 }
 
@@ -1112,9 +1206,11 @@ impl AssociateAddressRequestSerializer {
 }
 
 #[doc="<p>Contains the output of AssociateAddress.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateAddressResult {
     #[doc="<p>[EC2-VPC] The ID that represents the association of the Elastic IP address with an instance.</p>"]
+    #[serde(rename="AssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association_id: Option<String>,
 }
 
@@ -1161,13 +1257,17 @@ impl AssociateAddressResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AssociateDhcpOptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateDhcpOptionsRequest {
     #[doc="<p>The ID of the DHCP options set, or <code>default</code> to associate no DHCP options with the VPC.</p>"]
+    #[serde(rename="DhcpOptionsId")]
     pub dhcp_options_id: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -1193,11 +1293,13 @@ impl AssociateDhcpOptionsRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateIamInstanceProfileRequest {
     #[doc="<p>The IAM instance profile.</p>"]
+    #[serde(rename="IamInstanceProfile")]
     pub iam_instance_profile: IamInstanceProfileSpecification,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
 }
 
@@ -1222,9 +1324,11 @@ impl AssociateIamInstanceProfileRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateIamInstanceProfileResult {
     #[doc="<p>Information about the IAM instance profile association.</p>"]
+    #[serde(rename="IamInstanceProfileAssociation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile_association: Option<IamInstanceProfileAssociation>,
 }
 
@@ -1271,13 +1375,17 @@ impl AssociateIamInstanceProfileResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AssociateRouteTable.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateRouteTableRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the route table.</p>"]
+    #[serde(rename="RouteTableId")]
     pub route_table_id: String,
     #[doc="<p>The ID of the subnet.</p>"]
+    #[serde(rename="SubnetId")]
     pub subnet_id: String,
 }
 
@@ -1304,9 +1412,11 @@ impl AssociateRouteTableRequestSerializer {
 }
 
 #[doc="<p>Contains the output of AssociateRouteTable.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateRouteTableResult {
     #[doc="<p>The route table association ID (needed to disassociate the route table).</p>"]
+    #[serde(rename="AssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association_id: Option<String>,
 }
 
@@ -1352,11 +1462,13 @@ impl AssociateRouteTableResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateSubnetCidrBlockRequest {
     #[doc="<p>The IPv6 CIDR block for your subnet. The subnet must have a /64 prefix length.</p>"]
+    #[serde(rename="Ipv6CidrBlock")]
     pub ipv_6_cidr_block: String,
     #[doc="<p>The ID of your subnet.</p>"]
+    #[serde(rename="SubnetId")]
     pub subnet_id: String,
 }
 
@@ -1378,11 +1490,15 @@ impl AssociateSubnetCidrBlockRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateSubnetCidrBlockResult {
     #[doc="<p>Information about the IPv6 CIDR block association.</p>"]
+    #[serde(rename="Ipv6CidrBlockAssociation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block_association: Option<SubnetIpv6CidrBlockAssociation>,
     #[doc="<p>The ID of the subnet.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
 }
 
@@ -1431,11 +1547,14 @@ impl AssociateSubnetCidrBlockResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateVpcCidrBlockRequest {
     #[doc="<p>Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IPv6 addresses, or the size of the CIDR block.</p>"]
+    #[serde(rename="AmazonProvidedIpv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub amazon_provided_ipv_6_cidr_block: Option<bool>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -1459,11 +1578,15 @@ impl AssociateVpcCidrBlockRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateVpcCidrBlockResult {
     #[doc="<p>Information about the IPv6 CIDR block association.</p>"]
+    #[serde(rename="Ipv6CidrBlockAssociation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block_association: Option<VpcIpv6CidrBlockAssociation>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -1525,15 +1648,20 @@ impl AssociationIdListSerializer {
 }
 
 #[doc="<p>Contains the parameters for AttachClassicLinkVpc.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachClassicLinkVpcRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of one or more of the VPC's security groups. You cannot specify security groups from a different VPC.</p>"]
+    #[serde(rename="Groups")]
     pub groups: Vec<String>,
     #[doc="<p>The ID of an EC2-Classic instance to link to the ClassicLink-enabled VPC.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>The ID of a ClassicLink-enabled VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -1563,9 +1691,11 @@ impl AttachClassicLinkVpcRequestSerializer {
 }
 
 #[doc="<p>Contains the output of AttachClassicLinkVpc.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachClassicLinkVpcResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -1612,13 +1742,17 @@ impl AttachClassicLinkVpcResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AttachInternetGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachInternetGatewayRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the Internet gateway.</p>"]
+    #[serde(rename="InternetGatewayId")]
     pub internet_gateway_id: String,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -1645,15 +1779,20 @@ impl AttachInternetGatewayRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for AttachNetworkInterface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachNetworkInterfaceRequest {
     #[doc="<p>The index of the device for the network interface attachment.</p>"]
+    #[serde(rename="DeviceIndex")]
     pub device_index: i64,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
     pub network_interface_id: String,
 }
 
@@ -1682,9 +1821,11 @@ impl AttachNetworkInterfaceRequestSerializer {
 }
 
 #[doc="<p>Contains the output of AttachNetworkInterface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachNetworkInterfaceResult {
     #[doc="<p>The ID of the network interface attachment.</p>"]
+    #[serde(rename="AttachmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachment_id: Option<String>,
 }
 
@@ -1731,15 +1872,20 @@ impl AttachNetworkInterfaceResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AttachVolume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachVolumeRequest {
     #[doc="<p>The device name to expose to the instance (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>"]
+    #[serde(rename="Device")]
     pub device: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>The ID of the EBS volume. The volume and instance must be within the same Availability Zone.</p>"]
+    #[serde(rename="VolumeId")]
     pub volume_id: String,
 }
 
@@ -1768,13 +1914,17 @@ impl AttachVolumeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for AttachVpnGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachVpnGatewayRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
     #[doc="<p>The ID of the virtual private gateway.</p>"]
+    #[serde(rename="VpnGatewayId")]
     pub vpn_gateway_id: String,
 }
 
@@ -1801,9 +1951,11 @@ impl AttachVpnGatewayRequestSerializer {
 }
 
 #[doc="<p>Contains the output of AttachVpnGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachVpnGatewayResult {
     #[doc="<p>Information about the attachment.</p>"]
+    #[serde(rename="VpcAttachment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_attachment: Option<VpcAttachment>,
 }
 
@@ -1865,9 +2017,11 @@ impl AttachmentStatusDeserializer {
     }
 }
 #[doc="<p>Describes a value for a resource attribute that is a Boolean value.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttributeBooleanValue {
     #[doc="<p>The attribute value. The valid values are <code>true</code> or <code>false</code>.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<bool>,
 }
 
@@ -1932,9 +2086,11 @@ impl AttributeBooleanValueSerializer {
 }
 
 #[doc="<p>Describes a value for a resource attribute that is a String.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttributeValue {
     #[doc="<p>The attribute value. Note that the value is case-sensitive.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -1998,25 +2154,42 @@ impl AttributeValueSerializer {
 }
 
 #[doc="<p>Contains the parameters for AuthorizeSecurityGroupEgress.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthorizeSecurityGroupEgressRequest {
     #[doc="<p>The CIDR IPv4 address range. We recommend that you specify the CIDR range in a set of IP permissions instead.</p>"]
+    #[serde(rename="CidrIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_ip: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The start of port range for the TCP and UDP protocols, or an ICMP type number. We recommend that you specify the port range in a set of IP permissions instead.</p>"]
+    #[serde(rename="FromPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub from_port: Option<i64>,
     #[doc="<p>The ID of the security group.</p>"]
+    #[serde(rename="GroupId")]
     pub group_id: String,
     #[doc="<p>A set of IP permissions. You can't specify a destination security group and a CIDR IP address range.</p>"]
+    #[serde(rename="IpPermissions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_permissions: Option<Vec<IpPermission>>,
     #[doc="<p>The IP protocol name or number. We recommend that you specify the protocol in a set of IP permissions instead.</p>"]
+    #[serde(rename="IpProtocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_protocol: Option<String>,
     #[doc="<p>The name of a destination security group. To authorize outbound access to a destination security group, we recommend that you use a set of IP permissions instead.</p>"]
+    #[serde(rename="SourceSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_security_group_name: Option<String>,
     #[doc="<p>The AWS account number for a destination security group. To authorize outbound access to a destination security group, we recommend that you use a set of IP permissions instead.</p>"]
+    #[serde(rename="SourceSecurityGroupOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_security_group_owner_id: Option<String>,
     #[doc="<p>The end of port range for the TCP and UDP protocols, or an ICMP type number. We recommend that you specify the port range in a set of IP permissions instead.</p>"]
+    #[serde(rename="ToPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub to_port: Option<i64>,
 }
 
@@ -2070,27 +2243,47 @@ impl AuthorizeSecurityGroupEgressRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for AuthorizeSecurityGroupIngress.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthorizeSecurityGroupIngressRequest {
     #[doc="<p>The CIDR IPv4 address range. You can't specify this parameter when specifying a source security group.</p>"]
+    #[serde(rename="CidrIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_ip: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type number. For the ICMP/ICMPv6 type number, use <code>-1</code> to specify all types.</p>"]
+    #[serde(rename="FromPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub from_port: Option<i64>,
     #[doc="<p>The ID of the security group. Required for a nondefault VPC.</p>"]
+    #[serde(rename="GroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_id: Option<String>,
     #[doc="<p>[EC2-Classic, default VPC] The name of the security group.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>A set of IP permissions. Can be used to specify multiple rules in a single command.</p>"]
+    #[serde(rename="IpPermissions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_permissions: Option<Vec<IpPermission>>,
     #[doc="<p>The IP protocol name (<code>tcp</code>, <code>udp</code>, <code>icmp</code>) or number (see <a href=\"http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml\">Protocol Numbers</a>). (VPC only) Use <code>-1</code> to specify all protocols. If you specify <code>-1</code>, or a protocol number other than <code>tcp</code>, <code>udp</code>, <code>icmp</code>, or <code>58</code> (ICMPv6), traffic on all ports is allowed, regardless of any ports you specify. For <code>tcp</code>, <code>udp</code>, and <code>icmp</code>, you must specify a port range. For protocol <code>58</code> (ICMPv6), you can optionally specify a port range; if you don't, traffic for all types and codes is allowed.</p>"]
+    #[serde(rename="IpProtocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_protocol: Option<String>,
     #[doc="<p>[EC2-Classic, default VPC] The name of the source security group. You can't specify this parameter in combination with the following parameters: the CIDR IP address range, the start of the port range, the IP protocol, and the end of the port range. Creates rules that grant full ICMP, UDP, and TCP access. To create a rule with a specific IP protocol and port range, use a set of IP permissions instead. For EC2-VPC, the source security group must be in the same VPC.</p>"]
+    #[serde(rename="SourceSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_security_group_name: Option<String>,
     #[doc="<p>[EC2-Classic] The AWS account number for the source security group, if the source security group is in a different account. You can't specify this parameter in combination with the following parameters: the CIDR IP address range, the IP protocol, the start of the port range, and the end of the port range. Creates rules that grant full ICMP, UDP, and TCP access. To create a rule with a specific IP protocol and port range, use a set of IP permissions instead.</p>"]
+    #[serde(rename="SourceSecurityGroupOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_security_group_owner_id: Option<String>,
     #[doc="<p>The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code number. For the ICMP/ICMPv6 code number, use <code>-1</code> to specify all codes.</p>"]
+    #[serde(rename="ToPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub to_port: Option<i64>,
 }
 
@@ -2164,15 +2357,23 @@ impl AutoPlacementDeserializer {
     }
 }
 #[doc="<p>Describes an Availability Zone.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AvailabilityZone {
     #[doc="<p>Any messages about the Availability Zone.</p>"]
+    #[serde(rename="Messages")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub messages: Option<Vec<AvailabilityZoneMessage>>,
     #[doc="<p>The name of the region.</p>"]
+    #[serde(rename="RegionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub region_name: Option<String>,
     #[doc="<p>The state of the Availability Zone.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The name of the Availability Zone.</p>"]
+    #[serde(rename="ZoneName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub zone_name: Option<String>,
 }
 
@@ -2272,9 +2473,11 @@ impl AvailabilityZoneListDeserializer {
     }
 }
 #[doc="<p>Describes a message about an Availability Zone.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AvailabilityZoneMessage {
     #[doc="<p>The message about the Availability Zone.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
 }
 
@@ -2377,11 +2580,15 @@ impl AvailabilityZoneStateDeserializer {
     }
 }
 #[doc="<p>The capacity information for instances launched onto the Dedicated Host.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AvailableCapacity {
     #[doc="<p>The total number of instances that the Dedicated Host supports.</p>"]
+    #[serde(rename="AvailableInstanceCapacity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub available_instance_capacity: Option<Vec<InstanceCapacity>>,
     #[doc="<p>The number of vCPUs available on the Dedicated Host.</p>"]
+    #[serde(rename="AvailableVCpus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub available_v_cpus: Option<i64>,
 }
 
@@ -2512,8 +2719,14 @@ impl BlobDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BlobAttributeValue {
+    #[serde(rename="Value")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub value: Option<Vec<u8>>,
 }
 
@@ -2538,15 +2751,23 @@ impl BlobAttributeValueSerializer {
 }
 
 #[doc="<p>Describes a block device mapping.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BlockDeviceMapping {
     #[doc="<p>The device name exposed to the instance (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>"]
+    #[serde(rename="DeviceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device_name: Option<String>,
     #[doc="<p>Parameters used to automatically set up EBS volumes when the instance is launched.</p>"]
+    #[serde(rename="Ebs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs: Option<EbsBlockDevice>,
     #[doc="<p>Suppresses the specified device included in the block device mapping of the AMI.</p>"]
+    #[serde(rename="NoDevice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub no_device: Option<String>,
     #[doc="<p>The virtual device name (<code>ephemeral</code>N). Instance store volumes are numbered starting from 0. An instance type with 2 available instance store volumes can specify mappings for <code>ephemeral0</code> and <code>ephemeral1</code>.The number of available instance store volumes depends on the instance type. After you connect to the instance, you must mount the volume.</p> <p>Constraints: For M3 instances, you must specify instance store volumes in the block device mapping for the instance. When you launch an M3 instance, we ignore any instance store volumes specified in the block device mapping for the AMI.</p>"]
+    #[serde(rename="VirtualName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub virtual_name: Option<String>,
 }
 
@@ -2727,13 +2948,17 @@ impl BundleIdStringListSerializer {
 }
 
 #[doc="<p>Contains the parameters for BundleInstance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BundleInstanceRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the instance to bundle.</p> <p>Type: String</p> <p>Default: None</p> <p>Required: Yes</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>The bucket in which to store the AMI. You can specify a bucket that you already own or a new bucket that Amazon EC2 creates on your behalf. If you specify a bucket that belongs to someone else, Amazon EC2 returns an error.</p>"]
+    #[serde(rename="Storage")]
     pub storage: Storage,
 }
 
@@ -2759,9 +2984,11 @@ impl BundleInstanceRequestSerializer {
 }
 
 #[doc="<p>Contains the output of BundleInstance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BundleInstanceResult {
     #[doc="<p>Information about the bundle task.</p>"]
+    #[serde(rename="BundleTask")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bundle_task: Option<BundleTask>,
 }
 
@@ -2809,23 +3036,39 @@ impl BundleInstanceResultDeserializer {
     }
 }
 #[doc="<p>Describes a bundle task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BundleTask {
     #[doc="<p>The ID of the bundle task.</p>"]
+    #[serde(rename="BundleId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bundle_id: Option<String>,
     #[doc="<p>If the task fails, a description of the error.</p>"]
+    #[serde(rename="BundleTaskError")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bundle_task_error: Option<BundleTaskError>,
     #[doc="<p>The ID of the instance associated with this bundle task.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The level of task completion, as a percent (for example, 20%).</p>"]
+    #[serde(rename="Progress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress: Option<String>,
     #[doc="<p>The time this task started.</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
     #[doc="<p>The state of the task.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The Amazon S3 storage locations.</p>"]
+    #[serde(rename="Storage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage: Option<Storage>,
     #[doc="<p>The time of the most recent update for the task.</p>"]
+    #[serde(rename="UpdateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub update_time: Option<String>,
 }
 
@@ -2901,11 +3144,15 @@ impl BundleTaskDeserializer {
     }
 }
 #[doc="<p>Describes an error for <a>BundleInstance</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BundleTaskError {
     #[doc="<p>The error code.</p>"]
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<String>,
     #[doc="<p>The error message.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
 }
 
@@ -3024,11 +3271,14 @@ impl CancelBatchErrorCodeDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CancelBundleTask.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelBundleTaskRequest {
     #[doc="<p>The ID of the bundle task.</p>"]
+    #[serde(rename="BundleId")]
     pub bundle_id: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -3053,9 +3303,11 @@ impl CancelBundleTaskRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CancelBundleTask.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelBundleTaskResult {
     #[doc="<p>Information about the bundle task.</p>"]
+    #[serde(rename="BundleTask")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bundle_task: Option<BundleTask>,
 }
 
@@ -3103,13 +3355,18 @@ impl CancelBundleTaskResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CancelConversionTask.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelConversionRequest {
     #[doc="<p>The ID of the conversion task.</p>"]
+    #[serde(rename="ConversionTaskId")]
     pub conversion_task_id: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The reason for canceling the conversion task.</p>"]
+    #[serde(rename="ReasonMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reason_message: Option<String>,
 }
 
@@ -3138,9 +3395,10 @@ impl CancelConversionRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for CancelExportTask.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelExportTaskRequest {
     #[doc="<p>The ID of the export task. This is the ID returned by <code>CreateInstanceExportTask</code>.</p>"]
+    #[serde(rename="ExportTaskId")]
     pub export_task_id: String,
 }
 
@@ -3161,13 +3419,19 @@ impl CancelExportTaskRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for CancelImportTask.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelImportTaskRequest {
     #[doc="<p>The reason for canceling the task.</p>"]
+    #[serde(rename="CancelReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cancel_reason: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the import image or import snapshot task to be canceled.</p>"]
+    #[serde(rename="ImportTaskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_task_id: Option<String>,
 }
 
@@ -3198,13 +3462,19 @@ impl CancelImportTaskRequestSerializer {
 }
 
 #[doc="<p>Contains the output for CancelImportTask.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelImportTaskResult {
     #[doc="<p>The ID of the task being canceled.</p>"]
+    #[serde(rename="ImportTaskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_task_id: Option<String>,
     #[doc="<p>The current state of the task being canceled.</p>"]
+    #[serde(rename="PreviousState")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub previous_state: Option<String>,
     #[doc="<p>The current state of the task being canceled.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -3258,9 +3528,10 @@ impl CancelImportTaskResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CancelReservedInstancesListing.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelReservedInstancesListingRequest {
     #[doc="<p>The ID of the Reserved Instance listing.</p>"]
+    #[serde(rename="ReservedInstancesListingId")]
     pub reserved_instances_listing_id: String,
 }
 
@@ -3281,9 +3552,11 @@ impl CancelReservedInstancesListingRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CancelReservedInstancesListing.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelReservedInstancesListingResult {
     #[doc="<p>The Reserved Instance listing.</p>"]
+    #[serde(rename="ReservedInstancesListings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_listings: Option<Vec<ReservedInstancesListing>>,
 }
 
@@ -3330,11 +3603,13 @@ impl CancelReservedInstancesListingResultDeserializer {
     }
 }
 #[doc="<p>Describes a Spot fleet error.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelSpotFleetRequestsError {
     #[doc="<p>The error code.</p>"]
+    #[serde(rename="Code")]
     pub code: String,
     #[doc="<p>The description for the error code.</p>"]
+    #[serde(rename="Message")]
     pub message: String,
 }
 
@@ -3384,11 +3659,13 @@ impl CancelSpotFleetRequestsErrorDeserializer {
     }
 }
 #[doc="<p>Describes a Spot fleet request that was not successfully canceled.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelSpotFleetRequestsErrorItem {
     #[doc="<p>The error.</p>"]
+    #[serde(rename="Error")]
     pub error: CancelSpotFleetRequestsError,
     #[doc="<p>The ID of the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestId")]
     pub spot_fleet_request_id: String,
 }
 
@@ -3483,13 +3760,17 @@ impl CancelSpotFleetRequestsErrorSetDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CancelSpotFleetRequests.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelSpotFleetRequestsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The IDs of the Spot fleet requests.</p>"]
+    #[serde(rename="SpotFleetRequestIds")]
     pub spot_fleet_request_ids: Vec<String>,
     #[doc="<p>Indicates whether to terminate instances for a Spot fleet request if it is canceled successfully.</p>"]
+    #[serde(rename="TerminateInstances")]
     pub terminate_instances: bool,
 }
 
@@ -3517,11 +3798,15 @@ impl CancelSpotFleetRequestsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CancelSpotFleetRequests.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelSpotFleetRequestsResponse {
     #[doc="<p>Information about the Spot fleet requests that are successfully canceled.</p>"]
+    #[serde(rename="SuccessfulFleetRequests")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub successful_fleet_requests: Option<Vec<CancelSpotFleetRequestsSuccessItem>>,
     #[doc="<p>Information about the Spot fleet requests that are not successfully canceled.</p>"]
+    #[serde(rename="UnsuccessfulFleetRequests")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unsuccessful_fleet_requests: Option<Vec<CancelSpotFleetRequestsErrorItem>>,
 }
 
@@ -3571,13 +3856,16 @@ impl CancelSpotFleetRequestsResponseDeserializer {
     }
 }
 #[doc="<p>Describes a Spot fleet request that was successfully canceled.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelSpotFleetRequestsSuccessItem {
     #[doc="<p>The current state of the Spot fleet request.</p>"]
+    #[serde(rename="CurrentSpotFleetRequestState")]
     pub current_spot_fleet_request_state: String,
     #[doc="<p>The previous state of the Spot fleet request.</p>"]
+    #[serde(rename="PreviousSpotFleetRequestState")]
     pub previous_spot_fleet_request_state: String,
     #[doc="<p>The ID of the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestId")]
     pub spot_fleet_request_id: String,
 }
 
@@ -3691,11 +3979,14 @@ impl CancelSpotInstanceRequestStateDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CancelSpotInstanceRequests.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelSpotInstanceRequestsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more Spot instance request IDs.</p>"]
+    #[serde(rename="SpotInstanceRequestIds")]
     pub spot_instance_request_ids: Vec<String>,
 }
 
@@ -3723,9 +4014,11 @@ impl CancelSpotInstanceRequestsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CancelSpotInstanceRequests.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelSpotInstanceRequestsResult {
     #[doc="<p>One or more Spot instance requests.</p>"]
+    #[serde(rename="CancelledSpotInstanceRequests")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cancelled_spot_instance_requests: Option<Vec<CancelledSpotInstanceRequest>>,
 }
 
@@ -3772,11 +4065,15 @@ impl CancelSpotInstanceRequestsResultDeserializer {
     }
 }
 #[doc="<p>Describes a request to cancel a Spot instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelledSpotInstanceRequest {
     #[doc="<p>The ID of the Spot instance request.</p>"]
+    #[serde(rename="SpotInstanceRequestId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_instance_request_id: Option<String>,
     #[doc="<p>The state of the Spot instance request.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -3869,11 +4166,15 @@ impl CancelledSpotInstanceRequestListDeserializer {
     }
 }
 #[doc="<p>Describes the ClassicLink DNS support status of a VPC.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClassicLinkDnsSupport {
     #[doc="<p>Indicates whether ClassicLink DNS support is enabled for the VPC.</p>"]
+    #[serde(rename="ClassicLinkDnsSupported")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub classic_link_dns_supported: Option<bool>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -3967,15 +4268,23 @@ impl ClassicLinkDnsSupportListDeserializer {
     }
 }
 #[doc="<p>Describes a linked EC2-Classic instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClassicLinkInstance {
     #[doc="<p>A list of security groups.</p>"]
+    #[serde(rename="Groups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub groups: Option<Vec<GroupIdentifier>>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>Any tags assigned to the instance.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -4076,15 +4385,23 @@ impl ClassicLinkInstanceListDeserializer {
     }
 }
 #[doc="<p>Describes the client-specific data.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClientData {
     #[doc="<p>A user-defined comment about the disk upload.</p>"]
+    #[serde(rename="Comment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub comment: Option<String>,
     #[doc="<p>The time that the disk upload ends.</p>"]
+    #[serde(rename="UploadEnd")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_end: Option<String>,
     #[doc="<p>The size of the uploaded disk image, in GiB.</p>"]
+    #[serde(rename="UploadSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_size: Option<f64>,
     #[doc="<p>The time that the disk upload starts.</p>"]
+    #[serde(rename="UploadStart")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_start: Option<String>,
 }
 
@@ -4119,13 +4436,17 @@ impl ClientDataSerializer {
 }
 
 #[doc="<p>Contains the parameters for ConfirmProductInstance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmProductInstanceRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>The product code. This must be a product code that you own.</p>"]
+    #[serde(rename="ProductCode")]
     pub product_code: String,
 }
 
@@ -4152,11 +4473,15 @@ impl ConfirmProductInstanceRequestSerializer {
 }
 
 #[doc="<p>Contains the output of ConfirmProductInstance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmProductInstanceResult {
     #[doc="<p>The AWS account ID of the instance owner. This is only present if the product code is attached to the instance.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
     #[doc="<p>The return value of the request. Returns <code>true</code> if the specified product code is owned by the requester and associated with the specified instance.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -4233,21 +4558,33 @@ impl ConversionIdStringListSerializer {
 }
 
 #[doc="<p>Describes a conversion task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConversionTask {
     #[doc="<p>The ID of the conversion task.</p>"]
+    #[serde(rename="ConversionTaskId")]
     pub conversion_task_id: String,
     #[doc="<p>The time when the task expires. If the upload isn't complete before the expiration time, we automatically cancel the task.</p>"]
+    #[serde(rename="ExpirationTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expiration_time: Option<String>,
     #[doc="<p>If the task is for importing an instance, this contains information about the import instance task.</p>"]
+    #[serde(rename="ImportInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_instance: Option<ImportInstanceTaskDetails>,
     #[doc="<p>If the task is for importing a volume, this contains information about the import volume task.</p>"]
+    #[serde(rename="ImportVolume")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_volume: Option<ImportVolumeTaskDetails>,
     #[doc="<p>The state of the conversion task.</p>"]
+    #[serde(rename="State")]
     pub state: String,
     #[doc="<p>The status message related to the conversion task.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
     #[doc="<p>Any tags assigned to the task.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -4333,23 +4670,36 @@ impl ConversionTaskStateDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CopyImage.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyImageRequest {
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html\">How to Ensure Idempotency</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>A description for the new AMI in the destination region.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Specifies whether the destination snapshots of the copied image should be encrypted. The default CMK for EBS is used unless a non-default AWS Key Management Service (AWS KMS) CMK is specified with <code>KmsKeyId</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html\">Amazon EBS Encryption</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>The full ARN of the AWS Key Management Service (AWS KMS) CMK to use when encrypting the snapshots of an image during a copy operation. This parameter is only required if you want to use a non-default CMK; if this parameter is not specified, the default CMK for EBS is used. The ARN contains the <code>arn:aws:kms</code> namespace, followed by the region of the CMK, the AWS account ID of the CMK owner, the <code>key</code> namespace, and then the CMK ID. For example, arn:aws:kms:<i>us-east-1</i>:<i>012345678910</i>:key/<i>abcd1234-a123-456a-a12b-a123b4cd56ef</i>. The specified CMK must exist in the region that the snapshot is being copied to. If a <code>KmsKeyId</code> is specified, the <code>Encrypted</code> flag must also be set.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The name of the new AMI in the destination region.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The ID of the AMI to copy.</p>"]
+    #[serde(rename="SourceImageId")]
     pub source_image_id: String,
     #[doc="<p>The name of the region that contains the AMI to copy.</p>"]
+    #[serde(rename="SourceRegion")]
     pub source_region: String,
 }
 
@@ -4394,9 +4744,11 @@ impl CopyImageRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CopyImage.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyImageResult {
     #[doc="<p>The ID of the new AMI.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
 }
 
@@ -4443,23 +4795,37 @@ impl CopyImageResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CopySnapshot.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopySnapshotRequest {
     #[doc="<p>A description for the EBS snapshot.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The destination region to use in the <code>PresignedUrl</code> parameter of a snapshot copy operation. This parameter is only valid for specifying the destination region in a <code>PresignedUrl</code> parameter, where it is required.</p> <note> <p> <code>CopySnapshot</code> sends the snapshot copy to the regional endpoint that you send the HTTP request to, such as <code>ec2.us-east-1.amazonaws.com</code> (in the AWS CLI, this is specified with the <code>--region</code> parameter or the default region in your AWS configuration file).</p> </note>"]
+    #[serde(rename="DestinationRegion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_region: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Specifies whether the destination snapshot should be encrypted. You can encrypt a copy of an unencrypted snapshot using this flag, but you cannot use it to create an unencrypted copy from an encrypted snapshot. Your default CMK for EBS is used unless a non-default AWS Key Management Service (AWS KMS) CMK is specified with <code>KmsKeyId</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html\">Amazon EBS Encryption</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>The full ARN of the AWS Key Management Service (AWS KMS) CMK to use when creating the snapshot copy. This parameter is only required if you want to use a non-default CMK; if this parameter is not specified, the default CMK for EBS is used. The ARN contains the <code>arn:aws:kms</code> namespace, followed by the region of the CMK, the AWS account ID of the CMK owner, the <code>key</code> namespace, and then the CMK ID. For example, arn:aws:kms:<i>us-east-1</i>:<i>012345678910</i>:key/<i>abcd1234-a123-456a-a12b-a123b4cd56ef</i>. The specified CMK must exist in the region that the snapshot is being copied to. If a <code>KmsKeyId</code> is specified, the <code>Encrypted</code> flag must also be set.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The pre-signed URL that facilitates copying an encrypted snapshot. This parameter is only required when copying an encrypted snapshot with the Amazon EC2 Query API; it is available as an optional parameter in all other cases. The <code>PresignedUrl</code> should use the snapshot source endpoint, the <code>CopySnapshot</code> action, and include the <code>SourceRegion</code>, <code>SourceSnapshotId</code>, and <code>DestinationRegion</code> parameters. The <code>PresignedUrl</code> must be signed using AWS Signature Version 4. Because EBS snapshots are stored in Amazon S3, the signing algorithm for this parameter uses the same logic that is described in <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\">Authenticating Requests by Using Query Parameters (AWS Signature Version 4)</a> in the <i>Amazon Simple Storage Service API Reference</i>. An invalid or improperly signed <code>PresignedUrl</code> will cause the copy operation to fail asynchronously, and the snapshot will move to an <code>error</code> state.</p>"]
+    #[serde(rename="PresignedUrl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub presigned_url: Option<String>,
     #[doc="<p>The ID of the region that contains the snapshot to be copied.</p>"]
+    #[serde(rename="SourceRegion")]
     pub source_region: String,
     #[doc="<p>The ID of the EBS snapshot to copy.</p>"]
+    #[serde(rename="SourceSnapshotId")]
     pub source_snapshot_id: String,
 }
 
@@ -4506,9 +4872,11 @@ impl CopySnapshotRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CopySnapshot.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopySnapshotResult {
     #[doc="<p>The ID of the new snapshot.</p>"]
+    #[serde(rename="SnapshotId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_id: Option<String>,
 }
 
@@ -4555,15 +4923,20 @@ impl CopySnapshotResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateCustomerGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCustomerGatewayRequest {
     #[doc="<p>For devices that support BGP, the customer gateway's BGP ASN.</p> <p>Default: 65000</p>"]
+    #[serde(rename="BgpAsn")]
     pub bgp_asn: i64,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The Internet-routable IP address for the customer gateway's outside interface. The address must be static.</p>"]
+    #[serde(rename="PublicIp")]
     pub public_ip: String,
     #[doc="<p>The type of VPN connection that this customer gateway supports (<code>ipsec.1</code>).</p>"]
+    #[serde(rename="Type")]
     pub type_: String,
 }
 
@@ -4592,9 +4965,11 @@ impl CreateCustomerGatewayRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateCustomerGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCustomerGatewayResult {
     #[doc="<p>Information about the customer gateway.</p>"]
+    #[serde(rename="CustomerGateway")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub customer_gateway: Option<CustomerGateway>,
 }
 
@@ -4642,9 +5017,11 @@ impl CreateCustomerGatewayResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateDefaultVpc.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDefaultVpcRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -4667,9 +5044,11 @@ impl CreateDefaultVpcRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateDefaultVpc.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDefaultVpcResult {
     #[doc="<p>Information about the VPC.</p>"]
+    #[serde(rename="Vpc")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc: Option<Vpc>,
 }
 
@@ -4715,11 +5094,14 @@ impl CreateDefaultVpcResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateDhcpOptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDhcpOptionsRequest {
     #[doc="<p>A DHCP configuration option.</p>"]
+    #[serde(rename="DhcpConfigurations")]
     pub dhcp_configurations: Vec<NewDhcpConfiguration>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -4747,9 +5129,11 @@ impl CreateDhcpOptionsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateDhcpOptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDhcpOptionsResult {
     #[doc="<p>A set of DHCP options.</p>"]
+    #[serde(rename="DhcpOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dhcp_options: Option<DhcpOptions>,
 }
 
@@ -4796,13 +5180,18 @@ impl CreateDhcpOptionsResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEgressOnlyInternetGatewayRequest {
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html\">How to Ensure Idempotency</a>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC for which to create the egress-only Internet gateway.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -4830,11 +5219,15 @@ impl CreateEgressOnlyInternetGatewayRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEgressOnlyInternetGatewayResult {
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>Information about the egress-only Internet gateway.</p>"]
+    #[serde(rename="EgressOnlyInternetGateway")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub egress_only_internet_gateway: Option<EgressOnlyInternetGateway>,
 }
 
@@ -4885,19 +5278,26 @@ impl CreateEgressOnlyInternetGatewayResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateFlowLogs.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFlowLogsRequest {
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html\">How to Ensure Idempotency</a>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>The ARN for the IAM role that's used to post flow logs to a CloudWatch Logs log group.</p>"]
+    #[serde(rename="DeliverLogsPermissionArn")]
     pub deliver_logs_permission_arn: String,
     #[doc="<p>The name of the CloudWatch log group.</p>"]
+    #[serde(rename="LogGroupName")]
     pub log_group_name: String,
     #[doc="<p>One or more subnet, network interface, or VPC IDs.</p> <p>Constraints: Maximum of 1000 resources</p>"]
+    #[serde(rename="ResourceIds")]
     pub resource_ids: Vec<String>,
     #[doc="<p>The type of resource on which to create the flow log.</p>"]
+    #[serde(rename="ResourceType")]
     pub resource_type: String,
     #[doc="<p>The type of traffic to log.</p>"]
+    #[serde(rename="TrafficType")]
     pub traffic_type: String,
 }
 
@@ -4931,13 +5331,19 @@ impl CreateFlowLogsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateFlowLogs.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFlowLogsResult {
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>The IDs of the flow logs.</p>"]
+    #[serde(rename="FlowLogIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub flow_log_ids: Option<Vec<String>>,
     #[doc="<p>Information about the flow logs that could not be created successfully.</p>"]
+    #[serde(rename="Unsuccessful")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unsuccessful: Option<Vec<UnsuccessfulItem>>,
 }
 
@@ -4993,19 +5399,30 @@ impl CreateFlowLogsResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFpgaImageRequest {
     #[doc="<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html\">Ensuring Idempotency</a>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>A description for the AFI.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The location of the encrypted design checkpoint in Amazon S3. The input must be a tarball.</p>"]
+    #[serde(rename="InputStorageLocation")]
     pub input_storage_location: StorageLocation,
     #[doc="<p>The location in Amazon S3 for the output logs.</p>"]
+    #[serde(rename="LogsStorageLocation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub logs_storage_location: Option<StorageLocation>,
     #[doc="<p>A name for the AFI.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -5047,11 +5464,15 @@ impl CreateFpgaImageRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFpgaImageResult {
     #[doc="<p>The global FPGA image identifier (AGFI ID).</p>"]
+    #[serde(rename="FpgaImageGlobalId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fpga_image_global_id: Option<String>,
     #[doc="<p>The FPGA image identifier (AFI ID).</p>"]
+    #[serde(rename="FpgaImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fpga_image_id: Option<String>,
 }
 
@@ -5103,19 +5524,29 @@ impl CreateFpgaImageResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateImage.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateImageRequest {
     #[doc="<p>Information about one or more block device mappings.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
     #[doc="<p>A description for the new image.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>A name for the new image.</p> <p>Constraints: 3-128 alphanumeric characters, parentheses (()), square brackets ([]), spaces ( ), periods (.), slashes (/), dashes (-), single quotes ('), at-signs (@), or underscores(_)</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>By default, Amazon EC2 attempts to shut down and reboot the instance before creating the image. If the 'No Reboot' option is set, Amazon EC2 doesn't shut down the instance before creating the image. When this option is used, file system integrity on the created image can't be guaranteed.</p>"]
+    #[serde(rename="NoReboot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub no_reboot: Option<bool>,
 }
 
@@ -5157,9 +5588,11 @@ impl CreateImageRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateImage.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateImageResult {
     #[doc="<p>The ID of the new AMI.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
 }
 
@@ -5206,15 +5639,22 @@ impl CreateImageResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateInstanceExportTask.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstanceExportTaskRequest {
     #[doc="<p>A description for the conversion task or the resource being exported. The maximum length is 255 bytes.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The format and location for an instance export task.</p>"]
+    #[serde(rename="ExportToS3Task")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub export_to_s3_task: Option<ExportToS3TaskSpecification>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>The target virtualization environment.</p>"]
+    #[serde(rename="TargetEnvironment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_environment: Option<String>,
 }
 
@@ -5250,9 +5690,11 @@ impl CreateInstanceExportTaskRequestSerializer {
 }
 
 #[doc="<p>Contains the output for CreateInstanceExportTask.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstanceExportTaskResult {
     #[doc="<p>Information about the instance export task.</p>"]
+    #[serde(rename="ExportTask")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub export_task: Option<ExportTask>,
 }
 
@@ -5300,9 +5742,11 @@ impl CreateInstanceExportTaskResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateInternetGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInternetGatewayRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -5325,9 +5769,11 @@ impl CreateInternetGatewayRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateInternetGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInternetGatewayResult {
     #[doc="<p>Information about the Internet gateway.</p>"]
+    #[serde(rename="InternetGateway")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub internet_gateway: Option<InternetGateway>,
 }
 
@@ -5375,11 +5821,14 @@ impl CreateInternetGatewayResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateKeyPair.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateKeyPairRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>A unique name for the key pair.</p> <p>Constraints: Up to 255 ASCII characters</p>"]
+    #[serde(rename="KeyName")]
     pub key_name: String,
 }
 
@@ -5404,13 +5853,17 @@ impl CreateKeyPairRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for CreateNatGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNatGatewayRequest {
     #[doc="<p>The allocation ID of an Elastic IP address to associate with the NAT gateway. If the Elastic IP address is associated with another resource, you must first disassociate it.</p>"]
+    #[serde(rename="AllocationId")]
     pub allocation_id: String,
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html\">How to Ensure Idempotency</a>.</p> <p>Constraint: Maximum 64 ASCII characters.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>The subnet in which to create the NAT gateway.</p>"]
+    #[serde(rename="SubnetId")]
     pub subnet_id: String,
 }
 
@@ -5437,11 +5890,15 @@ impl CreateNatGatewayRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateNatGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNatGatewayResult {
     #[doc="<p>Unique, case-sensitive identifier to ensure the idempotency of the request. Only returned if a client token was provided in the request.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>Information about the NAT gateway.</p>"]
+    #[serde(rename="NatGateway")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nat_gateway: Option<NatGateway>,
 }
 
@@ -5493,27 +5950,42 @@ impl CreateNatGatewayResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateNetworkAclEntry.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNetworkAclEntryRequest {
     #[doc="<p>The IPv4 network range to allow or deny, in CIDR notation (for example <code>172.16.0.0/24</code>).</p>"]
+    #[serde(rename="CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_block: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Indicates whether this is an egress rule (rule is applied to traffic leaving the subnet).</p>"]
+    #[serde(rename="Egress")]
     pub egress: bool,
     #[doc="<p>ICMP protocol: The ICMP or ICMPv6 type and code. Required if specifying the ICMP protocol, or protocol 58 (ICMPv6) with an IPv6 CIDR block.</p>"]
+    #[serde(rename="IcmpTypeCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub icmp_type_code: Option<IcmpTypeCode>,
     #[doc="<p>The IPv6 network range to allow or deny, in CIDR notation (for example <code>2001:db8:1234:1a00::/64</code>).</p>"]
+    #[serde(rename="Ipv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block: Option<String>,
     #[doc="<p>The ID of the network ACL.</p>"]
+    #[serde(rename="NetworkAclId")]
     pub network_acl_id: String,
     #[doc="<p>TCP or UDP protocols: The range of ports the rule applies to.</p>"]
+    #[serde(rename="PortRange")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port_range: Option<PortRange>,
     #[doc="<p>The protocol. A value of <code>-1</code> or <code>all</code> means all protocols. If you specify <code>all</code>, <code>-1</code>, or a protocol number other than <code>tcp</code>, <code>udp</code>, or <code>icmp</code>, traffic on all ports is allowed, regardless of any ports or ICMP types or codes you specify. If you specify protocol <code>58</code> (ICMPv6) and specify an IPv4 CIDR block, traffic for all ICMP types and codes allowed, regardless of any that you specify. If you specify protocol <code>58</code> (ICMPv6) and specify an IPv6 CIDR block, you must specify an ICMP type and code.</p>"]
+    #[serde(rename="Protocol")]
     pub protocol: String,
     #[doc="<p>Indicates whether to allow or deny the traffic that matches the rule.</p>"]
+    #[serde(rename="RuleAction")]
     pub rule_action: String,
     #[doc="<p>The rule number for the entry (for example, 100). ACL entries are processed in ascending order by rule number.</p> <p>Constraints: Positive integer from 1 to 32766. The range 32767 to 65535 is reserved for internal use.</p>"]
+    #[serde(rename="RuleNumber")]
     pub rule_number: i64,
 }
 
@@ -5564,11 +6036,14 @@ impl CreateNetworkAclEntryRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for CreateNetworkAcl.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNetworkAclRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -5593,9 +6068,11 @@ impl CreateNetworkAclRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateNetworkAcl.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNetworkAclResult {
     #[doc="<p>Information about the network ACL.</p>"]
+    #[serde(rename="NetworkAcl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_acl: Option<NetworkAcl>,
 }
 
@@ -5643,17 +6120,25 @@ impl CreateNetworkAclResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateNetworkInterfacePermission.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNetworkInterfacePermissionRequest {
     #[doc="<p>The AWS account ID.</p>"]
+    #[serde(rename="AwsAccountId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub aws_account_id: Option<String>,
     #[doc="<p>The AWS service. Currently not supported.</p>"]
+    #[serde(rename="AwsService")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub aws_service: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
     pub network_interface_id: String,
     #[doc="<p>The type of permission to grant.</p>"]
+    #[serde(rename="Permission")]
     pub permission: String,
 }
 
@@ -5688,9 +6173,11 @@ impl CreateNetworkInterfacePermissionRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateNetworkInterfacePermission.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNetworkInterfacePermissionResult {
     #[doc="<p>Information about the permission for the network interface.</p>"]
+    #[serde(rename="InterfacePermission")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub interface_permission: Option<NetworkInterfacePermission>,
 }
 
@@ -5737,25 +6224,42 @@ impl CreateNetworkInterfacePermissionResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateNetworkInterface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNetworkInterfaceRequest {
     #[doc="<p>A description for the network interface.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The IDs of one or more security groups.</p>"]
+    #[serde(rename="Groups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub groups: Option<Vec<String>>,
     #[doc="<p>The number of IPv6 addresses to assign to a network interface. Amazon EC2 automatically selects the IPv6 addresses from the subnet range. You can't use this option if specifying specific IPv6 addresses. If your subnet has the <code>AssignIpv6AddressOnCreation</code> attribute set to <code>true</code>, you can specify <code>0</code> to override this setting.</p>"]
+    #[serde(rename="Ipv6AddressCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_address_count: Option<i64>,
     #[doc="<p>One or more specific IPv6 addresses from the IPv6 CIDR block range of your subnet. You can't use this option if you're specifying a number of IPv6 addresses.</p>"]
+    #[serde(rename="Ipv6Addresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_addresses: Option<Vec<InstanceIpv6Address>>,
     #[doc="<p>The primary private IPv4 address of the network interface. If you don't specify an IPv4 address, Amazon EC2 selects one for you from the subnet's IPv4 CIDR range. If you specify an IP address, you cannot indicate any IP addresses specified in <code>privateIpAddresses</code> as primary (only one IP address can be designated as primary).</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
     #[doc="<p>One or more private IPv4 addresses.</p>"]
+    #[serde(rename="PrivateIpAddresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_addresses: Option<Vec<PrivateIpAddressSpecification>>,
     #[doc="<p>The number of secondary private IPv4 addresses to assign to a network interface. When you specify a number of secondary IPv4 addresses, Amazon EC2 selects these IP addresses within the subnet's IPv4 CIDR range. You can't specify this option and specify more than one private IP address using <code>privateIpAddresses</code>.</p> <p>The number of IP addresses you can assign to a network interface varies by instance type. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI\">IP Addresses Per ENI Per Instance Type</a> in the <i>Amazon Virtual Private Cloud User Guide</i>.</p>"]
+    #[serde(rename="SecondaryPrivateIpAddressCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub secondary_private_ip_address_count: Option<i64>,
     #[doc="<p>The ID of the subnet to associate with the network interface.</p>"]
+    #[serde(rename="SubnetId")]
     pub subnet_id: String,
 }
 
@@ -5815,9 +6319,11 @@ impl CreateNetworkInterfaceRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateNetworkInterface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNetworkInterfaceResult {
     #[doc="<p>Information about the network interface.</p>"]
+    #[serde(rename="NetworkInterface")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface: Option<NetworkInterface>,
 }
 
@@ -5865,13 +6371,17 @@ impl CreateNetworkInterfaceResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreatePlacementGroup.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePlacementGroupRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>A name for the placement group.</p> <p>Constraints: Up to 255 ASCII characters</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>The placement strategy.</p>"]
+    #[serde(rename="Strategy")]
     pub strategy: String,
 }
 
@@ -5898,15 +6408,19 @@ impl CreatePlacementGroupRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for CreateReservedInstancesListing.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReservedInstancesListingRequest {
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure idempotency of your listings. This helps avoid duplicate listings. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html\">Ensuring Idempotency</a>.</p>"]
+    #[serde(rename="ClientToken")]
     pub client_token: String,
     #[doc="<p>The number of instances that are a part of a Reserved Instance account to be listed in the Reserved Instance Marketplace. This number should be less than or equal to the instance count associated with the Reserved Instance ID specified in this call.</p>"]
+    #[serde(rename="InstanceCount")]
     pub instance_count: i64,
     #[doc="<p>A list specifying the price of the Standard Reserved Instance for each month remaining in the Reserved Instance term.</p>"]
+    #[serde(rename="PriceSchedules")]
     pub price_schedules: Vec<PriceScheduleSpecification>,
     #[doc="<p>The ID of the active Standard Reserved Instance.</p>"]
+    #[serde(rename="ReservedInstancesId")]
     pub reserved_instances_id: String,
 }
 
@@ -5936,9 +6450,11 @@ impl CreateReservedInstancesListingRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateReservedInstancesListing.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReservedInstancesListingResult {
     #[doc="<p>Information about the Standard Reserved Instance listing.</p>"]
+    #[serde(rename="ReservedInstancesListings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_listings: Option<Vec<ReservedInstancesListing>>,
 }
 
@@ -5985,27 +6501,46 @@ impl CreateReservedInstancesListingResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateRoute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRouteRequest {
     #[doc="<p>The IPv4 CIDR address block used for the destination match. Routing decisions are based on the most specific match.</p>"]
+    #[serde(rename="DestinationCidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_cidr_block: Option<String>,
     #[doc="<p>The IPv6 CIDR block used for the destination match. Routing decisions are based on the most specific match.</p>"]
+    #[serde(rename="DestinationIpv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_ipv_6_cidr_block: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>[IPv6 traffic only] The ID of an egress-only Internet gateway.</p>"]
+    #[serde(rename="EgressOnlyInternetGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub egress_only_internet_gateway_id: Option<String>,
     #[doc="<p>The ID of an Internet gateway or virtual private gateway attached to your VPC.</p>"]
+    #[serde(rename="GatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub gateway_id: Option<String>,
     #[doc="<p>The ID of a NAT instance in your VPC. The operation fails if you specify an instance ID unless exactly one network interface is attached.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>[IPv4 traffic only] The ID of a NAT gateway.</p>"]
+    #[serde(rename="NatGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nat_gateway_id: Option<String>,
     #[doc="<p>The ID of a network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>The ID of the route table for the route.</p>"]
+    #[serde(rename="RouteTableId")]
     pub route_table_id: String,
     #[doc="<p>The ID of a VPC peering connection.</p>"]
+    #[serde(rename="VpcPeeringConnectionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_peering_connection_id: Option<String>,
 }
 
@@ -6062,9 +6597,11 @@ impl CreateRouteRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateRoute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRouteResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -6111,11 +6648,14 @@ impl CreateRouteResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateRouteTable.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRouteTableRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -6140,9 +6680,11 @@ impl CreateRouteTableRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateRouteTable.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRouteTableResult {
     #[doc="<p>Information about the route table.</p>"]
+    #[serde(rename="RouteTable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub route_table: Option<RouteTable>,
 }
 
@@ -6190,15 +6732,21 @@ impl CreateRouteTableResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateSecurityGroup.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSecurityGroupRequest {
     #[doc="<p>A description for the security group. This is informational only.</p> <p>Constraints: Up to 255 characters in length</p> <p>Constraints for EC2-Classic: ASCII characters</p> <p>Constraints for EC2-VPC: a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&amp;;{}!$*</p>"]
+    #[serde(rename="Description")]
     pub description: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The name of the security group.</p> <p>Constraints: Up to 255 characters in length</p> <p>Constraints for EC2-Classic: ASCII characters</p> <p>Constraints for EC2-VPC: a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&amp;;{}!$*</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>[EC2-VPC] The ID of the VPC. Required for EC2-VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -6229,9 +6777,11 @@ impl CreateSecurityGroupRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateSecurityGroup.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSecurityGroupResult {
     #[doc="<p>The ID of the security group.</p>"]
+    #[serde(rename="GroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_id: Option<String>,
 }
 
@@ -6278,13 +6828,18 @@ impl CreateSecurityGroupResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateSnapshot.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSnapshotRequest {
     #[doc="<p>A description for the snapshot.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the EBS volume.</p>"]
+    #[serde(rename="VolumeId")]
     pub volume_id: String,
 }
 
@@ -6313,13 +6868,18 @@ impl CreateSnapshotRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for CreateSpotDatafeedSubscription.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSpotDatafeedSubscriptionRequest {
     #[doc="<p>The Amazon S3 bucket in which to store the Spot instance data feed.</p>"]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>A prefix for the data feed file names.</p>"]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
 }
 
@@ -6348,9 +6908,11 @@ impl CreateSpotDatafeedSubscriptionRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateSpotDatafeedSubscription.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSpotDatafeedSubscriptionResult {
     #[doc="<p>The Spot instance data feed subscription.</p>"]
+    #[serde(rename="SpotDatafeedSubscription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_datafeed_subscription: Option<SpotDatafeedSubscription>,
 }
 
@@ -6397,17 +6959,25 @@ impl CreateSpotDatafeedSubscriptionResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateSubnet.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubnetRequest {
     #[doc="<p>The Availability Zone for the subnet.</p> <p>Default: AWS selects one for you. If you create more than one subnet in your VPC, we may not necessarily select a different zone for each subnet.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The IPv4 network range for the subnet, in CIDR notation. For example, <code>10.0.0.0/24</code>.</p>"]
+    #[serde(rename="CidrBlock")]
     pub cidr_block: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The IPv6 network range for the subnet, in CIDR notation. The subnet size must use a /64 prefix length.</p>"]
+    #[serde(rename="Ipv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block: Option<String>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -6442,9 +7012,11 @@ impl CreateSubnetRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateSubnet.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubnetResult {
     #[doc="<p>Information about the subnet.</p>"]
+    #[serde(rename="Subnet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet: Option<Subnet>,
 }
 
@@ -6491,13 +7063,17 @@ impl CreateSubnetResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTagsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The IDs of one or more resources to tag. For example, ami-1a2b3c4d.</p>"]
+    #[serde(rename="Resources")]
     pub resources: Vec<String>,
     #[doc="<p>One or more tags. The <code>value</code> parameter is required, but if you don't want the tag to have a value, specify the parameter with no value, and we set the value to an empty string. </p>"]
+    #[serde(rename="Tags")]
     pub tags: Vec<Tag>,
 }
 
@@ -6524,11 +7100,15 @@ impl CreateTagsRequestSerializer {
 }
 
 #[doc="<p>Describes the user or group to be added or removed from the permissions for a volume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVolumePermission {
     #[doc="<p>The specific group that is to be added or removed from a volume's list of create volume permissions.</p>"]
+    #[serde(rename="Group")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group: Option<String>,
     #[doc="<p>The specific AWS account ID that is to be added or removed from a volume's list of create volume permissions.</p>"]
+    #[serde(rename="UserId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_id: Option<String>,
 }
 
@@ -6655,11 +7235,15 @@ impl CreateVolumePermissionListSerializer {
 }
 
 #[doc="<p>Describes modifications to the permissions for a volume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVolumePermissionModifications {
     #[doc="<p>Adds a specific AWS account ID or group to a volume's list of create volume permissions.</p>"]
+    #[serde(rename="Add")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub add: Option<Vec<CreateVolumePermission>>,
     #[doc="<p>Removes a specific AWS account ID or group from a volume's list of create volume permissions.</p>"]
+    #[serde(rename="Remove")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub remove: Option<Vec<CreateVolumePermission>>,
 }
 
@@ -6688,25 +7272,42 @@ impl CreateVolumePermissionModificationsSerializer {
 }
 
 #[doc="<p>Contains the parameters for CreateVolume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVolumeRequest {
     #[doc="<p>The Availability Zone in which to create the volume. Use <a>DescribeAvailabilityZones</a> to list the Availability Zones that are currently available to you.</p>"]
+    #[serde(rename="AvailabilityZone")]
     pub availability_zone: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Specifies whether the volume should be encrypted. Encrypted Amazon EBS volumes may only be attached to instances that support Amazon EBS encryption. Volumes that are created from encrypted snapshots are automatically encrypted. There is no way to create an encrypted volume from an unencrypted snapshot or vice versa. If your AMI uses encrypted volumes, you can only launch it on supported instance types. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html\">Amazon EBS Encryption</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>Only valid for Provisioned IOPS SSD volumes. The number of I/O operations per second (IOPS) to provision for the volume, with a maximum ratio of 50 IOPS/GiB.</p> <p>Constraint: Range is 100 to 20000 for Provisioned IOPS SSD volumes </p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use when creating the encrypted volume. This parameter is only required if you want to use a non-default CMK; if this parameter is not specified, the default CMK for EBS is used. The ARN contains the <code>arn:aws:kms</code> namespace, followed by the region of the CMK, the AWS account ID of the CMK owner, the <code>key</code> namespace, and then the CMK ID. For example, arn:aws:kms:<i>us-east-1</i>:<i>012345678910</i>:key/<i>abcd1234-a123-456a-a12b-a123b4cd56ef</i>. If a <code>KmsKeyId</code> is specified, the <code>Encrypted</code> flag must also be set.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The size of the volume, in GiBs.</p> <p>Constraints: 1-16384 for <code>gp2</code>, 4-16384 for <code>io1</code>, 500-16384 for <code>st1</code>, 500-16384 for <code>sc1</code>, and 1-1024 for <code>standard</code>. If you specify a snapshot, the volume size must be equal to or larger than the snapshot size.</p> <p>Default: If you're creating the volume from a snapshot and don't specify a volume size, the default is the snapshot size.</p>"]
+    #[serde(rename="Size")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub size: Option<i64>,
     #[doc="<p>The snapshot from which to create the volume.</p>"]
+    #[serde(rename="SnapshotId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_id: Option<String>,
     #[doc="<p>The tags to apply to the volume during creation.</p>"]
+    #[serde(rename="TagSpecifications")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_specifications: Option<Vec<TagSpecification>>,
     #[doc="<p>The volume type. This can be <code>gp2</code> for General Purpose SSD, <code>io1</code> for Provisioned IOPS SSD, <code>st1</code> for Throughput Optimized HDD, <code>sc1</code> for Cold HDD, or <code>standard</code> for Magnetic volumes.</p> <p>Default: <code>standard</code> </p>"]
+    #[serde(rename="VolumeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_type: Option<String>,
 }
 
@@ -6760,19 +7361,29 @@ impl CreateVolumeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for CreateVpcEndpoint.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVpcEndpointRequest {
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html\">How to Ensure Idempotency</a>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>A policy to attach to the endpoint that controls access to the service. The policy must be in valid JSON format. If this parameter is not specified, we attach a default policy that allows full access to the service.</p>"]
+    #[serde(rename="PolicyDocument")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_document: Option<String>,
     #[doc="<p>One or more route table IDs.</p>"]
+    #[serde(rename="RouteTableIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub route_table_ids: Option<Vec<String>>,
     #[doc="<p>The AWS service name, in the form <code>com.amazonaws.<i>region</i>.<i>service</i> </code>. To get a list of available services, use the <a>DescribeVpcEndpointServices</a> request.</p>"]
+    #[serde(rename="ServiceName")]
     pub service_name: String,
     #[doc="<p>The ID of the VPC in which the endpoint will be used.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -6812,11 +7423,15 @@ impl CreateVpcEndpointRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateVpcEndpoint.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVpcEndpointResult {
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>Information about the endpoint.</p>"]
+    #[serde(rename="VpcEndpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_endpoint: Option<VpcEndpoint>,
 }
 
@@ -6868,15 +7483,23 @@ impl CreateVpcEndpointResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateVpcPeeringConnection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVpcPeeringConnectionRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The AWS account ID of the owner of the peer VPC.</p> <p>Default: Your AWS account ID</p>"]
+    #[serde(rename="PeerOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub peer_owner_id: Option<String>,
     #[doc="<p>The ID of the VPC with which you are creating the VPC peering connection.</p>"]
+    #[serde(rename="PeerVpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub peer_vpc_id: Option<String>,
     #[doc="<p>The ID of the requester VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -6911,9 +7534,11 @@ impl CreateVpcPeeringConnectionRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateVpcPeeringConnection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVpcPeeringConnectionResult {
     #[doc="<p>Information about the VPC peering connection.</p>"]
+    #[serde(rename="VpcPeeringConnection")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_peering_connection: Option<VpcPeeringConnection>,
 }
 
@@ -6962,15 +7587,22 @@ impl CreateVpcPeeringConnectionResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateVpc.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVpcRequest {
     #[doc="<p>Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block.</p>"]
+    #[serde(rename="AmazonProvidedIpv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub amazon_provided_ipv_6_cidr_block: Option<bool>,
     #[doc="<p>The IPv4 network range for the VPC, in CIDR notation. For example, <code>10.0.0.0/16</code>.</p>"]
+    #[serde(rename="CidrBlock")]
     pub cidr_block: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The tenancy options for instances launched into the VPC. For <code>default</code>, instances are launched with shared tenancy by default. You can launch instances with any tenancy into a shared tenancy VPC. For <code>dedicated</code>, instances are launched as dedicated tenancy instances by default. You can only launch instances with a tenancy of <code>dedicated</code> or <code>host</code> into a dedicated tenancy VPC. </p> <p> <b>Important:</b> The <code>host</code> value cannot be used with this parameter. Use the <code>default</code> or <code>dedicated</code> values only.</p> <p>Default: <code>default</code> </p>"]
+    #[serde(rename="InstanceTenancy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_tenancy: Option<String>,
 }
 
@@ -7003,9 +7635,11 @@ impl CreateVpcRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateVpc.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVpcResult {
     #[doc="<p>Information about the VPC.</p>"]
+    #[serde(rename="Vpc")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc: Option<Vpc>,
 }
 
@@ -7051,17 +7685,24 @@ impl CreateVpcResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateVpnConnection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVpnConnectionRequest {
     #[doc="<p>The ID of the customer gateway.</p>"]
+    #[serde(rename="CustomerGatewayId")]
     pub customer_gateway_id: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Indicates whether the VPN connection requires static routes. If you are creating a VPN connection for a device that does not support BGP, you must specify <code>true</code>.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="Options")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options: Option<VpnConnectionOptionsSpecification>,
     #[doc="<p>The type of VPN connection (<code>ipsec.1</code>).</p>"]
+    #[serde(rename="Type")]
     pub type_: String,
     #[doc="<p>The ID of the virtual private gateway.</p>"]
+    #[serde(rename="VpnGatewayId")]
     pub vpn_gateway_id: String,
 }
 
@@ -7097,9 +7738,11 @@ impl CreateVpnConnectionRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateVpnConnection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVpnConnectionResult {
     #[doc="<p>Information about the VPN connection.</p>"]
+    #[serde(rename="VpnConnection")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpn_connection: Option<VpnConnection>,
 }
 
@@ -7147,11 +7790,13 @@ impl CreateVpnConnectionResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateVpnConnectionRoute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVpnConnectionRouteRequest {
     #[doc="<p>The CIDR block associated with the local subnet of the customer network.</p>"]
+    #[serde(rename="DestinationCidrBlock")]
     pub destination_cidr_block: String,
     #[doc="<p>The ID of the VPN connection.</p>"]
+    #[serde(rename="VpnConnectionId")]
     pub vpn_connection_id: String,
 }
 
@@ -7174,13 +7819,18 @@ impl CreateVpnConnectionRouteRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for CreateVpnGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVpnGatewayRequest {
     #[doc="<p>The Availability Zone for the virtual private gateway.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The type of VPN connection this virtual private gateway supports.</p>"]
+    #[serde(rename="Type")]
     pub type_: String,
 }
 
@@ -7209,9 +7859,11 @@ impl CreateVpnGatewayRequestSerializer {
 }
 
 #[doc="<p>Contains the output of CreateVpnGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVpnGatewayResult {
     #[doc="<p>Information about the virtual private gateway.</p>"]
+    #[serde(rename="VpnGateway")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpn_gateway: Option<VpnGateway>,
 }
 
@@ -7273,19 +7925,31 @@ impl CurrencyCodeValuesDeserializer {
     }
 }
 #[doc="<p>Describes a customer gateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CustomerGateway {
     #[doc="<p>The customer gateway's Border Gateway Protocol (BGP) Autonomous System Number (ASN).</p>"]
+    #[serde(rename="BgpAsn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bgp_asn: Option<String>,
     #[doc="<p>The ID of the customer gateway.</p>"]
+    #[serde(rename="CustomerGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub customer_gateway_id: Option<String>,
     #[doc="<p>The Internet-routable IP address of the customer gateway's outside interface.</p>"]
+    #[serde(rename="IpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_address: Option<String>,
     #[doc="<p>The current state of the customer gateway (<code>pending | available | deleting | deleted</code>).</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>Any tags assigned to the customer gateway.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The type of VPN connection the customer gateway supports (<code>ipsec.1</code>).</p>"]
+    #[serde(rename="Type")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
 }
 
@@ -7432,11 +8096,14 @@ impl DateTimeDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteCustomerGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCustomerGatewayRequest {
     #[doc="<p>The ID of the customer gateway.</p>"]
+    #[serde(rename="CustomerGatewayId")]
     pub customer_gateway_id: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -7461,11 +8128,14 @@ impl DeleteCustomerGatewayRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteDhcpOptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDhcpOptionsRequest {
     #[doc="<p>The ID of the DHCP options set.</p>"]
+    #[serde(rename="DhcpOptionsId")]
     pub dhcp_options_id: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -7489,11 +8159,14 @@ impl DeleteDhcpOptionsRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEgressOnlyInternetGatewayRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the egress-only Internet gateway.</p>"]
+    #[serde(rename="EgressOnlyInternetGatewayId")]
     pub egress_only_internet_gateway_id: String,
 }
 
@@ -7517,9 +8190,11 @@ impl DeleteEgressOnlyInternetGatewayRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEgressOnlyInternetGatewayResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>"]
+    #[serde(rename="ReturnCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_code: Option<bool>,
 }
 
@@ -7567,9 +8242,10 @@ impl DeleteEgressOnlyInternetGatewayResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteFlowLogs.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFlowLogsRequest {
     #[doc="<p>One or more flow log IDs.</p>"]
+    #[serde(rename="FlowLogIds")]
     pub flow_log_ids: Vec<String>,
 }
 
@@ -7591,9 +8267,11 @@ impl DeleteFlowLogsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DeleteFlowLogs.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFlowLogsResult {
     #[doc="<p>Information about the flow logs that could not be deleted successfully.</p>"]
+    #[serde(rename="Unsuccessful")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unsuccessful: Option<Vec<UnsuccessfulItem>>,
 }
 
@@ -7641,11 +8319,14 @@ impl DeleteFlowLogsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteInternetGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteInternetGatewayRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the Internet gateway.</p>"]
+    #[serde(rename="InternetGatewayId")]
     pub internet_gateway_id: String,
 }
 
@@ -7670,11 +8351,14 @@ impl DeleteInternetGatewayRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteKeyPair.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteKeyPairRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The name of the key pair.</p>"]
+    #[serde(rename="KeyName")]
     pub key_name: String,
 }
 
@@ -7699,9 +8383,10 @@ impl DeleteKeyPairRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteNatGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNatGatewayRequest {
     #[doc="<p>The ID of the NAT gateway.</p>"]
+    #[serde(rename="NatGatewayId")]
     pub nat_gateway_id: String,
 }
 
@@ -7722,9 +8407,11 @@ impl DeleteNatGatewayRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DeleteNatGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNatGatewayResult {
     #[doc="<p>The ID of the NAT gateway.</p>"]
+    #[serde(rename="NatGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nat_gateway_id: Option<String>,
 }
 
@@ -7771,15 +8458,20 @@ impl DeleteNatGatewayResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteNetworkAclEntry.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNetworkAclEntryRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Indicates whether the rule is an egress rule.</p>"]
+    #[serde(rename="Egress")]
     pub egress: bool,
     #[doc="<p>The ID of the network ACL.</p>"]
+    #[serde(rename="NetworkAclId")]
     pub network_acl_id: String,
     #[doc="<p>The rule number of the entry to delete.</p>"]
+    #[serde(rename="RuleNumber")]
     pub rule_number: i64,
 }
 
@@ -7808,11 +8500,14 @@ impl DeleteNetworkAclEntryRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteNetworkAcl.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNetworkAclRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the network ACL.</p>"]
+    #[serde(rename="NetworkAclId")]
     pub network_acl_id: String,
 }
 
@@ -7837,13 +8532,18 @@ impl DeleteNetworkAclRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteNetworkInterfacePermission.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNetworkInterfacePermissionRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Specify <code>true</code> to remove the permission even if the network interface is attached to an instance.</p>"]
+    #[serde(rename="Force")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub force: Option<bool>,
     #[doc="<p>The ID of the network interface permission.</p>"]
+    #[serde(rename="NetworkInterfacePermissionId")]
     pub network_interface_permission_id: String,
 }
 
@@ -7872,9 +8572,11 @@ impl DeleteNetworkInterfacePermissionRequestSerializer {
 }
 
 #[doc="<p>Contains the output for DeleteNetworkInterfacePermission.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNetworkInterfacePermissionResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds, otherwise returns an error.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -7922,11 +8624,14 @@ impl DeleteNetworkInterfacePermissionResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteNetworkInterface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNetworkInterfaceRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
     pub network_interface_id: String,
 }
 
@@ -7951,11 +8656,14 @@ impl DeleteNetworkInterfaceRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeletePlacementGroup.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePlacementGroupRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The name of the placement group.</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
 }
 
@@ -7980,15 +8688,22 @@ impl DeletePlacementGroupRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteRoute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRouteRequest {
     #[doc="<p>The IPv4 CIDR range for the route. The value you specify must match the CIDR for the route exactly.</p>"]
+    #[serde(rename="DestinationCidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_cidr_block: Option<String>,
     #[doc="<p>The IPv6 CIDR range for the route. The value you specify must match the CIDR for the route exactly.</p>"]
+    #[serde(rename="DestinationIpv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_ipv_6_cidr_block: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the route table.</p>"]
+    #[serde(rename="RouteTableId")]
     pub route_table_id: String,
 }
 
@@ -8021,11 +8736,14 @@ impl DeleteRouteRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteRouteTable.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRouteTableRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the route table.</p>"]
+    #[serde(rename="RouteTableId")]
     pub route_table_id: String,
 }
 
@@ -8050,13 +8768,19 @@ impl DeleteRouteTableRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteSecurityGroup.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSecurityGroupRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the security group. Required for a nondefault VPC.</p>"]
+    #[serde(rename="GroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_id: Option<String>,
     #[doc="<p>[EC2-Classic, default VPC] The name of the security group. You can specify either the security group name or the security group ID.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
 }
 
@@ -8087,11 +8811,14 @@ impl DeleteSecurityGroupRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteSnapshot.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSnapshotRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the EBS snapshot.</p>"]
+    #[serde(rename="SnapshotId")]
     pub snapshot_id: String,
 }
 
@@ -8116,9 +8843,11 @@ impl DeleteSnapshotRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteSpotDatafeedSubscription.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSpotDatafeedSubscriptionRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -8141,11 +8870,14 @@ impl DeleteSpotDatafeedSubscriptionRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteSubnet.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSubnetRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the subnet.</p>"]
+    #[serde(rename="SubnetId")]
     pub subnet_id: String,
 }
 
@@ -8170,13 +8902,18 @@ impl DeleteSubnetRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the resource. For example, ami-1a2b3c4d. You can specify more than one resource ID.</p>"]
+    #[serde(rename="Resources")]
     pub resources: Vec<String>,
     #[doc="<p>One or more tags to delete. If you omit the <code>value</code> parameter, we delete the tag regardless of its value. If you specify this parameter with an empty string as the value, we delete the key only if its value is an empty string.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -8205,11 +8942,14 @@ impl DeleteTagsRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteVolume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVolumeRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the volume.</p>"]
+    #[serde(rename="VolumeId")]
     pub volume_id: String,
 }
 
@@ -8234,11 +8974,14 @@ impl DeleteVolumeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteVpcEndpoints.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVpcEndpointsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more endpoint IDs.</p>"]
+    #[serde(rename="VpcEndpointIds")]
     pub vpc_endpoint_ids: Vec<String>,
 }
 
@@ -8264,9 +9007,11 @@ impl DeleteVpcEndpointsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DeleteVpcEndpoints.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVpcEndpointsResult {
     #[doc="<p>Information about the endpoints that were not successfully deleted.</p>"]
+    #[serde(rename="Unsuccessful")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unsuccessful: Option<Vec<UnsuccessfulItem>>,
 }
 
@@ -8314,11 +9059,14 @@ impl DeleteVpcEndpointsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteVpcPeeringConnection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVpcPeeringConnectionRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC peering connection.</p>"]
+    #[serde(rename="VpcPeeringConnectionId")]
     pub vpc_peering_connection_id: String,
 }
 
@@ -8343,9 +9091,11 @@ impl DeleteVpcPeeringConnectionRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DeleteVpcPeeringConnection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVpcPeeringConnectionResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -8393,11 +9143,14 @@ impl DeleteVpcPeeringConnectionResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteVpc.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVpcRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -8422,11 +9175,14 @@ impl DeleteVpcRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteVpnConnection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVpnConnectionRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPN connection.</p>"]
+    #[serde(rename="VpnConnectionId")]
     pub vpn_connection_id: String,
 }
 
@@ -8451,11 +9207,13 @@ impl DeleteVpnConnectionRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteVpnConnectionRoute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVpnConnectionRouteRequest {
     #[doc="<p>The CIDR block associated with the local subnet of the customer network.</p>"]
+    #[serde(rename="DestinationCidrBlock")]
     pub destination_cidr_block: String,
     #[doc="<p>The ID of the VPN connection.</p>"]
+    #[serde(rename="VpnConnectionId")]
     pub vpn_connection_id: String,
 }
 
@@ -8478,11 +9236,14 @@ impl DeleteVpnConnectionRouteRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeleteVpnGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVpnGatewayRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the virtual private gateway.</p>"]
+    #[serde(rename="VpnGatewayId")]
     pub vpn_gateway_id: String,
 }
 
@@ -8507,11 +9268,14 @@ impl DeleteVpnGatewayRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DeregisterImage.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterImageRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the AMI.</p>"]
+    #[serde(rename="ImageId")]
     pub image_id: String,
 }
 
@@ -8536,11 +9300,15 @@ impl DeregisterImageRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribeAccountAttributes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountAttributesRequest {
     #[doc="<p>One or more account attribute names.</p>"]
+    #[serde(rename="AttributeNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_names: Option<Vec<String>>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -8570,9 +9338,11 @@ impl DescribeAccountAttributesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeAccountAttributes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountAttributesResult {
     #[doc="<p>Information about one or more account attributes.</p>"]
+    #[serde(rename="AccountAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account_attributes: Option<Vec<AccountAttribute>>,
 }
 
@@ -8621,15 +9391,23 @@ impl DescribeAccountAttributesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeAddresses.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAddressesRequest {
     #[doc="<p>[EC2-VPC] One or more allocation IDs.</p> <p>Default: Describes all your Elastic IP addresses.</p>"]
+    #[serde(rename="AllocationIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocation_ids: Option<Vec<String>>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters. Filter names and values are case-sensitive.</p> <ul> <li> <p> <code>allocation-id</code> - [EC2-VPC] The allocation ID for the address.</p> </li> <li> <p> <code>association-id</code> - [EC2-VPC] The association ID for the address.</p> </li> <li> <p> <code>domain</code> - Indicates whether the address is for use in EC2-Classic (<code>standard</code>) or in a VPC (<code>vpc</code>).</p> </li> <li> <p> <code>instance-id</code> - The ID of the instance the address is associated with, if any.</p> </li> <li> <p> <code>network-interface-id</code> - [EC2-VPC] The ID of the network interface that the address is associated with, if any.</p> </li> <li> <p> <code>network-interface-owner-id</code> - The AWS account ID of the owner.</p> </li> <li> <p> <code>private-ip-address</code> - [EC2-VPC] The private IP address associated with the Elastic IP address.</p> </li> <li> <p> <code>public-ip</code> - The Elastic IP address.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>[EC2-Classic] One or more Elastic IP addresses.</p> <p>Default: Describes all your Elastic IP addresses.</p>"]
+    #[serde(rename="PublicIps")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ips: Option<Vec<String>>,
 }
 
@@ -8667,9 +9445,11 @@ impl DescribeAddressesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeAddresses.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAddressesResult {
     #[doc="<p>Information about one or more Elastic IP addresses.</p>"]
+    #[serde(rename="Addresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub addresses: Option<Vec<Address>>,
 }
 
@@ -8716,13 +9496,19 @@ impl DescribeAddressesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeAvailabilityZones.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAvailabilityZonesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>message</code> - Information about the Availability Zone.</p> </li> <li> <p> <code>region-name</code> - The name of the region for the Availability Zone (for example, <code>us-east-1</code>).</p> </li> <li> <p> <code>state</code> - The state of the Availability Zone (<code>available</code> | <code>information</code> | <code>impaired</code> | <code>unavailable</code>).</p> </li> <li> <p> <code>zone-name</code> - The name of the Availability Zone (for example, <code>us-east-1a</code>).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The names of one or more Availability Zones.</p>"]
+    #[serde(rename="ZoneNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub zone_names: Option<Vec<String>>,
 }
 
@@ -8755,9 +9541,11 @@ impl DescribeAvailabilityZonesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeAvailabiltyZones.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAvailabilityZonesResult {
     #[doc="<p>Information about one or more Availability Zones.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<AvailabilityZone>>,
 }
 
@@ -8806,13 +9594,19 @@ impl DescribeAvailabilityZonesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeBundleTasks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBundleTasksRequest {
     #[doc="<p>One or more bundle task IDs.</p> <p>Default: Describes all your bundle tasks.</p>"]
+    #[serde(rename="BundleIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bundle_ids: Option<Vec<String>>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>bundle-id</code> - The ID of the bundle task.</p> </li> <li> <p> <code>error-code</code> - If the task failed, the error code returned.</p> </li> <li> <p> <code>error-message</code> - If the task failed, the error message returned.</p> </li> <li> <p> <code>instance-id</code> - The ID of the instance.</p> </li> <li> <p> <code>progress</code> - The level of task completion, as a percentage (for example, 20%).</p> </li> <li> <p> <code>s3-bucket</code> - The Amazon S3 bucket to store the AMI.</p> </li> <li> <p> <code>s3-prefix</code> - The beginning of the AMI name.</p> </li> <li> <p> <code>start-time</code> - The time the task started (for example, 2013-09-15T17:15:20.000Z).</p> </li> <li> <p> <code>state</code> - The state of the task (<code>pending</code> | <code>waiting-for-shutdown</code> | <code>bundling</code> | <code>storing</code> | <code>cancelling</code> | <code>complete</code> | <code>failed</code>).</p> </li> <li> <p> <code>update-time</code> - The time of the most recent update for the task.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
 }
 
@@ -8845,9 +9639,11 @@ impl DescribeBundleTasksRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeBundleTasks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBundleTasksResult {
     #[doc="<p>Information about one or more bundle tasks.</p>"]
+    #[serde(rename="BundleTasks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bundle_tasks: Option<Vec<BundleTask>>,
 }
 
@@ -8895,17 +9691,27 @@ impl DescribeBundleTasksResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeClassicLinkInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClassicLinkInstancesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>group-id</code> - The ID of a VPC security group that's associated with the instance.</p> </li> <li> <p> <code>instance-id</code> - The ID of the instance.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>vpc-id</code> - The ID of the VPC that the instance is linked to.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more instance IDs. Must be instances linked to a VPC through ClassicLink.</p>"]
+    #[serde(rename="InstanceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_ids: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return for the request in a single page. The remaining results of the initial request can be seen by sending another request with the returned <code>NextToken</code> value. This value can be between 5 and 1000; if <code>MaxResults</code> is given a value larger than 1000, only 1000 results are returned. You cannot specify this parameter and the instance IDs parameter in the same request.</p> <p>Constraint: If the value is greater than 1000, we return only 1000 items.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -8946,11 +9752,15 @@ impl DescribeClassicLinkInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeClassicLinkInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClassicLinkInstancesResult {
     #[doc="<p>Information about one or more linked EC2-Classic instances.</p>"]
+    #[serde(rename="Instances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instances: Option<Vec<ClassicLinkInstance>>,
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -9044,11 +9854,15 @@ impl DescribeConversionTaskListDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeConversionTasks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConversionTasksRequest {
     #[doc="<p>One or more conversion task IDs.</p>"]
+    #[serde(rename="ConversionTaskIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub conversion_task_ids: Option<Vec<String>>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -9078,9 +9892,11 @@ impl DescribeConversionTasksRequestSerializer {
 }
 
 #[doc="<p>Contains the output for DescribeConversionTasks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConversionTasksResult {
     #[doc="<p>Information about the conversion tasks.</p>"]
+    #[serde(rename="ConversionTasks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub conversion_tasks: Option<Vec<ConversionTask>>,
 }
 
@@ -9126,13 +9942,19 @@ impl DescribeConversionTasksResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeCustomerGateways.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCustomerGatewaysRequest {
     #[doc="<p>One or more customer gateway IDs.</p> <p>Default: Describes all your customer gateways.</p>"]
+    #[serde(rename="CustomerGatewayIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub customer_gateway_ids: Option<Vec<String>>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>bgp-asn</code> - The customer gateway's Border Gateway Protocol (BGP) Autonomous System Number (ASN).</p> </li> <li> <p> <code>customer-gateway-id</code> - The ID of the customer gateway.</p> </li> <li> <p> <code>ip-address</code> - The IP address of the customer gateway's Internet-routable external interface.</p> </li> <li> <p> <code>state</code> - The state of the customer gateway (<code>pending</code> | <code>available</code> | <code>deleting</code> | <code>deleted</code>).</p> </li> <li> <p> <code>type</code> - The type of customer gateway. Currently, the only supported type is <code>ipsec.1</code>.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
 }
 
@@ -9167,9 +9989,11 @@ impl DescribeCustomerGatewaysRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeCustomerGateways.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCustomerGatewaysResult {
     #[doc="<p>Information about one or more customer gateways.</p>"]
+    #[serde(rename="CustomerGateways")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub customer_gateways: Option<Vec<CustomerGateway>>,
 }
 
@@ -9217,13 +10041,19 @@ impl DescribeCustomerGatewaysResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeDhcpOptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDhcpOptionsRequest {
     #[doc="<p>The IDs of one or more DHCP options sets.</p> <p>Default: Describes all your DHCP options sets.</p>"]
+    #[serde(rename="DhcpOptionsIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dhcp_options_ids: Option<Vec<String>>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>dhcp-options-id</code> - The ID of a set of DHCP options.</p> </li> <li> <p> <code>key</code> - The key for one of the options (for example, <code>domain-name</code>).</p> </li> <li> <p> <code>value</code> - The value for one of the options.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
 }
 
@@ -9256,9 +10086,11 @@ impl DescribeDhcpOptionsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeDhcpOptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDhcpOptionsResult {
     #[doc="<p>Information about one or more DHCP options sets.</p>"]
+    #[serde(rename="DhcpOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dhcp_options: Option<Vec<DhcpOptions>>,
 }
 
@@ -9305,15 +10137,23 @@ impl DescribeDhcpOptionsResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEgressOnlyInternetGatewaysRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more egress-only Internet gateway IDs.</p>"]
+    #[serde(rename="EgressOnlyInternetGatewayIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub egress_only_internet_gateway_ids: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return for the request in a single page. The remaining results can be seen by sending another request with the returned <code>NextToken</code> value. This value can be between 5 and 1000; if <code>MaxResults</code> is given a value larger than 1000, only 1000 results are returned.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -9352,11 +10192,15 @@ impl DescribeEgressOnlyInternetGatewaysRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEgressOnlyInternetGatewaysResult {
     #[doc="<p>Information about the egress-only Internet gateways.</p>"]
+    #[serde(rename="EgressOnlyInternetGateways")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub egress_only_internet_gateways: Option<Vec<EgressOnlyInternetGateway>>,
     #[doc="<p>The token to use to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -9406,17 +10250,27 @@ impl DescribeEgressOnlyInternetGatewaysResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeElasticGpusRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more Elastic GPU IDs.</p>"]
+    #[serde(rename="ElasticGpuIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_ids: Option<Vec<String>>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>availability-zone</code> - The Availability Zone in which the Elastic GPU resides.</p> </li> <li> <p> <code>elastic-gpu-health</code> - The status of the Elastic GPU (<code>OK</code> | <code>IMPAIRED</code>).</p> </li> <li> <p> <code>elastic-gpu-state</code> - The state of the Elastic GPU (<code>ATTACHED</code>).</p> </li> <li> <p> <code>elastic-gpu-type</code> - The type of Elastic GPU; for example, <code>eg1.medium</code>.</p> </li> <li> <p> <code>instance-id</code> - The ID of the instance to which the Elastic GPU is associated.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of results to return in a single call. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value. This value can be between 5 and 1000.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to request the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -9456,13 +10310,19 @@ impl DescribeElasticGpusRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeElasticGpusResult {
     #[doc="<p>Information about the Elastic GPUs.</p>"]
+    #[serde(rename="ElasticGpuSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_set: Option<Vec<ElasticGpus>>,
     #[doc="<p>The total number of items to return. If the total number of items available is more than the value specified in max-items then a Next-Token will be provided in the output that you can use to resume pagination.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -9518,9 +10378,11 @@ impl DescribeElasticGpusResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeExportTasks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExportTasksRequest {
     #[doc="<p>One or more export task IDs.</p>"]
+    #[serde(rename="ExportTaskIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub export_task_ids: Option<Vec<String>>,
 }
 
@@ -9544,9 +10406,11 @@ impl DescribeExportTasksRequestSerializer {
 }
 
 #[doc="<p>Contains the output for DescribeExportTasks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExportTasksResult {
     #[doc="<p>Information about the export tasks.</p>"]
+    #[serde(rename="ExportTasks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub export_tasks: Option<Vec<ExportTask>>,
 }
 
@@ -9594,15 +10458,23 @@ impl DescribeExportTasksResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeFlowLogs.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFlowLogsRequest {
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>deliver-log-status</code> - The status of the logs delivery (<code>SUCCESS</code> | <code>FAILED</code>).</p> </li> <li> <p> <code>flow-log-id</code> - The ID of the flow log.</p> </li> <li> <p> <code>log-group-name</code> - The name of the log group.</p> </li> <li> <p> <code>resource-id</code> - The ID of the VPC, subnet, or network interface.</p> </li> <li> <p> <code>traffic-type</code> - The type of traffic (<code>ACCEPT</code> | <code>REJECT</code> | <code>ALL</code>)</p> </li> </ul>"]
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<Vec<Filter>>,
     #[doc="<p>One or more flow log IDs.</p>"]
+    #[serde(rename="FlowLogIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub flow_log_ids: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return for the request in a single page. The remaining results can be seen by sending another request with the returned <code>NextToken</code> value. This value can be between 5 and 1000; if <code>MaxResults</code> is given a value larger than 1000, only 1000 results are returned. You cannot specify this parameter and the flow log IDs parameter in the same request.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -9639,11 +10511,15 @@ impl DescribeFlowLogsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeFlowLogs.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFlowLogsResult {
     #[doc="<p>Information about the flow logs.</p>"]
+    #[serde(rename="FlowLogs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub flow_logs: Option<Vec<FlowLog>>,
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -9693,19 +10569,31 @@ impl DescribeFlowLogsResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFpgaImagesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>create-time</code> - The creation time of the AFI.</p> </li> <li> <p> <code>fpga-image-id</code> - The FPGA image identifier (AFI ID).</p> </li> <li> <p> <code>fpga-image-global-id</code> - The global FPGA image identifier (AGFI ID).</p> </li> <li> <p> <code>name</code> - The name of the AFI.</p> </li> <li> <p> <code>owner-id</code> - The AWS account ID of the AFI owner.</p> </li> <li> <p> <code>product-code</code> - The product code.</p> </li> <li> <p> <code>shell-version</code> - The version of the AWS Shell that was used to create the bitstream.</p> </li> <li> <p> <code>state</code> - The state of the AFI (<code>pending</code> | <code>failed</code> | <code>available</code> | <code>unavailable</code>).</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>update-time</code> - The time of the most recent update.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more AFI IDs.</p>"]
+    #[serde(rename="FpgaImageIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fpga_image_ids: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return in a single call.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Filters the AFI by owner. Specify an AWS account ID, <code>self</code> (owner is the sender of the request), or an AWS owner alias (valid values are <code>amazon</code> | <code>aws-marketplace</code>).</p>"]
+    #[serde(rename="Owners")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owners: Option<Vec<String>>,
 }
 
@@ -9750,11 +10638,15 @@ impl DescribeFpgaImagesRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFpgaImagesResult {
     #[doc="<p>Information about one or more FPGA images.</p>"]
+    #[serde(rename="FpgaImages")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fpga_images: Option<Vec<FpgaImage>>,
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -9805,19 +10697,31 @@ impl DescribeFpgaImagesResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHostReservationOfferingsRequest {
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>instance-family</code> - The instance family of the offering (e.g., <code>m4</code>).</p> </li> <li> <p> <code>payment-option</code> - The payment option (<code>NoUpfront</code> | <code>PartialUpfront</code> | <code>AllUpfront</code>).</p> </li> </ul>"]
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<Vec<Filter>>,
     #[doc="<p>This is the maximum duration of the reservation you'd like to purchase, specified in seconds. Reservations are available in one-year and three-year terms. The number of seconds specified must be the number of seconds in a year (365x24x60x60) times one of the supported durations (1 or 3). For example, specify 94608000 for three years.</p>"]
+    #[serde(rename="MaxDuration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_duration: Option<i64>,
     #[doc="<p>The maximum number of results to return for the request in a single page. The remaining results can be seen by sending another request with the returned <code>nextToken</code> value. This value can be between 5 and 500; if <code>maxResults</code> is given a larger value than 500, you will receive an error.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>This is the minimum duration of the reservation you'd like to purchase, specified in seconds. Reservations are available in one-year and three-year terms. The number of seconds specified must be the number of seconds in a year (365x24x60x60) times one of the supported durations (1 or 3). For example, specify 31536000 for one year.</p>"]
+    #[serde(rename="MinDuration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_duration: Option<i64>,
     #[doc="<p>The token to use to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The ID of the reservation offering.</p>"]
+    #[serde(rename="OfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_id: Option<String>,
 }
 
@@ -9860,11 +10764,15 @@ impl DescribeHostReservationOfferingsRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHostReservationOfferingsResult {
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Information about the offerings.</p>"]
+    #[serde(rename="OfferingSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_set: Option<Vec<HostOffering>>,
 }
 
@@ -9916,15 +10824,23 @@ impl DescribeHostReservationOfferingsResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHostReservationsRequest {
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>instance-family</code> - The instance family (e.g., <code>m4</code>).</p> </li> <li> <p> <code>payment-option</code> - The payment option (<code>NoUpfront</code> | <code>PartialUpfront</code> | <code>AllUpfront</code>).</p> </li> <li> <p> <code>state</code> - The state of the reservation (<code>payment-pending</code> | <code>payment-failed</code> | <code>active</code> | <code>retired</code>).</p> </li> </ul>"]
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<Vec<Filter>>,
     #[doc="<p>One or more host reservation IDs.</p>"]
+    #[serde(rename="HostReservationIdSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_reservation_id_set: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return for the request in a single page. The remaining results can be seen by sending another request with the returned <code>nextToken</code> value. This value can be between 5 and 500; if <code>maxResults</code> is given a larger value than 500, you will receive an error.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to use to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -9962,11 +10878,15 @@ impl DescribeHostReservationsRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHostReservationsResult {
     #[doc="<p>Details about the reservation's configuration.</p>"]
+    #[serde(rename="HostReservationSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_reservation_set: Option<Vec<HostReservation>>,
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10018,15 +10938,23 @@ impl DescribeHostReservationsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeHosts.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHostsRequest {
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>instance-type</code> - The instance type size that the Dedicated Host is configured to support.</p> </li> <li> <p> <code>auto-placement</code> - Whether auto-placement is enabled or disabled (<code>on</code> | <code>off</code>).</p> </li> <li> <p> <code>host-reservation-id</code> - The ID of the reservation assigned to this host.</p> </li> <li> <p> <code>client-token</code> - The idempotency token you provided when you launched the instance</p> </li> <li> <p> <code>state</code>- The allocation state of the Dedicated Host (<code>available</code> | <code>under-assessment</code> | <code>permanent-failure</code> | <code>released</code> | <code>released-permanent-failure</code>).</p> </li> <li> <p> <code>availability-zone</code> - The Availability Zone of the host.</p> </li> </ul>"]
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<Vec<Filter>>,
     #[doc="<p>The IDs of the Dedicated Hosts. The IDs are used for targeted instance launches.</p>"]
+    #[serde(rename="HostIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_ids: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return for the request in a single page. The remaining results can be seen by sending another request with the returned <code>nextToken</code> value. This value can be between 5 and 500; if <code>maxResults</code> is given a larger value than 500, you will receive an error. You cannot specify this parameter and the host IDs parameter in the same request.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10063,11 +10991,15 @@ impl DescribeHostsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeHosts.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHostsResult {
     #[doc="<p>Information about the Dedicated Hosts.</p>"]
+    #[serde(rename="Hosts")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hosts: Option<Vec<Host>>,
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10117,15 +11049,23 @@ impl DescribeHostsResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIamInstanceProfileAssociationsRequest {
     #[doc="<p>One or more IAM instance profile associations.</p>"]
+    #[serde(rename="AssociationIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association_ids: Option<Vec<String>>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>instance-id</code> - The ID of the instance.</p> </li> <li> <p> <code>state</code> - The state of the association (<code>associating</code> | <code>associated</code> | <code>disassociating</code> | <code>disassociated</code>).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of results to return in a single call. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to request the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10163,11 +11103,15 @@ impl DescribeIamInstanceProfileAssociationsRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIamInstanceProfileAssociationsResult {
     #[doc="<p>Information about one or more IAM instance profile associations.</p>"]
+    #[serde(rename="IamInstanceProfileAssociations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile_associations: Option<Vec<IamInstanceProfileAssociation>>,
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10218,9 +11162,11 @@ impl DescribeIamInstanceProfileAssociationsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeIdFormat.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdFormatRequest {
     #[doc="<p>The type of resource: <code>instance</code> | <code>reservation</code> | <code>snapshot</code> | <code>volume</code> </p>"]
+    #[serde(rename="Resource")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource: Option<String>,
 }
 
@@ -10243,9 +11189,11 @@ impl DescribeIdFormatRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeIdFormat.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdFormatResult {
     #[doc="<p>Information about the ID format for the resource.</p>"]
+    #[serde(rename="Statuses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub statuses: Option<Vec<IdFormat>>,
 }
 
@@ -10292,11 +11240,14 @@ impl DescribeIdFormatResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeIdentityIdFormat.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdentityIdFormatRequest {
     #[doc="<p>The ARN of the principal, which can be an IAM role, IAM user, or the root user.</p>"]
+    #[serde(rename="PrincipalArn")]
     pub principal_arn: String,
     #[doc="<p>The type of resource: <code>instance</code> | <code>reservation</code> | <code>snapshot</code> | <code>volume</code> </p>"]
+    #[serde(rename="Resource")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource: Option<String>,
 }
 
@@ -10321,9 +11272,11 @@ impl DescribeIdentityIdFormatRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeIdentityIdFormat.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeIdentityIdFormatResult {
     #[doc="<p>Information about the ID format for the resources.</p>"]
+    #[serde(rename="Statuses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub statuses: Option<Vec<IdFormat>>,
 }
 
@@ -10370,13 +11323,17 @@ impl DescribeIdentityIdFormatResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeImageAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImageAttributeRequest {
     #[doc="<p>The AMI attribute.</p> <p> <b>Note</b>: Depending on your account privileges, the <code>blockDeviceMapping</code> attribute may return a <code>Client.AuthFailure</code> error. If this happens, use <a>DescribeImages</a> to get information about the block device mapping for the AMI.</p>"]
+    #[serde(rename="Attribute")]
     pub attribute: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the AMI.</p>"]
+    #[serde(rename="ImageId")]
     pub image_id: String,
 }
 
@@ -10403,17 +11360,27 @@ impl DescribeImageAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribeImages.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImagesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Scopes the images by users with explicit launch permissions. Specify an AWS account ID, <code>self</code> (the sender of the request), or <code>all</code> (public AMIs).</p>"]
+    #[serde(rename="ExecutableUsers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub executable_users: Option<Vec<String>>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>architecture</code> - The image architecture (<code>i386</code> | <code>x86_64</code>).</p> </li> <li> <p> <code>block-device-mapping.delete-on-termination</code> - A Boolean value that indicates whether the Amazon EBS volume is deleted on instance termination.</p> </li> <li> <p> <code>block-device-mapping.device-name</code> - The device name for the EBS volume (for example, <code>/dev/sdh</code>).</p> </li> <li> <p> <code>block-device-mapping.snapshot-id</code> - The ID of the snapshot used for the EBS volume.</p> </li> <li> <p> <code>block-device-mapping.volume-size</code> - The volume size of the EBS volume, in GiB.</p> </li> <li> <p> <code>block-device-mapping.volume-type</code> - The volume type of the EBS volume (<code>gp2</code> | <code>io1</code> | <code>st1 </code>| <code>sc1</code> | <code>standard</code>).</p> </li> <li> <p> <code>description</code> - The description of the image (provided during image creation).</p> </li> <li> <p> <code>ena-support</code> - A Boolean that indicates whether enhanced networking with ENA is enabled.</p> </li> <li> <p> <code>hypervisor</code> - The hypervisor type (<code>ovm</code> | <code>xen</code>).</p> </li> <li> <p> <code>image-id</code> - The ID of the image.</p> </li> <li> <p> <code>image-type</code> - The image type (<code>machine</code> | <code>kernel</code> | <code>ramdisk</code>).</p> </li> <li> <p> <code>is-public</code> - A Boolean that indicates whether the image is public.</p> </li> <li> <p> <code>kernel-id</code> - The kernel ID.</p> </li> <li> <p> <code>manifest-location</code> - The location of the image manifest.</p> </li> <li> <p> <code>name</code> - The name of the AMI (provided during image creation).</p> </li> <li> <p> <code>owner-alias</code> - String value from an Amazon-maintained list (<code>amazon</code> | <code>aws-marketplace</code> | <code>microsoft</code>) of snapshot owners. Not to be confused with the user-configured AWS account alias, which is set from the IAM console.</p> </li> <li> <p> <code>owner-id</code> - The AWS account ID of the image owner.</p> </li> <li> <p> <code>platform</code> - The platform. To only list Windows-based AMIs, use <code>windows</code>.</p> </li> <li> <p> <code>product-code</code> - The product code.</p> </li> <li> <p> <code>product-code.type</code> - The type of the product code (<code>devpay</code> | <code>marketplace</code>).</p> </li> <li> <p> <code>ramdisk-id</code> - The RAM disk ID.</p> </li> <li> <p> <code>root-device-name</code> - The name of the root device volume (for example, <code>/dev/sda1</code>).</p> </li> <li> <p> <code>root-device-type</code> - The type of the root device volume (<code>ebs</code> | <code>instance-store</code>).</p> </li> <li> <p> <code>state</code> - The state of the image (<code>available</code> | <code>pending</code> | <code>failed</code>).</p> </li> <li> <p> <code>state-reason-code</code> - The reason code for the state change.</p> </li> <li> <p> <code>state-reason-message</code> - The message for the state change.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the tag-value filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>virtualization-type</code> - The virtualization type (<code>paravirtual</code> | <code>hvm</code>).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more image IDs.</p> <p>Default: Describes all images available to you.</p>"]
+    #[serde(rename="ImageIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_ids: Option<Vec<String>>,
     #[doc="<p>Filters the images by the owner. Specify an AWS account ID, <code>self</code> (owner is the sender of the request), or an AWS owner alias (valid values are <code>amazon</code> | <code>aws-marketplace</code> | <code>microsoft</code>). Omitting this option returns all images for which you have launch permissions, regardless of ownership.</p>"]
+    #[serde(rename="Owners")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owners: Option<Vec<String>>,
 }
 
@@ -10456,9 +11423,11 @@ impl DescribeImagesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeImages.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImagesResult {
     #[doc="<p>Information about one or more images.</p>"]
+    #[serde(rename="Images")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub images: Option<Vec<Image>>,
 }
 
@@ -10505,17 +11474,27 @@ impl DescribeImagesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeImportImageTasks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImportImageTasksRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Filter tasks using the <code>task-state</code> filter and one of the following values: active, completed, deleting, deleted.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>A list of import image task IDs.</p>"]
+    #[serde(rename="ImportTaskIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_task_ids: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return in a single call. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>A token that indicates the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10556,11 +11535,15 @@ impl DescribeImportImageTasksRequestSerializer {
 }
 
 #[doc="<p>Contains the output for DescribeImportImageTasks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImportImageTasksResult {
     #[doc="<p>A list of zero or more import image tasks that are currently active or were completed or canceled in the previous 7 days.</p>"]
+    #[serde(rename="ImportImageTasks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_image_tasks: Option<Vec<ImportImageTask>>,
     #[doc="<p>The token to use to get the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10612,17 +11595,27 @@ impl DescribeImportImageTasksResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeImportSnapshotTasks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImportSnapshotTasksRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>A list of import snapshot task IDs.</p>"]
+    #[serde(rename="ImportTaskIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_task_ids: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return in a single call. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>A token that indicates the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10663,11 +11656,15 @@ impl DescribeImportSnapshotTasksRequestSerializer {
 }
 
 #[doc="<p>Contains the output for DescribeImportSnapshotTasks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImportSnapshotTasksResult {
     #[doc="<p>A list of zero or more import snapshot tasks that are currently active or were completed or canceled in the previous 7 days.</p>"]
+    #[serde(rename="ImportSnapshotTasks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_snapshot_tasks: Option<Vec<ImportSnapshotTask>>,
     #[doc="<p>The token to use to get the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10720,13 +11717,17 @@ impl DescribeImportSnapshotTasksResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeInstanceAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstanceAttributeRequest {
     #[doc="<p>The instance attribute.</p> <p>Note: The <code>enaSupport</code> attribute is not supported at this time.</p>"]
+    #[serde(rename="Attribute")]
     pub attribute: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
 }
 
@@ -10753,19 +11754,31 @@ impl DescribeInstanceAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribeInstanceStatus.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstanceStatusRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>availability-zone</code> - The Availability Zone of the instance.</p> </li> <li> <p> <code>event.code</code> - The code for the scheduled event (<code>instance-reboot</code> | <code>system-reboot</code> | <code>system-maintenance</code> | <code>instance-retirement</code> | <code>instance-stop</code>).</p> </li> <li> <p> <code>event.description</code> - A description of the event.</p> </li> <li> <p> <code>event.not-after</code> - The latest end time for the scheduled event (for example, <code>2014-09-15T17:15:20.000Z</code>).</p> </li> <li> <p> <code>event.not-before</code> - The earliest start time for the scheduled event (for example, <code>2014-09-15T17:15:20.000Z</code>).</p> </li> <li> <p> <code>instance-state-code</code> - The code for the instance state, as a 16-bit unsigned integer. The high byte is an opaque internal value and should be ignored. The low byte is set based on the state represented. The valid values are 0 (pending), 16 (running), 32 (shutting-down), 48 (terminated), 64 (stopping), and 80 (stopped).</p> </li> <li> <p> <code>instance-state-name</code> - The state of the instance (<code>pending</code> | <code>running</code> | <code>shutting-down</code> | <code>terminated</code> | <code>stopping</code> | <code>stopped</code>).</p> </li> <li> <p> <code>instance-status.reachability</code> - Filters on instance status where the name is <code>reachability</code> (<code>passed</code> | <code>failed</code> | <code>initializing</code> | <code>insufficient-data</code>).</p> </li> <li> <p> <code>instance-status.status</code> - The status of the instance (<code>ok</code> | <code>impaired</code> | <code>initializing</code> | <code>insufficient-data</code> | <code>not-applicable</code>).</p> </li> <li> <p> <code>system-status.reachability</code> - Filters on system status where the name is <code>reachability</code> (<code>passed</code> | <code>failed</code> | <code>initializing</code> | <code>insufficient-data</code>).</p> </li> <li> <p> <code>system-status.status</code> - The system status of the instance (<code>ok</code> | <code>impaired</code> | <code>initializing</code> | <code>insufficient-data</code> | <code>not-applicable</code>).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>When <code>true</code>, includes the health status for all instances. When <code>false</code>, includes the health status for running instances only.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="IncludeAllInstances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub include_all_instances: Option<bool>,
     #[doc="<p>One or more instance IDs.</p> <p>Default: Describes all your instances.</p> <p>Constraints: Maximum 100 explicitly specified instance IDs.</p>"]
+    #[serde(rename="InstanceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_ids: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return in a single call. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value. This value can be between 5 and 1000. You cannot specify this parameter and the instance IDs parameter in the same call.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10810,11 +11823,15 @@ impl DescribeInstanceStatusRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeInstanceStatus.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstanceStatusResult {
     #[doc="<p>One or more instance status descriptions.</p>"]
+    #[serde(rename="InstanceStatuses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_statuses: Option<Vec<InstanceStatus>>,
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10866,17 +11883,27 @@ impl DescribeInstanceStatusResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>affinity</code> - The affinity setting for an instance running on a Dedicated Host (<code>default</code> | <code>host</code>).</p> </li> <li> <p> <code>architecture</code> - The instance architecture (<code>i386</code> | <code>x86_64</code>).</p> </li> <li> <p> <code>availability-zone</code> - The Availability Zone of the instance.</p> </li> <li> <p> <code>block-device-mapping.attach-time</code> - The attach time for an EBS volume mapped to the instance, for example, <code>2010-09-15T17:15:20.000Z</code>.</p> </li> <li> <p> <code>block-device-mapping.delete-on-termination</code> - A Boolean that indicates whether the EBS volume is deleted on instance termination.</p> </li> <li> <p> <code>block-device-mapping.device-name</code> - The device name for the EBS volume (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p> </li> <li> <p> <code>block-device-mapping.status</code> - The status for the EBS volume (<code>attaching</code> | <code>attached</code> | <code>detaching</code> | <code>detached</code>).</p> </li> <li> <p> <code>block-device-mapping.volume-id</code> - The volume ID of the EBS volume.</p> </li> <li> <p> <code>client-token</code> - The idempotency token you provided when you launched the instance.</p> </li> <li> <p> <code>dns-name</code> - The public DNS name of the instance.</p> </li> <li> <p> <code>group-id</code> - The ID of the security group for the instance. EC2-Classic only.</p> </li> <li> <p> <code>group-name</code> - The name of the security group for the instance. EC2-Classic only.</p> </li> <li> <p> <code>host-id</code> - The ID of the Dedicated Host on which the instance is running, if applicable.</p> </li> <li> <p> <code>hypervisor</code> - The hypervisor type of the instance (<code>ovm</code> | <code>xen</code>).</p> </li> <li> <p> <code>iam-instance-profile.arn</code> - The instance profile associated with the instance. Specified as an ARN.</p> </li> <li> <p> <code>image-id</code> - The ID of the image used to launch the instance.</p> </li> <li> <p> <code>instance-id</code> - The ID of the instance.</p> </li> <li> <p> <code>instance-lifecycle</code> - Indicates whether this is a Spot Instance or a Scheduled Instance (<code>spot</code> | <code>scheduled</code>).</p> </li> <li> <p> <code>instance-state-code</code> - The state of the instance, as a 16-bit unsigned integer. The high byte is an opaque internal value and should be ignored. The low byte is set based on the state represented. The valid values are: 0 (pending), 16 (running), 32 (shutting-down), 48 (terminated), 64 (stopping), and 80 (stopped).</p> </li> <li> <p> <code>instance-state-name</code> - The state of the instance (<code>pending</code> | <code>running</code> | <code>shutting-down</code> | <code>terminated</code> | <code>stopping</code> | <code>stopped</code>).</p> </li> <li> <p> <code>instance-type</code> - The type of instance (for example, <code>t2.micro</code>).</p> </li> <li> <p> <code>instance.group-id</code> - The ID of the security group for the instance. </p> </li> <li> <p> <code>instance.group-name</code> - The name of the security group for the instance. </p> </li> <li> <p> <code>ip-address</code> - The public IPv4 address of the instance.</p> </li> <li> <p> <code>kernel-id</code> - The kernel ID.</p> </li> <li> <p> <code>key-name</code> - The name of the key pair used when the instance was launched.</p> </li> <li> <p> <code>launch-index</code> - When launching multiple instances, this is the index for the instance in the launch group (for example, 0, 1, 2, and so on). </p> </li> <li> <p> <code>launch-time</code> - The time when the instance was launched.</p> </li> <li> <p> <code>monitoring-state</code> - Indicates whether detailed monitoring is enabled (<code>disabled</code> | <code>enabled</code>).</p> </li> <li> <p> <code>network-interface.addresses.private-ip-address</code> - The private IPv4 address associated with the network interface.</p> </li> <li> <p> <code>network-interface.addresses.primary</code> - Specifies whether the IPv4 address of the network interface is the primary private IPv4 address.</p> </li> <li> <p> <code>network-interface.addresses.association.public-ip</code> - The ID of the association of an Elastic IP address (IPv4) with a network interface.</p> </li> <li> <p> <code>network-interface.addresses.association.ip-owner-id</code> - The owner ID of the private IPv4 address associated with the network interface.</p> </li> <li> <p> <code>network-interface.association.public-ip</code> - The address of the Elastic IP address (IPv4) bound to the network interface.</p> </li> <li> <p> <code>network-interface.association.ip-owner-id</code> - The owner of the Elastic IP address (IPv4) associated with the network interface.</p> </li> <li> <p> <code>network-interface.association.allocation-id</code> - The allocation ID returned when you allocated the Elastic IP address (IPv4) for your network interface.</p> </li> <li> <p> <code>network-interface.association.association-id</code> - The association ID returned when the network interface was associated with an IPv4 address.</p> </li> <li> <p> <code>network-interface.attachment.attachment-id</code> - The ID of the interface attachment.</p> </li> <li> <p> <code>network-interface.attachment.instance-id</code> - The ID of the instance to which the network interface is attached.</p> </li> <li> <p> <code>network-interface.attachment.instance-owner-id</code> - The owner ID of the instance to which the network interface is attached.</p> </li> <li> <p> <code>network-interface.attachment.device-index</code> - The device index to which the network interface is attached.</p> </li> <li> <p> <code>network-interface.attachment.status</code> - The status of the attachment (<code>attaching</code> | <code>attached</code> | <code>detaching</code> | <code>detached</code>).</p> </li> <li> <p> <code>network-interface.attachment.attach-time</code> - The time that the network interface was attached to an instance.</p> </li> <li> <p> <code>network-interface.attachment.delete-on-termination</code> - Specifies whether the attachment is deleted when an instance is terminated.</p> </li> <li> <p> <code>network-interface.availability-zone</code> - The Availability Zone for the network interface.</p> </li> <li> <p> <code>network-interface.description</code> - The description of the network interface.</p> </li> <li> <p> <code>network-interface.group-id</code> - The ID of a security group associated with the network interface.</p> </li> <li> <p> <code>network-interface.group-name</code> - The name of a security group associated with the network interface.</p> </li> <li> <p> <code>network-interface.ipv6-addresses.ipv6-address</code> - The IPv6 address associated with the network interface.</p> </li> <li> <p> <code>network-interface.mac-address</code> - The MAC address of the network interface.</p> </li> <li> <p> <code>network-interface.network-interface-id</code> - The ID of the network interface.</p> </li> <li> <p> <code>network-interface.owner-id</code> - The ID of the owner of the network interface.</p> </li> <li> <p> <code>network-interface.private-dns-name</code> - The private DNS name of the network interface.</p> </li> <li> <p> <code>network-interface.requester-id</code> - The requester ID for the network interface.</p> </li> <li> <p> <code>network-interface.requester-managed</code> - Indicates whether the network interface is being managed by AWS.</p> </li> <li> <p> <code>network-interface.status</code> - The status of the network interface (<code>available</code>) | <code>in-use</code>).</p> </li> <li> <p> <code>network-interface.source-dest-check</code> - Whether the network interface performs source/destination checking. A value of <code>true</code> means checking is enabled, and <code>false</code> means checking is disabled. The value must be <code>false</code> for the network interface to perform network address translation (NAT) in your VPC.</p> </li> <li> <p> <code>network-interface.subnet-id</code> - The ID of the subnet for the network interface.</p> </li> <li> <p> <code>network-interface.vpc-id</code> - The ID of the VPC for the network interface.</p> </li> <li> <p> <code>owner-id</code> - The AWS account ID of the instance owner.</p> </li> <li> <p> <code>placement-group-name</code> - The name of the placement group for the instance.</p> </li> <li> <p> <code>platform</code> - The platform. Use <code>windows</code> if you have Windows instances; otherwise, leave blank.</p> </li> <li> <p> <code>private-dns-name</code> - The private IPv4 DNS name of the instance.</p> </li> <li> <p> <code>private-ip-address</code> - The private IPv4 address of the instance.</p> </li> <li> <p> <code>product-code</code> - The product code associated with the AMI used to launch the instance.</p> </li> <li> <p> <code>product-code.type</code> - The type of product code (<code>devpay</code> | <code>marketplace</code>).</p> </li> <li> <p> <code>ramdisk-id</code> - The RAM disk ID.</p> </li> <li> <p> <code>reason</code> - The reason for the current state of the instance (for example, shows \"User Initiated [date]\" when you stop or terminate the instance). Similar to the state-reason-code filter.</p> </li> <li> <p> <code>requester-id</code> - The ID of the entity that launched the instance on your behalf (for example, AWS Management Console, Auto Scaling, and so on).</p> </li> <li> <p> <code>reservation-id</code> - The ID of the instance's reservation. A reservation ID is created any time you launch an instance. A reservation ID has a one-to-one relationship with an instance launch request, but can be associated with more than one instance if you launch multiple instances using the same launch request. For example, if you launch one instance, you'll get one reservation ID. If you launch ten instances using the same launch request, you'll also get one reservation ID.</p> </li> <li> <p> <code>root-device-name</code> - The name of the root device for the instance (for example, <code>/dev/sda1</code> or <code>/dev/xvda</code>).</p> </li> <li> <p> <code>root-device-type</code> - The type of root device that the instance uses (<code>ebs</code> | <code>instance-store</code>).</p> </li> <li> <p> <code>source-dest-check</code> - Indicates whether the instance performs source/destination checking. A value of <code>true</code> means that checking is enabled, and <code>false</code> means checking is disabled. The value must be <code>false</code> for the instance to perform network address translation (NAT) in your VPC. </p> </li> <li> <p> <code>spot-instance-request-id</code> - The ID of the Spot instance request.</p> </li> <li> <p> <code>state-reason-code</code> - The reason code for the state change.</p> </li> <li> <p> <code>state-reason-message</code> - A message that describes the state change.</p> </li> <li> <p> <code>subnet-id</code> - The ID of the subnet for the instance.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>tenancy</code> - The tenancy of an instance (<code>dedicated</code> | <code>default</code> | <code>host</code>).</p> </li> <li> <p> <code>virtualization-type</code> - The virtualization type of the instance (<code>paravirtual</code> | <code>hvm</code>).</p> </li> <li> <p> <code>vpc-id</code> - The ID of the VPC that the instance is running in.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more instance IDs.</p> <p>Default: Describes all your instances.</p>"]
+    #[serde(rename="InstanceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_ids: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return in a single call. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value. This value can be between 5 and 1000. You cannot specify this parameter and the instance IDs parameter or tag filters in the same call.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to request the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -10917,11 +11944,15 @@ impl DescribeInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancesResult {
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Zero or more reservations.</p>"]
+    #[serde(rename="Reservations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reservations: Option<Vec<Reservation>>,
 }
 
@@ -10973,13 +12004,19 @@ impl DescribeInstancesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeInternetGateways.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInternetGatewaysRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>attachment.state</code> - The current state of the attachment between the gateway and the VPC (<code>available</code>). Present only if a VPC is attached.</p> </li> <li> <p> <code>attachment.vpc-id</code> - The ID of an attached VPC.</p> </li> <li> <p> <code>internet-gateway-id</code> - The ID of the Internet gateway.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more Internet gateway IDs.</p> <p>Default: Describes all your Internet gateways.</p>"]
+    #[serde(rename="InternetGatewayIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub internet_gateway_ids: Option<Vec<String>>,
 }
 
@@ -11012,9 +12049,11 @@ impl DescribeInternetGatewaysRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeInternetGateways.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInternetGatewaysResult {
     #[doc="<p>Information about one or more Internet gateways.</p>"]
+    #[serde(rename="InternetGateways")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub internet_gateways: Option<Vec<InternetGateway>>,
 }
 
@@ -11062,13 +12101,19 @@ impl DescribeInternetGatewaysResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeKeyPairs.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeKeyPairsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>fingerprint</code> - The fingerprint of the key pair.</p> </li> <li> <p> <code>key-name</code> - The name of the key pair.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more key pair names.</p> <p>Default: Describes all your key pairs.</p>"]
+    #[serde(rename="KeyNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_names: Option<Vec<String>>,
 }
 
@@ -11101,9 +12146,11 @@ impl DescribeKeyPairsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeKeyPairs.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeKeyPairsResult {
     #[doc="<p>Information about one or more key pairs.</p>"]
+    #[serde(rename="KeyPairs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_pairs: Option<Vec<KeyPairInfo>>,
 }
 
@@ -11150,17 +12197,27 @@ impl DescribeKeyPairsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeMovingAddresses.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMovingAddressesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>moving-status</code> - The status of the Elastic IP address (<code>MovingToVpc</code> | <code>RestoringToClassic</code>).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of results to return for the request in a single page. The remaining results of the initial request can be seen by sending another request with the returned <code>NextToken</code> value. This value can be between 5 and 1000; if <code>MaxResults</code> is given a value outside of this range, an error is returned.</p> <p>Default: If no value is provided, the default is 1000.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to use to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>One or more Elastic IP addresses.</p>"]
+    #[serde(rename="PublicIps")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ips: Option<Vec<String>>,
 }
 
@@ -11201,11 +12258,15 @@ impl DescribeMovingAddressesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeMovingAddresses.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMovingAddressesResult {
     #[doc="<p>The status for each Elastic IP address.</p>"]
+    #[serde(rename="MovingAddressStatuses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub moving_address_statuses: Option<Vec<MovingAddressStatus>>,
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -11257,15 +12318,23 @@ impl DescribeMovingAddressesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeNatGateways.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNatGatewaysRequest {
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>nat-gateway-id</code> - The ID of the NAT gateway.</p> </li> <li> <p> <code>state</code> - The state of the NAT gateway (<code>pending</code> | <code>failed</code> | <code>available</code> | <code>deleting</code> | <code>deleted</code>).</p> </li> <li> <p> <code>subnet-id</code> - The ID of the subnet in which the NAT gateway resides.</p> </li> <li> <p> <code>vpc-id</code> - The ID of the VPC in which the NAT gateway resides.</p> </li> </ul>"]
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of items to return for this request. The request returns a token that you can specify in a subsequent call to get the next set of results.</p> <p>Constraint: If the value specified is greater than 1000, we return only 1000 items.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>One or more NAT gateway IDs.</p>"]
+    #[serde(rename="NatGatewayIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nat_gateway_ids: Option<Vec<String>>,
     #[doc="<p>The token to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -11302,11 +12371,15 @@ impl DescribeNatGatewaysRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeNatGateways.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNatGatewaysResult {
     #[doc="<p>Information about the NAT gateways.</p>"]
+    #[serde(rename="NatGateways")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nat_gateways: Option<Vec<NatGateway>>,
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -11358,13 +12431,19 @@ impl DescribeNatGatewaysResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeNetworkAcls.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNetworkAclsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>association.association-id</code> - The ID of an association ID for the ACL.</p> </li> <li> <p> <code>association.network-acl-id</code> - The ID of the network ACL involved in the association.</p> </li> <li> <p> <code>association.subnet-id</code> - The ID of the subnet involved in the association.</p> </li> <li> <p> <code>default</code> - Indicates whether the ACL is the default network ACL for the VPC.</p> </li> <li> <p> <code>entry.cidr</code> - The IPv4 CIDR range specified in the entry.</p> </li> <li> <p> <code>entry.egress</code> - Indicates whether the entry applies to egress traffic.</p> </li> <li> <p> <code>entry.icmp.code</code> - The ICMP code specified in the entry, if any.</p> </li> <li> <p> <code>entry.icmp.type</code> - The ICMP type specified in the entry, if any.</p> </li> <li> <p> <code>entry.ipv6-cidr</code> - The IPv6 CIDR range specified in the entry.</p> </li> <li> <p> <code>entry.port-range.from</code> - The start of the port range specified in the entry. </p> </li> <li> <p> <code>entry.port-range.to</code> - The end of the port range specified in the entry. </p> </li> <li> <p> <code>entry.protocol</code> - The protocol specified in the entry (<code>tcp</code> | <code>udp</code> | <code>icmp</code> or a protocol number).</p> </li> <li> <p> <code>entry.rule-action</code> - Allows or denies the matching traffic (<code>allow</code> | <code>deny</code>).</p> </li> <li> <p> <code>entry.rule-number</code> - The number of an entry (in other words, rule) in the ACL's set of entries.</p> </li> <li> <p> <code>network-acl-id</code> - The ID of the network ACL.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>vpc-id</code> - The ID of the VPC for the network ACL.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more network ACL IDs.</p> <p>Default: Describes all your network ACLs.</p>"]
+    #[serde(rename="NetworkAclIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_acl_ids: Option<Vec<String>>,
 }
 
@@ -11397,9 +12476,11 @@ impl DescribeNetworkAclsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeNetworkAcls.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNetworkAclsResult {
     #[doc="<p>Information about one or more network ACLs.</p>"]
+    #[serde(rename="NetworkAcls")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_acls: Option<Vec<NetworkAcl>>,
 }
 
@@ -11447,13 +12528,18 @@ impl DescribeNetworkAclsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeNetworkInterfaceAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNetworkInterfaceAttributeRequest {
     #[doc="<p>The attribute of the network interface. This parameter is required.</p>"]
+    #[serde(rename="Attribute")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
     pub network_interface_id: String,
 }
 
@@ -11482,17 +12568,27 @@ impl DescribeNetworkInterfaceAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeNetworkInterfaceAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNetworkInterfaceAttributeResult {
     #[doc="<p>The attachment (if any) of the network interface.</p>"]
+    #[serde(rename="Attachment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachment: Option<NetworkInterfaceAttachment>,
     #[doc="<p>The description of the network interface.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<AttributeValue>,
     #[doc="<p>The security groups associated with the network interface.</p>"]
+    #[serde(rename="Groups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub groups: Option<Vec<GroupIdentifier>>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>Indicates whether source/destination checking is enabled.</p>"]
+    #[serde(rename="SourceDestCheck")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_dest_check: Option<AttributeBooleanValue>,
 }
 
@@ -11559,15 +12655,23 @@ impl DescribeNetworkInterfaceAttributeResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeNetworkInterfacePermissions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNetworkInterfacePermissionsRequest {
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>network-interface-permission.network-interface-permission-id</code> - The ID of the permission.</p> </li> <li> <p> <code>network-interface-permission.network-interface-id</code> - The ID of the network interface.</p> </li> <li> <p> <code>network-interface-permission.aws-account-id</code> - The AWS account ID.</p> </li> <li> <p> <code>network-interface-permission.aws-service</code> - The AWS service.</p> </li> <li> <p> <code>network-interface-permission.permission</code> - The type of permission (<code>INSTANCE-ATTACH</code> | <code>EIP-ASSOCIATE</code>).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of results to return in a single call. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value. If this parameter is not specified, up to 50 results are returned by default.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>One or more network interface permission IDs.</p>"]
+    #[serde(rename="NetworkInterfacePermissionIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_permission_ids: Option<Vec<String>>,
     #[doc="<p>The token to request the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -11608,11 +12712,15 @@ impl DescribeNetworkInterfacePermissionsRequestSerializer {
 }
 
 #[doc="<p>Contains the output for DescribeNetworkInterfacePermissions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNetworkInterfacePermissionsResult {
     #[doc="<p>The network interface permissions.</p>"]
+    #[serde(rename="NetworkInterfacePermissions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_permissions: Option<Vec<NetworkInterfacePermission>>,
     #[doc="<p>The token to use to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -11663,13 +12771,19 @@ impl DescribeNetworkInterfacePermissionsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeNetworkInterfaces.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNetworkInterfacesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>addresses.private-ip-address</code> - The private IPv4 addresses associated with the network interface.</p> </li> <li> <p> <code>addresses.primary</code> - Whether the private IPv4 address is the primary IP address associated with the network interface. </p> </li> <li> <p> <code>addresses.association.public-ip</code> - The association ID returned when the network interface was associated with the Elastic IP address (IPv4).</p> </li> <li> <p> <code>addresses.association.owner-id</code> - The owner ID of the addresses associated with the network interface.</p> </li> <li> <p> <code>association.association-id</code> - The association ID returned when the network interface was associated with an IPv4 address.</p> </li> <li> <p> <code>association.allocation-id</code> - The allocation ID returned when you allocated the Elastic IP address (IPv4) for your network interface.</p> </li> <li> <p> <code>association.ip-owner-id</code> - The owner of the Elastic IP address (IPv4) associated with the network interface.</p> </li> <li> <p> <code>association.public-ip</code> - The address of the Elastic IP address (IPv4) bound to the network interface.</p> </li> <li> <p> <code>association.public-dns-name</code> - The public DNS name for the network interface (IPv4).</p> </li> <li> <p> <code>attachment.attachment-id</code> - The ID of the interface attachment.</p> </li> <li> <p> <code>attachment.attach.time</code> - The time that the network interface was attached to an instance.</p> </li> <li> <p> <code>attachment.delete-on-termination</code> - Indicates whether the attachment is deleted when an instance is terminated.</p> </li> <li> <p> <code>attachment.device-index</code> - The device index to which the network interface is attached.</p> </li> <li> <p> <code>attachment.instance-id</code> - The ID of the instance to which the network interface is attached.</p> </li> <li> <p> <code>attachment.instance-owner-id</code> - The owner ID of the instance to which the network interface is attached.</p> </li> <li> <p> <code>attachment.nat-gateway-id</code> - The ID of the NAT gateway to which the network interface is attached.</p> </li> <li> <p> <code>attachment.status</code> - The status of the attachment (<code>attaching</code> | <code>attached</code> | <code>detaching</code> | <code>detached</code>).</p> </li> <li> <p> <code>availability-zone</code> - The Availability Zone of the network interface.</p> </li> <li> <p> <code>description</code> - The description of the network interface.</p> </li> <li> <p> <code>group-id</code> - The ID of a security group associated with the network interface.</p> </li> <li> <p> <code>group-name</code> - The name of a security group associated with the network interface.</p> </li> <li> <p> <code>ipv6-addresses.ipv6-address</code> - An IPv6 address associated with the network interface.</p> </li> <li> <p> <code>mac-address</code> - The MAC address of the network interface.</p> </li> <li> <p> <code>network-interface-id</code> - The ID of the network interface.</p> </li> <li> <p> <code>owner-id</code> - The AWS account ID of the network interface owner.</p> </li> <li> <p> <code>private-ip-address</code> - The private IPv4 address or addresses of the network interface.</p> </li> <li> <p> <code>private-dns-name</code> - The private DNS name of the network interface (IPv4).</p> </li> <li> <p> <code>requester-id</code> - The ID of the entity that launched the instance on your behalf (for example, AWS Management Console, Auto Scaling, and so on).</p> </li> <li> <p> <code>requester-managed</code> - Indicates whether the network interface is being managed by an AWS service (for example, AWS Management Console, Auto Scaling, and so on).</p> </li> <li> <p> <code>source-desk-check</code> - Indicates whether the network interface performs source/destination checking. A value of <code>true</code> means checking is enabled, and <code>false</code> means checking is disabled. The value must be <code>false</code> for the network interface to perform network address translation (NAT) in your VPC. </p> </li> <li> <p> <code>status</code> - The status of the network interface. If the network interface is not attached to an instance, the status is <code>available</code>; if a network interface is attached to an instance the status is <code>in-use</code>.</p> </li> <li> <p> <code>subnet-id</code> - The ID of the subnet for the network interface.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>vpc-id</code> - The ID of the VPC for the network interface.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more network interface IDs.</p> <p>Default: Describes all your network interfaces.</p>"]
+    #[serde(rename="NetworkInterfaceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_ids: Option<Vec<String>>,
 }
 
@@ -11704,9 +12818,11 @@ impl DescribeNetworkInterfacesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeNetworkInterfaces.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNetworkInterfacesResult {
     #[doc="<p>Information about one or more network interfaces.</p>"]
+    #[serde(rename="NetworkInterfaces")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interfaces: Option<Vec<NetworkInterface>>,
 }
 
@@ -11755,13 +12871,19 @@ impl DescribeNetworkInterfacesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribePlacementGroups.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePlacementGroupsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>group-name</code> - The name of the placement group.</p> </li> <li> <p> <code>state</code> - The state of the placement group (<code>pending</code> | <code>available</code> | <code>deleting</code> | <code>deleted</code>).</p> </li> <li> <p> <code>strategy</code> - The strategy of the placement group (<code>cluster</code>).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more placement group names.</p> <p>Default: Describes all your placement groups, or only those otherwise specified.</p>"]
+    #[serde(rename="GroupNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_names: Option<Vec<String>>,
 }
 
@@ -11794,9 +12916,11 @@ impl DescribePlacementGroupsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribePlacementGroups.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePlacementGroupsResult {
     #[doc="<p>One or more placement groups.</p>"]
+    #[serde(rename="PlacementGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement_groups: Option<Vec<PlacementGroup>>,
 }
 
@@ -11844,17 +12968,27 @@ impl DescribePlacementGroupsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribePrefixLists.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePrefixListsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>prefix-list-id</code>: The ID of a prefix list.</p> </li> <li> <p> <code>prefix-list-name</code>: The name of a prefix list.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of items to return for this request. The request returns a token that you can specify in a subsequent call to get the next set of results.</p> <p>Constraint: If the value specified is greater than 1000, we return only 1000 items.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a prior call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>One or more prefix list IDs.</p>"]
+    #[serde(rename="PrefixListIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix_list_ids: Option<Vec<String>>,
 }
 
@@ -11895,11 +13029,15 @@ impl DescribePrefixListsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribePrefixLists.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePrefixListsResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>All available prefix lists.</p>"]
+    #[serde(rename="PrefixLists")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix_lists: Option<Vec<PrefixList>>,
 }
 
@@ -11951,13 +13089,19 @@ impl DescribePrefixListsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeRegions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRegionsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>endpoint</code> - The endpoint of the region (for example, <code>ec2.us-east-1.amazonaws.com</code>).</p> </li> <li> <p> <code>region-name</code> - The name of the region (for example, <code>us-east-1</code>).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The names of one or more regions.</p>"]
+    #[serde(rename="RegionNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub region_names: Option<Vec<String>>,
 }
 
@@ -11990,9 +13134,11 @@ impl DescribeRegionsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeRegions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRegionsResult {
     #[doc="<p>Information about one or more regions.</p>"]
+    #[serde(rename="Regions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub regions: Option<Vec<Region>>,
 }
 
@@ -12039,13 +13185,19 @@ impl DescribeRegionsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeReservedInstancesListings.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedInstancesListingsRequest {
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>reserved-instances-id</code> - The ID of the Reserved Instances.</p> </li> <li> <p> <code>reserved-instances-listing-id</code> - The ID of the Reserved Instances listing.</p> </li> <li> <p> <code>status</code> - The status of the Reserved Instance listing (<code>pending</code> | <code>active</code> | <code>cancelled</code> | <code>closed</code>).</p> </li> <li> <p> <code>status-message</code> - The reason for the status.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more Reserved Instance IDs.</p>"]
+    #[serde(rename="ReservedInstancesId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_id: Option<String>,
     #[doc="<p>One or more Reserved Instance listing IDs.</p>"]
+    #[serde(rename="ReservedInstancesListingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_listing_id: Option<String>,
 }
 
@@ -12077,9 +13229,11 @@ impl DescribeReservedInstancesListingsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeReservedInstancesListings.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedInstancesListingsResult {
     #[doc="<p>Information about the Reserved Instance listing.</p>"]
+    #[serde(rename="ReservedInstancesListings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_listings: Option<Vec<ReservedInstancesListing>>,
 }
 
@@ -12126,13 +13280,19 @@ impl DescribeReservedInstancesListingsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeReservedInstancesModifications.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedInstancesModificationsRequest {
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>client-token</code> - The idempotency token for the modification request.</p> </li> <li> <p> <code>create-date</code> - The time when the modification request was created.</p> </li> <li> <p> <code>effective-date</code> - The time when the modification becomes effective.</p> </li> <li> <p> <code>modification-result.reserved-instances-id</code> - The ID for the Reserved Instances created as part of the modification request. This ID is only available when the status of the modification is <code>fulfilled</code>.</p> </li> <li> <p> <code>modification-result.target-configuration.availability-zone</code> - The Availability Zone for the new Reserved Instances.</p> </li> <li> <p> <code>modification-result.target-configuration.instance-count </code> - The number of new Reserved Instances.</p> </li> <li> <p> <code>modification-result.target-configuration.instance-type</code> - The instance type of the new Reserved Instances.</p> </li> <li> <p> <code>modification-result.target-configuration.platform</code> - The network platform of the new Reserved Instances (<code>EC2-Classic</code> | <code>EC2-VPC</code>).</p> </li> <li> <p> <code>reserved-instances-id</code> - The ID of the Reserved Instances modified.</p> </li> <li> <p> <code>reserved-instances-modification-id</code> - The ID of the modification request.</p> </li> <li> <p> <code>status</code> - The status of the Reserved Instances modification request (<code>processing</code> | <code>fulfilled</code> | <code>failed</code>).</p> </li> <li> <p> <code>status-message</code> - The reason for the status.</p> </li> <li> <p> <code>update-date</code> - The time when the modification request was last updated.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The token to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>IDs for the submitted modification request.</p>"]
+    #[serde(rename="ReservedInstancesModificationIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_modification_ids: Option<Vec<String>>,
 }
 
@@ -12169,11 +13329,15 @@ impl DescribeReservedInstancesModificationsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeReservedInstancesModifications.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedInstancesModificationsResult {
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The Reserved Instance modification information.</p>"]
+    #[serde(rename="ReservedInstancesModifications")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_modifications: Option<Vec<ReservedInstancesModification>>,
 }
 
@@ -12224,37 +13388,67 @@ impl DescribeReservedInstancesModificationsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeReservedInstancesOfferings.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedInstancesOfferingsRequest {
     #[doc="<p>The Availability Zone in which the Reserved Instance can be used.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>availability-zone</code> - The Availability Zone where the Reserved Instance can be used.</p> </li> <li> <p> <code>duration</code> - The duration of the Reserved Instance (for example, one year or three years), in seconds (<code>31536000</code> | <code>94608000</code>).</p> </li> <li> <p> <code>fixed-price</code> - The purchase price of the Reserved Instance (for example, 9800.0).</p> </li> <li> <p> <code>instance-type</code> - The instance type that is covered by the reservation.</p> </li> <li> <p> <code>marketplace</code> - Set to <code>true</code> to show only Reserved Instance Marketplace offerings. When this filter is not used, which is the default behavior, all offerings from both AWS and the Reserved Instance Marketplace are listed.</p> </li> <li> <p> <code>product-description</code> - The Reserved Instance product platform description. Instances that include <code>(Amazon VPC)</code> in the product platform description will only be displayed to EC2-Classic account holders and are for use with Amazon VPC. (<code>Linux/UNIX</code> | <code>Linux/UNIX (Amazon VPC)</code> | <code>SUSE Linux</code> | <code>SUSE Linux (Amazon VPC)</code> | <code>Red Hat Enterprise Linux</code> | <code>Red Hat Enterprise Linux (Amazon VPC)</code> | <code>Windows</code> | <code>Windows (Amazon VPC)</code> | <code>Windows with SQL Server Standard</code> | <code>Windows with SQL Server Standard (Amazon VPC)</code> | <code>Windows with SQL Server Web</code> | <code> Windows with SQL Server Web (Amazon VPC)</code> | <code>Windows with SQL Server Enterprise</code> | <code>Windows with SQL Server Enterprise (Amazon VPC)</code>) </p> </li> <li> <p> <code>reserved-instances-offering-id</code> - The Reserved Instances offering ID.</p> </li> <li> <p> <code>scope</code> - The scope of the Reserved Instance (<code>Availability Zone</code> or <code>Region</code>).</p> </li> <li> <p> <code>usage-price</code> - The usage price of the Reserved Instance, per hour (for example, 0.84).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>Include Reserved Instance Marketplace offerings in the response.</p>"]
+    #[serde(rename="IncludeMarketplace")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub include_marketplace: Option<bool>,
     #[doc="<p>The tenancy of the instances covered by the reservation. A Reserved Instance with a tenancy of <code>dedicated</code> is applied to instances that run in a VPC on single-tenant hardware (i.e., Dedicated Instances).</p> <p> <b>Important:</b> The <code>host</code> value cannot be used with this parameter. Use the <code>default</code> or <code>dedicated</code> values only.</p> <p>Default: <code>default</code> </p>"]
+    #[serde(rename="InstanceTenancy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_tenancy: Option<String>,
     #[doc="<p>The instance type that the reservation will cover (for example, <code>m1.small</code>). For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html\">Instance Types</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The maximum duration (in seconds) to filter when searching for offerings.</p> <p>Default: 94608000 (3 years)</p>"]
+    #[serde(rename="MaxDuration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_duration: Option<i64>,
     #[doc="<p>The maximum number of instances to filter when searching for offerings.</p> <p>Default: 20</p>"]
+    #[serde(rename="MaxInstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_instance_count: Option<i64>,
     #[doc="<p>The maximum number of results to return for the request in a single page. The remaining results of the initial request can be seen by sending another request with the returned <code>NextToken</code> value. The maximum is 100.</p> <p>Default: 100</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The minimum duration (in seconds) to filter when searching for offerings.</p> <p>Default: 2592000 (1 month)</p>"]
+    #[serde(rename="MinDuration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_duration: Option<i64>,
     #[doc="<p>The token to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The offering class of the Reserved Instance. Can be <code>standard</code> or <code>convertible</code>.</p>"]
+    #[serde(rename="OfferingClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_class: Option<String>,
     #[doc="<p>The Reserved Instance offering type. If you are using tools that predate the 2011-11-01 API version, you only have access to the <code>Medium Utilization</code> Reserved Instance offering type. </p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The Reserved Instance product platform description. Instances that include <code>(Amazon VPC)</code> in the description are for use with Amazon VPC.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>One or more Reserved Instances offering IDs.</p>"]
+    #[serde(rename="ReservedInstancesOfferingIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_offering_ids: Option<Vec<String>>,
 }
 
@@ -12339,11 +13533,15 @@ impl DescribeReservedInstancesOfferingsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeReservedInstancesOfferings.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedInstancesOfferingsResult {
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of Reserved Instances offerings.</p>"]
+    #[serde(rename="ReservedInstancesOfferings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_offerings: Option<Vec<ReservedInstancesOffering>>,
 }
 
@@ -12394,17 +13592,27 @@ impl DescribeReservedInstancesOfferingsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeReservedInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedInstancesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>availability-zone</code> - The Availability Zone where the Reserved Instance can be used.</p> </li> <li> <p> <code>duration</code> - The duration of the Reserved Instance (one year or three years), in seconds (<code>31536000</code> | <code>94608000</code>).</p> </li> <li> <p> <code>end</code> - The time when the Reserved Instance expires (for example, 2015-08-07T11:54:42.000Z).</p> </li> <li> <p> <code>fixed-price</code> - The purchase price of the Reserved Instance (for example, 9800.0).</p> </li> <li> <p> <code>instance-type</code> - The instance type that is covered by the reservation.</p> </li> <li> <p> <code>scope</code> - The scope of the Reserved Instance (<code>Region</code> or <code>Availability Zone</code>).</p> </li> <li> <p> <code>product-description</code> - The Reserved Instance product platform description. Instances that include <code>(Amazon VPC)</code> in the product platform description will only be displayed to EC2-Classic account holders and are for use with Amazon VPC (<code>Linux/UNIX</code> | <code>Linux/UNIX (Amazon VPC)</code> | <code>SUSE Linux</code> | <code>SUSE Linux (Amazon VPC)</code> | <code>Red Hat Enterprise Linux</code> | <code>Red Hat Enterprise Linux (Amazon VPC)</code> | <code>Windows</code> | <code>Windows (Amazon VPC)</code> | <code>Windows with SQL Server Standard</code> | <code>Windows with SQL Server Standard (Amazon VPC)</code> | <code>Windows with SQL Server Web</code> | <code>Windows with SQL Server Web (Amazon VPC)</code> | <code>Windows with SQL Server Enterprise</code> | <code>Windows with SQL Server Enterprise (Amazon VPC)</code>).</p> </li> <li> <p> <code>reserved-instances-id</code> - The ID of the Reserved Instance.</p> </li> <li> <p> <code>start</code> - The time at which the Reserved Instance purchase request was placed (for example, 2014-08-07T11:54:42.000Z).</p> </li> <li> <p> <code>state</code> - The state of the Reserved Instance (<code>payment-pending</code> | <code>active</code> | <code>payment-failed</code> | <code>retired</code>).</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>usage-price</code> - The usage price of the Reserved Instance, per hour (for example, 0.84).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>Describes whether the Reserved Instance is Standard or Convertible.</p>"]
+    #[serde(rename="OfferingClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_class: Option<String>,
     #[doc="<p>The Reserved Instance offering type. If you are using tools that predate the 2011-11-01 API version, you only have access to the <code>Medium Utilization</code> Reserved Instance offering type.</p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>One or more Reserved Instance IDs.</p> <p>Default: Describes all your Reserved Instances, or only those otherwise specified.</p>"]
+    #[serde(rename="ReservedInstancesIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_ids: Option<Vec<String>>,
 }
 
@@ -12447,9 +13655,11 @@ impl DescribeReservedInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output for DescribeReservedInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedInstancesResult {
     #[doc="<p>A list of Reserved Instances.</p>"]
+    #[serde(rename="ReservedInstances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances: Option<Vec<ReservedInstances>>,
 }
 
@@ -12498,13 +13708,19 @@ impl DescribeReservedInstancesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeRouteTables.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRouteTablesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>association.route-table-association-id</code> - The ID of an association ID for the route table.</p> </li> <li> <p> <code>association.route-table-id</code> - The ID of the route table involved in the association.</p> </li> <li> <p> <code>association.subnet-id</code> - The ID of the subnet involved in the association.</p> </li> <li> <p> <code>association.main</code> - Indicates whether the route table is the main route table for the VPC (<code>true</code> | <code>false</code>). Route tables that do not have an association ID are not returned in the response.</p> </li> <li> <p> <code>route-table-id</code> - The ID of the route table.</p> </li> <li> <p> <code>route.destination-cidr-block</code> - The IPv4 CIDR range specified in a route in the table.</p> </li> <li> <p> <code>route.destination-ipv6-cidr-block</code> - The IPv6 CIDR range specified in a route in the route table.</p> </li> <li> <p> <code>route.destination-prefix-list-id</code> - The ID (prefix) of the AWS service specified in a route in the table.</p> </li> <li> <p> <code>route.egress-only-internet-gateway-id</code> - The ID of an egress-only Internet gateway specified in a route in the route table.</p> </li> <li> <p> <code>route.gateway-id</code> - The ID of a gateway specified in a route in the table.</p> </li> <li> <p> <code>route.instance-id</code> - The ID of an instance specified in a route in the table.</p> </li> <li> <p> <code>route.nat-gateway-id</code> - The ID of a NAT gateway.</p> </li> <li> <p> <code>route.origin</code> - Describes how the route was created. <code>CreateRouteTable</code> indicates that the route was automatically created when the route table was created; <code>CreateRoute</code> indicates that the route was manually added to the route table; <code>EnableVgwRoutePropagation</code> indicates that the route was propagated by route propagation.</p> </li> <li> <p> <code>route.state</code> - The state of a route in the route table (<code>active</code> | <code>blackhole</code>). The blackhole state indicates that the route's target isn't available (for example, the specified gateway isn't attached to the VPC, the specified NAT instance has been terminated, and so on).</p> </li> <li> <p> <code>route.vpc-peering-connection-id</code> - The ID of a VPC peering connection specified in a route in the table.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>vpc-id</code> - The ID of the VPC for the route table.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more route table IDs.</p> <p>Default: Describes all your route tables.</p>"]
+    #[serde(rename="RouteTableIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub route_table_ids: Option<Vec<String>>,
 }
 
@@ -12537,9 +13753,11 @@ impl DescribeRouteTablesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeRouteTables.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRouteTablesResult {
     #[doc="<p>Information about one or more route tables.</p>"]
+    #[serde(rename="RouteTables")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub route_tables: Option<Vec<RouteTable>>,
 }
 
@@ -12587,23 +13805,37 @@ impl DescribeRouteTablesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeScheduledInstanceAvailability.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScheduledInstanceAvailabilityRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>availability-zone</code> - The Availability Zone (for example, <code>us-west-2a</code>).</p> </li> <li> <p> <code>instance-type</code> - The instance type (for example, <code>c4.large</code>).</p> </li> <li> <p> <code>network-platform</code> - The network platform (<code>EC2-Classic</code> or <code>EC2-VPC</code>).</p> </li> <li> <p> <code>platform</code> - The platform (<code>Linux/UNIX</code> or <code>Windows</code>).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The time period for the first schedule to start.</p>"]
+    #[serde(rename="FirstSlotStartTimeRange")]
     pub first_slot_start_time_range: SlotDateTimeRangeRequest,
     #[doc="<p>The maximum number of results to return in a single call. This value can be between 5 and 300. The default value is 300. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The maximum available duration, in hours. This value must be greater than <code>MinSlotDurationInHours</code> and less than 1,720.</p>"]
+    #[serde(rename="MaxSlotDurationInHours")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_slot_duration_in_hours: Option<i64>,
     #[doc="<p>The minimum available duration, in hours. The minimum required duration is 1,200 hours per year. For example, the minimum daily schedule is 4 hours, the minimum weekly schedule is 24 hours, and the minimum monthly schedule is 100 hours.</p>"]
+    #[serde(rename="MinSlotDurationInHours")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_slot_duration_in_hours: Option<i64>,
     #[doc="<p>The token for the next set of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The schedule recurrence.</p>"]
+    #[serde(rename="Recurrence")]
     pub recurrence: ScheduledInstanceRecurrenceRequest,
 }
 
@@ -12659,11 +13891,15 @@ impl DescribeScheduledInstanceAvailabilityRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeScheduledInstanceAvailability.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScheduledInstanceAvailabilityResult {
     #[doc="<p>The token required to retrieve the next set of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Information about the available Scheduled Instances.</p>"]
+    #[serde(rename="ScheduledInstanceAvailabilitySet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheduled_instance_availability_set: Option<Vec<ScheduledInstanceAvailability>>,
 }
 
@@ -12714,19 +13950,31 @@ impl DescribeScheduledInstanceAvailabilityResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeScheduledInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScheduledInstancesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>availability-zone</code> - The Availability Zone (for example, <code>us-west-2a</code>).</p> </li> <li> <p> <code>instance-type</code> - The instance type (for example, <code>c4.large</code>).</p> </li> <li> <p> <code>network-platform</code> - The network platform (<code>EC2-Classic</code> or <code>EC2-VPC</code>).</p> </li> <li> <p> <code>platform</code> - The platform (<code>Linux/UNIX</code> or <code>Windows</code>).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of results to return in a single call. This value can be between 5 and 300. The default value is 100. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token for the next set of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>One or more Scheduled Instance IDs.</p>"]
+    #[serde(rename="ScheduledInstanceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheduled_instance_ids: Option<Vec<String>>,
     #[doc="<p>The time period for the first schedule to start.</p>"]
+    #[serde(rename="SlotStartTimeRange")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub slot_start_time_range: Option<SlotStartTimeRangeRequest>,
 }
 
@@ -12776,11 +14024,15 @@ impl DescribeScheduledInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeScheduledInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScheduledInstancesResult {
     #[doc="<p>The token required to retrieve the next set of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Information about the Scheduled Instances.</p>"]
+    #[serde(rename="ScheduledInstanceSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheduled_instance_set: Option<Vec<ScheduledInstance>>,
 }
 
@@ -12832,11 +14084,14 @@ impl DescribeScheduledInstancesResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSecurityGroupReferencesRequest {
     #[doc="<p>Checks whether you have the required permissions for the operation, without actually making the request, and provides an error response. If you have the required permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more security group IDs in your account.</p>"]
+    #[serde(rename="GroupId")]
     pub group_id: Vec<String>,
 }
 
@@ -12859,9 +14114,11 @@ impl DescribeSecurityGroupReferencesRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSecurityGroupReferencesResult {
     #[doc="<p>Information about the VPCs with the referencing security groups.</p>"]
+    #[serde(rename="SecurityGroupReferenceSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_group_reference_set: Option<Vec<SecurityGroupReference>>,
 }
 
@@ -12910,15 +14167,23 @@ impl DescribeSecurityGroupReferencesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeSecurityGroups.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSecurityGroupsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters. If using multiple filters for rules, the results include security groups for which any combination of rules - not necessarily a single rule - match all filters.</p> <ul> <li> <p> <code>description</code> - The description of the security group.</p> </li> <li> <p> <code>egress.ip-permission.prefix-list-id</code> - The ID (prefix) of the AWS service to which the security group allows access.</p> </li> <li> <p> <code>group-id</code> - The ID of the security group. </p> </li> <li> <p> <code>group-name</code> - The name of the security group.</p> </li> <li> <p> <code>ip-permission.cidr</code> - An IPv4 CIDR range that has been granted permission in a security group rule.</p> </li> <li> <p> <code>ip-permission.from-port</code> - The start of port range for the TCP and UDP protocols, or an ICMP type number.</p> </li> <li> <p> <code>ip-permission.group-id</code> - The ID of a security group that has been granted permission.</p> </li> <li> <p> <code>ip-permission.group-name</code> - The name of a security group that has been granted permission.</p> </li> <li> <p> <code>ip-permission.ipv6-cidr</code> - An IPv6 CIDR range that has been granted permission in a security group rule.</p> </li> <li> <p> <code>ip-permission.protocol</code> - The IP protocol for the permission (<code>tcp</code> | <code>udp</code> | <code>icmp</code> or a protocol number).</p> </li> <li> <p> <code>ip-permission.to-port</code> - The end of port range for the TCP and UDP protocols, or an ICMP code.</p> </li> <li> <p> <code>ip-permission.user-id</code> - The ID of an AWS account that has been granted permission.</p> </li> <li> <p> <code>owner-id</code> - The AWS account ID of the owner of the security group.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the security group.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the security group.</p> </li> <li> <p> <code>vpc-id</code> - The ID of the VPC specified when the security group was created.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more security group IDs. Required for security groups in a nondefault VPC.</p> <p>Default: Describes all your security groups.</p>"]
+    #[serde(rename="GroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_ids: Option<Vec<String>>,
     #[doc="<p>[EC2-Classic and default VPC only] One or more security group names. You can specify either the security group name or the security group ID. For security groups in a nondefault VPC, use the <code>group-name</code> filter to describe security groups by name.</p> <p>Default: Describes all your security groups.</p>"]
+    #[serde(rename="GroupNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_names: Option<Vec<String>>,
 }
 
@@ -12956,9 +14221,11 @@ impl DescribeSecurityGroupsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeSecurityGroups.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSecurityGroupsResult {
     #[doc="<p>Information about one or more security groups.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<SecurityGroup>>,
 }
 
@@ -13006,13 +14273,17 @@ impl DescribeSecurityGroupsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeSnapshotAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSnapshotAttributeRequest {
     #[doc="<p>The snapshot attribute you would like to view.</p>"]
+    #[serde(rename="Attribute")]
     pub attribute: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the EBS snapshot.</p>"]
+    #[serde(rename="SnapshotId")]
     pub snapshot_id: String,
 }
 
@@ -13039,13 +14310,19 @@ impl DescribeSnapshotAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeSnapshotAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSnapshotAttributeResult {
     #[doc="<p>A list of permissions for creating volumes from the snapshot.</p>"]
+    #[serde(rename="CreateVolumePermissions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_volume_permissions: Option<Vec<CreateVolumePermission>>,
     #[doc="<p>A list of product codes.</p>"]
+    #[serde(rename="ProductCodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_codes: Option<Vec<ProductCode>>,
     #[doc="<p>The ID of the EBS snapshot.</p>"]
+    #[serde(rename="SnapshotId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_id: Option<String>,
 }
 
@@ -13101,21 +14378,35 @@ impl DescribeSnapshotAttributeResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeSnapshots.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSnapshotsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>description</code> - A description of the snapshot.</p> </li> <li> <p> <code>owner-alias</code> - Value from an Amazon-maintained list (<code>amazon</code> | <code>aws-marketplace</code> | <code>microsoft</code>) of snapshot owners. Not to be confused with the user-configured AWS account alias, which is set from the IAM console.</p> </li> <li> <p> <code>owner-id</code> - The ID of the AWS account that owns the snapshot.</p> </li> <li> <p> <code>progress</code> - The progress of the snapshot, as a percentage (for example, 80%).</p> </li> <li> <p> <code>snapshot-id</code> - The snapshot ID.</p> </li> <li> <p> <code>start-time</code> - The time stamp when the snapshot was initiated.</p> </li> <li> <p> <code>status</code> - The status of the snapshot (<code>pending</code> | <code>completed</code> | <code>error</code>).</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>volume-id</code> - The ID of the volume the snapshot is for.</p> </li> <li> <p> <code>volume-size</code> - The size of the volume, in GiB.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of snapshot results returned by <code>DescribeSnapshots</code> in paginated output. When this parameter is used, <code>DescribeSnapshots</code> only returns <code>MaxResults</code> results in a single page along with a <code>NextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>DescribeSnapshots</code> request with the returned <code>NextToken</code> value. This value can be between 5 and 1000; if <code>MaxResults</code> is given a value larger than 1000, only 1000 results are returned. If this parameter is not used, then <code>DescribeSnapshots</code> returns all results. You cannot specify this parameter and the snapshot IDs parameter in the same request.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The <code>NextToken</code> value returned from a previous paginated <code>DescribeSnapshots</code> request where <code>MaxResults</code> was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the <code>NextToken</code> value. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Returns the snapshots owned by the specified owner. Multiple owners can be specified.</p>"]
+    #[serde(rename="OwnerIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_ids: Option<Vec<String>>,
     #[doc="<p>One or more AWS accounts IDs that can create volumes from the snapshot.</p>"]
+    #[serde(rename="RestorableByUserIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub restorable_by_user_ids: Option<Vec<String>>,
     #[doc="<p>One or more snapshot IDs.</p> <p>Default: Describes snapshots for which you have launch permissions.</p>"]
+    #[serde(rename="SnapshotIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_ids: Option<Vec<String>>,
 }
 
@@ -13166,11 +14457,15 @@ impl DescribeSnapshotsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeSnapshots.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSnapshotsResult {
     #[doc="<p>The <code>NextToken</code> value to include in a future <code>DescribeSnapshots</code> request. When the results of a <code>DescribeSnapshots</code> request exceed <code>MaxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Information about the snapshots.</p>"]
+    #[serde(rename="Snapshots")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshots: Option<Vec<Snapshot>>,
 }
 
@@ -13222,9 +14517,11 @@ impl DescribeSnapshotsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeSpotDatafeedSubscription.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotDatafeedSubscriptionRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -13247,9 +14544,11 @@ impl DescribeSpotDatafeedSubscriptionRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeSpotDatafeedSubscription.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotDatafeedSubscriptionResult {
     #[doc="<p>The Spot instance data feed subscription.</p>"]
+    #[serde(rename="SpotDatafeedSubscription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_datafeed_subscription: Option<SpotDatafeedSubscription>,
 }
 
@@ -13296,15 +14595,22 @@ impl DescribeSpotDatafeedSubscriptionResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeSpotFleetInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotFleetInstancesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The maximum number of results to return in a single call. Specify a value between 1 and 1000. The default value is 1000. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token for the next set of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The ID of the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestId")]
     pub spot_fleet_request_id: String,
 }
 
@@ -13337,13 +14643,17 @@ impl DescribeSpotFleetInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeSpotFleetInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotFleetInstancesResponse {
     #[doc="<p>The running instances. Note that this list is refreshed periodically and might be out of date.</p>"]
+    #[serde(rename="ActiveInstances")]
     pub active_instances: Vec<ActiveInstance>,
     #[doc="<p>The token required to retrieve the next set of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The ID of the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestId")]
     pub spot_fleet_request_id: String,
 }
 
@@ -13400,19 +14710,29 @@ impl DescribeSpotFleetInstancesResponseDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeSpotFleetRequestHistory.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotFleetRequestHistoryRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The type of events to describe. By default, all events are described.</p>"]
+    #[serde(rename="EventType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_type: Option<String>,
     #[doc="<p>The maximum number of results to return in a single call. Specify a value between 1 and 1000. The default value is 1000. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token for the next set of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The ID of the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestId")]
     pub spot_fleet_request_id: String,
     #[doc="<p>The starting date and time for the events, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z).</p>"]
+    #[serde(rename="StartTime")]
     pub start_time: String,
 }
 
@@ -13451,17 +14771,23 @@ impl DescribeSpotFleetRequestHistoryRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeSpotFleetRequestHistory.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotFleetRequestHistoryResponse {
     #[doc="<p>Information about the events in the history of the Spot fleet request.</p>"]
+    #[serde(rename="HistoryRecords")]
     pub history_records: Vec<HistoryRecord>,
     #[doc="<p>The last date and time for the events, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z). All records up to this time were retrieved.</p> <p>If <code>nextToken</code> indicates that there are more results, this value is not present.</p>"]
+    #[serde(rename="LastEvaluatedTime")]
     pub last_evaluated_time: String,
     #[doc="<p>The token required to retrieve the next set of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The ID of the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestId")]
     pub spot_fleet_request_id: String,
     #[doc="<p>The starting date and time for the events, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z).</p>"]
+    #[serde(rename="StartTime")]
     pub start_time: String,
 }
 
@@ -13526,15 +14852,23 @@ impl DescribeSpotFleetRequestHistoryResponseDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeSpotFleetRequests.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotFleetRequestsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The maximum number of results to return in a single call. Specify a value between 1 and 1000. The default value is 1000. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token for the next set of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The IDs of the Spot fleet requests.</p>"]
+    #[serde(rename="SpotFleetRequestIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_fleet_request_ids: Option<Vec<String>>,
 }
 
@@ -13570,11 +14904,14 @@ impl DescribeSpotFleetRequestsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeSpotFleetRequests.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotFleetRequestsResponse {
     #[doc="<p>The token required to retrieve the next set of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Information about the configuration of your Spot fleet.</p>"]
+    #[serde(rename="SpotFleetRequestConfigs")]
     pub spot_fleet_request_configs: Vec<SpotFleetRequestConfig>,
 }
 
@@ -13627,13 +14964,19 @@ impl DescribeSpotFleetRequestsResponseDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeSpotInstanceRequests.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotInstanceRequestsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>availability-zone-group</code> - The Availability Zone group.</p> </li> <li> <p> <code>create-time</code> - The time stamp when the Spot instance request was created.</p> </li> <li> <p> <code>fault-code</code> - The fault code related to the request.</p> </li> <li> <p> <code>fault-message</code> - The fault message related to the request.</p> </li> <li> <p> <code>instance-id</code> - The ID of the instance that fulfilled the request.</p> </li> <li> <p> <code>launch-group</code> - The Spot instance launch group.</p> </li> <li> <p> <code>launch.block-device-mapping.delete-on-termination</code> - Indicates whether the Amazon EBS volume is deleted on instance termination.</p> </li> <li> <p> <code>launch.block-device-mapping.device-name</code> - The device name for the Amazon EBS volume (for example, <code>/dev/sdh</code>).</p> </li> <li> <p> <code>launch.block-device-mapping.snapshot-id</code> - The ID of the snapshot used for the Amazon EBS volume.</p> </li> <li> <p> <code>launch.block-device-mapping.volume-size</code> - The size of the Amazon EBS volume, in GiB.</p> </li> <li> <p> <code>launch.block-device-mapping.volume-type</code> - The type of the Amazon EBS volume: <code>gp2</code> for General Purpose SSD, <code>io1</code> for Provisioned IOPS SSD, <code>st1</code> for Throughput Optimized HDD, <code>sc1</code>for Cold HDD, or <code>standard</code> for Magnetic.</p> </li> <li> <p> <code>launch.group-id</code> - The security group for the instance.</p> </li> <li> <p> <code>launch.image-id</code> - The ID of the AMI.</p> </li> <li> <p> <code>launch.instance-type</code> - The type of instance (for example, <code>m3.medium</code>).</p> </li> <li> <p> <code>launch.kernel-id</code> - The kernel ID.</p> </li> <li> <p> <code>launch.key-name</code> - The name of the key pair the instance launched with.</p> </li> <li> <p> <code>launch.monitoring-enabled</code> - Whether monitoring is enabled for the Spot instance.</p> </li> <li> <p> <code>launch.ramdisk-id</code> - The RAM disk ID.</p> </li> <li> <p> <code>network-interface.network-interface-id</code> - The ID of the network interface.</p> </li> <li> <p> <code>network-interface.device-index</code> - The index of the device for the network interface attachment on the instance.</p> </li> <li> <p> <code>network-interface.subnet-id</code> - The ID of the subnet for the instance.</p> </li> <li> <p> <code>network-interface.description</code> - A description of the network interface.</p> </li> <li> <p> <code>network-interface.private-ip-address</code> - The primary private IP address of the network interface.</p> </li> <li> <p> <code>network-interface.delete-on-termination</code> - Indicates whether the network interface is deleted when the instance is terminated.</p> </li> <li> <p> <code>network-interface.group-id</code> - The ID of the security group associated with the network interface.</p> </li> <li> <p> <code>network-interface.group-name</code> - The name of the security group associated with the network interface.</p> </li> <li> <p> <code>network-interface.addresses.primary</code> - Indicates whether the IP address is the primary private IP address.</p> </li> <li> <p> <code>product-description</code> - The product description associated with the instance (<code>Linux/UNIX</code> | <code>Windows</code>).</p> </li> <li> <p> <code>spot-instance-request-id</code> - The Spot instance request ID.</p> </li> <li> <p> <code>spot-price</code> - The maximum hourly price for any Spot instance launched to fulfill the request.</p> </li> <li> <p> <code>state</code> - The state of the Spot instance request (<code>open</code> | <code>active</code> | <code>closed</code> | <code>cancelled</code> | <code>failed</code>). Spot bid status information can help you track your Amazon EC2 Spot instance requests. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html\">Spot Bid Status</a> in the Amazon Elastic Compute Cloud User Guide.</p> </li> <li> <p> <code>status-code</code> - The short code describing the most recent evaluation of your Spot instance request.</p> </li> <li> <p> <code>status-message</code> - The message explaining the status of the Spot instance request.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>type</code> - The type of Spot instance request (<code>one-time</code> | <code>persistent</code>).</p> </li> <li> <p> <code>launched-availability-zone</code> - The Availability Zone in which the bid is launched.</p> </li> <li> <p> <code>valid-from</code> - The start date of the request.</p> </li> <li> <p> <code>valid-until</code> - The end date of the request.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more Spot instance request IDs.</p>"]
+    #[serde(rename="SpotInstanceRequestIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_instance_request_ids: Option<Vec<String>>,
 }
 
@@ -13668,9 +15011,11 @@ impl DescribeSpotInstanceRequestsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeSpotInstanceRequests.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotInstanceRequestsResult {
     #[doc="<p>One or more Spot instance requests.</p>"]
+    #[serde(rename="SpotInstanceRequests")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_instance_requests: Option<Vec<SpotInstanceRequest>>,
 }
 
@@ -13719,25 +15064,43 @@ impl DescribeSpotInstanceRequestsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeSpotPriceHistory.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotPriceHistoryRequest {
     #[doc="<p>Filters the results by the specified Availability Zone.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The date and time, up to the current date, from which to stop retrieving the price history data, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z).</p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>availability-zone</code> - The Availability Zone for which prices should be returned.</p> </li> <li> <p> <code>instance-type</code> - The type of instance (for example, <code>m3.medium</code>).</p> </li> <li> <p> <code>product-description</code> - The product description for the Spot price (<code>Linux/UNIX</code> | <code>SUSE Linux</code> | <code>Windows</code> | <code>Linux/UNIX (Amazon VPC)</code> | <code>SUSE Linux (Amazon VPC)</code> | <code>Windows (Amazon VPC)</code>).</p> </li> <li> <p> <code>spot-price</code> - The Spot price. The value must match exactly (or use wildcards; greater than or less than comparison is not supported).</p> </li> <li> <p> <code>timestamp</code> - The timestamp of the Spot price history, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z). You can use wildcards (* and ?). Greater than or less than comparison is not supported.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>Filters the results by the specified instance types. Note that T2 and HS1 instance types are not supported.</p>"]
+    #[serde(rename="InstanceTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_types: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return in a single call. Specify a value between 1 and 1000. The default value is 1000. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token for the next set of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Filters the results by the specified basic product descriptions.</p>"]
+    #[serde(rename="ProductDescriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_descriptions: Option<Vec<String>>,
     #[doc="<p>The date and time, up to the past 90 days, from which to start retrieving the price history data, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z).</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
 }
 
@@ -13797,11 +15160,15 @@ impl DescribeSpotPriceHistoryRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeSpotPriceHistory.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSpotPriceHistoryResult {
     #[doc="<p>The token required to retrieve the next set of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The historical Spot prices.</p>"]
+    #[serde(rename="SpotPriceHistory")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_price_history: Option<Vec<SpotPrice>>,
 }
 
@@ -13852,15 +15219,22 @@ impl DescribeSpotPriceHistoryResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStaleSecurityGroupsRequest {
     #[doc="<p>Checks whether you have the required permissions for the operation, without actually making the request, and provides an error response. If you have the required permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The maximum number of items to return for this request. The request returns a token that you can specify in a subsequent call to get the next set of results.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a prior call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -13892,11 +15266,15 @@ impl DescribeStaleSecurityGroupsRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStaleSecurityGroupsResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Information about the stale security groups.</p>"]
+    #[serde(rename="StaleSecurityGroupSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stale_security_group_set: Option<Vec<StaleSecurityGroup>>,
 }
 
@@ -13949,13 +15327,19 @@ impl DescribeStaleSecurityGroupsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeSubnets.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSubnetsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>availabilityZone</code> - The Availability Zone for the subnet. You can also use <code>availability-zone</code> as the filter name.</p> </li> <li> <p> <code>available-ip-address-count</code> - The number of IPv4 addresses in the subnet that are available.</p> </li> <li> <p> <code>cidrBlock</code> - The IPv4 CIDR block of the subnet. The CIDR block you specify must exactly match the subnet's CIDR block for information to be returned for the subnet. You can also use <code>cidr</code> or <code>cidr-block</code> as the filter names.</p> </li> <li> <p> <code>defaultForAz</code> - Indicates whether this is the default subnet for the Availability Zone. You can also use <code>default-for-az</code> as the filter name.</p> </li> <li> <p> <code>ipv6-cidr-block-association.ipv6-cidr-block</code> - An IPv6 CIDR block associated with the subnet.</p> </li> <li> <p> <code>ipv6-cidr-block-association.association-id</code> - An association ID for an IPv6 CIDR block associated with the subnet.</p> </li> <li> <p> <code>ipv6-cidr-block-association.state</code> - The state of an IPv6 CIDR block associated with the subnet.</p> </li> <li> <p> <code>state</code> - The state of the subnet (<code>pending</code> | <code>available</code>).</p> </li> <li> <p> <code>subnet-id</code> - The ID of the subnet.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>vpc-id</code> - The ID of the VPC for the subnet.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more subnet IDs.</p> <p>Default: Describes all your subnets.</p>"]
+    #[serde(rename="SubnetIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_ids: Option<Vec<String>>,
 }
 
@@ -13988,9 +15372,11 @@ impl DescribeSubnetsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeSubnets.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSubnetsResult {
     #[doc="<p>Information about one or more subnets.</p>"]
+    #[serde(rename="Subnets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnets: Option<Vec<Subnet>>,
 }
 
@@ -14037,15 +15423,23 @@ impl DescribeSubnetsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>key</code> - The tag key.</p> </li> <li> <p> <code>resource-id</code> - The resource ID.</p> </li> <li> <p> <code>resource-type</code> - The resource type (<code>customer-gateway</code> | <code>dhcp-options</code> | <code>image</code> | <code>instance</code> | <code>internet-gateway</code> | <code>network-acl</code> | <code>network-interface</code> | <code>reserved-instances</code> | <code>route-table</code> | <code>security-group</code> | <code>snapshot</code> | <code>spot-instances-request</code> | <code>subnet</code> | <code>volume</code> | <code>vpc</code> | <code>vpn-connection</code> | <code>vpn-gateway</code>).</p> </li> <li> <p> <code>value</code> - The tag value.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of results to return in a single call. This value can be between 5 and 1000. To retrieve the remaining results, make another call with the returned <code>NextToken</code> value.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token to retrieve the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -14081,11 +15475,15 @@ impl DescribeTagsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsResult {
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return..</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of tags.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<TagDescription>>,
 }
 
@@ -14137,13 +15535,18 @@ impl DescribeTagsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVolumeAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVolumeAttributeRequest {
     #[doc="<p>The attribute of the volume. This parameter is required.</p>"]
+    #[serde(rename="Attribute")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the volume.</p>"]
+    #[serde(rename="VolumeId")]
     pub volume_id: String,
 }
 
@@ -14172,13 +15575,19 @@ impl DescribeVolumeAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVolumeAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVolumeAttributeResult {
     #[doc="<p>The state of <code>autoEnableIO</code> attribute.</p>"]
+    #[serde(rename="AutoEnableIO")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_enable_io: Option<AttributeBooleanValue>,
     #[doc="<p>A list of product codes.</p>"]
+    #[serde(rename="ProductCodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_codes: Option<Vec<ProductCode>>,
     #[doc="<p>The ID of the volume.</p>"]
+    #[serde(rename="VolumeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_id: Option<String>,
 }
 
@@ -14235,17 +15644,27 @@ impl DescribeVolumeAttributeResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVolumeStatus.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVolumeStatusRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>action.code</code> - The action code for the event (for example, <code>enable-volume-io</code>).</p> </li> <li> <p> <code>action.description</code> - A description of the action.</p> </li> <li> <p> <code>action.event-id</code> - The event ID associated with the action.</p> </li> <li> <p> <code>availability-zone</code> - The Availability Zone of the instance.</p> </li> <li> <p> <code>event.description</code> - A description of the event.</p> </li> <li> <p> <code>event.event-id</code> - The event ID.</p> </li> <li> <p> <code>event.event-type</code> - The event type (for <code>io-enabled</code>: <code>passed</code> | <code>failed</code>; for <code>io-performance</code>: <code>io-performance:degraded</code> | <code>io-performance:severely-degraded</code> | <code>io-performance:stalled</code>).</p> </li> <li> <p> <code>event.not-after</code> - The latest end time for the event.</p> </li> <li> <p> <code>event.not-before</code> - The earliest start time for the event.</p> </li> <li> <p> <code>volume-status.details-name</code> - The cause for <code>volume-status.status</code> (<code>io-enabled</code> | <code>io-performance</code>).</p> </li> <li> <p> <code>volume-status.details-status</code> - The status of <code>volume-status.details-name</code> (for <code>io-enabled</code>: <code>passed</code> | <code>failed</code>; for <code>io-performance</code>: <code>normal</code> | <code>degraded</code> | <code>severely-degraded</code> | <code>stalled</code>).</p> </li> <li> <p> <code>volume-status.status</code> - The status of the volume (<code>ok</code> | <code>impaired</code> | <code>warning</code> | <code>insufficient-data</code>).</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of volume results returned by <code>DescribeVolumeStatus</code> in paginated output. When this parameter is used, the request only returns <code>MaxResults</code> results in a single page along with a <code>NextToken</code> response element. The remaining results of the initial request can be seen by sending another request with the returned <code>NextToken</code> value. This value can be between 5 and 1000; if <code>MaxResults</code> is given a value larger than 1000, only 1000 results are returned. If this parameter is not used, then <code>DescribeVolumeStatus</code> returns all results. You cannot specify this parameter and the volume IDs parameter in the same request.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The <code>NextToken</code> value to include in a future <code>DescribeVolumeStatus</code> request. When the results of the request exceed <code>MaxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>One or more volume IDs.</p> <p>Default: Describes all your volumes.</p>"]
+    #[serde(rename="VolumeIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_ids: Option<Vec<String>>,
 }
 
@@ -14286,11 +15705,15 @@ impl DescribeVolumeStatusRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVolumeStatus.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVolumeStatusResult {
     #[doc="<p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of volumes.</p>"]
+    #[serde(rename="VolumeStatuses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_statuses: Option<Vec<VolumeStatusItem>>,
 }
 
@@ -14341,17 +15764,27 @@ impl DescribeVolumeStatusResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVolumesModificationsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters. Supported filters: <code>volume-id</code>, <code>modification-state</code>, <code>target-size</code>, <code>target-iops</code>, <code>target-volume-type</code>, <code>original-size</code>, <code>original-iops</code>, <code>original-volume-type</code>, <code>start-time</code>. </p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of results (up to a limit of 500) to be returned in a paginated request.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The <code>nextToken</code> value returned by a previous paginated request.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>One or more volume IDs for which in-progress modifications will be described.</p>"]
+    #[serde(rename="VolumeIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_ids: Option<Vec<String>>,
 }
 
@@ -14391,11 +15824,15 @@ impl DescribeVolumesModificationsRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVolumesModificationsResult {
     #[doc="<p>Token for pagination, null if there are no more results </p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of returned <a>VolumeModification</a> objects.</p>"]
+    #[serde(rename="VolumesModifications")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volumes_modifications: Option<Vec<VolumeModification>>,
 }
 
@@ -14448,17 +15885,27 @@ impl DescribeVolumesModificationsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVolumes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVolumesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>attachment.attach-time</code> - The time stamp when the attachment initiated.</p> </li> <li> <p> <code>attachment.delete-on-termination</code> - Whether the volume is deleted on instance termination.</p> </li> <li> <p> <code>attachment.device</code> - The device name that is exposed to the instance (for example, <code>/dev/sda1</code>).</p> </li> <li> <p> <code>attachment.instance-id</code> - The ID of the instance the volume is attached to.</p> </li> <li> <p> <code>attachment.status</code> - The attachment state (<code>attaching</code> | <code>attached</code> | <code>detaching</code> | <code>detached</code>).</p> </li> <li> <p> <code>availability-zone</code> - The Availability Zone in which the volume was created.</p> </li> <li> <p> <code>create-time</code> - The time stamp when the volume was created.</p> </li> <li> <p> <code>encrypted</code> - The encryption status of the volume.</p> </li> <li> <p> <code>size</code> - The size of the volume, in GiB.</p> </li> <li> <p> <code>snapshot-id</code> - The snapshot from which the volume was created.</p> </li> <li> <p> <code>status</code> - The status of the volume (<code>creating</code> | <code>available</code> | <code>in-use</code> | <code>deleting</code> | <code>deleted</code> | <code>error</code>).</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>volume-id</code> - The volume ID.</p> </li> <li> <p> <code>volume-type</code> - The Amazon EBS volume type. This can be <code>gp2</code> for General Purpose SSD, <code>io1</code> for Provisioned IOPS SSD, <code>st1</code> for Throughput Optimized HDD, <code>sc1</code> for Cold HDD, or <code>standard</code> for Magnetic volumes.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of volume results returned by <code>DescribeVolumes</code> in paginated output. When this parameter is used, <code>DescribeVolumes</code> only returns <code>MaxResults</code> results in a single page along with a <code>NextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>DescribeVolumes</code> request with the returned <code>NextToken</code> value. This value can be between 5 and 500; if <code>MaxResults</code> is given a value larger than 500, only 500 results are returned. If this parameter is not used, then <code>DescribeVolumes</code> returns all results. You cannot specify this parameter and the volume IDs parameter in the same request.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The <code>NextToken</code> value returned from a previous paginated <code>DescribeVolumes</code> request where <code>MaxResults</code> was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the <code>NextToken</code> value. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>One or more volume IDs.</p>"]
+    #[serde(rename="VolumeIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_ids: Option<Vec<String>>,
 }
 
@@ -14499,11 +15946,15 @@ impl DescribeVolumesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVolumes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVolumesResult {
     #[doc="<p>The <code>NextToken</code> value to include in a future <code>DescribeVolumes</code> request. When the results of a <code>DescribeVolumes</code> request exceed <code>MaxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Information about the volumes.</p>"]
+    #[serde(rename="Volumes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volumes: Option<Vec<Volume>>,
 }
 
@@ -14554,13 +16005,17 @@ impl DescribeVolumesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVpcAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcAttributeRequest {
     #[doc="<p>The VPC attribute.</p>"]
+    #[serde(rename="Attribute")]
     pub attribute: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -14587,13 +16042,19 @@ impl DescribeVpcAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVpcAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcAttributeResult {
     #[doc="<p>Indicates whether the instances launched in the VPC get DNS hostnames. If this attribute is <code>true</code>, instances in the VPC get DNS hostnames; otherwise, they do not.</p>"]
+    #[serde(rename="EnableDnsHostnames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_dns_hostnames: Option<AttributeBooleanValue>,
     #[doc="<p>Indicates whether DNS resolution is enabled for the VPC. If this attribute is <code>true</code>, the Amazon DNS server resolves DNS hostnames for your instances to their corresponding IP addresses; otherwise, it does not.</p>"]
+    #[serde(rename="EnableDnsSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_dns_support: Option<AttributeBooleanValue>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -14650,13 +16111,19 @@ impl DescribeVpcAttributeResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVpcClassicLinkDnsSupport.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcClassicLinkDnsSupportRequest {
     #[doc="<p>The maximum number of items to return for this request. The request returns a token that you can specify in a subsequent call to get the next set of results.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a prior call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>One or more VPC IDs.</p>"]
+    #[serde(rename="VpcIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_ids: Option<Vec<String>>,
 }
 
@@ -14688,11 +16155,15 @@ impl DescribeVpcClassicLinkDnsSupportRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVpcClassicLinkDnsSupport.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcClassicLinkDnsSupportResult {
     #[doc="<p>The token to use when requesting the next set of items.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Information about the ClassicLink DNS support status of the VPCs.</p>"]
+    #[serde(rename="Vpcs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpcs: Option<Vec<ClassicLinkDnsSupport>>,
 }
 
@@ -14743,13 +16214,19 @@ impl DescribeVpcClassicLinkDnsSupportResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVpcClassicLink.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcClassicLinkRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>is-classic-link-enabled</code> - Whether the VPC is enabled for ClassicLink (<code>true</code> | <code>false</code>).</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more VPCs for which you want to describe the ClassicLink status.</p>"]
+    #[serde(rename="VpcIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_ids: Option<Vec<String>>,
 }
 
@@ -14782,9 +16259,11 @@ impl DescribeVpcClassicLinkRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVpcClassicLink.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcClassicLinkResult {
     #[doc="<p>The ClassicLink status of one or more VPCs.</p>"]
+    #[serde(rename="Vpcs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpcs: Option<Vec<VpcClassicLink>>,
 }
 
@@ -14832,13 +16311,19 @@ impl DescribeVpcClassicLinkResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVpcEndpointServices.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcEndpointServicesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The maximum number of items to return for this request. The request returns a token that you can specify in a subsequent call to get the next set of results.</p> <p>Constraint: If the value is greater than 1000, we return only 1000 items.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a prior call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -14869,11 +16354,15 @@ impl DescribeVpcEndpointServicesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVpcEndpointServices.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcEndpointServicesResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of supported AWS services.</p>"]
+    #[serde(rename="ServiceNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub service_names: Option<Vec<String>>,
 }
 
@@ -14926,17 +16415,27 @@ impl DescribeVpcEndpointServicesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVpcEndpoints.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcEndpointsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>service-name</code>: The name of the AWS service.</p> </li> <li> <p> <code>vpc-id</code>: The ID of the VPC in which the endpoint resides.</p> </li> <li> <p> <code>vpc-endpoint-id</code>: The ID of the endpoint.</p> </li> <li> <p> <code>vpc-endpoint-state</code>: The state of the endpoint. (<code>pending</code> | <code>available</code> | <code>deleting</code> | <code>deleted</code>)</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The maximum number of items to return for this request. The request returns a token that you can specify in a subsequent call to get the next set of results.</p> <p>Constraint: If the value is greater than 1000, we return only 1000 items.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<i64>,
     #[doc="<p>The token for the next set of items to return. (You received this token from a prior call.)</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>One or more endpoint IDs.</p>"]
+    #[serde(rename="VpcEndpointIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_endpoint_ids: Option<Vec<String>>,
 }
 
@@ -14977,11 +16476,15 @@ impl DescribeVpcEndpointsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVpcEndpoints.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcEndpointsResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Information about the endpoints.</p>"]
+    #[serde(rename="VpcEndpoints")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_endpoints: Option<Vec<VpcEndpoint>>,
 }
 
@@ -15033,13 +16536,19 @@ impl DescribeVpcEndpointsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVpcPeeringConnections.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcPeeringConnectionsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>accepter-vpc-info.cidr-block</code> - The IPv4 CIDR block of the peer VPC.</p> </li> <li> <p> <code>accepter-vpc-info.owner-id</code> - The AWS account ID of the owner of the peer VPC.</p> </li> <li> <p> <code>accepter-vpc-info.vpc-id</code> - The ID of the peer VPC.</p> </li> <li> <p> <code>expiration-time</code> - The expiration date and time for the VPC peering connection.</p> </li> <li> <p> <code>requester-vpc-info.cidr-block</code> - The IPv4 CIDR block of the requester's VPC.</p> </li> <li> <p> <code>requester-vpc-info.owner-id</code> - The AWS account ID of the owner of the requester VPC.</p> </li> <li> <p> <code>requester-vpc-info.vpc-id</code> - The ID of the requester VPC.</p> </li> <li> <p> <code>status-code</code> - The status of the VPC peering connection (<code>pending-acceptance</code> | <code>failed</code> | <code>expired</code> | <code>provisioning</code> | <code>active</code> | <code>deleted</code> | <code>rejected</code>).</p> </li> <li> <p> <code>status-message</code> - A message that provides more information about the status of the VPC peering connection, if applicable.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>vpc-peering-connection-id</code> - The ID of the VPC peering connection.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more VPC peering connection IDs.</p> <p>Default: Describes all your VPC peering connections.</p>"]
+    #[serde(rename="VpcPeeringConnectionIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_peering_connection_ids: Option<Vec<String>>,
 }
 
@@ -15074,9 +16583,11 @@ impl DescribeVpcPeeringConnectionsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVpcPeeringConnections.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcPeeringConnectionsResult {
     #[doc="<p>Information about the VPC peering connections.</p>"]
+    #[serde(rename="VpcPeeringConnections")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_peering_connections: Option<Vec<VpcPeeringConnection>>,
 }
 
@@ -15123,13 +16634,19 @@ impl DescribeVpcPeeringConnectionsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVpcs.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>cidr</code> - The IPv4 CIDR block of the VPC. The CIDR block you specify must exactly match the VPC's CIDR block for information to be returned for the VPC. Must contain the slash followed by one or two digits (for example, <code>/28</code>).</p> </li> <li> <p> <code>dhcp-options-id</code> - The ID of a set of DHCP options.</p> </li> <li> <p> <code>ipv6-cidr-block-association.ipv6-cidr-block</code> - An IPv6 CIDR block associated with the VPC.</p> </li> <li> <p> <code>ipv6-cidr-block-association.association-id</code> - The association ID for an IPv6 CIDR block associated with the VPC.</p> </li> <li> <p> <code>ipv6-cidr-block-association.state</code> - The state of an IPv6 CIDR block associated with the VPC.</p> </li> <li> <p> <code>isDefault</code> - Indicates whether the VPC is the default VPC.</p> </li> <li> <p> <code>state</code> - The state of the VPC (<code>pending</code> | <code>available</code>).</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>vpc-id</code> - The ID of the VPC.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more VPC IDs.</p> <p>Default: Describes all your VPCs.</p>"]
+    #[serde(rename="VpcIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_ids: Option<Vec<String>>,
 }
 
@@ -15162,9 +16679,11 @@ impl DescribeVpcsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVpcs.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpcsResult {
     #[doc="<p>Information about one or more VPCs.</p>"]
+    #[serde(rename="Vpcs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpcs: Option<Vec<Vpc>>,
 }
 
@@ -15211,13 +16730,19 @@ impl DescribeVpcsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVpnConnections.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpnConnectionsRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>customer-gateway-configuration</code> - The configuration information for the customer gateway.</p> </li> <li> <p> <code>customer-gateway-id</code> - The ID of a customer gateway associated with the VPN connection.</p> </li> <li> <p> <code>state</code> - The state of the VPN connection (<code>pending</code> | <code>available</code> | <code>deleting</code> | <code>deleted</code>).</p> </li> <li> <p> <code>option.static-routes-only</code> - Indicates whether the connection has static routes only. Used for devices that do not support Border Gateway Protocol (BGP).</p> </li> <li> <p> <code>route.destination-cidr-block</code> - The destination CIDR block. This corresponds to the subnet used in a customer data center.</p> </li> <li> <p> <code>bgp-asn</code> - The BGP Autonomous System Number (ASN) associated with a BGP device.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>type</code> - The type of VPN connection. Currently the only supported type is <code>ipsec.1</code>.</p> </li> <li> <p> <code>vpn-connection-id</code> - The ID of the VPN connection.</p> </li> <li> <p> <code>vpn-gateway-id</code> - The ID of a virtual private gateway associated with the VPN connection.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more VPN connection IDs.</p> <p>Default: Describes your VPN connections.</p>"]
+    #[serde(rename="VpnConnectionIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpn_connection_ids: Option<Vec<String>>,
 }
 
@@ -15252,9 +16777,11 @@ impl DescribeVpnConnectionsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVpnConnections.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpnConnectionsResult {
     #[doc="<p>Information about one or more VPN connections.</p>"]
+    #[serde(rename="VpnConnections")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpn_connections: Option<Vec<VpnConnection>>,
 }
 
@@ -15302,13 +16829,19 @@ impl DescribeVpnConnectionsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeVpnGateways.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpnGatewaysRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more filters.</p> <ul> <li> <p> <code>attachment.state</code> - The current state of the attachment between the gateway and the VPC (<code>attaching</code> | <code>attached</code> | <code>detaching</code> | <code>detached</code>).</p> </li> <li> <p> <code>attachment.vpc-id</code> - The ID of an attached VPC.</p> </li> <li> <p> <code>availability-zone</code> - The Availability Zone for the virtual private gateway (if applicable).</p> </li> <li> <p> <code>state</code> - The state of the virtual private gateway (<code>pending</code> | <code>available</code> | <code>deleting</code> | <code>deleted</code>).</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter \"tag-key=Purpose\" and the filter \"tag-value=X\", you get any resources assigned both the tag key Purpose (regardless of what the tag's value is), and the tag value X (regardless of what the tag's key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>type</code> - The type of virtual private gateway. Currently the only supported type is <code>ipsec.1</code>.</p> </li> <li> <p> <code>vpn-gateway-id</code> - The ID of the virtual private gateway.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>One or more virtual private gateway IDs.</p> <p>Default: Describes all your virtual private gateways.</p>"]
+    #[serde(rename="VpnGatewayIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpn_gateway_ids: Option<Vec<String>>,
 }
 
@@ -15341,9 +16874,11 @@ impl DescribeVpnGatewaysRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeVpnGateways.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVpnGatewaysResult {
     #[doc="<p>Information about one or more virtual private gateways.</p>"]
+    #[serde(rename="VpnGateways")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpn_gateways: Option<Vec<VpnGateway>>,
 }
 
@@ -15391,13 +16926,17 @@ impl DescribeVpnGatewaysResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DetachClassicLinkVpc.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachClassicLinkVpcRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the instance to unlink from the VPC.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>The ID of the VPC to which the instance is linked.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -15424,9 +16963,11 @@ impl DetachClassicLinkVpcRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DetachClassicLinkVpc.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachClassicLinkVpcResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -15473,13 +17014,17 @@ impl DetachClassicLinkVpcResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DetachInternetGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachInternetGatewayRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the Internet gateway.</p>"]
+    #[serde(rename="InternetGatewayId")]
     pub internet_gateway_id: String,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -15506,13 +17051,18 @@ impl DetachInternetGatewayRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DetachNetworkInterface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachNetworkInterfaceRequest {
     #[doc="<p>The ID of the attachment.</p>"]
+    #[serde(rename="AttachmentId")]
     pub attachment_id: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Specifies whether to force a detachment.</p>"]
+    #[serde(rename="Force")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub force: Option<bool>,
 }
 
@@ -15541,17 +17091,26 @@ impl DetachNetworkInterfaceRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DetachVolume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachVolumeRequest {
     #[doc="<p>The device name.</p>"]
+    #[serde(rename="Device")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Forces detachment if the previous detachment attempt did not occur cleanly (for example, logging into an instance, unmounting the volume, and detaching normally). This option can lead to data loss or a corrupted file system. Use this option only as a last resort to detach a volume from a failed instance. The instance won't have an opportunity to flush file system caches or file system metadata. If you use this option, you must perform file system check and repair procedures.</p>"]
+    #[serde(rename="Force")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub force: Option<bool>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The ID of the volume.</p>"]
+    #[serde(rename="VolumeId")]
     pub volume_id: String,
 }
 
@@ -15588,13 +17147,17 @@ impl DetachVolumeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DetachVpnGateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachVpnGatewayRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
     #[doc="<p>The ID of the virtual private gateway.</p>"]
+    #[serde(rename="VpnGatewayId")]
     pub vpn_gateway_id: String,
 }
 
@@ -15635,11 +17198,15 @@ impl DeviceTypeDeserializer {
     }
 }
 #[doc="<p>Describes a DHCP configuration option.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DhcpConfiguration {
     #[doc="<p>The name of a DHCP option.</p>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>One or more values for the DHCP option.</p>"]
+    #[serde(rename="Values")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub values: Option<Vec<AttributeValue>>,
 }
 
@@ -15770,13 +17337,19 @@ impl DhcpConfigurationValueListDeserializer {
     }
 }
 #[doc="<p>Describes a set of DHCP options.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DhcpOptions {
     #[doc="<p>One or more DHCP options in the set.</p>"]
+    #[serde(rename="DhcpConfigurations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dhcp_configurations: Option<Vec<DhcpConfiguration>>,
     #[doc="<p>The ID of the set of DHCP options.</p>"]
+    #[serde(rename="DhcpOptionsId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dhcp_options_id: Option<String>,
     #[doc="<p>Any tags assigned to the DHCP options set.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -15885,11 +17458,13 @@ impl DhcpOptionsListDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DisableVgwRoutePropagation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableVgwRoutePropagationRequest {
     #[doc="<p>The ID of the virtual private gateway.</p>"]
+    #[serde(rename="GatewayId")]
     pub gateway_id: String,
     #[doc="<p>The ID of the route table.</p>"]
+    #[serde(rename="RouteTableId")]
     pub route_table_id: String,
 }
 
@@ -15912,9 +17487,11 @@ impl DisableVgwRoutePropagationRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for DisableVpcClassicLinkDnsSupport.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableVpcClassicLinkDnsSupportRequest {
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -15937,9 +17514,11 @@ impl DisableVpcClassicLinkDnsSupportRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DisableVpcClassicLinkDnsSupport.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableVpcClassicLinkDnsSupportResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -15987,11 +17566,14 @@ impl DisableVpcClassicLinkDnsSupportResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DisableVpcClassicLink.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableVpcClassicLinkRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -16016,9 +17598,11 @@ impl DisableVpcClassicLinkRequestSerializer {
 }
 
 #[doc="<p>Contains the output of DisableVpcClassicLink.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableVpcClassicLinkResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -16065,13 +17649,19 @@ impl DisableVpcClassicLinkResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DisassociateAddress.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateAddressRequest {
     #[doc="<p>[EC2-VPC] The association ID. Required for EC2-VPC.</p>"]
+    #[serde(rename="AssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association_id: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>[EC2-Classic] The Elastic IP address. Required for EC2-Classic.</p>"]
+    #[serde(rename="PublicIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip: Option<String>,
 }
 
@@ -16101,9 +17691,10 @@ impl DisassociateAddressRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateIamInstanceProfileRequest {
     #[doc="<p>The ID of the IAM instance profile association.</p>"]
+    #[serde(rename="AssociationId")]
     pub association_id: String,
 }
 
@@ -16123,9 +17714,11 @@ impl DisassociateIamInstanceProfileRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateIamInstanceProfileResult {
     #[doc="<p>Information about the IAM instance profile association.</p>"]
+    #[serde(rename="IamInstanceProfileAssociation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile_association: Option<IamInstanceProfileAssociation>,
 }
 
@@ -16172,11 +17765,14 @@ impl DisassociateIamInstanceProfileResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DisassociateRouteTable.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateRouteTableRequest {
     #[doc="<p>The association ID representing the current association between the route table and subnet.</p>"]
+    #[serde(rename="AssociationId")]
     pub association_id: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
 }
 
@@ -16200,9 +17796,10 @@ impl DisassociateRouteTableRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateSubnetCidrBlockRequest {
     #[doc="<p>The association ID for the CIDR block.</p>"]
+    #[serde(rename="AssociationId")]
     pub association_id: String,
 }
 
@@ -16222,11 +17819,15 @@ impl DisassociateSubnetCidrBlockRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateSubnetCidrBlockResult {
     #[doc="<p>Information about the IPv6 CIDR block association.</p>"]
+    #[serde(rename="Ipv6CidrBlockAssociation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block_association: Option<SubnetIpv6CidrBlockAssociation>,
     #[doc="<p>The ID of the subnet.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
 }
 
@@ -16276,9 +17877,10 @@ impl DisassociateSubnetCidrBlockResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateVpcCidrBlockRequest {
     #[doc="<p>The association ID for the CIDR block.</p>"]
+    #[serde(rename="AssociationId")]
     pub association_id: String,
 }
 
@@ -16298,11 +17900,15 @@ impl DisassociateVpcCidrBlockRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateVpcCidrBlockResult {
     #[doc="<p>Information about the IPv6 CIDR block association.</p>"]
+    #[serde(rename="Ipv6CidrBlockAssociation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block_association: Option<VpcIpv6CidrBlockAssociation>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -16352,13 +17958,19 @@ impl DisassociateVpcCidrBlockResultDeserializer {
     }
 }
 #[doc="<p>Describes a disk image.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DiskImage {
     #[doc="<p>A description of the disk image.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Information about the disk image.</p>"]
+    #[serde(rename="Image")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image: Option<DiskImageDetail>,
     #[doc="<p>Information about the volume.</p>"]
+    #[serde(rename="Volume")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume: Option<VolumeDetail>,
 }
 
@@ -16391,15 +18003,20 @@ impl DiskImageSerializer {
 }
 
 #[doc="<p>Describes a disk image.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DiskImageDescription {
     #[doc="<p>The checksum computed for the disk image.</p>"]
+    #[serde(rename="Checksum")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub checksum: Option<String>,
     #[doc="<p>The disk image format.</p>"]
+    #[serde(rename="Format")]
     pub format: String,
     #[doc="<p>A presigned URL for the import manifest stored in Amazon S3. For information about creating a presigned URL for an Amazon S3 object, read the \"Query String Request Authentication Alternative\" section of the <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html\">Authenticating REST Requests</a> topic in the <i>Amazon Simple Storage Service Developer Guide</i>.</p> <p>For information about the import manifest referenced by this API action, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/manifest.html\">VM Import Manifest</a>.</p>"]
+    #[serde(rename="ImportManifestUrl")]
     pub import_manifest_url: String,
     #[doc="<p>The size of the disk image, in GiB.</p>"]
+    #[serde(rename="Size")]
     pub size: i64,
 }
 
@@ -16457,13 +18074,16 @@ impl DiskImageDescriptionDeserializer {
     }
 }
 #[doc="<p>Describes a disk image.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DiskImageDetail {
     #[doc="<p>The size of the disk image, in GiB.</p>"]
+    #[serde(rename="Bytes")]
     pub bytes: i64,
     #[doc="<p>The disk image format.</p>"]
+    #[serde(rename="Format")]
     pub format: String,
     #[doc="<p>A presigned URL for the import manifest stored in Amazon S3 and presented here as an Amazon S3 presigned URL. For information about creating a presigned URL for an Amazon S3 object, read the \"Query String Request Authentication Alternative\" section of the <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html\">Authenticating REST Requests</a> topic in the <i>Amazon Simple Storage Service Developer Guide</i>.</p> <p>For information about the import manifest referenced by this API action, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/manifest.html\">VM Import Manifest</a>.</p>"]
+    #[serde(rename="ImportManifestUrl")]
     pub import_manifest_url: String,
 }
 
@@ -16514,11 +18134,14 @@ impl DiskImageListSerializer {
 }
 
 #[doc="<p>Describes a disk image volume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DiskImageVolumeDescription {
     #[doc="<p>The volume identifier.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The size of the volume, in GiB.</p>"]
+    #[serde(rename="Size")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub size: Option<i64>,
 }
 
@@ -16595,19 +18218,31 @@ impl DoubleDeserializer {
     }
 }
 #[doc="<p>Describes a block device for an EBS volume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EbsBlockDevice {
     #[doc="<p>Indicates whether the EBS volume is deleted on instance termination.</p>"]
+    #[serde(rename="DeleteOnTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_on_termination: Option<bool>,
     #[doc="<p>Indicates whether the EBS volume is encrypted. Encrypted Amazon EBS volumes may only be attached to instances that support Amazon EBS encryption.</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>The number of I/O operations per second (IOPS) that the volume supports. For <code>io1</code>, this represents the number of IOPS that are provisioned for the volume. For <code>gp2</code>, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting. For more information about General Purpose SSD baseline performance, I/O credits, and bursting, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html\">Amazon EBS Volume Types</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p> <p>Constraint: Range is 100-20000 IOPS for <code>io1</code> volumes and 100-10000 IOPS for <code>gp2</code> volumes.</p> <p>Condition: This parameter is required for requests to create <code>io1</code> volumes; it is not used in requests to create <code>gp2</code>, <code>st1</code>, <code>sc1</code>, or <code>standard</code> volumes.</p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>The ID of the snapshot.</p>"]
+    #[serde(rename="SnapshotId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_id: Option<String>,
     #[doc="<p>The size of the volume, in GiB.</p> <p>Constraints: 1-16384 for General Purpose SSD (<code>gp2</code>), 4-16384 for Provisioned IOPS SSD (<code>io1</code>), 500-16384 for Throughput Optimized HDD (<code>st1</code>), 500-16384 for Cold HDD (<code>sc1</code>), and 1-1024 for Magnetic (<code>standard</code>) volumes. If you specify a snapshot, the volume size must be equal to or larger than the snapshot size.</p> <p>Default: If you're creating the volume from a snapshot and don't specify a volume size, the default is the snapshot size.</p>"]
+    #[serde(rename="VolumeSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_size: Option<i64>,
     #[doc="<p>The volume type: <code>gp2</code>, <code>io1</code>, <code>st1</code>, <code>sc1</code>, or <code>standard</code>.</p> <p>Default: <code>standard</code> </p>"]
+    #[serde(rename="VolumeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_type: Option<String>,
 }
 
@@ -16713,15 +18348,23 @@ impl EbsBlockDeviceSerializer {
 }
 
 #[doc="<p>Describes a parameter used to set up an EBS volume in a block device mapping.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EbsInstanceBlockDevice {
     #[doc="<p>The time stamp when the attachment initiated.</p>"]
+    #[serde(rename="AttachTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attach_time: Option<String>,
     #[doc="<p>Indicates whether the volume is deleted on instance termination.</p>"]
+    #[serde(rename="DeleteOnTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_on_termination: Option<bool>,
     #[doc="<p>The attachment state.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The ID of the EBS volume.</p>"]
+    #[serde(rename="VolumeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_id: Option<String>,
 }
 
@@ -16782,11 +18425,15 @@ impl EbsInstanceBlockDeviceDeserializer {
     }
 }
 #[doc="<p>Describes information used to set up an EBS volume specified in a block device mapping.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EbsInstanceBlockDeviceSpecification {
     #[doc="<p>Indicates whether the volume is deleted on instance termination.</p>"]
+    #[serde(rename="DeleteOnTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_on_termination: Option<bool>,
     #[doc="<p>The ID of the EBS volume.</p>"]
+    #[serde(rename="VolumeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_id: Option<String>,
 }
 
@@ -16813,11 +18460,15 @@ impl EbsInstanceBlockDeviceSpecificationSerializer {
 }
 
 #[doc="<p>Describes an egress-only Internet gateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EgressOnlyInternetGateway {
     #[doc="<p>Information about the attachment of the egress-only Internet gateway.</p>"]
+    #[serde(rename="Attachments")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachments: Option<Vec<InternetGatewayAttachment>>,
     #[doc="<p>The ID of the egress-only Internet gateway.</p>"]
+    #[serde(rename="EgressOnlyInternetGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub egress_only_internet_gateway_id: Option<String>,
 }
 
@@ -16934,15 +18585,23 @@ impl EgressOnlyInternetGatewayListDeserializer {
     }
 }
 #[doc="<p>Describes the association between an instance and an Elastic GPU.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticGpuAssociation {
     #[doc="<p>The ID of the association.</p>"]
+    #[serde(rename="ElasticGpuAssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_association_id: Option<String>,
     #[doc="<p>The state of the association between the instance and the Elastic GPU.</p>"]
+    #[serde(rename="ElasticGpuAssociationState")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_association_state: Option<String>,
     #[doc="<p>The time the Elastic GPU was associated with the instance.</p>"]
+    #[serde(rename="ElasticGpuAssociationTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_association_time: Option<String>,
     #[doc="<p>The ID of the Elastic GPU.</p>"]
+    #[serde(rename="ElasticGpuId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_id: Option<String>,
 }
 
@@ -17046,9 +18705,11 @@ impl ElasticGpuAssociationListDeserializer {
     }
 }
 #[doc="<p>Describes the status of an Elastic GPU.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticGpuHealth {
     #[doc="<p>The health status.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -17149,9 +18810,10 @@ impl ElasticGpuSetDeserializer {
     }
 }
 #[doc="<p>A specification for an Elastic GPU.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticGpuSpecification {
     #[doc="<p>The type of Elastic GPU.</p>"]
+    #[serde(rename="Type")]
     pub type_: String,
 }
 
@@ -17212,19 +18874,31 @@ impl ElasticGpuStatusDeserializer {
     }
 }
 #[doc="<p>Describes an Elastic GPU.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticGpus {
     #[doc="<p>The Availability Zone in the which the Elastic GPU resides.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The status of the Elastic GPU.</p>"]
+    #[serde(rename="ElasticGpuHealth")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_health: Option<ElasticGpuHealth>,
     #[doc="<p>The ID of the Elastic GPU.</p>"]
+    #[serde(rename="ElasticGpuId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_id: Option<String>,
     #[doc="<p>The state of the Elastic GPU.</p>"]
+    #[serde(rename="ElasticGpuState")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_state: Option<String>,
     #[doc="<p>The type of Elastic GPU.</p>"]
+    #[serde(rename="ElasticGpuType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_type: Option<String>,
     #[doc="<p>The ID of the instance to which the Elastic GPU is attached.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
 }
 
@@ -17295,11 +18969,13 @@ impl ElasticGpusDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for EnableVgwRoutePropagation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableVgwRoutePropagationRequest {
     #[doc="<p>The ID of the virtual private gateway.</p>"]
+    #[serde(rename="GatewayId")]
     pub gateway_id: String,
     #[doc="<p>The ID of the route table.</p>"]
+    #[serde(rename="RouteTableId")]
     pub route_table_id: String,
 }
 
@@ -17322,11 +18998,14 @@ impl EnableVgwRoutePropagationRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for EnableVolumeIO.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableVolumeIORequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the volume.</p>"]
+    #[serde(rename="VolumeId")]
     pub volume_id: String,
 }
 
@@ -17351,9 +19030,11 @@ impl EnableVolumeIORequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for EnableVpcClassicLinkDnsSupport.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableVpcClassicLinkDnsSupportRequest {
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -17376,9 +19057,11 @@ impl EnableVpcClassicLinkDnsSupportRequestSerializer {
 }
 
 #[doc="<p>Contains the output of EnableVpcClassicLinkDnsSupport.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableVpcClassicLinkDnsSupportResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -17426,11 +19109,14 @@ impl EnableVpcClassicLinkDnsSupportResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for EnableVpcClassicLink.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableVpcClassicLinkRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -17455,9 +19141,11 @@ impl EnableVpcClassicLinkRequestSerializer {
 }
 
 #[doc="<p>Contains the output of EnableVpcClassicLink.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableVpcClassicLinkResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -17518,13 +19206,19 @@ impl EventCodeDeserializer {
     }
 }
 #[doc="<p>Describes a Spot fleet event.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventInformation {
     #[doc="<p>The description of the event.</p>"]
+    #[serde(rename="EventDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_description: Option<String>,
     #[doc="<p>The event.</p> <p>The following are the <code>error</code> events.</p> <ul> <li> <p> <code>iamFleetRoleInvalid</code> - The Spot fleet did not have the required permissions either to launch or terminate an instance.</p> </li> <li> <p> <code>launchSpecTemporarilyBlacklisted</code> - The configuration is not valid and several attempts to launch instances have failed. For more information, see the description of the event.</p> </li> <li> <p> <code>spotFleetRequestConfigurationInvalid</code> - The configuration is not valid. For more information, see the description of the event.</p> </li> <li> <p> <code>spotInstanceCountLimitExceeded</code> - You've reached the limit on the number of Spot instances that you can launch.</p> </li> </ul> <p>The following are the <code>fleetRequestChange</code> events.</p> <ul> <li> <p> <code>active</code> - The Spot fleet has been validated and Amazon EC2 is attempting to maintain the target number of running Spot instances.</p> </li> <li> <p> <code>cancelled</code> - The Spot fleet is canceled and has no running Spot instances. The Spot fleet will be deleted two days after its instances were terminated.</p> </li> <li> <p> <code>cancelled_running</code> - The Spot fleet is canceled and will not launch additional Spot instances, but its existing Spot instances continue to run until they are interrupted or terminated.</p> </li> <li> <p> <code>cancelled_terminating</code> - The Spot fleet is canceled and its Spot instances are terminating.</p> </li> <li> <p> <code>expired</code> - The Spot fleet request has expired. A subsequent event indicates that the instances were terminated, if the request was created with <code>TerminateInstancesWithExpiration</code> set.</p> </li> <li> <p> <code>modify_in_progress</code> - A request to modify the Spot fleet request was accepted and is in progress.</p> </li> <li> <p> <code>modify_successful</code> - The Spot fleet request was modified.</p> </li> <li> <p> <code>price_update</code> - The bid price for a launch configuration was adjusted because it was too high. This change is permanent.</p> </li> <li> <p> <code>submitted</code> - The Spot fleet request is being evaluated and Amazon EC2 is preparing to launch the target number of Spot instances.</p> </li> </ul> <p>The following are the <code>instanceChange</code> events.</p> <ul> <li> <p> <code>launched</code> - A bid was fulfilled and a new instance was launched.</p> </li> <li> <p> <code>terminated</code> - An instance was terminated by the user.</p> </li> </ul>"]
+    #[serde(rename="EventSubType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_sub_type: Option<String>,
     #[doc="<p>The ID of the instance. This information is available only for <code>instanceChange</code> events.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
 }
 
@@ -17634,19 +19328,31 @@ impl ExportEnvironmentDeserializer {
     }
 }
 #[doc="<p>Describes an instance export task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExportTask {
     #[doc="<p>A description of the resource being exported.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of the export task.</p>"]
+    #[serde(rename="ExportTaskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub export_task_id: Option<String>,
     #[doc="<p>Information about the export task.</p>"]
+    #[serde(rename="ExportToS3Task")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub export_to_s3_task: Option<ExportToS3Task>,
     #[doc="<p>Information about the instance to export.</p>"]
+    #[serde(rename="InstanceExportDetails")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_export_details: Option<InstanceExportDetails>,
     #[doc="<p>The state of the export task.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The status message related to the export task.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
 }
 
@@ -17782,15 +19488,23 @@ impl ExportTaskStateDeserializer {
     }
 }
 #[doc="<p>Describes the format and location for an instance export task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExportToS3Task {
     #[doc="<p>The container format used to combine disk images with metadata (such as OVF). If absent, only the disk image is exported.</p>"]
+    #[serde(rename="ContainerFormat")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub container_format: Option<String>,
     #[doc="<p>The format for the exported image.</p>"]
+    #[serde(rename="DiskImageFormat")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disk_image_format: Option<String>,
     #[doc="<p>The S3 bucket for the destination image. The destination bucket must exist and grant WRITE and READ_ACP permissions to the AWS account <code>vm-import-export@amazon.com</code>.</p>"]
+    #[serde(rename="S3Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_bucket: Option<String>,
     #[doc="<p>The encryption key for your S3 bucket.</p>"]
+    #[serde(rename="S3Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_key: Option<String>,
 }
 
@@ -17851,15 +19565,23 @@ impl ExportToS3TaskDeserializer {
     }
 }
 #[doc="<p>Describes an instance export task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExportToS3TaskSpecification {
     #[doc="<p>The container format used to combine disk images with metadata (such as OVF). If absent, only the disk image is exported.</p>"]
+    #[serde(rename="ContainerFormat")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub container_format: Option<String>,
     #[doc="<p>The format for the exported image.</p>"]
+    #[serde(rename="DiskImageFormat")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disk_image_format: Option<String>,
     #[doc="<p>The S3 bucket for the destination image. The destination bucket must exist and grant WRITE and READ_ACP permissions to the AWS account <code>vm-import-export@amazon.com</code>.</p>"]
+    #[serde(rename="S3Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_bucket: Option<String>,
     #[doc="<p>The image is written to a single object in the S3 bucket at the S3 key s3prefix + exportTaskId + '.' + diskImageFormat.</p>"]
+    #[serde(rename="S3Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_prefix: Option<String>,
 }
 
@@ -17894,11 +19616,15 @@ impl ExportToS3TaskSpecificationSerializer {
 }
 
 #[doc="<p>A filter name and value pair that is used to return a more specific list of results. Filters can be used to match a set of resources by various criteria, such as tags, attributes, or IDs.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Filter {
     #[doc="<p>The name of the filter. Filter names are case-sensitive.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>One or more filter values. Filter values are case-sensitive.</p>"]
+    #[serde(rename="Values")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub values: Option<Vec<String>>,
 }
 
@@ -17966,25 +19692,43 @@ impl FloatDeserializer {
     }
 }
 #[doc="<p>Describes a flow log.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FlowLog {
     #[doc="<p>The date and time the flow log was created.</p>"]
+    #[serde(rename="CreationTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub creation_time: Option<String>,
     #[doc="<p>Information about the error that occurred. <code>Rate limited</code> indicates that CloudWatch logs throttling has been applied for one or more network interfaces, or that you've reached the limit on the number of CloudWatch Logs log groups that you can create. <code>Access error</code> indicates that the IAM role associated with the flow log does not have sufficient permissions to publish to CloudWatch Logs. <code>Unknown error</code> indicates an internal error.</p>"]
+    #[serde(rename="DeliverLogsErrorMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deliver_logs_error_message: Option<String>,
     #[doc="<p>The ARN of the IAM role that posts logs to CloudWatch Logs.</p>"]
+    #[serde(rename="DeliverLogsPermissionArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deliver_logs_permission_arn: Option<String>,
     #[doc="<p>The status of the logs delivery (<code>SUCCESS</code> | <code>FAILED</code>).</p>"]
+    #[serde(rename="DeliverLogsStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deliver_logs_status: Option<String>,
     #[doc="<p>The flow log ID.</p>"]
+    #[serde(rename="FlowLogId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub flow_log_id: Option<String>,
     #[doc="<p>The status of the flow log (<code>ACTIVE</code>).</p>"]
+    #[serde(rename="FlowLogStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub flow_log_status: Option<String>,
     #[doc="<p>The name of the flow log group.</p>"]
+    #[serde(rename="LogGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub log_group_name: Option<String>,
     #[doc="<p>The ID of the resource on which the flow log was created.</p>"]
+    #[serde(rename="ResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_id: Option<String>,
     #[doc="<p>The type of traffic captured for the flow log.</p>"]
+    #[serde(rename="TrafficType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_type: Option<String>,
 }
 
@@ -18109,33 +19853,59 @@ impl FlowLogSetDeserializer {
     }
 }
 #[doc="<p>Describes an Amazon FPGA image (AFI).</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FpgaImage {
     #[doc="<p>The date and time the AFI was created.</p>"]
+    #[serde(rename="CreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_time: Option<String>,
     #[doc="<p>The description of the AFI.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The global FPGA image identifier (AGFI ID).</p>"]
+    #[serde(rename="FpgaImageGlobalId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fpga_image_global_id: Option<String>,
     #[doc="<p>The FPGA image identifier (AFI ID).</p>"]
+    #[serde(rename="FpgaImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fpga_image_id: Option<String>,
     #[doc="<p>The name of the AFI.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The alias of the AFI owner. Possible values include <code>self</code>, <code>amazon</code>, and <code>aws-marketplace</code>.</p>"]
+    #[serde(rename="OwnerAlias")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_alias: Option<String>,
     #[doc="<p>The AWS account ID of the AFI owner.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
     #[doc="<p>Information about the PCI bus.</p>"]
+    #[serde(rename="PciId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pci_id: Option<PciId>,
     #[doc="<p>The product codes for the AFI.</p>"]
+    #[serde(rename="ProductCodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_codes: Option<Vec<ProductCode>>,
     #[doc="<p>The version of the AWS Shell that was used to create the bitstream.</p>"]
+    #[serde(rename="ShellVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub shell_version: Option<String>,
     #[doc="<p>Information about the state of the AFI.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<FpgaImageState>,
     #[doc="<p>Any tags assigned to the AFI.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The time of the most recent update to the AFI.</p>"]
+    #[serde(rename="UpdateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub update_time: Option<String>,
 }
 
@@ -18282,11 +20052,15 @@ impl FpgaImageListDeserializer {
     }
 }
 #[doc="<p>Describes the state of the bitstream generation process for an Amazon FPGA image (AFI).</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FpgaImageState {
     #[doc="<p>The state. The following are the possible values:</p> <ul> <li> <p> <code>pending</code> - AFI bitstream generation is in progress.</p> </li> <li> <p> <code>available</code> - The AFI is available for use.</p> </li> <li> <p> <code>failed</code> - AFI bitstream generation failed.</p> </li> <li> <p> <code>unavailable</code> - The AFI is no longer available for use.</p> </li> </ul>"]
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<String>,
     #[doc="<p>If the state is <code>failed</code>, this is the error message.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
 }
 
@@ -18366,11 +20140,14 @@ impl GatewayTypeDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for GetConsoleOutput.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConsoleOutputRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
 }
 
@@ -18395,13 +20172,19 @@ impl GetConsoleOutputRequestSerializer {
 }
 
 #[doc="<p>Contains the output of GetConsoleOutput.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConsoleOutputResult {
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The console output, Base64-encoded. If using a command line tool, the tool decodes the output for you.</p>"]
+    #[serde(rename="Output")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub output: Option<String>,
     #[doc="<p>The time the output was last updated.</p>"]
+    #[serde(rename="Timestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timestamp: Option<String>,
 }
 
@@ -18456,13 +20239,18 @@ impl GetConsoleOutputResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for the request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConsoleScreenshotRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>When set to <code>true</code>, acts as keystroke input and wakes up an instance that's in standby or \"sleep\" mode.</p>"]
+    #[serde(rename="WakeUp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub wake_up: Option<bool>,
 }
 
@@ -18491,11 +20279,15 @@ impl GetConsoleScreenshotRequestSerializer {
 }
 
 #[doc="<p>Contains the output of the request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConsoleScreenshotResult {
     #[doc="<p>The data that comprises the image.</p>"]
+    #[serde(rename="ImageData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_data: Option<String>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
 }
 
@@ -18545,11 +20337,13 @@ impl GetConsoleScreenshotResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetHostReservationPurchasePreviewRequest {
     #[doc="<p>The ID/s of the Dedicated Host/s that the reservation will be associated with.</p>"]
+    #[serde(rename="HostIdSet")]
     pub host_id_set: Vec<String>,
     #[doc="<p>The offering ID of the reservation.</p>"]
+    #[serde(rename="OfferingId")]
     pub offering_id: String,
 }
 
@@ -18572,15 +20366,23 @@ impl GetHostReservationPurchasePreviewRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetHostReservationPurchasePreviewResult {
     #[doc="<p>The currency in which the <code>totalUpfrontPrice</code> and <code>totalHourlyPrice</code> amounts are specified. At this time, the only supported currency is <code>USD</code>.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The purchase information of the Dedicated Host Reservation and the Dedicated Hosts associated with it.</p>"]
+    #[serde(rename="Purchase")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub purchase: Option<Vec<Purchase>>,
     #[doc="<p>The potential total hourly price of the reservation per hour.</p>"]
+    #[serde(rename="TotalHourlyPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub total_hourly_price: Option<String>,
     #[doc="<p>The potential total upfront price. This is billed immediately.</p>"]
+    #[serde(rename="TotalUpfrontPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub total_upfront_price: Option<String>,
 }
 
@@ -18643,11 +20445,14 @@ impl GetHostReservationPurchasePreviewResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for GetPasswordData.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPasswordDataRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the Windows instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
 }
 
@@ -18672,13 +20477,19 @@ impl GetPasswordDataRequestSerializer {
 }
 
 #[doc="<p>Contains the output of GetPasswordData.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPasswordDataResult {
     #[doc="<p>The ID of the Windows instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The password of the instance.</p>"]
+    #[serde(rename="PasswordData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password_data: Option<String>,
     #[doc="<p>The time the data was last updated.</p>"]
+    #[serde(rename="Timestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timestamp: Option<String>,
 }
 
@@ -18733,13 +20544,18 @@ impl GetPasswordDataResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for GetReservedInstanceExchangeQuote.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetReservedInstancesExchangeQuoteRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The IDs of the Convertible Reserved Instances to exchange.</p>"]
+    #[serde(rename="ReservedInstanceIds")]
     pub reserved_instance_ids: Vec<String>,
     #[doc="<p>The configuration requirements of the Convertible Reserved Instances to exchange for your current Convertible Reserved Instances.</p>"]
+    #[serde(rename="TargetConfigurations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_configurations: Option<Vec<TargetConfigurationRequest>>,
 }
 
@@ -18772,25 +20588,43 @@ impl GetReservedInstancesExchangeQuoteRequestSerializer {
 }
 
 #[doc="<p>Contains the output of GetReservedInstancesExchangeQuote.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetReservedInstancesExchangeQuoteResult {
     #[doc="<p>The currency of the transaction.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>If <code>true</code>, the exchange is valid. If <code>false</code>, the exchange cannot be completed.</p>"]
+    #[serde(rename="IsValidExchange")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_valid_exchange: Option<bool>,
     #[doc="<p>The new end date of the reservation term.</p>"]
+    #[serde(rename="OutputReservedInstancesWillExpireAt")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub output_reserved_instances_will_expire_at: Option<String>,
     #[doc="<p>The total true upfront charge for the exchange.</p>"]
+    #[serde(rename="PaymentDue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub payment_due: Option<String>,
     #[doc="<p>The cost associated with the Reserved Instance.</p>"]
+    #[serde(rename="ReservedInstanceValueRollup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instance_value_rollup: Option<ReservationValue>,
     #[doc="<p>The configuration of your Convertible Reserved Instances.</p>"]
+    #[serde(rename="ReservedInstanceValueSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instance_value_set: Option<Vec<ReservedInstanceReservationValue>>,
     #[doc="<p>The cost associated with the Reserved Instance.</p>"]
+    #[serde(rename="TargetConfigurationValueRollup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_configuration_value_rollup: Option<ReservationValue>,
     #[doc="<p>The values of the target Convertible Reserved Instances.</p>"]
+    #[serde(rename="TargetConfigurationValueSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_configuration_value_set: Option<Vec<TargetReservationValue>>,
     #[doc="<p>Describes the reason why the exchange cannot be completed.</p>"]
+    #[serde(rename="ValidationFailureReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub validation_failure_reason: Option<String>,
 }
 
@@ -18885,11 +20719,15 @@ impl GroupIdStringListSerializer {
 }
 
 #[doc="<p>Describes a security group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GroupIdentifier {
     #[doc="<p>The ID of the security group.</p>"]
+    #[serde(rename="GroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_id: Option<String>,
     #[doc="<p>The name of the security group.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
 }
 
@@ -19039,13 +20877,16 @@ impl GroupNameStringListSerializer {
 }
 
 #[doc="<p>Describes an event in the history of the Spot fleet request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HistoryRecord {
     #[doc="<p>Information about the event.</p>"]
+    #[serde(rename="EventInformation")]
     pub event_information: EventInformation,
     #[doc="<p>The event type.</p> <ul> <li> <p> <code>error</code> - Indicates an error with the Spot fleet request.</p> </li> <li> <p> <code>fleetRequestChange</code> - Indicates a change in the status or configuration of the Spot fleet request.</p> </li> <li> <p> <code>instanceChange</code> - Indicates that an instance was launched or terminated.</p> </li> </ul>"]
+    #[serde(rename="EventType")]
     pub event_type: String,
     #[doc="<p>The date and time of the event, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z).</p>"]
+    #[serde(rename="Timestamp")]
     pub timestamp: String,
 }
 
@@ -19142,25 +20983,43 @@ impl HistoryRecordsDeserializer {
     }
 }
 #[doc="<p>Describes the properties of the Dedicated Host.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Host {
     #[doc="<p>Whether auto-placement is on or off.</p>"]
+    #[serde(rename="AutoPlacement")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_placement: Option<String>,
     #[doc="<p>The Availability Zone of the Dedicated Host.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The number of new instances that can be launched onto the Dedicated Host.</p>"]
+    #[serde(rename="AvailableCapacity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub available_capacity: Option<AvailableCapacity>,
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html\">How to Ensure Idempotency</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>. </p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>The ID of the Dedicated Host.</p>"]
+    #[serde(rename="HostId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_id: Option<String>,
     #[doc="<p>The hardware specifications of the Dedicated Host.</p>"]
+    #[serde(rename="HostProperties")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_properties: Option<HostProperties>,
     #[doc="<p>The reservation ID of the Dedicated Host. This returns a <code>null</code> response if the Dedicated Host doesn't have an associated reservation.</p>"]
+    #[serde(rename="HostReservationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_reservation_id: Option<String>,
     #[doc="<p>The IDs and instance type that are currently running on the Dedicated Host.</p>"]
+    #[serde(rename="Instances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instances: Option<Vec<HostInstance>>,
     #[doc="<p>The Dedicated Host's state.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -19245,11 +21104,15 @@ impl HostDeserializer {
     }
 }
 #[doc="<p>Describes an instance running on a Dedicated Host.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HostInstance {
     #[doc="<p>the IDs of instances that are running on the Dedicated Host.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The instance type size (for example, <code>m3.medium</code>) of the running instance.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
 }
 
@@ -19382,21 +21245,35 @@ impl HostListDeserializer {
     }
 }
 #[doc="<p>Details about the Dedicated Host Reservation offering.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HostOffering {
     #[doc="<p>The currency of the offering.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The duration of the offering (in seconds).</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The hourly price of the offering.</p>"]
+    #[serde(rename="HourlyPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hourly_price: Option<String>,
     #[doc="<p>The instance family of the offering.</p>"]
+    #[serde(rename="InstanceFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_family: Option<String>,
     #[doc="<p>The ID of the offering.</p>"]
+    #[serde(rename="OfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_id: Option<String>,
     #[doc="<p>The available payment option.</p>"]
+    #[serde(rename="PaymentOption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub payment_option: Option<String>,
     #[doc="<p>The upfront price of the offering. Does not apply to No Upfront offerings.</p>"]
+    #[serde(rename="UpfrontPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upfront_price: Option<String>,
 }
 
@@ -19511,15 +21388,23 @@ impl HostOfferingSetDeserializer {
     }
 }
 #[doc="<p>Describes properties of a Dedicated Host.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HostProperties {
     #[doc="<p>The number of cores on the Dedicated Host.</p>"]
+    #[serde(rename="Cores")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cores: Option<i64>,
     #[doc="<p>The instance type size that the Dedicated Host supports (for example, <code>m3.medium</code>).</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The number of sockets on the Dedicated Host.</p>"]
+    #[serde(rename="Sockets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sockets: Option<i64>,
     #[doc="<p>The number of vCPUs on the Dedicated Host.</p>"]
+    #[serde(rename="TotalVCpus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub total_v_cpus: Option<i64>,
 }
 
@@ -19578,33 +21463,59 @@ impl HostPropertiesDeserializer {
     }
 }
 #[doc="<p>Details about the Dedicated Host Reservation and associated Dedicated Hosts.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HostReservation {
     #[doc="<p>The number of Dedicated Hosts the reservation is associated with.</p>"]
+    #[serde(rename="Count")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub count: Option<i64>,
     #[doc="<p>The currency in which the <code>upfrontPrice</code> and <code>hourlyPrice</code> amounts are specified. At this time, the only supported currency is <code>USD</code>.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The length of the reservation's term, specified in seconds. Can be <code>31536000 (1 year)</code> | <code>94608000 (3 years)</code>.</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The date and time that the reservation ends.</p>"]
+    #[serde(rename="End")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end: Option<String>,
     #[doc="<p>The IDs of the Dedicated Hosts associated with the reservation.</p>"]
+    #[serde(rename="HostIdSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_id_set: Option<Vec<String>>,
     #[doc="<p>The ID of the reservation that specifies the associated Dedicated Hosts.</p>"]
+    #[serde(rename="HostReservationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_reservation_id: Option<String>,
     #[doc="<p>The hourly price of the reservation.</p>"]
+    #[serde(rename="HourlyPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hourly_price: Option<String>,
     #[doc="<p>The instance family of the Dedicated Host Reservation. The instance family on the Dedicated Host must be the same in order for it to benefit from the reservation.</p>"]
+    #[serde(rename="InstanceFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_family: Option<String>,
     #[doc="<p>The ID of the reservation. This remains the same regardless of which Dedicated Hosts are associated with it.</p>"]
+    #[serde(rename="OfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_id: Option<String>,
     #[doc="<p>The payment option selected for this reservation.</p>"]
+    #[serde(rename="PaymentOption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub payment_option: Option<String>,
     #[doc="<p>The date and time that the reservation started.</p>"]
+    #[serde(rename="Start")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start: Option<String>,
     #[doc="<p>The state of the reservation.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The upfront price of the reservation.</p>"]
+    #[serde(rename="UpfrontPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upfront_price: Option<String>,
 }
 
@@ -19771,11 +21682,15 @@ impl HypervisorTypeDeserializer {
     }
 }
 #[doc="<p>Describes an IAM instance profile.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IamInstanceProfile {
     #[doc="<p>The Amazon Resource Name (ARN) of the instance profile.</p>"]
+    #[serde(rename="Arn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
     #[doc="<p>The ID of the instance profile.</p>"]
+    #[serde(rename="Id")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
 }
 
@@ -19824,17 +21739,27 @@ impl IamInstanceProfileDeserializer {
     }
 }
 #[doc="<p>Describes an association between an IAM instance profile and an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IamInstanceProfileAssociation {
     #[doc="<p>The ID of the association.</p>"]
+    #[serde(rename="AssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association_id: Option<String>,
     #[doc="<p>The IAM instance profile.</p>"]
+    #[serde(rename="IamInstanceProfile")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile: Option<IamInstanceProfile>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The state of the association.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The time the IAM instance profile was associated with the instance.</p>"]
+    #[serde(rename="Timestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timestamp: Option<String>,
 }
 
@@ -19953,11 +21878,15 @@ impl IamInstanceProfileAssociationStateDeserializer {
     }
 }
 #[doc="<p>Describes an IAM instance profile.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IamInstanceProfileSpecification {
     #[doc="<p>The Amazon Resource Name (ARN) of the instance profile.</p>"]
+    #[serde(rename="Arn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
     #[doc="<p>The name of the instance profile.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -20029,11 +21958,15 @@ impl IamInstanceProfileSpecificationSerializer {
 }
 
 #[doc="<p>Describes the ICMP type and code.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IcmpTypeCode {
     #[doc="<p>The ICMP code. A value of -1 means all codes for the specified ICMP type.</p>"]
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<i64>,
     #[doc="<p>The ICMP type. A value of -1 means all types.</p>"]
+    #[serde(rename="Type")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<i64>,
 }
 
@@ -20104,13 +22037,19 @@ impl IcmpTypeCodeSerializer {
 }
 
 #[doc="<p>Describes the ID format for a resource.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IdFormat {
     #[doc="<p>The date in UTC at which you are permanently switched over to using longer IDs. If a deadline is not yet available for this resource type, this field is not returned.</p>"]
+    #[serde(rename="Deadline")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deadline: Option<String>,
     #[doc="<p>The type of resource.</p>"]
+    #[serde(rename="Resource")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource: Option<String>,
     #[doc="<p>Indicates whether longer IDs (17-character IDs) are enabled for the resource.</p>"]
+    #[serde(rename="UseLongIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub use_long_ids: Option<bool>,
 }
 
@@ -20206,55 +22145,103 @@ impl IdFormatListDeserializer {
     }
 }
 #[doc="<p>Describes an image.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Image {
     #[doc="<p>The architecture of the image.</p>"]
+    #[serde(rename="Architecture")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub architecture: Option<String>,
     #[doc="<p>Any block device mapping entries.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
     #[doc="<p>The date and time the image was created.</p>"]
+    #[serde(rename="CreationDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub creation_date: Option<String>,
     #[doc="<p>The description of the AMI that was provided during image creation.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Specifies whether enhanced networking with ENA is enabled.</p>"]
+    #[serde(rename="EnaSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ena_support: Option<bool>,
     #[doc="<p>The hypervisor type of the image.</p>"]
+    #[serde(rename="Hypervisor")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hypervisor: Option<String>,
     #[doc="<p>The ID of the AMI.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
     #[doc="<p>The location of the AMI.</p>"]
+    #[serde(rename="ImageLocation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_location: Option<String>,
     #[doc="<p>The AWS account alias (for example, <code>amazon</code>, <code>self</code>) or the AWS account ID of the AMI owner.</p>"]
+    #[serde(rename="ImageOwnerAlias")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_owner_alias: Option<String>,
     #[doc="<p>The type of image.</p>"]
+    #[serde(rename="ImageType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_type: Option<String>,
     #[doc="<p>The kernel associated with the image, if any. Only applicable for machine images.</p>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<String>,
     #[doc="<p>The name of the AMI that was provided during image creation.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The AWS account ID of the image owner.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
     #[doc="<p>The value is <code>Windows</code> for Windows AMIs; otherwise blank.</p>"]
+    #[serde(rename="Platform")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform: Option<String>,
     #[doc="<p>Any product codes associated with the AMI.</p>"]
+    #[serde(rename="ProductCodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_codes: Option<Vec<ProductCode>>,
     #[doc="<p>Indicates whether the image has public launch permissions. The value is <code>true</code> if this image has public launch permissions or <code>false</code> if it has only implicit and explicit launch permissions.</p>"]
+    #[serde(rename="Public")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public: Option<bool>,
     #[doc="<p>The RAM disk associated with the image, if any. Only applicable for machine images.</p>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<String>,
     #[doc="<p>The device name of the root device (for example, <code>/dev/sda1</code> or <code>/dev/xvda</code>).</p>"]
+    #[serde(rename="RootDeviceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub root_device_name: Option<String>,
     #[doc="<p>The type of root device used by the AMI. The AMI can use an EBS volume or an instance store volume.</p>"]
+    #[serde(rename="RootDeviceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub root_device_type: Option<String>,
     #[doc="<p>Specifies whether enhanced networking with the Intel 82599 Virtual Function interface is enabled.</p>"]
+    #[serde(rename="SriovNetSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sriov_net_support: Option<String>,
     #[doc="<p>The current state of the AMI. If the state is <code>available</code>, the image is successfully registered and can be used to launch an instance.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The reason for the state change.</p>"]
+    #[serde(rename="StateReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state_reason: Option<StateReason>,
     #[doc="<p>Any tags assigned to the image.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The type of virtualization of the AMI.</p>"]
+    #[serde(rename="VirtualizationType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub virtualization_type: Option<String>,
 }
 
@@ -20404,23 +22391,39 @@ impl ImageDeserializer {
     }
 }
 #[doc="<p>Describes an image attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImageAttribute {
     #[doc="<p>One or more block device mapping entries.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
     #[doc="<p>A description for the AMI.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<AttributeValue>,
     #[doc="<p>The ID of the AMI.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
     #[doc="<p>The kernel ID.</p>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<AttributeValue>,
     #[doc="<p>One or more launch permissions.</p>"]
+    #[serde(rename="LaunchPermissions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_permissions: Option<Vec<LaunchPermission>>,
     #[doc="<p>One or more product codes.</p>"]
+    #[serde(rename="ProductCodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_codes: Option<Vec<ProductCode>>,
     #[doc="<p>The RAM disk ID.</p>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<AttributeValue>,
     #[doc="<p>Indicates whether enhanced networking with the Intel 82599 Virtual Function interface is enabled.</p>"]
+    #[serde(rename="SriovNetSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sriov_net_support: Option<AttributeValue>,
 }
 
@@ -20502,19 +22505,31 @@ impl ImageAttributeDeserializer {
     }
 }
 #[doc="<p>Describes the disk container object for an import image task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImageDiskContainer {
     #[doc="<p>The description of the disk image.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The block device mapping for the disk.</p>"]
+    #[serde(rename="DeviceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device_name: Option<String>,
     #[doc="<p>The format of the disk image being imported.</p> <p>Valid values: <code>RAW</code> | <code>VHD</code> | <code>VMDK</code> | <code>OVA</code> </p>"]
+    #[serde(rename="Format")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub format: Option<String>,
     #[doc="<p>The ID of the EBS snapshot to be used for importing the snapshot.</p>"]
+    #[serde(rename="SnapshotId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_id: Option<String>,
     #[doc="<p>The URL to the Amazon S3-based disk image being imported. The URL can either be a https URL (https://..) or an Amazon S3 URL (s3://..)</p>"]
+    #[serde(rename="Url")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
     #[doc="<p>The S3 bucket for the disk image.</p>"]
+    #[serde(rename="UserBucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_bucket: Option<UserBucket>,
 }
 
@@ -20651,27 +22666,47 @@ impl ImageTypeValuesDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ImportImage.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportImageRequest {
     #[doc="<p>The architecture of the virtual machine.</p> <p>Valid values: <code>i386</code> | <code>x86_64</code> </p>"]
+    #[serde(rename="Architecture")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub architecture: Option<String>,
     #[doc="<p>The client-specific data.</p>"]
+    #[serde(rename="ClientData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_data: Option<ClientData>,
     #[doc="<p>The token to enable idempotency for VM import requests.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>A description string for the import image task.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Information about the disk containers.</p>"]
+    #[serde(rename="DiskContainers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disk_containers: Option<Vec<ImageDiskContainer>>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The target hypervisor platform.</p> <p>Valid values: <code>xen</code> </p>"]
+    #[serde(rename="Hypervisor")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hypervisor: Option<String>,
     #[doc="<p>The license type to be used for the Amazon Machine Image (AMI) after importing.</p> <p> <b>Note:</b> You may only use BYOL if you have existing licenses with rights to use these licenses in a third party cloud like AWS. For more information, see <a href=\"http://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html#prerequisites-image\">Prerequisites</a> in the VM Import/Export User Guide.</p> <p>Valid values: <code>AWS</code> | <code>BYOL</code> </p>"]
+    #[serde(rename="LicenseType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_type: Option<String>,
     #[doc="<p>The operating system of the virtual machine.</p> <p>Valid values: <code>Windows</code> | <code>Linux</code> </p>"]
+    #[serde(rename="Platform")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform: Option<String>,
     #[doc="<p>The name of the role to use when not using the default role, 'vmimport'.</p>"]
+    #[serde(rename="RoleName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_name: Option<String>,
 }
 
@@ -20732,29 +22767,51 @@ impl ImportImageRequestSerializer {
 }
 
 #[doc="<p>Contains the output for ImportImage.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportImageResult {
     #[doc="<p>The architecture of the virtual machine.</p>"]
+    #[serde(rename="Architecture")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub architecture: Option<String>,
     #[doc="<p>A description of the import task.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The target hypervisor of the import task.</p>"]
+    #[serde(rename="Hypervisor")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hypervisor: Option<String>,
     #[doc="<p>The ID of the Amazon Machine Image (AMI) created by the import task.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
     #[doc="<p>The task ID of the import image task.</p>"]
+    #[serde(rename="ImportTaskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_task_id: Option<String>,
     #[doc="<p>The license type of the virtual machine.</p>"]
+    #[serde(rename="LicenseType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_type: Option<String>,
     #[doc="<p>The operating system of the virtual machine.</p>"]
+    #[serde(rename="Platform")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform: Option<String>,
     #[doc="<p>The progress of the task.</p>"]
+    #[serde(rename="Progress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress: Option<String>,
     #[doc="<p>Information about the snapshots.</p>"]
+    #[serde(rename="SnapshotDetails")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_details: Option<Vec<SnapshotDetail>>,
     #[doc="<p>A brief status of the task.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>A detailed status message of the import task.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
 }
 
@@ -20842,29 +22899,51 @@ impl ImportImageResultDeserializer {
     }
 }
 #[doc="<p>Describes an import image task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportImageTask {
     #[doc="<p>The architecture of the virtual machine.</p> <p>Valid values: <code>i386</code> | <code>x86_64</code> </p>"]
+    #[serde(rename="Architecture")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub architecture: Option<String>,
     #[doc="<p>A description of the import task.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The target hypervisor for the import task.</p> <p>Valid values: <code>xen</code> </p>"]
+    #[serde(rename="Hypervisor")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hypervisor: Option<String>,
     #[doc="<p>The ID of the Amazon Machine Image (AMI) of the imported virtual machine.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
     #[doc="<p>The ID of the import image task.</p>"]
+    #[serde(rename="ImportTaskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_task_id: Option<String>,
     #[doc="<p>The license type of the virtual machine.</p>"]
+    #[serde(rename="LicenseType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_type: Option<String>,
     #[doc="<p>The description string for the import image task.</p>"]
+    #[serde(rename="Platform")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform: Option<String>,
     #[doc="<p>The percentage of progress of the import image task.</p>"]
+    #[serde(rename="Progress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress: Option<String>,
     #[doc="<p>Information about the snapshots.</p>"]
+    #[serde(rename="SnapshotDetails")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_details: Option<Vec<SnapshotDetail>>,
     #[doc="<p>A brief status for the import image task.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>A descriptive status message for the import image task.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
 }
 
@@ -20993,29 +23072,51 @@ impl ImportImageTaskListDeserializer {
     }
 }
 #[doc="<p>Describes the launch specification for VM import.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportInstanceLaunchSpecification {
     #[doc="<p>Reserved.</p>"]
+    #[serde(rename="AdditionalInfo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub additional_info: Option<String>,
     #[doc="<p>The architecture of the instance.</p>"]
+    #[serde(rename="Architecture")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub architecture: Option<String>,
     #[doc="<p>One or more security group IDs.</p>"]
+    #[serde(rename="GroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_ids: Option<Vec<String>>,
     #[doc="<p>One or more security group names.</p>"]
+    #[serde(rename="GroupNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_names: Option<Vec<String>>,
     #[doc="<p>Indicates whether an instance stops or terminates when you initiate shutdown from the instance (using the operating system command for system shutdown).</p>"]
+    #[serde(rename="InstanceInitiatedShutdownBehavior")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_initiated_shutdown_behavior: Option<String>,
     #[doc="<p>The instance type. For more information about the instance types that you can import, see <a href=\"http://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html#vmimport-instance-types\">Instance Types</a> in the VM Import/Export User Guide.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>Indicates whether monitoring is enabled.</p>"]
+    #[serde(rename="Monitoring")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring: Option<bool>,
     #[doc="<p>The placement information for the instance.</p>"]
+    #[serde(rename="Placement")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement: Option<Placement>,
     #[doc="<p>[EC2-VPC] An available IP address from the IP address range of the subnet.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
     #[doc="<p>[EC2-VPC] The ID of the subnet in which to launch the instance.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>The user data to make available to the instance. If you are using an AWS SDK or command line tool, Base64-encoding is performed for you, and you can load the text from a file. Otherwise, you must provide Base64-encoded text.</p>"]
+    #[serde(rename="UserData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_data: Option<UserData>,
 }
 
@@ -21082,17 +23183,26 @@ impl ImportInstanceLaunchSpecificationSerializer {
 }
 
 #[doc="<p>Contains the parameters for ImportInstance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportInstanceRequest {
     #[doc="<p>A description for the instance being imported.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The disk image.</p>"]
+    #[serde(rename="DiskImages")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disk_images: Option<Vec<DiskImage>>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The launch specification.</p>"]
+    #[serde(rename="LaunchSpecification")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_specification: Option<ImportInstanceLaunchSpecification>,
     #[doc="<p>The instance operating system.</p>"]
+    #[serde(rename="Platform")]
     pub platform: String,
 }
 
@@ -21133,9 +23243,11 @@ impl ImportInstanceRequestSerializer {
 }
 
 #[doc="<p>Contains the output for ImportInstance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportInstanceResult {
     #[doc="<p>Information about the conversion task.</p>"]
+    #[serde(rename="ConversionTask")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub conversion_task: Option<ConversionTask>,
 }
 
@@ -21183,15 +23295,22 @@ impl ImportInstanceResultDeserializer {
     }
 }
 #[doc="<p>Describes an import instance task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportInstanceTaskDetails {
     #[doc="<p>A description of the task.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The instance operating system.</p>"]
+    #[serde(rename="Platform")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform: Option<String>,
     #[doc="<p>One or more volumes.</p>"]
+    #[serde(rename="Volumes")]
     pub volumes: Vec<ImportInstanceVolumeDetailItem>,
 }
 
@@ -21252,21 +23371,30 @@ impl ImportInstanceTaskDetailsDeserializer {
     }
 }
 #[doc="<p>Describes an import volume task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportInstanceVolumeDetailItem {
     #[doc="<p>The Availability Zone where the resulting instance will reside.</p>"]
+    #[serde(rename="AvailabilityZone")]
     pub availability_zone: String,
     #[doc="<p>The number of bytes converted so far.</p>"]
+    #[serde(rename="BytesConverted")]
     pub bytes_converted: i64,
     #[doc="<p>A description of the task.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The image.</p>"]
+    #[serde(rename="Image")]
     pub image: DiskImageDescription,
     #[doc="<p>The status of the import of this particular disk image.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The status information or errors related to the disk image.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
     #[doc="<p>The volume.</p>"]
+    #[serde(rename="Volume")]
     pub volume: DiskImageVolumeDescription,
 }
 
@@ -21379,13 +23507,22 @@ impl ImportInstanceVolumeDetailSetDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ImportKeyPair.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportKeyPairRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>A unique name for the key pair.</p>"]
+    #[serde(rename="KeyName")]
     pub key_name: String,
     #[doc="<p>The public key. For API calls, the text must be base64-encoded. For command line tools, base64 encoding is performed for you.</p>"]
+    #[serde(rename="PublicKeyMaterial")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub public_key_material: Vec<u8>,
 }
 
@@ -21414,11 +23551,15 @@ impl ImportKeyPairRequestSerializer {
 }
 
 #[doc="<p>Contains the output of ImportKeyPair.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportKeyPairResult {
     #[doc="<p>The MD5 public key fingerprint as specified in section 4 of RFC 4716.</p>"]
+    #[serde(rename="KeyFingerprint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_fingerprint: Option<String>,
     #[doc="<p>The key pair name you provided.</p>"]
+    #[serde(rename="KeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_name: Option<String>,
 }
 
@@ -21470,19 +23611,31 @@ impl ImportKeyPairResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ImportSnapshot.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportSnapshotRequest {
     #[doc="<p>The client-specific data.</p>"]
+    #[serde(rename="ClientData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_data: Option<ClientData>,
     #[doc="<p>Token to enable idempotency for VM import requests.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>The description string for the import snapshot task.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Information about the disk container.</p>"]
+    #[serde(rename="DiskContainer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disk_container: Option<SnapshotDiskContainer>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The name of the role to use when not using the default role, 'vmimport'.</p>"]
+    #[serde(rename="RoleName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_name: Option<String>,
 }
 
@@ -21527,13 +23680,19 @@ impl ImportSnapshotRequestSerializer {
 }
 
 #[doc="<p>Contains the output for ImportSnapshot.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportSnapshotResult {
     #[doc="<p>A description of the import snapshot task.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of the import snapshot task.</p>"]
+    #[serde(rename="ImportTaskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_task_id: Option<String>,
     #[doc="<p>Information about the import snapshot task.</p>"]
+    #[serde(rename="SnapshotTaskDetail")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_task_detail: Option<SnapshotTaskDetail>,
 }
 
@@ -21589,13 +23748,19 @@ impl ImportSnapshotResultDeserializer {
     }
 }
 #[doc="<p>Describes an import snapshot task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportSnapshotTask {
     #[doc="<p>A description of the import snapshot task.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of the import snapshot task.</p>"]
+    #[serde(rename="ImportTaskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_task_id: Option<String>,
     #[doc="<p>Describes an import snapshot task.</p>"]
+    #[serde(rename="SnapshotTaskDetail")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_task_detail: Option<SnapshotTaskDetail>,
 }
 
@@ -21704,17 +23869,24 @@ impl ImportTaskIdListSerializer {
 }
 
 #[doc="<p>Contains the parameters for ImportVolume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportVolumeRequest {
     #[doc="<p>The Availability Zone for the resulting EBS volume.</p>"]
+    #[serde(rename="AvailabilityZone")]
     pub availability_zone: String,
     #[doc="<p>A description of the volume.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The disk image.</p>"]
+    #[serde(rename="Image")]
     pub image: DiskImageDetail,
     #[doc="<p>The volume size.</p>"]
+    #[serde(rename="Volume")]
     pub volume: VolumeDetail,
 }
 
@@ -21745,9 +23917,11 @@ impl ImportVolumeRequestSerializer {
 }
 
 #[doc="<p>Contains the output for ImportVolume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportVolumeResult {
     #[doc="<p>Information about the conversion task.</p>"]
+    #[serde(rename="ConversionTask")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub conversion_task: Option<ConversionTask>,
 }
 
@@ -21795,17 +23969,23 @@ impl ImportVolumeResultDeserializer {
     }
 }
 #[doc="<p>Describes an import volume task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportVolumeTaskDetails {
     #[doc="<p>The Availability Zone where the resulting volume will reside.</p>"]
+    #[serde(rename="AvailabilityZone")]
     pub availability_zone: String,
     #[doc="<p>The number of bytes converted so far.</p>"]
+    #[serde(rename="BytesConverted")]
     pub bytes_converted: i64,
     #[doc="<p>The description you provided when starting the import volume task.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The image.</p>"]
+    #[serde(rename="Image")]
     pub image: DiskImageDescription,
     #[doc="<p>The volume.</p>"]
+    #[serde(rename="Volume")]
     pub volume: DiskImageVolumeDescription,
 }
 
@@ -21869,85 +24049,163 @@ impl ImportVolumeTaskDetailsDeserializer {
     }
 }
 #[doc="<p>Describes an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Instance {
     #[doc="<p>The AMI launch index, which can be used to find this instance in the launch group.</p>"]
+    #[serde(rename="AmiLaunchIndex")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ami_launch_index: Option<i64>,
     #[doc="<p>The architecture of the image.</p>"]
+    #[serde(rename="Architecture")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub architecture: Option<String>,
     #[doc="<p>Any block device mapping entries for the instance.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<InstanceBlockDeviceMapping>>,
     #[doc="<p>The idempotency token you provided when you launched the instance, if applicable.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>Indicates whether the instance is optimized for EBS I/O. This optimization provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal I/O performance. This optimization isn't available with all instance types. Additional usage charges apply when using an EBS Optimized instance.</p>"]
+    #[serde(rename="EbsOptimized")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs_optimized: Option<bool>,
     #[doc="<p>The Elastic GPU associated with the instance.</p>"]
+    #[serde(rename="ElasticGpuAssociations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_associations: Option<Vec<ElasticGpuAssociation>>,
     #[doc="<p>Specifies whether enhanced networking with ENA is enabled.</p>"]
+    #[serde(rename="EnaSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ena_support: Option<bool>,
     #[doc="<p>The hypervisor type of the instance.</p>"]
+    #[serde(rename="Hypervisor")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hypervisor: Option<String>,
     #[doc="<p>The IAM instance profile associated with the instance, if applicable.</p>"]
+    #[serde(rename="IamInstanceProfile")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile: Option<IamInstanceProfile>,
     #[doc="<p>The ID of the AMI used to launch the instance.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>Indicates whether this is a Spot instance or a Scheduled Instance.</p>"]
+    #[serde(rename="InstanceLifecycle")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_lifecycle: Option<String>,
     #[doc="<p>The instance type.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The kernel associated with this instance, if applicable.</p>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<String>,
     #[doc="<p>The name of the key pair, if this instance was launched with an associated key pair.</p>"]
+    #[serde(rename="KeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_name: Option<String>,
     #[doc="<p>The time the instance was launched.</p>"]
+    #[serde(rename="LaunchTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_time: Option<String>,
     #[doc="<p>The monitoring for the instance.</p>"]
+    #[serde(rename="Monitoring")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring: Option<Monitoring>,
     #[doc="<p>[EC2-VPC] One or more network interfaces for the instance.</p>"]
+    #[serde(rename="NetworkInterfaces")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interfaces: Option<Vec<InstanceNetworkInterface>>,
     #[doc="<p>The location where the instance launched, if applicable.</p>"]
+    #[serde(rename="Placement")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement: Option<Placement>,
     #[doc="<p>The value is <code>Windows</code> for Windows instances; otherwise blank.</p>"]
+    #[serde(rename="Platform")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform: Option<String>,
     #[doc="<p>(IPv4 only) The private DNS hostname name assigned to the instance. This DNS hostname can only be used inside the Amazon EC2 network. This name is not available until the instance enters the <code>running</code> state. </p> <p>[EC2-VPC] The Amazon-provided DNS server will resolve Amazon-provided private DNS hostnames if you've enabled DNS resolution and DNS hostnames in your VPC. If you are not using the Amazon-provided DNS server in your VPC, your custom domain name servers must resolve the hostname as appropriate.</p>"]
+    #[serde(rename="PrivateDnsName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_dns_name: Option<String>,
     #[doc="<p>The private IPv4 address assigned to the instance.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
     #[doc="<p>The product codes attached to this instance, if applicable.</p>"]
+    #[serde(rename="ProductCodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_codes: Option<Vec<ProductCode>>,
     #[doc="<p>(IPv4 only) The public DNS name assigned to the instance. This name is not available until the instance enters the <code>running</code> state. For EC2-VPC, this name is only available if you've enabled DNS hostnames for your VPC.</p>"]
+    #[serde(rename="PublicDnsName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_dns_name: Option<String>,
     #[doc="<p>The public IPv4 address assigned to the instance, if applicable.</p>"]
+    #[serde(rename="PublicIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip_address: Option<String>,
     #[doc="<p>The RAM disk associated with this instance, if applicable.</p>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<String>,
     #[doc="<p>The root device name (for example, <code>/dev/sda1</code> or <code>/dev/xvda</code>).</p>"]
+    #[serde(rename="RootDeviceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub root_device_name: Option<String>,
     #[doc="<p>The root device type used by the AMI. The AMI can use an EBS volume or an instance store volume.</p>"]
+    #[serde(rename="RootDeviceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub root_device_type: Option<String>,
     #[doc="<p>One or more security groups for the instance.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<GroupIdentifier>>,
     #[doc="<p>Specifies whether to enable an instance launched in a VPC to perform NAT. This controls whether source/destination checking is enabled on the instance. A value of <code>true</code> means checking is enabled, and <code>false</code> means checking is disabled. The value must be <code>false</code> for the instance to perform NAT. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_NAT_Instance.html\">NAT Instances</a> in the <i>Amazon Virtual Private Cloud User Guide</i>.</p>"]
+    #[serde(rename="SourceDestCheck")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_dest_check: Option<bool>,
     #[doc="<p>If the request is a Spot instance request, the ID of the request.</p>"]
+    #[serde(rename="SpotInstanceRequestId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_instance_request_id: Option<String>,
     #[doc="<p>Specifies whether enhanced networking with the Intel 82599 Virtual Function interface is enabled.</p>"]
+    #[serde(rename="SriovNetSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sriov_net_support: Option<String>,
     #[doc="<p>The current state of the instance.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<InstanceState>,
     #[doc="<p>The reason for the most recent state transition.</p>"]
+    #[serde(rename="StateReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state_reason: Option<StateReason>,
     #[doc="<p>The reason for the most recent state transition. This might be an empty string.</p>"]
+    #[serde(rename="StateTransitionReason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state_transition_reason: Option<String>,
     #[doc="<p>[EC2-VPC] The ID of the subnet in which the instance is running.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>Any tags assigned to the instance.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The virtualization type of the instance.</p>"]
+    #[serde(rename="VirtualizationType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub virtualization_type: Option<String>,
     #[doc="<p>[EC2-VPC] The ID of the VPC in which the instance is running.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -22161,37 +24419,67 @@ impl InstanceDeserializer {
     }
 }
 #[doc="<p>Describes an instance attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceAttribute {
     #[doc="<p>The block device mapping of the instance.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<InstanceBlockDeviceMapping>>,
     #[doc="<p>If the value is <code>true</code>, you can't terminate the instance through the Amazon EC2 console, CLI, or API; otherwise, you can.</p>"]
+    #[serde(rename="DisableApiTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disable_api_termination: Option<AttributeBooleanValue>,
     #[doc="<p>Indicates whether the instance is optimized for EBS I/O.</p>"]
+    #[serde(rename="EbsOptimized")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs_optimized: Option<AttributeBooleanValue>,
     #[doc="<p>Indicates whether enhanced networking with ENA is enabled.</p>"]
+    #[serde(rename="EnaSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ena_support: Option<AttributeBooleanValue>,
     #[doc="<p>The security groups associated with the instance.</p>"]
+    #[serde(rename="Groups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub groups: Option<Vec<GroupIdentifier>>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>Indicates whether an instance stops or terminates when you initiate shutdown from the instance (using the operating system command for system shutdown).</p>"]
+    #[serde(rename="InstanceInitiatedShutdownBehavior")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_initiated_shutdown_behavior: Option<AttributeValue>,
     #[doc="<p>The instance type.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<AttributeValue>,
     #[doc="<p>The kernel ID.</p>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<AttributeValue>,
     #[doc="<p>A list of product codes.</p>"]
+    #[serde(rename="ProductCodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_codes: Option<Vec<ProductCode>>,
     #[doc="<p>The RAM disk ID.</p>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<AttributeValue>,
     #[doc="<p>The name of the root device (for example, <code>/dev/sda1</code> or <code>/dev/xvda</code>).</p>"]
+    #[serde(rename="RootDeviceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub root_device_name: Option<AttributeValue>,
     #[doc="<p>Indicates whether source/destination checking is enabled. A value of <code>true</code> means checking is enabled, and <code>false</code> means checking is disabled. This value must be <code>false</code> for a NAT instance to perform NAT.</p>"]
+    #[serde(rename="SourceDestCheck")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_dest_check: Option<AttributeBooleanValue>,
     #[doc="<p>Indicates whether enhanced networking with the Intel 82599 Virtual Function interface is enabled.</p>"]
+    #[serde(rename="SriovNetSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sriov_net_support: Option<AttributeValue>,
     #[doc="<p>The user data.</p>"]
+    #[serde(rename="UserData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_data: Option<AttributeValue>,
 }
 
@@ -22306,11 +24594,15 @@ impl InstanceAttributeDeserializer {
     }
 }
 #[doc="<p>Describes a block device mapping.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceBlockDeviceMapping {
     #[doc="<p>The device name exposed to the instance (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>"]
+    #[serde(rename="DeviceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device_name: Option<String>,
     #[doc="<p>Parameters used to automatically set up EBS volumes when the instance is launched.</p>"]
+    #[serde(rename="Ebs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs: Option<EbsInstanceBlockDevice>,
 }
 
@@ -22405,15 +24697,23 @@ impl InstanceBlockDeviceMappingListDeserializer {
     }
 }
 #[doc="<p>Describes a block device mapping entry.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceBlockDeviceMappingSpecification {
     #[doc="<p>The device name exposed to the instance (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>"]
+    #[serde(rename="DeviceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device_name: Option<String>,
     #[doc="<p>Parameters used to automatically set up EBS volumes when the instance is launched.</p>"]
+    #[serde(rename="Ebs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs: Option<EbsInstanceBlockDeviceSpecification>,
     #[doc="<p>suppress the specified device included in the block device mapping.</p>"]
+    #[serde(rename="NoDevice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub no_device: Option<String>,
     #[doc="<p>The virtual device name.</p>"]
+    #[serde(rename="VirtualName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub virtual_name: Option<String>,
 }
 
@@ -22465,13 +24765,19 @@ impl InstanceBlockDeviceMappingSpecificationListSerializer {
 }
 
 #[doc="<p>Information about the instance type that the Dedicated Host supports.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceCapacity {
     #[doc="<p>The number of instances that can still be launched onto the Dedicated Host.</p>"]
+    #[serde(rename="AvailableCapacity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub available_capacity: Option<i64>,
     #[doc="<p>The instance type size supported by the Dedicated Host.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The total number of instances that can be launched onto the Dedicated Host.</p>"]
+    #[serde(rename="TotalCapacity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub total_capacity: Option<i64>,
 }
 
@@ -22528,11 +24834,15 @@ impl InstanceCapacityDeserializer {
     }
 }
 #[doc="<p>Describes a Reserved Instance listing state.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceCount {
     #[doc="<p>The number of listed Reserved Instances in the state specified by the <code>state</code>.</p>"]
+    #[serde(rename="InstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_count: Option<i64>,
     #[doc="<p>The states of the listed Reserved Instances.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -22625,11 +24935,15 @@ impl InstanceCountListDeserializer {
     }
 }
 #[doc="<p>Describes an instance to export.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceExportDetails {
     #[doc="<p>The ID of the resource being exported.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The target virtualization environment.</p>"]
+    #[serde(rename="TargetEnvironment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_environment: Option<String>,
 }
 
@@ -22748,9 +25062,11 @@ impl InstanceIdStringListSerializer {
 }
 
 #[doc="<p>Describes an IPv6 address.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceIpv6Address {
     #[doc="<p>The IPv6 address.</p>"]
+    #[serde(rename="Ipv6Address")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_address: Option<String>,
 }
 
@@ -22923,11 +25239,15 @@ impl InstanceListDeserializer {
     }
 }
 #[doc="<p>Describes the monitoring of an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceMonitoring {
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The monitoring for the instance.</p>"]
+    #[serde(rename="Monitoring")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring: Option<Monitoring>,
 }
 
@@ -23019,37 +25339,67 @@ impl InstanceMonitoringListDeserializer {
     }
 }
 #[doc="<p>Describes a network interface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceNetworkInterface {
     #[doc="<p>The association information for an Elastic IPv4 associated with the network interface.</p>"]
+    #[serde(rename="Association")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association: Option<InstanceNetworkInterfaceAssociation>,
     #[doc="<p>The network interface attachment.</p>"]
+    #[serde(rename="Attachment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachment: Option<InstanceNetworkInterfaceAttachment>,
     #[doc="<p>The description.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>One or more security groups.</p>"]
+    #[serde(rename="Groups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub groups: Option<Vec<GroupIdentifier>>,
     #[doc="<p>One or more IPv6 addresses associated with the network interface.</p>"]
+    #[serde(rename="Ipv6Addresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_addresses: Option<Vec<InstanceIpv6Address>>,
     #[doc="<p>The MAC address.</p>"]
+    #[serde(rename="MacAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub mac_address: Option<String>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>The ID of the AWS account that created the network interface.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
     #[doc="<p>The private DNS name.</p>"]
+    #[serde(rename="PrivateDnsName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_dns_name: Option<String>,
     #[doc="<p>The IPv4 address of the network interface within the subnet.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
     #[doc="<p>One or more private IPv4 addresses associated with the network interface.</p>"]
+    #[serde(rename="PrivateIpAddresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_addresses: Option<Vec<InstancePrivateIpAddress>>,
     #[doc="<p>Indicates whether to validate network traffic to or from this network interface.</p>"]
+    #[serde(rename="SourceDestCheck")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_dest_check: Option<bool>,
     #[doc="<p>The status of the network interface.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The ID of the subnet.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -23156,13 +25506,19 @@ impl InstanceNetworkInterfaceDeserializer {
     }
 }
 #[doc="<p>Describes association information for an Elastic IP address (IPv4).</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceNetworkInterfaceAssociation {
     #[doc="<p>The ID of the owner of the Elastic IP address.</p>"]
+    #[serde(rename="IpOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_owner_id: Option<String>,
     #[doc="<p>The public DNS name.</p>"]
+    #[serde(rename="PublicDnsName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_dns_name: Option<String>,
     #[doc="<p>The public IP address or Elastic IP address bound to the network interface.</p>"]
+    #[serde(rename="PublicIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip: Option<String>,
 }
 
@@ -23218,17 +25574,27 @@ impl InstanceNetworkInterfaceAssociationDeserializer {
     }
 }
 #[doc="<p>Describes a network interface attachment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceNetworkInterfaceAttachment {
     #[doc="<p>The time stamp when the attachment initiated.</p>"]
+    #[serde(rename="AttachTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attach_time: Option<String>,
     #[doc="<p>The ID of the network interface attachment.</p>"]
+    #[serde(rename="AttachmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachment_id: Option<String>,
     #[doc="<p>Indicates whether the network interface is deleted when the instance is terminated.</p>"]
+    #[serde(rename="DeleteOnTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_on_termination: Option<bool>,
     #[doc="<p>The index of the device on the instance for the network interface attachment.</p>"]
+    #[serde(rename="DeviceIndex")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device_index: Option<i64>,
     #[doc="<p>The attachment state.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -23336,31 +25702,55 @@ impl InstanceNetworkInterfaceListDeserializer {
     }
 }
 #[doc="<p>Describes a network interface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceNetworkInterfaceSpecification {
     #[doc="<p>Indicates whether to assign a public IPv4 address to an instance you launch in a VPC. The public IP address can only be assigned to a network interface for eth0, and can only be assigned to a new network interface, not an existing one. You cannot specify more than one network interface in the request. If launching into a default subnet, the default value is <code>true</code>.</p>"]
+    #[serde(rename="AssociatePublicIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub associate_public_ip_address: Option<bool>,
     #[doc="<p>If set to <code>true</code>, the interface is deleted when the instance is terminated. You can specify <code>true</code> only if creating a new network interface when launching an instance.</p>"]
+    #[serde(rename="DeleteOnTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_on_termination: Option<bool>,
     #[doc="<p>The description of the network interface. Applies only if creating a network interface when launching an instance.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The index of the device on the instance for the network interface attachment. If you are specifying a network interface in a <a>RunInstances</a> request, you must provide the device index.</p>"]
+    #[serde(rename="DeviceIndex")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device_index: Option<i64>,
     #[doc="<p>The IDs of the security groups for the network interface. Applies only if creating a network interface when launching an instance.</p>"]
+    #[serde(rename="Groups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub groups: Option<Vec<String>>,
     #[doc="<p>A number of IPv6 addresses to assign to the network interface. Amazon EC2 chooses the IPv6 addresses from the range of the subnet. You cannot specify this option and the option to assign specific IPv6 addresses in the same request. You can specify this option if you've specified a minimum number of instances to launch.</p>"]
+    #[serde(rename="Ipv6AddressCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_address_count: Option<i64>,
     #[doc="<p>One or more IPv6 addresses to assign to the network interface. You cannot specify this option and the option to assign a number of IPv6 addresses in the same request. You cannot specify this option if you've specified a minimum number of instances to launch.</p>"]
+    #[serde(rename="Ipv6Addresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_addresses: Option<Vec<InstanceIpv6Address>>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>The private IPv4 address of the network interface. Applies only if creating a network interface when launching an instance. You cannot specify this option if you're launching more than one instance in a <a>RunInstances</a> request.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
     #[doc="<p>One or more private IPv4 addresses to assign to the network interface. Only one private IPv4 address can be designated as primary. You cannot specify this option if you're launching more than one instance in a <a>RunInstances</a> request.</p>"]
+    #[serde(rename="PrivateIpAddresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_addresses: Option<Vec<PrivateIpAddressSpecification>>,
     #[doc="<p>The number of secondary private IPv4 addresses. You can't specify this option and specify more than one private IP address using the private IP addresses option. You cannot specify this option if you're launching more than one instance in a <a>RunInstances</a> request.</p>"]
+    #[serde(rename="SecondaryPrivateIpAddressCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub secondary_private_ip_address_count: Option<i64>,
     #[doc="<p>The ID of the subnet associated with the network string. Applies only if creating a network interface when launching an instance.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
 }
 
@@ -23584,15 +25974,23 @@ impl InstanceNetworkInterfaceSpecificationListSerializer {
 }
 
 #[doc="<p>Describes a private IPv4 address.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstancePrivateIpAddress {
     #[doc="<p>The association information for an Elastic IP address for the network interface.</p>"]
+    #[serde(rename="Association")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association: Option<InstanceNetworkInterfaceAssociation>,
     #[doc="<p>Indicates whether this IPv4 address is the primary private IP address of the network interface.</p>"]
+    #[serde(rename="Primary")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub primary: Option<bool>,
     #[doc="<p>The private IPv4 DNS name.</p>"]
+    #[serde(rename="PrivateDnsName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_dns_name: Option<String>,
     #[doc="<p>The private IPv4 address of the network interface.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
 }
 
@@ -23694,11 +26092,15 @@ impl InstancePrivateIpAddressListDeserializer {
     }
 }
 #[doc="<p>Describes the current state of an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceState {
     #[doc="<p>The low byte represents the state. The high byte is an opaque internal value and should be ignored.</p> <ul> <li> <p> <code>0</code> : <code>pending</code> </p> </li> <li> <p> <code>16</code> : <code>running</code> </p> </li> <li> <p> <code>32</code> : <code>shutting-down</code> </p> </li> <li> <p> <code>48</code> : <code>terminated</code> </p> </li> <li> <p> <code>64</code> : <code>stopping</code> </p> </li> <li> <p> <code>80</code> : <code>stopped</code> </p> </li> </ul>"]
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<i64>,
     #[doc="<p>The current state of the instance.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -23749,13 +26151,19 @@ impl InstanceStateDeserializer {
     }
 }
 #[doc="<p>Describes an instance state change.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceStateChange {
     #[doc="<p>The current state of the instance.</p>"]
+    #[serde(rename="CurrentState")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub current_state: Option<InstanceState>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The previous state of the instance.</p>"]
+    #[serde(rename="PreviousState")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub previous_state: Option<InstanceState>,
 }
 
@@ -23867,19 +26275,31 @@ impl InstanceStateNameDeserializer {
     }
 }
 #[doc="<p>Describes the status of an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceStatus {
     #[doc="<p>The Availability Zone of the instance.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>Any scheduled events associated with the instance.</p>"]
+    #[serde(rename="Events")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<InstanceStatusEvent>>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The intended state of the instance. <a>DescribeInstanceStatus</a> requires that an instance be in the <code>running</code> state.</p>"]
+    #[serde(rename="InstanceState")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_state: Option<InstanceState>,
     #[doc="<p>Reports impaired functionality that stems from issues internal to the instance, such as impaired reachability.</p>"]
+    #[serde(rename="InstanceStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_status: Option<InstanceStatusSummary>,
     #[doc="<p>Reports impaired functionality that stems from issues related to the systems that support an instance, such as hardware failures and network connectivity problems.</p>"]
+    #[serde(rename="SystemStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub system_status: Option<InstanceStatusSummary>,
 }
 
@@ -23951,13 +26371,19 @@ impl InstanceStatusDeserializer {
     }
 }
 #[doc="<p>Describes the instance status.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceStatusDetails {
     #[doc="<p>The time when a status check failed. For an instance that was launched and impaired, this is the time when the instance was launched.</p>"]
+    #[serde(rename="ImpairedSince")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub impaired_since: Option<String>,
     #[doc="<p>The type of instance status.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The status.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -24055,15 +26481,23 @@ impl InstanceStatusDetailsListDeserializer {
     }
 }
 #[doc="<p>Describes a scheduled event for an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceStatusEvent {
     #[doc="<p>The event code.</p>"]
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<String>,
     #[doc="<p>A description of the event.</p> <p>After a scheduled event is completed, it can still be described for up to a week. If the event has been completed, this description starts with the following text: [Completed].</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The latest scheduled end time for the event.</p>"]
+    #[serde(rename="NotAfter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub not_after: Option<String>,
     #[doc="<p>The earliest scheduled start time for the event.</p>"]
+    #[serde(rename="NotBefore")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub not_before: Option<String>,
 }
 
@@ -24204,11 +26638,15 @@ impl InstanceStatusListDeserializer {
     }
 }
 #[doc="<p>Describes the status of an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceStatusSummary {
     #[doc="<p>The system instance health or application instance health.</p>"]
+    #[serde(rename="Details")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub details: Option<Vec<InstanceStatusDetails>>,
     #[doc="<p>The status.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -24312,13 +26750,19 @@ impl InterfacePermissionTypeDeserializer {
     }
 }
 #[doc="<p>Describes an Internet gateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InternetGateway {
     #[doc="<p>Any VPCs attached to the Internet gateway.</p>"]
+    #[serde(rename="Attachments")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachments: Option<Vec<InternetGatewayAttachment>>,
     #[doc="<p>The ID of the Internet gateway.</p>"]
+    #[serde(rename="InternetGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub internet_gateway_id: Option<String>,
     #[doc="<p>Any tags assigned to the Internet gateway.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -24373,11 +26817,15 @@ impl InternetGatewayDeserializer {
     }
 }
 #[doc="<p>Describes the attachment of a VPC to an Internet gateway or an egress-only Internet gateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InternetGatewayAttachment {
     #[doc="<p>The current state of the attachment.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -24512,21 +26960,35 @@ impl InternetGatewayListDeserializer {
     }
 }
 #[doc="<p>Describes a security group rule.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IpPermission {
     #[doc="<p>The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type number. A value of <code>-1</code> indicates all ICMP/ICMPv6 types.</p>"]
+    #[serde(rename="FromPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub from_port: Option<i64>,
     #[doc="<p>The IP protocol name (<code>tcp</code>, <code>udp</code>, <code>icmp</code>) or number (see <a href=\"http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml\">Protocol Numbers</a>). </p> <p>[EC2-VPC only] Use <code>-1</code> to specify all protocols. When authorizing security group rules, specifying <code>-1</code> or a protocol number other than <code>tcp</code>, <code>udp</code>, <code>icmp</code>, or <code>58</code> (ICMPv6) allows traffic on all ports, regardless of any port range you specify. For <code>tcp</code>, <code>udp</code>, and <code>icmp</code>, you must specify a port range. For <code>58</code> (ICMPv6), you can optionally specify a port range; if you don't, traffic for all types and codes is allowed when authorizing rules. </p>"]
+    #[serde(rename="IpProtocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_protocol: Option<String>,
     #[doc="<p>One or more IPv4 ranges.</p>"]
+    #[serde(rename="IpRanges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_ranges: Option<Vec<IpRange>>,
     #[doc="<p>[EC2-VPC only] One or more IPv6 ranges.</p>"]
+    #[serde(rename="Ipv6Ranges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_ranges: Option<Vec<Ipv6Range>>,
     #[doc="<p>(Valid for <a>AuthorizeSecurityGroupEgress</a>, <a>RevokeSecurityGroupEgress</a> and <a>DescribeSecurityGroups</a> only) One or more prefix list IDs for an AWS service. In an <a>AuthorizeSecurityGroupEgress</a> request, this is the AWS service that you want to access through a VPC endpoint from instances associated with the security group.</p>"]
+    #[serde(rename="PrefixListIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix_list_ids: Option<Vec<PrefixListId>>,
     #[doc="<p>The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code. A value of <code>-1</code> indicates all ICMP/ICMPv6 codes for the specified ICMP type.</p>"]
+    #[serde(rename="ToPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub to_port: Option<i64>,
     #[doc="<p>One or more security group and AWS account ID pairs.</p>"]
+    #[serde(rename="UserIdGroupPairs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_id_group_pairs: Option<Vec<UserIdGroupPair>>,
 }
 
@@ -24699,9 +27161,11 @@ impl IpPermissionListSerializer {
 }
 
 #[doc="<p>Describes an IPv4 range.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IpRange {
     #[doc="<p>The IPv4 CIDR range. You can either specify a CIDR range or a source security group, not both. To specify a single IPv4 address, use the /32 prefix.</p>"]
+    #[serde(rename="CidrIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_ip: Option<String>,
 }
 
@@ -24913,9 +27377,11 @@ impl Ipv6AddressListSerializer {
 }
 
 #[doc="<p>Describes an IPv6 CIDR block.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Ipv6CidrBlock {
     #[doc="<p>The IPv6 CIDR block.</p>"]
+    #[serde(rename="Ipv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block: Option<String>,
 }
 
@@ -25003,9 +27469,11 @@ impl Ipv6CidrBlockSetDeserializer {
     }
 }
 #[doc="<p>[EC2-VPC only] Describes an IPv6 range.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Ipv6Range {
     #[doc="<p>The IPv6 CIDR range. You can either specify a CIDR range or a source security group, not both. To specify a single IPv6 address, use the /128 prefix.</p>"]
+    #[serde(rename="CidrIpv6")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_ipv_6: Option<String>,
 }
 
@@ -25135,13 +27603,19 @@ impl KeyNameStringListSerializer {
 }
 
 #[doc="<p>Describes a key pair.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KeyPair {
     #[doc="<p>The SHA-1 digest of the DER encoded private key.</p>"]
+    #[serde(rename="KeyFingerprint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_fingerprint: Option<String>,
     #[doc="<p>An unencrypted PEM encoded RSA private key.</p>"]
+    #[serde(rename="KeyMaterial")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_material: Option<String>,
     #[doc="<p>The name of the key pair.</p>"]
+    #[serde(rename="KeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_name: Option<String>,
 }
 
@@ -25197,11 +27671,15 @@ impl KeyPairDeserializer {
     }
 }
 #[doc="<p>Describes a key pair.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KeyPairInfo {
     #[doc="<p>If you used <a>CreateKeyPair</a> to create the key pair, this is the SHA-1 digest of the DER encoded private key. If you used <a>ImportKeyPair</a> to provide AWS the public key, this is the MD5 public key fingerprint as specified in section 4 of RFC4716.</p>"]
+    #[serde(rename="KeyFingerprint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_fingerprint: Option<String>,
     #[doc="<p>The name of the key pair.</p>"]
+    #[serde(rename="KeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_name: Option<String>,
 }
 
@@ -25294,11 +27772,15 @@ impl KeyPairListDeserializer {
     }
 }
 #[doc="<p>Describes a launch permission.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LaunchPermission {
     #[doc="<p>The name of the group.</p>"]
+    #[serde(rename="Group")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group: Option<String>,
     #[doc="<p>The AWS account ID.</p>"]
+    #[serde(rename="UserId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_id: Option<String>,
 }
 
@@ -25424,11 +27906,15 @@ impl LaunchPermissionListSerializer {
 }
 
 #[doc="<p>Describes a launch permission modification.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LaunchPermissionModifications {
     #[doc="<p>The AWS account ID to add to the list of launch permissions for the AMI.</p>"]
+    #[serde(rename="Add")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub add: Option<Vec<LaunchPermission>>,
     #[doc="<p>The AWS account ID to remove from the list of launch permissions for the AMI.</p>"]
+    #[serde(rename="Remove")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub remove: Option<Vec<LaunchPermission>>,
 }
 
@@ -25457,36 +27943,66 @@ impl LaunchPermissionModificationsSerializer {
 }
 
 #[doc="<p>Describes the launch specification for an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LaunchSpecification {
     #[doc="<p>Deprecated.</p>"]
+    #[serde(rename="AddressingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub addressing_type: Option<String>,
     #[doc="<p>One or more block device mapping entries.</p> <p>Although you can specify encrypted EBS volumes in this block device mapping for your Spot Instances, these volumes are not encrypted.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
     #[doc="<p>Indicates whether the instance is optimized for EBS I/O. This optimization provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal EBS I/O performance. This optimization isn't available with all instance types. Additional usage charges apply when using an EBS Optimized instance.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EbsOptimized")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs_optimized: Option<bool>,
     #[doc="<p>The IAM instance profile.</p>"]
+    #[serde(rename="IamInstanceProfile")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile: Option<IamInstanceProfileSpecification>,
     #[doc="<p>The ID of the AMI.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
     #[doc="<p>The instance type.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The ID of the kernel.</p>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<String>,
     #[doc="<p>The name of the key pair.</p>"]
+    #[serde(rename="KeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_name: Option<String>,
+    #[serde(rename="Monitoring")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring: Option<RunInstancesMonitoringEnabled>,
     #[doc="<p>One or more network interfaces. If you specify a network interface, you must specify subnet IDs and security group IDs using the network interface.</p>"]
+    #[serde(rename="NetworkInterfaces")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interfaces: Option<Vec<InstanceNetworkInterfaceSpecification>>,
     #[doc="<p>The placement information for the instance.</p>"]
+    #[serde(rename="Placement")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement: Option<SpotPlacement>,
     #[doc="<p>The ID of the RAM disk.</p>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<String>,
     #[doc="<p>One or more security groups. When requesting instances in a VPC, you must specify the IDs of the security groups. When requesting instances in EC2-Classic, you can specify the names or the IDs of the security groups.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<GroupIdentifier>>,
     #[doc="<p>The ID of the subnet in which to launch the instance.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>The user data to make available to the instances. If you are using an AWS SDK or command line tool, Base64-encoding is performed for you, and you can load the text from a file. Otherwise, you must provide Base64-encoded text.</p>"]
+    #[serde(rename="UserData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_data: Option<String>,
 }
 
@@ -25687,11 +28203,13 @@ impl LongDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ModifyHosts.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyHostsRequest {
     #[doc="<p>Specify whether to enable or disable auto-placement.</p>"]
+    #[serde(rename="AutoPlacement")]
     pub auto_placement: String,
     #[doc="<p>The host IDs of the Dedicated Hosts you want to modify.</p>"]
+    #[serde(rename="HostIds")]
     pub host_ids: Vec<String>,
 }
 
@@ -25715,11 +28233,15 @@ impl ModifyHostsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of ModifyHosts.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyHostsResult {
     #[doc="<p>The IDs of the Dedicated Hosts that were successfully modified.</p>"]
+    #[serde(rename="Successful")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub successful: Option<Vec<String>>,
     #[doc="<p>The IDs of the Dedicated Hosts that could not be modified. Check whether the setting you requested can be used.</p>"]
+    #[serde(rename="Unsuccessful")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unsuccessful: Option<Vec<UnsuccessfulItem>>,
 }
 
@@ -25772,11 +28294,13 @@ impl ModifyHostsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters of ModifyIdFormat.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyIdFormatRequest {
     #[doc="<p>The type of resource: <code>instance</code> | <code>reservation</code> | <code>snapshot</code> | <code>volume</code> </p>"]
+    #[serde(rename="Resource")]
     pub resource: String,
     #[doc="<p>Indicate whether the resource should use longer IDs (17-character IDs).</p>"]
+    #[serde(rename="UseLongIds")]
     pub use_long_ids: bool,
 }
 
@@ -25799,13 +28323,16 @@ impl ModifyIdFormatRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters of ModifyIdentityIdFormat.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyIdentityIdFormatRequest {
     #[doc="<p>The ARN of the principal, which can be an IAM user, IAM role, or the root user. Specify <code>all</code> to modify the ID format for all IAM users, IAM roles, and the root user of the account.</p>"]
+    #[serde(rename="PrincipalArn")]
     pub principal_arn: String,
     #[doc="<p>The type of resource: <code>instance</code> | <code>reservation</code> | <code>snapshot</code> | <code>volume</code> </p>"]
+    #[serde(rename="Resource")]
     pub resource: String,
     #[doc="<p>Indicates whether the resource should use longer IDs (17-character IDs)</p>"]
+    #[serde(rename="UseLongIds")]
     pub use_long_ids: bool,
 }
 
@@ -25830,27 +28357,46 @@ impl ModifyIdentityIdFormatRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ModifyImageAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyImageAttributeRequest {
     #[doc="<p>The name of the attribute to modify.</p>"]
+    #[serde(rename="Attribute")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute: Option<String>,
     #[doc="<p>A description for the AMI.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<AttributeValue>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the AMI.</p>"]
+    #[serde(rename="ImageId")]
     pub image_id: String,
     #[doc="<p>A launch permission modification.</p>"]
+    #[serde(rename="LaunchPermission")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_permission: Option<LaunchPermissionModifications>,
     #[doc="<p>The operation type.</p>"]
+    #[serde(rename="OperationType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_type: Option<String>,
     #[doc="<p>One or more product codes. After you add a product code to an AMI, it can't be removed. This is only valid when modifying the <code>productCodes</code> attribute.</p>"]
+    #[serde(rename="ProductCodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_codes: Option<Vec<String>>,
     #[doc="<p>One or more user groups. This is only valid when modifying the <code>launchPermission</code> attribute.</p>"]
+    #[serde(rename="UserGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_groups: Option<Vec<String>>,
     #[doc="<p>One or more AWS account IDs. This is only valid when modifying the <code>launchPermission</code> attribute.</p>"]
+    #[serde(rename="UserIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_ids: Option<Vec<String>>,
     #[doc="<p>The value of the attribute being modified. This is only valid when modifying the <code>description</code> attribute.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -25914,39 +28460,70 @@ impl ModifyImageAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ModifyInstanceAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyInstanceAttributeRequest {
     #[doc="<p>The name of the attribute.</p>"]
+    #[serde(rename="Attribute")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute: Option<String>,
     #[doc="<p>Modifies the <code>DeleteOnTermination</code> attribute for volumes that are currently attached. The volume must be owned by the caller. If no value is specified for <code>DeleteOnTermination</code>, the default is <code>true</code> and the volume is deleted when the instance is terminated.</p> <p>To add instance store volumes to an Amazon EBS-backed instance, you must add them when you launch the instance. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html#Using_OverridingAMIBDM\">Updating the Block Device Mapping when Launching an Instance</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<InstanceBlockDeviceMappingSpecification>>,
     #[doc="<p>If the value is <code>true</code>, you can't terminate the instance using the Amazon EC2 console, CLI, or API; otherwise, you can. You cannot use this parameter for Spot Instances.</p>"]
+    #[serde(rename="DisableApiTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disable_api_termination: Option<AttributeBooleanValue>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Specifies whether the instance is optimized for EBS I/O. This optimization provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal EBS I/O performance. This optimization isn't available with all instance types. Additional usage charges apply when using an EBS Optimized instance.</p>"]
+    #[serde(rename="EbsOptimized")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs_optimized: Option<AttributeBooleanValue>,
     #[doc="<p>Set to <code>true</code> to enable enhanced networking with ENA for the instance.</p> <p>This option is supported only for HVM instances. Specifying this option with a PV instance can make it unreachable.</p>"]
+    #[serde(rename="EnaSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ena_support: Option<AttributeBooleanValue>,
     #[doc="<p>[EC2-VPC] Changes the security groups of the instance. You must specify at least one security group, even if it's just the default security group for the VPC. You must specify the security group ID, not the security group name.</p>"]
+    #[serde(rename="Groups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub groups: Option<Vec<String>>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>Specifies whether an instance stops or terminates when you initiate shutdown from the instance (using the operating system command for system shutdown).</p>"]
+    #[serde(rename="InstanceInitiatedShutdownBehavior")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_initiated_shutdown_behavior: Option<AttributeValue>,
     #[doc="<p>Changes the instance type to the specified value. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html\">Instance Types</a>. If the instance type is not valid, the error returned is <code>InvalidInstanceAttributeValue</code>.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<AttributeValue>,
     #[doc="<p>Changes the instance's kernel to the specified value. We recommend that you use PV-GRUB instead of kernels and RAM disks. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedKernels.html\">PV-GRUB</a>.</p>"]
+    #[serde(rename="Kernel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel: Option<AttributeValue>,
     #[doc="<p>Changes the instance's RAM disk to the specified value. We recommend that you use PV-GRUB instead of kernels and RAM disks. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedKernels.html\">PV-GRUB</a>.</p>"]
+    #[serde(rename="Ramdisk")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk: Option<AttributeValue>,
     #[doc="<p>Specifies whether source/destination checking is enabled. A value of <code>true</code> means that checking is enabled, and <code>false</code> means checking is disabled. This value must be <code>false</code> for a NAT instance to perform NAT.</p>"]
+    #[serde(rename="SourceDestCheck")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_dest_check: Option<AttributeBooleanValue>,
     #[doc="<p>Set to <code>simple</code> to enable enhanced networking with the Intel 82599 Virtual Function interface for the instance.</p> <p>There is no way to disable enhanced networking with the Intel 82599 Virtual Function interface at this time.</p> <p>This option is supported only for HVM instances. Specifying this option with a PV instance can make it unreachable.</p>"]
+    #[serde(rename="SriovNetSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sriov_net_support: Option<AttributeValue>,
     #[doc="<p>Changes the instance's user data to the specified value. If you are using an AWS SDK or command line tool, Base64-encoding is performed for you, and you can load the text from a file. Otherwise, you must provide Base64-encoded text.</p>"]
+    #[serde(rename="UserData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_data: Option<BlobAttributeValue>,
     #[doc="<p>A new value for the attribute. Use only with the <code>kernel</code>, <code>ramdisk</code>, <code>userData</code>, <code>disableApiTermination</code>, or <code>instanceInitiatedShutdownBehavior</code> attribute.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -26045,15 +28622,22 @@ impl ModifyInstanceAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ModifyInstancePlacement.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyInstancePlacementRequest {
     #[doc="<p>The new affinity setting for the instance.</p>"]
+    #[serde(rename="Affinity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub affinity: Option<String>,
     #[doc="<p>The ID of the Dedicated Host that the instance will have affinity with.</p>"]
+    #[serde(rename="HostId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_id: Option<String>,
     #[doc="<p>The ID of the instance that you are modifying.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
     #[doc="<p>The tenancy of the instance that you are modifying.</p>"]
+    #[serde(rename="Tenancy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tenancy: Option<String>,
 }
 
@@ -26086,9 +28670,11 @@ impl ModifyInstancePlacementRequestSerializer {
 }
 
 #[doc="<p>Contains the output of ModifyInstancePlacement.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyInstancePlacementResult {
     #[doc="<p>Is <code>true</code> if the request succeeds, and an error otherwise.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -26135,19 +28721,30 @@ impl ModifyInstancePlacementResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ModifyNetworkInterfaceAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyNetworkInterfaceAttributeRequest {
     #[doc="<p>Information about the interface attachment. If modifying the 'delete on termination' attribute, you must specify the ID of the interface attachment.</p>"]
+    #[serde(rename="Attachment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachment: Option<NetworkInterfaceAttachmentChanges>,
     #[doc="<p>A description for the network interface.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<AttributeValue>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Changes the security groups for the network interface. The new set of groups you specify replaces the current set. You must specify at least one group, even if it's just the default security group in the VPC. You must specify the ID of the security group, not the name.</p>"]
+    #[serde(rename="Groups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub groups: Option<Vec<String>>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
     pub network_interface_id: String,
     #[doc="<p>Indicates whether source/destination checking is enabled. A value of <code>true</code> means checking is enabled, and <code>false</code> means checking is disabled. This value must be <code>false</code> for a NAT instance to perform NAT. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_NAT_Instance.html\">NAT Instances</a> in the <i>Amazon Virtual Private Cloud User Guide</i>.</p>"]
+    #[serde(rename="SourceDestCheck")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_dest_check: Option<AttributeBooleanValue>,
 }
 
@@ -26196,13 +28793,17 @@ impl ModifyNetworkInterfaceAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ModifyReservedInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyReservedInstancesRequest {
     #[doc="<p>A unique, case-sensitive token you provide to ensure idempotency of your modification request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html\">Ensuring Idempotency</a>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>The IDs of the Reserved Instances to modify.</p>"]
+    #[serde(rename="ReservedInstancesIds")]
     pub reserved_instances_ids: Vec<String>,
     #[doc="<p>The configuration settings for the Reserved Instances to modify.</p>"]
+    #[serde(rename="TargetConfigurations")]
     pub target_configurations: Vec<ReservedInstancesConfiguration>,
 }
 
@@ -26235,9 +28836,11 @@ impl ModifyReservedInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of ModifyReservedInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyReservedInstancesResult {
     #[doc="<p>The ID for the modification.</p>"]
+    #[serde(rename="ReservedInstancesModificationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_modification_id: Option<String>,
 }
 
@@ -26285,21 +28888,34 @@ impl ModifyReservedInstancesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ModifySnapshotAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifySnapshotAttributeRequest {
     #[doc="<p>The snapshot attribute to modify.</p> <note> <p>Only volume creation permissions may be modified at the customer level.</p> </note>"]
+    #[serde(rename="Attribute")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute: Option<String>,
     #[doc="<p>A JSON representation of the snapshot attribute modification.</p>"]
+    #[serde(rename="CreateVolumePermission")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_volume_permission: Option<CreateVolumePermissionModifications>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The group to modify for the snapshot.</p>"]
+    #[serde(rename="GroupNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_names: Option<Vec<String>>,
     #[doc="<p>The type of operation to perform to the attribute.</p>"]
+    #[serde(rename="OperationType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operation_type: Option<String>,
     #[doc="<p>The ID of the snapshot.</p>"]
+    #[serde(rename="SnapshotId")]
     pub snapshot_id: String,
     #[doc="<p>The account ID to modify for the snapshot.</p>"]
+    #[serde(rename="UserIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_ids: Option<Vec<String>>,
 }
 
@@ -26349,13 +28965,18 @@ impl ModifySnapshotAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ModifySpotFleetRequest.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifySpotFleetRequestRequest {
     #[doc="<p>Indicates whether running Spot instances should be terminated if the target capacity of the Spot fleet request is decreased below the current size of the Spot fleet.</p>"]
+    #[serde(rename="ExcessCapacityTerminationPolicy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub excess_capacity_termination_policy: Option<String>,
     #[doc="<p>The ID of the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestId")]
     pub spot_fleet_request_id: String,
     #[doc="<p>The size of the fleet.</p>"]
+    #[serde(rename="TargetCapacity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_capacity: Option<i64>,
 }
 
@@ -26384,9 +29005,11 @@ impl ModifySpotFleetRequestRequestSerializer {
 }
 
 #[doc="<p>Contains the output of ModifySpotFleetRequest.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifySpotFleetRequestResponse {
     #[doc="<p>Is <code>true</code> if the request succeeds, and an error otherwise.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -26433,13 +29056,18 @@ impl ModifySpotFleetRequestResponseDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ModifySubnetAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifySubnetAttributeRequest {
     #[doc="<p>Specify <code>true</code> to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. This includes a network interface that's created when launching an instance into the subnet (the instance therefore receives an IPv6 address). </p> <p>If you enable the IPv6 addressing feature for your subnet, your network interface or instance only receives an IPv6 address if it's created using version <code>2016-11-15</code> or later of the Amazon EC2 API.</p>"]
+    #[serde(rename="AssignIpv6AddressOnCreation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub assign_ipv_6_address_on_creation: Option<AttributeBooleanValue>,
     #[doc="<p>Specify <code>true</code> to indicate that network interfaces created in the specified subnet should be assigned a public IPv4 address. This includes a network interface that's created when launching an instance into the subnet (the instance therefore receives a public IPv4 address).</p>"]
+    #[serde(rename="MapPublicIpOnLaunch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub map_public_ip_on_launch: Option<AttributeBooleanValue>,
     #[doc="<p>The ID of the subnet.</p>"]
+    #[serde(rename="SubnetId")]
     pub subnet_id: String,
 }
 
@@ -26474,13 +29102,18 @@ impl ModifySubnetAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ModifyVolumeAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyVolumeAttributeRequest {
     #[doc="<p>Indicates whether the volume should be auto-enabled for I/O operations.</p>"]
+    #[serde(rename="AutoEnableIO")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_enable_io: Option<AttributeBooleanValue>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the volume.</p>"]
+    #[serde(rename="VolumeId")]
     pub volume_id: String,
 }
 
@@ -26509,16 +29142,25 @@ impl ModifyVolumeAttributeRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyVolumeRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Target IOPS rate of the volume to be modified.</p> <p>Only valid for Provisioned IOPS SSD (<code>io1</code>) volumes. For more information about <code>io1</code> IOPS configuration, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html#EBSVolumeTypes_piops\">http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html#EBSVolumeTypes_piops</a>.</p> <p>Default: If no IOPS value is specified, the existing value is retained. </p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>Target size in GiB of the volume to be modified. Target volume size must be greater than or equal to than the existing size of the volume. For information about available EBS volume sizes, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html\">http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html</a>.</p> <p>Default: If no size is specified, the existing size is retained. </p>"]
+    #[serde(rename="Size")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub size: Option<i64>,
+    #[serde(rename="VolumeId")]
     pub volume_id: String,
     #[doc="<p>Target EBS volume type of the volume to be modified</p> <p> The API does not support modifications for volume type <code>standard</code>. You also cannot change the type of a volume to <code>standard</code>. </p> <p>Default: If no type is specified, the existing type is retained. </p>"]
+    #[serde(rename="VolumeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_type: Option<String>,
 }
 
@@ -26554,9 +29196,11 @@ impl ModifyVolumeRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyVolumeResult {
     #[doc="<p>A <a>VolumeModification</a> object.</p>"]
+    #[serde(rename="VolumeModification")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_modification: Option<VolumeModification>,
 }
 
@@ -26604,13 +29248,18 @@ impl ModifyVolumeResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ModifyVpcAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyVpcAttributeRequest {
     #[doc="<p>Indicates whether the instances launched in the VPC get DNS hostnames. If enabled, instances in the VPC get DNS hostnames; otherwise, they do not.</p> <p>You cannot modify the DNS resolution and DNS hostnames attributes in the same request. Use separate requests for each attribute. You can only enable DNS hostnames if you've enabled DNS support.</p>"]
+    #[serde(rename="EnableDnsHostnames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_dns_hostnames: Option<AttributeBooleanValue>,
     #[doc="<p>Indicates whether the DNS resolution is supported for the VPC. If enabled, queries to the Amazon provided DNS server at the 169.254.169.253 IP address, or the reserved IP address at the base of the VPC network range \"plus two\" will succeed. If disabled, the Amazon provided DNS service in the VPC that resolves public DNS hostnames to IP addresses is not enabled.</p> <p>You cannot modify the DNS resolution and DNS hostnames attributes in the same request. Use separate requests for each attribute.</p>"]
+    #[serde(rename="EnableDnsSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_dns_support: Option<AttributeBooleanValue>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -26645,19 +29294,30 @@ impl ModifyVpcAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ModifyVpcEndpoint.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyVpcEndpointRequest {
     #[doc="<p>One or more route tables IDs to associate with the endpoint.</p>"]
+    #[serde(rename="AddRouteTableIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub add_route_table_ids: Option<Vec<String>>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>A policy document to attach to the endpoint. The policy must be in valid JSON format.</p>"]
+    #[serde(rename="PolicyDocument")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_document: Option<String>,
     #[doc="<p>One or more route table IDs to disassociate from the endpoint.</p>"]
+    #[serde(rename="RemoveRouteTableIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub remove_route_table_ids: Option<Vec<String>>,
     #[doc="<p>Specify <code>true</code> to reset the policy document to the default policy. The default policy allows access to the service.</p>"]
+    #[serde(rename="ResetPolicy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reset_policy: Option<bool>,
     #[doc="<p>The ID of the endpoint.</p>"]
+    #[serde(rename="VpcEndpointId")]
     pub vpc_endpoint_id: String,
 }
 
@@ -26700,9 +29360,11 @@ impl ModifyVpcEndpointRequestSerializer {
 }
 
 #[doc="<p>Contains the output of ModifyVpcEndpoint.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyVpcEndpointResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -26748,15 +29410,22 @@ impl ModifyVpcEndpointResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyVpcPeeringConnectionOptionsRequest {
     #[doc="<p>The VPC peering connection options for the accepter VPC.</p>"]
+    #[serde(rename="AccepterPeeringConnectionOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub accepter_peering_connection_options: Option<PeeringConnectionOptionsRequest>,
     #[doc="<p>Checks whether you have the required permissions for the operation, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The VPC peering connection options for the requester VPC.</p>"]
+    #[serde(rename="RequesterPeeringConnectionOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub requester_peering_connection_options: Option<PeeringConnectionOptionsRequest>,
     #[doc="<p>The ID of the VPC peering connection.</p>"]
+    #[serde(rename="VpcPeeringConnectionId")]
     pub vpc_peering_connection_id: String,
 }
 
@@ -26794,11 +29463,15 @@ impl ModifyVpcPeeringConnectionOptionsRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyVpcPeeringConnectionOptionsResult {
     #[doc="<p>Information about the VPC peering connection options for the accepter VPC.</p>"]
+    #[serde(rename="AccepterPeeringConnectionOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub accepter_peering_connection_options: Option<PeeringConnectionOptions>,
     #[doc="<p>Information about the VPC peering connection options for the requester VPC.</p>"]
+    #[serde(rename="RequesterPeeringConnectionOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub requester_peering_connection_options: Option<PeeringConnectionOptions>,
 }
 
@@ -26848,11 +29521,14 @@ impl ModifyVpcPeeringConnectionOptionsResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for MonitorInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MonitorInstancesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more instance IDs.</p>"]
+    #[serde(rename="InstanceIds")]
     pub instance_ids: Vec<String>,
 }
 
@@ -26878,9 +29554,11 @@ impl MonitorInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of MonitorInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MonitorInstancesResult {
     #[doc="<p>The monitoring information.</p>"]
+    #[serde(rename="InstanceMonitorings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_monitorings: Option<Vec<InstanceMonitoring>>,
 }
 
@@ -26928,9 +29606,11 @@ impl MonitorInstancesResultDeserializer {
     }
 }
 #[doc="<p>Describes the monitoring of an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Monitoring {
     #[doc="<p>Indicates whether detailed monitoring is enabled. Otherwise, basic monitoring is enabled.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -26991,11 +29671,14 @@ impl MonitoringStateDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for MoveAddressToVpc.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MoveAddressToVpcRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The Elastic IP address.</p>"]
+    #[serde(rename="PublicIp")]
     pub public_ip: String,
 }
 
@@ -27020,11 +29703,15 @@ impl MoveAddressToVpcRequestSerializer {
 }
 
 #[doc="<p>Contains the output of MoveAddressToVpc.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MoveAddressToVpcResult {
     #[doc="<p>The allocation ID for the Elastic IP address.</p>"]
+    #[serde(rename="AllocationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocation_id: Option<String>,
     #[doc="<p>The status of the move of the IP address.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -27089,11 +29776,15 @@ impl MoveStatusDeserializer {
     }
 }
 #[doc="<p>Describes the status of a moving Elastic IP address.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MovingAddressStatus {
     #[doc="<p>The status of the Elastic IP address that's being moved to the EC2-VPC platform, or restored to the EC2-Classic platform.</p>"]
+    #[serde(rename="MoveStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub move_status: Option<String>,
     #[doc="<p>The Elastic IP address.</p>"]
+    #[serde(rename="PublicIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip: Option<String>,
 }
 
@@ -27186,27 +29877,47 @@ impl MovingAddressStatusSetDeserializer {
     }
 }
 #[doc="<p>Describes a NAT gateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NatGateway {
     #[doc="<p>The date and time the NAT gateway was created.</p>"]
+    #[serde(rename="CreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_time: Option<String>,
     #[doc="<p>The date and time the NAT gateway was deleted, if applicable.</p>"]
+    #[serde(rename="DeleteTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_time: Option<String>,
     #[doc="<p>If the NAT gateway could not be created, specifies the error code for the failure. (<code>InsufficientFreeAddressesInSubnet</code> | <code>Gateway.NotAttached</code> | <code>InvalidAllocationID.NotFound</code> | <code>Resource.AlreadyAssociated</code> | <code>InternalError</code> | <code>InvalidSubnetID.NotFound</code>)</p>"]
+    #[serde(rename="FailureCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub failure_code: Option<String>,
     #[doc="<p>If the NAT gateway could not be created, specifies the error message for the failure, that corresponds to the error code.</p> <ul> <li> <p>For InsufficientFreeAddressesInSubnet: \"Subnet has insufficient free addresses to create this NAT gateway\"</p> </li> <li> <p>For Gateway.NotAttached: \"Network vpc-xxxxxxxx has no Internet gateway attached\"</p> </li> <li> <p>For InvalidAllocationID.NotFound: \"Elastic IP address eipalloc-xxxxxxxx could not be associated with this NAT gateway\"</p> </li> <li> <p>For Resource.AlreadyAssociated: \"Elastic IP address eipalloc-xxxxxxxx is already associated\"</p> </li> <li> <p>For InternalError: \"Network interface eni-xxxxxxxx, created and used internally by this NAT gateway is in an invalid state. Please try again.\"</p> </li> <li> <p>For InvalidSubnetID.NotFound: \"The specified subnet subnet-xxxxxxxx does not exist or could not be found.\"</p> </li> </ul>"]
+    #[serde(rename="FailureMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub failure_message: Option<String>,
     #[doc="<p>Information about the IP addresses and network interface associated with the NAT gateway.</p>"]
+    #[serde(rename="NatGatewayAddresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nat_gateway_addresses: Option<Vec<NatGatewayAddress>>,
     #[doc="<p>The ID of the NAT gateway.</p>"]
+    #[serde(rename="NatGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nat_gateway_id: Option<String>,
     #[doc="<p>Reserved. If you need to sustain traffic greater than the <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html\">documented limits</a>, contact us through the <a href=\"https://console.aws.amazon.com/support/home?\">Support Center</a>.</p>"]
+    #[serde(rename="ProvisionedBandwidth")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub provisioned_bandwidth: Option<ProvisionedBandwidth>,
     #[doc="<p>The state of the NAT gateway.</p> <ul> <li> <p> <code>pending</code>: The NAT gateway is being created and is not ready to process traffic.</p> </li> <li> <p> <code>failed</code>: The NAT gateway could not be created. Check the <code>failureCode</code> and <code>failureMessage</code> fields for the reason.</p> </li> <li> <p> <code>available</code>: The NAT gateway is able to process traffic. This status remains until you delete the NAT gateway, and does not indicate the health of the NAT gateway.</p> </li> <li> <p> <code>deleting</code>: The NAT gateway is in the process of being terminated and may still be processing traffic.</p> </li> <li> <p> <code>deleted</code>: The NAT gateway has been terminated and is no longer processing traffic.</p> </li> </ul>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The ID of the subnet in which the NAT gateway is located.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>The ID of the VPC in which the NAT gateway is located.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -27292,15 +30003,23 @@ impl NatGatewayDeserializer {
     }
 }
 #[doc="<p>Describes the IP addresses and network interface associated with a NAT gateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NatGatewayAddress {
     #[doc="<p>The allocation ID of the Elastic IP address that's associated with the NAT gateway.</p>"]
+    #[serde(rename="AllocationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocation_id: Option<String>,
     #[doc="<p>The ID of the network interface associated with the NAT gateway.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>The private IP address associated with the Elastic IP address.</p>"]
+    #[serde(rename="PrivateIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip: Option<String>,
     #[doc="<p>The Elastic IP address associated with the NAT gateway.</p>"]
+    #[serde(rename="PublicIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip: Option<String>,
 }
 
@@ -27456,19 +30175,31 @@ impl NatGatewayStateDeserializer {
     }
 }
 #[doc="<p>Describes a network ACL.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkAcl {
     #[doc="<p>Any associations between the network ACL and one or more subnets</p>"]
+    #[serde(rename="Associations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub associations: Option<Vec<NetworkAclAssociation>>,
     #[doc="<p>One or more entries (rules) in the network ACL.</p>"]
+    #[serde(rename="Entries")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub entries: Option<Vec<NetworkAclEntry>>,
     #[doc="<p>Indicates whether this is the default network ACL for the VPC.</p>"]
+    #[serde(rename="IsDefault")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_default: Option<bool>,
     #[doc="<p>The ID of the network ACL.</p>"]
+    #[serde(rename="NetworkAclId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_acl_id: Option<String>,
     #[doc="<p>Any tags assigned to the network ACL.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The ID of the VPC for the network ACL.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -27535,13 +30266,19 @@ impl NetworkAclDeserializer {
     }
 }
 #[doc="<p>Describes an association between a network ACL and a subnet.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkAclAssociation {
     #[doc="<p>The ID of the association between a network ACL and a subnet.</p>"]
+    #[serde(rename="NetworkAclAssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_acl_association_id: Option<String>,
     #[doc="<p>The ID of the network ACL.</p>"]
+    #[serde(rename="NetworkAclId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_acl_id: Option<String>,
     #[doc="<p>The ID of the subnet.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
 }
 
@@ -27639,23 +30376,39 @@ impl NetworkAclAssociationListDeserializer {
     }
 }
 #[doc="<p>Describes an entry in a network ACL.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkAclEntry {
     #[doc="<p>The IPv4 network range to allow or deny, in CIDR notation.</p>"]
+    #[serde(rename="CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_block: Option<String>,
     #[doc="<p>Indicates whether the rule is an egress rule (applied to traffic leaving the subnet).</p>"]
+    #[serde(rename="Egress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub egress: Option<bool>,
     #[doc="<p>ICMP protocol: The ICMP type and code.</p>"]
+    #[serde(rename="IcmpTypeCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub icmp_type_code: Option<IcmpTypeCode>,
     #[doc="<p>The IPv6 network range to allow or deny, in CIDR notation.</p>"]
+    #[serde(rename="Ipv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block: Option<String>,
     #[doc="<p>TCP or UDP protocols: The range of ports the rule applies to.</p>"]
+    #[serde(rename="PortRange")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port_range: Option<PortRange>,
     #[doc="<p>The protocol. A value of <code>-1</code> means all protocols.</p>"]
+    #[serde(rename="Protocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub protocol: Option<String>,
     #[doc="<p>Indicates whether to allow or deny the traffic that matches the rule.</p>"]
+    #[serde(rename="RuleAction")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rule_action: Option<String>,
     #[doc="<p>The rule number for the entry. ACL entries are processed in ascending order by rule number.</p>"]
+    #[serde(rename="RuleNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rule_number: Option<i64>,
 }
 
@@ -27814,47 +30567,87 @@ impl NetworkAclListDeserializer {
     }
 }
 #[doc="<p>Describes a network interface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkInterface {
     #[doc="<p>The association information for an Elastic IP address (IPv4) associated with the network interface.</p>"]
+    #[serde(rename="Association")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association: Option<NetworkInterfaceAssociation>,
     #[doc="<p>The network interface attachment.</p>"]
+    #[serde(rename="Attachment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachment: Option<NetworkInterfaceAttachment>,
     #[doc="<p>The Availability Zone.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>A description.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Any security groups for the network interface.</p>"]
+    #[serde(rename="Groups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub groups: Option<Vec<GroupIdentifier>>,
     #[doc="<p>The type of interface.</p>"]
+    #[serde(rename="InterfaceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub interface_type: Option<String>,
     #[doc="<p>The IPv6 addresses associated with the network interface.</p>"]
+    #[serde(rename="Ipv6Addresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_addresses: Option<Vec<NetworkInterfaceIpv6Address>>,
     #[doc="<p>The MAC address.</p>"]
+    #[serde(rename="MacAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub mac_address: Option<String>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>The AWS account ID of the owner of the network interface.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
     #[doc="<p>The private DNS name.</p>"]
+    #[serde(rename="PrivateDnsName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_dns_name: Option<String>,
     #[doc="<p>The IPv4 address of the network interface within the subnet.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
     #[doc="<p>The private IPv4 addresses associated with the network interface.</p>"]
+    #[serde(rename="PrivateIpAddresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_addresses: Option<Vec<NetworkInterfacePrivateIpAddress>>,
     #[doc="<p>The ID of the entity that launched the instance on your behalf (for example, AWS Management Console or Auto Scaling).</p>"]
+    #[serde(rename="RequesterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub requester_id: Option<String>,
     #[doc="<p>Indicates whether the network interface is being managed by AWS.</p>"]
+    #[serde(rename="RequesterManaged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub requester_managed: Option<bool>,
     #[doc="<p>Indicates whether traffic to or from the instance is validated.</p>"]
+    #[serde(rename="SourceDestCheck")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_dest_check: Option<bool>,
     #[doc="<p>The status of the network interface.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The ID of the subnet.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>Any tags assigned to the network interface.</p>"]
+    #[serde(rename="TagSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_set: Option<Vec<Tag>>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -27982,17 +30775,27 @@ impl NetworkInterfaceDeserializer {
     }
 }
 #[doc="<p>Describes association information for an Elastic IP address (IPv4 only).</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkInterfaceAssociation {
     #[doc="<p>The allocation ID.</p>"]
+    #[serde(rename="AllocationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocation_id: Option<String>,
     #[doc="<p>The association ID.</p>"]
+    #[serde(rename="AssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association_id: Option<String>,
     #[doc="<p>The ID of the Elastic IP address owner.</p>"]
+    #[serde(rename="IpOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_owner_id: Option<String>,
     #[doc="<p>The public DNS name.</p>"]
+    #[serde(rename="PublicDnsName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_dns_name: Option<String>,
     #[doc="<p>The address of the Elastic IP address bound to the network interface.</p>"]
+    #[serde(rename="PublicIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip: Option<String>,
 }
 
@@ -28055,21 +30858,35 @@ impl NetworkInterfaceAssociationDeserializer {
     }
 }
 #[doc="<p>Describes a network interface attachment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkInterfaceAttachment {
     #[doc="<p>The timestamp indicating when the attachment initiated.</p>"]
+    #[serde(rename="AttachTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attach_time: Option<String>,
     #[doc="<p>The ID of the network interface attachment.</p>"]
+    #[serde(rename="AttachmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachment_id: Option<String>,
     #[doc="<p>Indicates whether the network interface is deleted when the instance is terminated.</p>"]
+    #[serde(rename="DeleteOnTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_on_termination: Option<bool>,
     #[doc="<p>The device index of the network interface attachment on the instance.</p>"]
+    #[serde(rename="DeviceIndex")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device_index: Option<i64>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The AWS account ID of the owner of the instance.</p>"]
+    #[serde(rename="InstanceOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_owner_id: Option<String>,
     #[doc="<p>The attachment state.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -28143,11 +30960,15 @@ impl NetworkInterfaceAttachmentDeserializer {
     }
 }
 #[doc="<p>Describes an attachment change.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkInterfaceAttachmentChanges {
     #[doc="<p>The ID of the network interface attachment.</p>"]
+    #[serde(rename="AttachmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachment_id: Option<String>,
     #[doc="<p>Indicates whether the network interface is deleted when the instance is terminated.</p>"]
+    #[serde(rename="DeleteOnTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_on_termination: Option<bool>,
 }
 
@@ -28186,9 +31007,11 @@ impl NetworkInterfaceIdListSerializer {
 }
 
 #[doc="<p>Describes an IPv6 address associated with a network interface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkInterfaceIpv6Address {
     #[doc="<p>The IPv6 address.</p>"]
+    #[serde(rename="Ipv6Address")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_address: Option<String>,
 }
 
@@ -28319,19 +31142,31 @@ impl NetworkInterfaceListDeserializer {
     }
 }
 #[doc="<p>Describes a permission for a network interface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkInterfacePermission {
     #[doc="<p>The AWS account ID.</p>"]
+    #[serde(rename="AwsAccountId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub aws_account_id: Option<String>,
     #[doc="<p>The AWS service.</p>"]
+    #[serde(rename="AwsService")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub aws_service: Option<String>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>The ID of the network interface permission.</p>"]
+    #[serde(rename="NetworkInterfacePermissionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_permission_id: Option<String>,
     #[doc="<p>The type of permission.</p>"]
+    #[serde(rename="Permission")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub permission: Option<String>,
     #[doc="<p>Information about the state of the permission.</p>"]
+    #[serde(rename="PermissionState")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub permission_state: Option<NetworkInterfacePermissionState>,
 }
 
@@ -28455,11 +31290,15 @@ impl NetworkInterfacePermissionListDeserializer {
     }
 }
 #[doc="<p>Describes the state of a network interface permission.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkInterfacePermissionState {
     #[doc="<p>The state of the permission.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>A status message, if applicable.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
 }
 
@@ -28524,15 +31363,23 @@ impl NetworkInterfacePermissionStateCodeDeserializer {
     }
 }
 #[doc="<p>Describes the private IPv4 address of a network interface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkInterfacePrivateIpAddress {
     #[doc="<p>The association information for an Elastic IP address (IPv4) associated with the network interface.</p>"]
+    #[serde(rename="Association")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association: Option<NetworkInterfaceAssociation>,
     #[doc="<p>Indicates whether this IPv4 address is the primary private IPv4 address of the network interface.</p>"]
+    #[serde(rename="Primary")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub primary: Option<bool>,
     #[doc="<p>The private DNS name.</p>"]
+    #[serde(rename="PrivateDnsName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_dns_name: Option<String>,
     #[doc="<p>The private IPv4 address.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
 }
 
@@ -28662,9 +31509,13 @@ impl NetworkInterfaceTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NewDhcpConfiguration {
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
+    #[serde(rename="Values")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub values: Option<Vec<String>>,
 }
 
@@ -28825,15 +31676,23 @@ impl PaymentOptionDeserializer {
     }
 }
 #[doc="<p>Describes the data that identifies an Amazon FPGA image (AFI) on the PCI bus.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PciId {
     #[doc="<p>The ID of the device.</p>"]
+    #[serde(rename="DeviceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device_id: Option<String>,
     #[doc="<p>The ID of the subsystem.</p>"]
+    #[serde(rename="SubsystemId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subsystem_id: Option<String>,
     #[doc="<p>The ID of the vendor for the subsystem.</p>"]
+    #[serde(rename="SubsystemVendorId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subsystem_vendor_id: Option<String>,
     #[doc="<p>The ID of the vendor.</p>"]
+    #[serde(rename="VendorId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vendor_id: Option<String>,
 }
 
@@ -28893,13 +31752,19 @@ impl PciIdDeserializer {
     }
 }
 #[doc="<p>Describes the VPC peering connection options.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PeeringConnectionOptions {
     #[doc="<p>If true, enables a local VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the peer VPC.</p>"]
+    #[serde(rename="AllowDnsResolutionFromRemoteVpc")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_dns_resolution_from_remote_vpc: Option<bool>,
     #[doc="<p>If true, enables outbound communication from an EC2-Classic instance that's linked to a local VPC via ClassicLink to instances in a peer VPC.</p>"]
+    #[serde(rename="AllowEgressFromLocalClassicLinkToRemoteVpc")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_egress_from_local_classic_link_to_remote_vpc: Option<bool>,
     #[doc="<p>If true, enables outbound communication from instances in a local VPC to an EC2-Classic instance that's linked to a peer VPC via ClassicLink.</p>"]
+    #[serde(rename="AllowEgressFromLocalVpcToRemoteClassicLink")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_egress_from_local_vpc_to_remote_classic_link: Option<bool>,
 }
 
@@ -28957,13 +31822,19 @@ impl PeeringConnectionOptionsDeserializer {
     }
 }
 #[doc="<p>The VPC peering connection options.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PeeringConnectionOptionsRequest {
     #[doc="<p>If true, enables a local VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the peer VPC.</p>"]
+    #[serde(rename="AllowDnsResolutionFromRemoteVpc")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_dns_resolution_from_remote_vpc: Option<bool>,
     #[doc="<p>If true, enables outbound communication from an EC2-Classic instance that's linked to a local VPC via ClassicLink to instances in a peer VPC.</p>"]
+    #[serde(rename="AllowEgressFromLocalClassicLinkToRemoteVpc")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_egress_from_local_classic_link_to_remote_vpc: Option<bool>,
     #[doc="<p>If true, enables outbound communication from instances in a local VPC to an EC2-Classic instance that's linked to a peer VPC via ClassicLink.</p>"]
+    #[serde(rename="AllowEgressFromLocalVpcToRemoteClassicLink")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_egress_from_local_vpc_to_remote_classic_link: Option<bool>,
 }
 
@@ -29008,19 +31879,31 @@ impl PermissionGroupDeserializer {
     }
 }
 #[doc="<p>Describes the placement of an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Placement {
     #[doc="<p>The affinity setting for the instance on the Dedicated Host. This parameter is not supported for the <a>ImportInstance</a> command.</p>"]
+    #[serde(rename="Affinity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub affinity: Option<String>,
     #[doc="<p>The Availability Zone of the instance.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The name of the placement group the instance is in (for cluster compute instances).</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>The ID of the Dedicated Host on which the instance resides. This parameter is not supported for the <a>ImportInstance</a> command.</p>"]
+    #[serde(rename="HostId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_id: Option<String>,
     #[doc="<p>Reserved for future use.</p>"]
+    #[serde(rename="SpreadDomain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spread_domain: Option<String>,
     #[doc="<p>The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of <code>dedicated</code> runs on single-tenant hardware. The <code>host</code> tenancy is not supported for the <a>ImportInstance</a> command.</p>"]
+    #[serde(rename="Tenancy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tenancy: Option<String>,
 }
 
@@ -29126,13 +32009,19 @@ impl PlacementSerializer {
 }
 
 #[doc="<p>Describes a placement group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlacementGroup {
     #[doc="<p>The name of the placement group.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>The state of the placement group.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The placement strategy.</p>"]
+    #[serde(rename="Strategy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub strategy: Option<String>,
 }
 
@@ -29284,11 +32173,15 @@ impl PlatformValuesDeserializer {
     }
 }
 #[doc="<p>Describes a range of ports.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PortRange {
     #[doc="<p>The first port in the range.</p>"]
+    #[serde(rename="From")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub from: Option<i64>,
     #[doc="<p>The last port in the range.</p>"]
+    #[serde(rename="To")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub to: Option<i64>,
 }
 
@@ -29359,13 +32252,19 @@ impl PortRangeSerializer {
 }
 
 #[doc="<p>Describes prefixes for AWS services.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PrefixList {
     #[doc="<p>The IP address range of the AWS service.</p>"]
+    #[serde(rename="Cidrs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidrs: Option<Vec<String>>,
     #[doc="<p>The ID of the prefix.</p>"]
+    #[serde(rename="PrefixListId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix_list_id: Option<String>,
     #[doc="<p>The name of the prefix.</p>"]
+    #[serde(rename="PrefixListName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix_list_name: Option<String>,
 }
 
@@ -29421,9 +32320,11 @@ impl PrefixListDeserializer {
     }
 }
 #[doc="<p>The ID of the prefix.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PrefixListId {
     #[doc="<p>The ID of the prefix.</p>"]
+    #[serde(rename="PrefixListId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix_list_id: Option<String>,
 }
 
@@ -29623,15 +32524,23 @@ impl PrefixListSetDeserializer {
     }
 }
 #[doc="<p>Describes the price for a Reserved Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PriceSchedule {
     #[doc="<p>The current price schedule, as determined by the term remaining for the Reserved Instance in the listing.</p> <p>A specific price schedule is always in effect, but only one price schedule can be active at any time. Take, for example, a Reserved Instance listing that has five months remaining in its term. When you specify price schedules for five months and two months, this means that schedule 1, covering the first three months of the remaining term, will be active during months 5, 4, and 3. Then schedule 2, covering the last two months of the term, will be active for months 2 and 1.</p>"]
+    #[serde(rename="Active")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub active: Option<bool>,
     #[doc="<p>The currency for transacting the Reserved Instance resale. At this time, the only supported currency is <code>USD</code>.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The fixed price for the term.</p>"]
+    #[serde(rename="Price")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub price: Option<f64>,
     #[doc="<p>The number of months remaining in the reservation. For example, 2 is the second to the last month before the capacity reservation expires.</p>"]
+    #[serde(rename="Term")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub term: Option<i64>,
 }
 
@@ -29730,13 +32639,19 @@ impl PriceScheduleListDeserializer {
     }
 }
 #[doc="<p>Describes the price for a Reserved Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PriceScheduleSpecification {
     #[doc="<p>The currency for transacting the Reserved Instance resale. At this time, the only supported currency is <code>USD</code>.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The fixed price for the term.</p>"]
+    #[serde(rename="Price")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub price: Option<f64>,
     #[doc="<p>The number of months remaining in the reservation. For example, 2 is the second to the last month before the capacity reservation expires.</p>"]
+    #[serde(rename="Term")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub term: Option<i64>,
 }
 
@@ -29779,11 +32694,15 @@ impl PriceScheduleSpecificationListSerializer {
 }
 
 #[doc="<p>Describes a Reserved Instance offering.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PricingDetail {
     #[doc="<p>The number of reservations available for the price.</p>"]
+    #[serde(rename="Count")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub count: Option<i64>,
     #[doc="<p>The price per instance.</p>"]
+    #[serde(rename="Price")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub price: Option<f64>,
 }
 
@@ -29888,11 +32807,14 @@ impl PrivateIpAddressConfigSetSerializer {
 }
 
 #[doc="<p>Describes a secondary private IPv4 address for a network interface.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PrivateIpAddressSpecification {
     #[doc="<p>Indicates whether the private IPv4 address is the primary private IPv4 address. Only one IPv4 address can be designated as primary.</p>"]
+    #[serde(rename="Primary")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub primary: Option<bool>,
     #[doc="<p>The private IPv4 addresses.</p>"]
+    #[serde(rename="PrivateIpAddress")]
     pub private_ip_address: String,
 }
 
@@ -30029,11 +32951,15 @@ impl PrivateIpAddressStringListSerializer {
 }
 
 #[doc="<p>Describes a product code.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProductCode {
     #[doc="<p>The product code.</p>"]
+    #[serde(rename="ProductCodeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_code_id: Option<String>,
     #[doc="<p>The type of product code.</p>"]
+    #[serde(rename="ProductCodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_code_type: Option<String>,
 }
 
@@ -30164,9 +33090,11 @@ impl ProductDescriptionListSerializer {
 }
 
 #[doc="<p>Describes a virtual private gateway propagating route.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PropagatingVgw {
     #[doc="<p>The ID of the virtual private gateway (VGW).</p>"]
+    #[serde(rename="GatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub gateway_id: Option<String>,
 }
 
@@ -30254,17 +33182,27 @@ impl PropagatingVgwListDeserializer {
     }
 }
 #[doc="<p>Reserved. If you need to sustain traffic greater than the <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html\">documented limits</a>, contact us through the <a href=\"https://console.aws.amazon.com/support/home?\">Support Center</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisionedBandwidth {
     #[doc="<p>Reserved. If you need to sustain traffic greater than the <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html\">documented limits</a>, contact us through the <a href=\"https://console.aws.amazon.com/support/home?\">Support Center</a>.</p>"]
+    #[serde(rename="ProvisionTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub provision_time: Option<String>,
     #[doc="<p>Reserved. If you need to sustain traffic greater than the <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html\">documented limits</a>, contact us through the <a href=\"https://console.aws.amazon.com/support/home?\">Support Center</a>.</p>"]
+    #[serde(rename="Provisioned")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub provisioned: Option<String>,
     #[doc="<p>Reserved. If you need to sustain traffic greater than the <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html\">documented limits</a>, contact us through the <a href=\"https://console.aws.amazon.com/support/home?\">Support Center</a>.</p>"]
+    #[serde(rename="RequestTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_time: Option<String>,
     #[doc="<p>Reserved. If you need to sustain traffic greater than the <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html\">documented limits</a>, contact us through the <a href=\"https://console.aws.amazon.com/support/home?\">Support Center</a>.</p>"]
+    #[serde(rename="Requested")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub requested: Option<String>,
     #[doc="<p>Reserved. If you need to sustain traffic greater than the <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html\">documented limits</a>, contact us through the <a href=\"https://console.aws.amazon.com/support/home?\">Support Center</a>.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -30340,23 +33278,39 @@ impl PublicIpStringListSerializer {
 }
 
 #[doc="<p>Describes the result of the purchase.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Purchase {
     #[doc="<p>The currency in which the <code>UpfrontPrice</code> and <code>HourlyPrice</code> amounts are specified. At this time, the only supported currency is <code>USD</code>.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The duration of the reservation's term in seconds.</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The IDs of the Dedicated Hosts associated with the reservation.</p>"]
+    #[serde(rename="HostIdSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_id_set: Option<Vec<String>>,
     #[doc="<p>The ID of the reservation.</p>"]
+    #[serde(rename="HostReservationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_reservation_id: Option<String>,
     #[doc="<p>The hourly price of the reservation per hour.</p>"]
+    #[serde(rename="HourlyPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hourly_price: Option<String>,
     #[doc="<p>The instance family on the Dedicated Host that the reservation can be associated with.</p>"]
+    #[serde(rename="InstanceFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_family: Option<String>,
     #[doc="<p>The payment option for the reservation.</p>"]
+    #[serde(rename="PaymentOption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub payment_option: Option<String>,
     #[doc="<p>The upfront price of the reservation.</p>"]
+    #[serde(rename="UpfrontPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upfront_price: Option<String>,
 }
 
@@ -30435,17 +33389,25 @@ impl PurchaseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseHostReservationRequest {
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html\">How to Ensure Idempotency</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>The currency in which the <code>totalUpfrontPrice</code>, <code>LimitPrice</code>, and <code>totalHourlyPrice</code> amounts are specified. At this time, the only supported currency is <code>USD</code>.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The ID/s of the Dedicated Host/s that the reservation will be associated with.</p>"]
+    #[serde(rename="HostIdSet")]
     pub host_id_set: Vec<String>,
     #[doc="<p>The specified limit is checked against the total upfront cost of the reservation (calculated as the offering's upfront cost multiplied by the host count). If the total upfront cost is greater than the specified price limit, the request will fail. This is used to ensure that the purchase does not exceed the expected upfront cost of the purchase. At this time, the only supported currency is <code>USD</code>. For example, to indicate a limit price of USD 100, specify 100.00.</p>"]
+    #[serde(rename="LimitPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub limit_price: Option<String>,
     #[doc="<p>The ID of the offering.</p>"]
+    #[serde(rename="OfferingId")]
     pub offering_id: String,
 }
 
@@ -30480,17 +33442,27 @@ impl PurchaseHostReservationRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseHostReservationResult {
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html\">How to Ensure Idempotency</a> in the <i>Amazon Elastic Compute Cloud User Guide</i> </p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>The currency in which the <code>totalUpfrontPrice</code> and <code>totalHourlyPrice</code> amounts are specified. At this time, the only supported currency is <code>USD</code>.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>Describes the details of the purchase.</p>"]
+    #[serde(rename="Purchase")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub purchase: Option<Vec<Purchase>>,
     #[doc="<p>The total hourly price of the reservation calculated per hour.</p>"]
+    #[serde(rename="TotalHourlyPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub total_hourly_price: Option<String>,
     #[doc="<p>The total amount that will be charged to your account when you purchase the reservation.</p>"]
+    #[serde(rename="TotalUpfrontPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub total_upfront_price: Option<String>,
 }
 
@@ -30556,11 +33528,13 @@ impl PurchaseHostReservationResultDeserializer {
     }
 }
 #[doc="<p>Describes a request to purchase Scheduled Instances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseRequest {
     #[doc="<p>The number of instances.</p>"]
+    #[serde(rename="InstanceCount")]
     pub instance_count: i64,
     #[doc="<p>The purchase token.</p>"]
+    #[serde(rename="PurchaseToken")]
     pub purchase_token: String,
 }
 
@@ -30595,15 +33569,21 @@ impl PurchaseRequestSetSerializer {
 }
 
 #[doc="<p>Contains the parameters for PurchaseReservedInstancesOffering.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseReservedInstancesOfferingRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The number of Reserved Instances to purchase.</p>"]
+    #[serde(rename="InstanceCount")]
     pub instance_count: i64,
     #[doc="<p>Specified for Reserved Instance Marketplace offerings to limit the total order and ensure that the Reserved Instances are not purchased at unexpected prices.</p>"]
+    #[serde(rename="LimitPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub limit_price: Option<ReservedInstanceLimitPrice>,
     #[doc="<p>The ID of the Reserved Instance offering to purchase.</p>"]
+    #[serde(rename="ReservedInstancesOfferingId")]
     pub reserved_instances_offering_id: String,
 }
 
@@ -30635,9 +33615,11 @@ impl PurchaseReservedInstancesOfferingRequestSerializer {
 }
 
 #[doc="<p>Contains the output of PurchaseReservedInstancesOffering.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseReservedInstancesOfferingResult {
     #[doc="<p>The IDs of the purchased Reserved Instances.</p>"]
+    #[serde(rename="ReservedInstancesId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_id: Option<String>,
 }
 
@@ -30686,13 +33668,18 @@ impl PurchaseReservedInstancesOfferingResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for PurchaseScheduledInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseScheduledInstancesRequest {
     #[doc="<p>Unique, case-sensitive identifier that ensures the idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html\">Ensuring Idempotency</a>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more purchase requests.</p>"]
+    #[serde(rename="PurchaseRequests")]
     pub purchase_requests: Vec<PurchaseRequest>,
 }
 
@@ -30722,9 +33709,11 @@ impl PurchaseScheduledInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of PurchaseScheduledInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseScheduledInstancesResult {
     #[doc="<p>Information about the Scheduled Instances.</p>"]
+    #[serde(rename="ScheduledInstanceSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheduled_instance_set: Option<Vec<ScheduledInstance>>,
 }
 
@@ -30879,11 +33868,14 @@ impl ReasonCodesListSerializer {
 }
 
 #[doc="<p>Contains the parameters for RebootInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootInstancesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more instance IDs.</p>"]
+    #[serde(rename="InstanceIds")]
     pub instance_ids: Vec<String>,
 }
 
@@ -30909,11 +33901,15 @@ impl RebootInstancesRequestSerializer {
 }
 
 #[doc="<p>Describes a recurring charge.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecurringCharge {
     #[doc="<p>The amount of the recurring charge.</p>"]
+    #[serde(rename="Amount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub amount: Option<f64>,
     #[doc="<p>The frequency of the recurring charge.</p>"]
+    #[serde(rename="Frequency")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub frequency: Option<String>,
 }
 
@@ -31018,11 +34014,15 @@ impl RecurringChargesListDeserializer {
     }
 }
 #[doc="<p>Describes a region.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Region {
     #[doc="<p>The region service endpoint.</p>"]
+    #[serde(rename="Endpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoint: Option<String>,
     #[doc="<p>The name of the region.</p>"]
+    #[serde(rename="RegionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub region_name: Option<String>,
 }
 
@@ -31126,33 +34126,58 @@ impl RegionNameStringListSerializer {
 }
 
 #[doc="<p>Contains the parameters for RegisterImage.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterImageRequest {
     #[doc="<p>The architecture of the AMI.</p> <p>Default: For Amazon EBS-backed AMIs, <code>i386</code>. For instance store-backed AMIs, the architecture specified in the manifest file.</p>"]
+    #[serde(rename="Architecture")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub architecture: Option<String>,
     #[doc="<p>The billing product codes. Your account must be authorized to specify billing product codes. Otherwise, you can use the AWS Marketplace to bill for the use of an AMI.</p>"]
+    #[serde(rename="BillingProducts")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub billing_products: Option<Vec<String>>,
     #[doc="<p>One or more block device mapping entries.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
     #[doc="<p>A description for your AMI.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Set to <code>true</code> to enable enhanced networking with ENA for the AMI and any instances that you launch from the AMI.</p> <p>This option is supported only for HVM AMIs. Specifying this option with a PV AMI can make instances launched from the AMI unreachable.</p>"]
+    #[serde(rename="EnaSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ena_support: Option<bool>,
     #[doc="<p>The full path to your AMI manifest in Amazon S3 storage.</p>"]
+    #[serde(rename="ImageLocation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_location: Option<String>,
     #[doc="<p>The ID of the kernel.</p>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<String>,
     #[doc="<p>A name for your AMI.</p> <p>Constraints: 3-128 alphanumeric characters, parentheses (()), square brackets ([]), spaces ( ), periods (.), slashes (/), dashes (-), single quotes ('), at-signs (@), or underscores(_)</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The ID of the RAM disk.</p>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<String>,
     #[doc="<p>The name of the root device (for example, <code>/dev/sda1</code>, or <code>/dev/xvda</code>).</p>"]
+    #[serde(rename="RootDeviceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub root_device_name: Option<String>,
     #[doc="<p>Set to <code>simple</code> to enable enhanced networking with the Intel 82599 Virtual Function interface for the AMI and any instances that you launch from the AMI.</p> <p>There is no way to disable <code>sriovNetSupport</code> at this time.</p> <p>This option is supported only for HVM AMIs. Specifying this option with a PV AMI can make instances launched from the AMI unreachable.</p>"]
+    #[serde(rename="SriovNetSupport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sriov_net_support: Option<String>,
     #[doc="<p>The type of virtualization.</p> <p>Default: <code>paravirtual</code> </p>"]
+    #[serde(rename="VirtualizationType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub virtualization_type: Option<String>,
 }
 
@@ -31225,9 +34250,11 @@ impl RegisterImageRequestSerializer {
 }
 
 #[doc="<p>Contains the output of RegisterImage.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterImageResult {
     #[doc="<p>The ID of the newly registered AMI.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
 }
 
@@ -31274,11 +34301,14 @@ impl RegisterImageResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for RejectVpcPeeringConnection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RejectVpcPeeringConnectionRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the VPC peering connection.</p>"]
+    #[serde(rename="VpcPeeringConnectionId")]
     pub vpc_peering_connection_id: String,
 }
 
@@ -31303,9 +34333,11 @@ impl RejectVpcPeeringConnectionRequestSerializer {
 }
 
 #[doc="<p>Contains the output of RejectVpcPeeringConnection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RejectVpcPeeringConnectionResult {
     #[doc="<p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>"]
+    #[serde(rename="Return")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_: Option<bool>,
 }
 
@@ -31353,13 +34385,19 @@ impl RejectVpcPeeringConnectionResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ReleaseAddress.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReleaseAddressRequest {
     #[doc="<p>[EC2-VPC] The allocation ID. Required for EC2-VPC.</p>"]
+    #[serde(rename="AllocationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocation_id: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>[EC2-Classic] The Elastic IP address. Required for EC2-Classic.</p>"]
+    #[serde(rename="PublicIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip: Option<String>,
 }
 
@@ -31390,9 +34428,10 @@ impl ReleaseAddressRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ReleaseHosts.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReleaseHostsRequest {
     #[doc="<p>The IDs of the Dedicated Hosts you want to release.</p>"]
+    #[serde(rename="HostIds")]
     pub host_ids: Vec<String>,
 }
 
@@ -31414,11 +34453,15 @@ impl ReleaseHostsRequestSerializer {
 }
 
 #[doc="<p>Contains the output of ReleaseHosts.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReleaseHostsResult {
     #[doc="<p>The IDs of the Dedicated Hosts that were successfully released.</p>"]
+    #[serde(rename="Successful")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub successful: Option<Vec<String>>,
     #[doc="<p>The IDs of the Dedicated Hosts that could not be released, including an error message.</p>"]
+    #[serde(rename="Unsuccessful")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unsuccessful: Option<Vec<UnsuccessfulItem>>,
 }
 
@@ -31470,11 +34513,13 @@ impl ReleaseHostsResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplaceIamInstanceProfileAssociationRequest {
     #[doc="<p>The ID of the existing IAM instance profile association.</p>"]
+    #[serde(rename="AssociationId")]
     pub association_id: String,
     #[doc="<p>The IAM instance profile.</p>"]
+    #[serde(rename="IamInstanceProfile")]
     pub iam_instance_profile: IamInstanceProfileSpecification,
 }
 
@@ -31501,9 +34546,11 @@ impl ReplaceIamInstanceProfileAssociationRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplaceIamInstanceProfileAssociationResult {
     #[doc="<p>Information about the IAM instance profile association.</p>"]
+    #[serde(rename="IamInstanceProfileAssociation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile_association: Option<IamInstanceProfileAssociation>,
 }
 
@@ -31550,13 +34597,17 @@ impl ReplaceIamInstanceProfileAssociationResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ReplaceNetworkAclAssociation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplaceNetworkAclAssociationRequest {
     #[doc="<p>The ID of the current association between the original network ACL and the subnet.</p>"]
+    #[serde(rename="AssociationId")]
     pub association_id: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the new network ACL to associate with the subnet.</p>"]
+    #[serde(rename="NetworkAclId")]
     pub network_acl_id: String,
 }
 
@@ -31583,9 +34634,11 @@ impl ReplaceNetworkAclAssociationRequestSerializer {
 }
 
 #[doc="<p>Contains the output of ReplaceNetworkAclAssociation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplaceNetworkAclAssociationResult {
     #[doc="<p>The ID of the new association.</p>"]
+    #[serde(rename="NewAssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_association_id: Option<String>,
 }
 
@@ -31634,27 +34687,42 @@ impl ReplaceNetworkAclAssociationResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ReplaceNetworkAclEntry.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplaceNetworkAclEntryRequest {
     #[doc="<p>The IPv4 network range to allow or deny, in CIDR notation (for example <code>172.16.0.0/24</code>).</p>"]
+    #[serde(rename="CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_block: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Indicates whether to replace the egress rule.</p> <p>Default: If no value is specified, we replace the ingress rule.</p>"]
+    #[serde(rename="Egress")]
     pub egress: bool,
     #[doc="<p>ICMP protocol: The ICMP or ICMPv6 type and code. Required if specifying the ICMP (1) protocol, or protocol 58 (ICMPv6) with an IPv6 CIDR block.</p>"]
+    #[serde(rename="IcmpTypeCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub icmp_type_code: Option<IcmpTypeCode>,
     #[doc="<p>The IPv6 network range to allow or deny, in CIDR notation (for example <code>2001:bd8:1234:1a00::/64</code>).</p>"]
+    #[serde(rename="Ipv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block: Option<String>,
     #[doc="<p>The ID of the ACL.</p>"]
+    #[serde(rename="NetworkAclId")]
     pub network_acl_id: String,
     #[doc="<p>TCP or UDP protocols: The range of ports the rule applies to. Required if specifying TCP (6) or UDP (17) for the protocol.</p>"]
+    #[serde(rename="PortRange")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port_range: Option<PortRange>,
     #[doc="<p>The IP protocol. You can specify <code>all</code> or <code>-1</code> to mean all protocols. If you specify <code>all</code>, <code>-1</code>, or a protocol number other than <code>tcp</code>, <code>udp</code>, or <code>icmp</code>, traffic on all ports is allowed, regardless of any ports or ICMP types or codes you specify. If you specify protocol <code>58</code> (ICMPv6) and specify an IPv4 CIDR block, traffic for all ICMP types and codes allowed, regardless of any that you specify. If you specify protocol <code>58</code> (ICMPv6) and specify an IPv6 CIDR block, you must specify an ICMP type and code.</p>"]
+    #[serde(rename="Protocol")]
     pub protocol: String,
     #[doc="<p>Indicates whether to allow or deny the traffic that matches the rule.</p>"]
+    #[serde(rename="RuleAction")]
     pub rule_action: String,
     #[doc="<p>The rule number of the entry to replace.</p>"]
+    #[serde(rename="RuleNumber")]
     pub rule_number: i64,
 }
 
@@ -31705,27 +34773,46 @@ impl ReplaceNetworkAclEntryRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ReplaceRoute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplaceRouteRequest {
     #[doc="<p>The IPv4 CIDR address block used for the destination match. The value you provide must match the CIDR of an existing route in the table.</p>"]
+    #[serde(rename="DestinationCidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_cidr_block: Option<String>,
     #[doc="<p>The IPv6 CIDR address block used for the destination match. The value you provide must match the CIDR of an existing route in the table.</p>"]
+    #[serde(rename="DestinationIpv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_ipv_6_cidr_block: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>[IPv6 traffic only] The ID of an egress-only Internet gateway.</p>"]
+    #[serde(rename="EgressOnlyInternetGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub egress_only_internet_gateway_id: Option<String>,
     #[doc="<p>The ID of an Internet gateway or virtual private gateway.</p>"]
+    #[serde(rename="GatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub gateway_id: Option<String>,
     #[doc="<p>The ID of a NAT instance in your VPC.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>[IPv4 traffic only] The ID of a NAT gateway.</p>"]
+    #[serde(rename="NatGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nat_gateway_id: Option<String>,
     #[doc="<p>The ID of a network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>The ID of the route table.</p>"]
+    #[serde(rename="RouteTableId")]
     pub route_table_id: String,
     #[doc="<p>The ID of a VPC peering connection.</p>"]
+    #[serde(rename="VpcPeeringConnectionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_peering_connection_id: Option<String>,
 }
 
@@ -31782,13 +34869,17 @@ impl ReplaceRouteRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ReplaceRouteTableAssociation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplaceRouteTableAssociationRequest {
     #[doc="<p>The association ID.</p>"]
+    #[serde(rename="AssociationId")]
     pub association_id: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the new route table to associate with the subnet.</p>"]
+    #[serde(rename="RouteTableId")]
     pub route_table_id: String,
 }
 
@@ -31815,9 +34906,11 @@ impl ReplaceRouteTableAssociationRequestSerializer {
 }
 
 #[doc="<p>Contains the output of ReplaceRouteTableAssociation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplaceRouteTableAssociationResult {
     #[doc="<p>The ID of the new association.</p>"]
+    #[serde(rename="NewAssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_association_id: Option<String>,
 }
 
@@ -31866,21 +34959,32 @@ impl ReplaceRouteTableAssociationResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ReportInstanceStatus.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReportInstanceStatusRequest {
     #[doc="<p>Descriptive text about the health state of your instance.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The time at which the reported instance health state ended.</p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>One or more instances.</p>"]
+    #[serde(rename="Instances")]
     pub instances: Vec<String>,
     #[doc="<p>One or more reason codes that describes the health state of your instance.</p> <ul> <li> <p> <code>instance-stuck-in-state</code>: My instance is stuck in a state.</p> </li> <li> <p> <code>unresponsive</code>: My instance is unresponsive.</p> </li> <li> <p> <code>not-accepting-credentials</code>: My instance is not accepting my credentials.</p> </li> <li> <p> <code>password-not-available</code>: A password is not available for my instance.</p> </li> <li> <p> <code>performance-network</code>: My instance is experiencing performance problems which I believe are network related.</p> </li> <li> <p> <code>performance-instance-store</code>: My instance is experiencing performance problems which I believe are related to the instance stores.</p> </li> <li> <p> <code>performance-ebs-volume</code>: My instance is experiencing performance problems which I believe are related to an EBS volume.</p> </li> <li> <p> <code>performance-other</code>: My instance is experiencing performance problems.</p> </li> <li> <p> <code>other</code>: [explain using the description parameter]</p> </li> </ul>"]
+    #[serde(rename="ReasonCodes")]
     pub reason_codes: Vec<String>,
     #[doc="<p>The time at which the reported instance health state began.</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
     #[doc="<p>The status of all instances listed.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
 }
 
@@ -31947,11 +35051,14 @@ impl RequestHostIdSetSerializer {
 }
 
 #[doc="<p>Contains the parameters for RequestSpotFleet.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestSpotFleetRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The configuration for the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestConfig")]
     pub spot_fleet_request_config: SpotFleetRequestConfigData,
 }
 
@@ -31979,9 +35086,10 @@ impl RequestSpotFleetRequestSerializer {
 }
 
 #[doc="<p>Contains the output of RequestSpotFleet.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestSpotFleetResponse {
     #[doc="<p>The ID of the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestId")]
     pub spot_fleet_request_id: String,
 }
 
@@ -32028,29 +35136,50 @@ impl RequestSpotFleetResponseDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for RequestSpotInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestSpotInstancesRequest {
     #[doc="<p>The user-specified name for a logical grouping of bids.</p> <p>When you specify an Availability Zone group in a Spot Instance request, all Spot instances in the request are launched in the same Availability Zone. Instance proximity is maintained with this parameter, but the choice of Availability Zone is not. The group applies only to bids for Spot Instances of the same instance type. Any additional Spot instance requests that are specified with the same Availability Zone group name are launched in that same Availability Zone, as long as at least one instance from the group is still active.</p> <p>If there is no active instance running in the Availability Zone group that you specify for a new Spot instance request (all instances are terminated, the bid is expired, or the bid falls below current market), then Amazon EC2 launches the instance in any Availability Zone where the constraint can be met. Consequently, the subsequent set of Spot instances could be placed in a different zone from the original request, even if you specified the same Availability Zone group.</p> <p>Default: Instances are launched in any available Availability Zone.</p>"]
+    #[serde(rename="AvailabilityZoneGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone_group: Option<String>,
     #[doc="<p>The required duration for the Spot instances (also known as Spot blocks), in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).</p> <p>The duration period starts as soon as your Spot instance receives its instance ID. At the end of the duration period, Amazon EC2 marks the Spot instance for termination and provides a Spot instance termination notice, which gives the instance a two-minute warning before it terminates.</p> <p>Note that you can't specify an Availability Zone group or a launch group if you specify a duration.</p>"]
+    #[serde(rename="BlockDurationMinutes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_duration_minutes: Option<i64>,
     #[doc="<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html\">How to Ensure Idempotency</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The maximum number of Spot instances to launch.</p> <p>Default: 1</p>"]
+    #[serde(rename="InstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_count: Option<i64>,
     #[doc="<p>The instance launch group. Launch groups are Spot instances that launch together and terminate together.</p> <p>Default: Instances are launched and terminated individually</p>"]
+    #[serde(rename="LaunchGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_group: Option<String>,
     #[doc="<p>The launch specification.</p>"]
+    #[serde(rename="LaunchSpecification")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_specification: Option<RequestSpotLaunchSpecification>,
     #[doc="<p>The maximum hourly price (bid) for any Spot instance launched to fulfill the request.</p>"]
+    #[serde(rename="SpotPrice")]
     pub spot_price: String,
     #[doc="<p>The Spot instance request type.</p> <p>Default: <code>one-time</code> </p>"]
+    #[serde(rename="Type")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
     #[doc="<p>The start date of the request. If this is a one-time request, the request becomes active at this date and time and remains active until all instances launch, the request expires, or the request is canceled. If the request is persistent, the request becomes active at this date and time and remains active until it expires or is canceled.</p> <p>Default: The request is effective indefinitely.</p>"]
+    #[serde(rename="ValidFrom")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub valid_from: Option<String>,
     #[doc="<p>The end date of the request. If this is a one-time request, the request remains active until all instances launch, the request is canceled, or this date is reached. If the request is persistent, it remains active until it is canceled or this date and time is reached.</p> <p>Default: The request is effective indefinitely.</p>"]
+    #[serde(rename="ValidUntil")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub valid_until: Option<String>,
 }
 
@@ -32114,9 +35243,11 @@ impl RequestSpotInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of RequestSpotInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestSpotInstancesResult {
     #[doc="<p>One or more Spot instance requests.</p>"]
+    #[serde(rename="SpotInstanceRequests")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_instance_requests: Option<Vec<SpotInstanceRequest>>,
 }
 
@@ -32164,39 +35295,71 @@ impl RequestSpotInstancesResultDeserializer {
     }
 }
 #[doc="<p>Describes the launch specification for an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestSpotLaunchSpecification {
     #[doc="<p>Deprecated.</p>"]
+    #[serde(rename="AddressingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub addressing_type: Option<String>,
     #[doc="<p>One or more block device mapping entries.</p> <p>Although you can specify encrypted EBS volumes in this block device mapping for your Spot Instances, these volumes are not encrypted.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
     #[doc="<p>Indicates whether the instance is optimized for EBS I/O. This optimization provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal EBS I/O performance. This optimization isn't available with all instance types. Additional usage charges apply when using an EBS Optimized instance.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EbsOptimized")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs_optimized: Option<bool>,
     #[doc="<p>The IAM instance profile.</p>"]
+    #[serde(rename="IamInstanceProfile")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile: Option<IamInstanceProfileSpecification>,
     #[doc="<p>The ID of the AMI.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
     #[doc="<p>The instance type.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The ID of the kernel.</p>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<String>,
     #[doc="<p>The name of the key pair.</p>"]
+    #[serde(rename="KeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_name: Option<String>,
     #[doc="<p>Indicates whether basic or detailed monitoring is enabled for the instance.</p> <p>Default: Disabled</p>"]
+    #[serde(rename="Monitoring")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring: Option<RunInstancesMonitoringEnabled>,
     #[doc="<p>One or more network interfaces. If you specify a network interface, you must specify subnet IDs and security group IDs using the network interface.</p>"]
+    #[serde(rename="NetworkInterfaces")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interfaces: Option<Vec<InstanceNetworkInterfaceSpecification>>,
     #[doc="<p>The placement information for the instance.</p>"]
+    #[serde(rename="Placement")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement: Option<SpotPlacement>,
     #[doc="<p>The ID of the RAM disk.</p>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<String>,
     #[doc="<p>One or more security group IDs.</p>"]
+    #[serde(rename="SecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_group_ids: Option<Vec<String>>,
     #[doc="<p>One or more security groups. When requesting instances in a VPC, you must specify the IDs of the security groups. When requesting instances in EC2-Classic, you can specify the names or the IDs of the security groups.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<String>>,
     #[doc="<p>The ID of the subnet in which to launch the instance.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>The user data to make available to the instances. If you are using an AWS SDK or command line tool, Base64-encoding is performed for you, and you can load the text from a file. Otherwise, you must provide Base64-encoded text.</p>"]
+    #[serde(rename="UserData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_data: Option<String>,
 }
 
@@ -32294,17 +35457,27 @@ impl RequestSpotLaunchSpecificationSerializer {
 }
 
 #[doc="<p>Describes a reservation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Reservation {
     #[doc="<p>[EC2-Classic only] One or more security groups.</p>"]
+    #[serde(rename="Groups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub groups: Option<Vec<GroupIdentifier>>,
     #[doc="<p>One or more instances.</p>"]
+    #[serde(rename="Instances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instances: Option<Vec<Instance>>,
     #[doc="<p>The ID of the AWS account that owns the reservation.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
     #[doc="<p>The ID of the requester that launched the instances on your behalf (for example, AWS Management Console or Auto Scaling).</p>"]
+    #[serde(rename="RequesterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub requester_id: Option<String>,
     #[doc="<p>The ID of the reservation.</p>"]
+    #[serde(rename="ReservationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reservation_id: Option<String>,
 }
 
@@ -32424,13 +35597,19 @@ impl ReservationStateDeserializer {
     }
 }
 #[doc="<p>The cost associated with the Reserved Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservationValue {
     #[doc="<p>The hourly rate of the reservation.</p>"]
+    #[serde(rename="HourlyPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hourly_price: Option<String>,
     #[doc="<p>The balance of the total value (the sum of remainingUpfrontValue + hourlyPrice * number of hours remaining).</p>"]
+    #[serde(rename="RemainingTotalValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub remaining_total_value: Option<String>,
     #[doc="<p>The remaining upfront cost of the reservation.</p>"]
+    #[serde(rename="RemainingUpfrontValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub remaining_upfront_value: Option<String>,
 }
 
@@ -32499,11 +35678,15 @@ impl ReservedInstanceIdSetSerializer {
 }
 
 #[doc="<p>Describes the limit price of a Reserved Instance offering.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedInstanceLimitPrice {
     #[doc="<p>Used for Reserved Instance Marketplace offerings. Specifies the limit price on the total order (instanceCount * price).</p>"]
+    #[serde(rename="Amount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub amount: Option<f64>,
     #[doc="<p>The currency in which the <code>limitPrice</code> amount is specified. At this time, the only supported currency is <code>USD</code>.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
 }
 
@@ -32530,11 +35713,15 @@ impl ReservedInstanceLimitPriceSerializer {
 }
 
 #[doc="<p>The total value of the Convertible Reserved Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedInstanceReservationValue {
     #[doc="<p>The total value of the Convertible Reserved Instance that you are exchanging.</p>"]
+    #[serde(rename="ReservationValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reservation_value: Option<ReservationValue>,
     #[doc="<p>The ID of the Convertible Reserved Instance that you are exchanging.</p>"]
+    #[serde(rename="ReservedInstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instance_id: Option<String>,
 }
 
@@ -32644,43 +35831,79 @@ impl ReservedInstanceStateDeserializer {
     }
 }
 #[doc="<p>Describes a Reserved Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedInstances {
     #[doc="<p>The Availability Zone in which the Reserved Instance can be used.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The currency of the Reserved Instance. It's specified using ISO 4217 standard currency codes. At this time, the only supported currency is <code>USD</code>.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The duration of the Reserved Instance, in seconds.</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The time when the Reserved Instance expires.</p>"]
+    #[serde(rename="End")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end: Option<String>,
     #[doc="<p>The purchase price of the Reserved Instance.</p>"]
+    #[serde(rename="FixedPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fixed_price: Option<f32>,
     #[doc="<p>The number of reservations purchased.</p>"]
+    #[serde(rename="InstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_count: Option<i64>,
     #[doc="<p>The tenancy of the instance.</p>"]
+    #[serde(rename="InstanceTenancy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_tenancy: Option<String>,
     #[doc="<p>The instance type on which the Reserved Instance can be used.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The offering class of the Reserved Instance.</p>"]
+    #[serde(rename="OfferingClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_class: Option<String>,
     #[doc="<p>The Reserved Instance offering type.</p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The Reserved Instance product platform description.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The recurring charge tag assigned to the resource.</p>"]
+    #[serde(rename="RecurringCharges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charges: Option<Vec<RecurringCharge>>,
     #[doc="<p>The ID of the Reserved Instance.</p>"]
+    #[serde(rename="ReservedInstancesId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_id: Option<String>,
     #[doc="<p>The scope of the Reserved Instance.</p>"]
+    #[serde(rename="Scope")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scope: Option<String>,
     #[doc="<p>The date and time the Reserved Instance started.</p>"]
+    #[serde(rename="Start")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start: Option<String>,
     #[doc="<p>The state of the Reserved Instance purchase.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>Any tags assigned to the resource.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The usage price of the Reserved Instance, per hour.</p>"]
+    #[serde(rename="UsagePrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub usage_price: Option<f32>,
 }
 
@@ -32804,17 +36027,27 @@ impl ReservedInstancesDeserializer {
     }
 }
 #[doc="<p>Describes the configuration settings for the modified Reserved Instances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedInstancesConfiguration {
     #[doc="<p>The Availability Zone for the modified Reserved Instances.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The number of modified Reserved Instances.</p>"]
+    #[serde(rename="InstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_count: Option<i64>,
     #[doc="<p>The instance type for the modified Reserved Instances.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The network platform of the modified Reserved Instances, which is either EC2-Classic or EC2-VPC.</p>"]
+    #[serde(rename="Platform")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform: Option<String>,
     #[doc="<p>Whether the Reserved Instance is applied to instances in a region or instances in a specific Availability Zone.</p>"]
+    #[serde(rename="Scope")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scope: Option<String>,
 }
 
@@ -32925,9 +36158,11 @@ impl ReservedInstancesConfigurationListSerializer {
 }
 
 #[doc="<p>Describes the ID of a Reserved Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedInstancesId {
     #[doc="<p>The ID of the Reserved Instance.</p>"]
+    #[serde(rename="ReservedInstancesId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_id: Option<String>,
 }
 
@@ -33028,27 +36263,47 @@ impl ReservedInstancesListDeserializer {
     }
 }
 #[doc="<p>Describes a Reserved Instance listing.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedInstancesListing {
     #[doc="<p>A unique, case-sensitive key supplied by the client to ensure that the request is idempotent. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html\">Ensuring Idempotency</a>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>The time the listing was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>The number of instances in this state.</p>"]
+    #[serde(rename="InstanceCounts")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_counts: Option<Vec<InstanceCount>>,
     #[doc="<p>The price of the Reserved Instance listing.</p>"]
+    #[serde(rename="PriceSchedules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub price_schedules: Option<Vec<PriceSchedule>>,
     #[doc="<p>The ID of the Reserved Instance.</p>"]
+    #[serde(rename="ReservedInstancesId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_id: Option<String>,
     #[doc="<p>The ID of the Reserved Instance listing.</p>"]
+    #[serde(rename="ReservedInstancesListingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_listing_id: Option<String>,
     #[doc="<p>The status of the Reserved Instance listing.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The reason for the current status of the Reserved Instance listing. The response can be blank.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
     #[doc="<p>Any tags assigned to the resource.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The last modified timestamp of the listing.</p>"]
+    #[serde(rename="UpdateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub update_date: Option<String>,
 }
 
@@ -33177,25 +36432,43 @@ impl ReservedInstancesListingListDeserializer {
     }
 }
 #[doc="<p>Describes a Reserved Instance modification.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedInstancesModification {
     #[doc="<p>A unique, case-sensitive key supplied by the client to ensure that the request is idempotent. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html\">Ensuring Idempotency</a>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>The time when the modification request was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>The time for the modification to become effective.</p>"]
+    #[serde(rename="EffectiveDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub effective_date: Option<String>,
     #[doc="<p>Contains target configurations along with their corresponding new Reserved Instance IDs.</p>"]
+    #[serde(rename="ModificationResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub modification_results: Option<Vec<ReservedInstancesModificationResult>>,
     #[doc="<p>The IDs of one or more Reserved Instances.</p>"]
+    #[serde(rename="ReservedInstancesIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_ids: Option<Vec<ReservedInstancesId>>,
     #[doc="<p>A unique ID for the Reserved Instance modification.</p>"]
+    #[serde(rename="ReservedInstancesModificationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_modification_id: Option<String>,
     #[doc="<p>The status of the Reserved Instances modification request.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The reason for the status.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
     #[doc="<p>The time when the modification request was last updated.</p>"]
+    #[serde(rename="UpdateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub update_date: Option<String>,
 }
 
@@ -33330,11 +36603,15 @@ impl ReservedInstancesModificationListDeserializer {
     }
 }
 #[doc="<p>Describes the modification request/s.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedInstancesModificationResult {
     #[doc="<p>The ID for the Reserved Instances that were created as part of the modification request. This field is only available when the modification is fulfilled.</p>"]
+    #[serde(rename="ReservedInstancesId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_id: Option<String>,
     #[doc="<p>The target Reserved Instances configurations supplied as part of the modification request.</p>"]
+    #[serde(rename="TargetConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_configuration: Option<ReservedInstancesConfiguration>,
 }
 
@@ -33428,37 +36705,67 @@ impl ReservedInstancesModificationResultListDeserializer {
     }
 }
 #[doc="<p>Describes a Reserved Instance offering.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedInstancesOffering {
     #[doc="<p>The Availability Zone in which the Reserved Instance can be used.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The currency of the Reserved Instance offering you are purchasing. It's specified using ISO 4217 standard currency codes. At this time, the only supported currency is <code>USD</code>.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The duration of the Reserved Instance, in seconds.</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The purchase price of the Reserved Instance.</p>"]
+    #[serde(rename="FixedPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fixed_price: Option<f32>,
     #[doc="<p>The tenancy of the instance.</p>"]
+    #[serde(rename="InstanceTenancy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_tenancy: Option<String>,
     #[doc="<p>The instance type on which the Reserved Instance can be used.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>Indicates whether the offering is available through the Reserved Instance Marketplace (resale) or AWS. If it's a Reserved Instance Marketplace offering, this is <code>true</code>.</p>"]
+    #[serde(rename="Marketplace")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marketplace: Option<bool>,
     #[doc="<p>If <code>convertible</code> it can be exchanged for Reserved Instances of the same or higher monetary value, with different configurations. If <code>standard</code>, it is not possible to perform an exchange.</p>"]
+    #[serde(rename="OfferingClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_class: Option<String>,
     #[doc="<p>The Reserved Instance offering type.</p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The pricing details of the Reserved Instance offering.</p>"]
+    #[serde(rename="PricingDetails")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pricing_details: Option<Vec<PricingDetail>>,
     #[doc="<p>The Reserved Instance product platform description.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The recurring charge tag assigned to the resource.</p>"]
+    #[serde(rename="RecurringCharges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charges: Option<Vec<RecurringCharge>>,
     #[doc="<p>The ID of the Reserved Instance offering. This is the offering ID used in <a>GetReservedInstancesExchangeQuote</a> to confirm that an exchange can be made.</p>"]
+    #[serde(rename="ReservedInstancesOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_instances_offering_id: Option<String>,
     #[doc="<p>Whether the Reserved Instance is applied to instances in a region or an Availability Zone.</p>"]
+    #[serde(rename="Scope")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scope: Option<String>,
     #[doc="<p>The usage price of the Reserved Instance, per hour.</p>"]
+    #[serde(rename="UsagePrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub usage_price: Option<f32>,
 }
 
@@ -33665,13 +36972,17 @@ impl ReservedIntancesIdsDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ResetImageAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetImageAttributeRequest {
     #[doc="<p>The attribute to reset (currently you can only reset the launch permission attribute).</p>"]
+    #[serde(rename="Attribute")]
     pub attribute: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the AMI.</p>"]
+    #[serde(rename="ImageId")]
     pub image_id: String,
 }
 
@@ -33698,13 +37009,17 @@ impl ResetImageAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ResetInstanceAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetInstanceAttributeRequest {
     #[doc="<p>The attribute to reset.</p> <important> <p>You can only reset the following attributes: <code>kernel</code> | <code>ramdisk</code> | <code>sourceDestCheck</code>. To change an instance attribute, use <a>ModifyInstanceAttribute</a>.</p> </important>"]
+    #[serde(rename="Attribute")]
     pub attribute: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
     pub instance_id: String,
 }
 
@@ -33731,13 +37046,18 @@ impl ResetInstanceAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ResetNetworkInterfaceAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetNetworkInterfaceAttributeRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
     pub network_interface_id: String,
     #[doc="<p>The source/destination checking attribute. Resets the value to <code>true</code>.</p>"]
+    #[serde(rename="SourceDestCheck")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_dest_check: Option<String>,
 }
 
@@ -33766,13 +37086,17 @@ impl ResetNetworkInterfaceAttributeRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for ResetSnapshotAttribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetSnapshotAttributeRequest {
     #[doc="<p>The attribute to reset. Currently, only the attribute for permission to create volumes can be reset.</p>"]
+    #[serde(rename="Attribute")]
     pub attribute: String,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The ID of the snapshot.</p>"]
+    #[serde(rename="SnapshotId")]
     pub snapshot_id: String,
 }
 
@@ -33919,11 +37243,14 @@ impl RestorableByStringListSerializer {
 }
 
 #[doc="<p>Contains the parameters for RestoreAddressToClassic.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreAddressToClassicRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The Elastic IP address.</p>"]
+    #[serde(rename="PublicIp")]
     pub public_ip: String,
 }
 
@@ -33948,11 +37275,15 @@ impl RestoreAddressToClassicRequestSerializer {
 }
 
 #[doc="<p>Contains the output of RestoreAddressToClassic.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreAddressToClassicResult {
     #[doc="<p>The Elastic IP address.</p>"]
+    #[serde(rename="PublicIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip: Option<String>,
     #[doc="<p>The move status for the IP address.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -34003,25 +37334,42 @@ impl RestoreAddressToClassicResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for RevokeSecurityGroupEgress.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevokeSecurityGroupEgressRequest {
     #[doc="<p>The CIDR IP address range. We recommend that you specify the CIDR range in a set of IP permissions instead.</p>"]
+    #[serde(rename="CidrIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_ip: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The start of port range for the TCP and UDP protocols, or an ICMP type number. We recommend that you specify the port range in a set of IP permissions instead.</p>"]
+    #[serde(rename="FromPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub from_port: Option<i64>,
     #[doc="<p>The ID of the security group.</p>"]
+    #[serde(rename="GroupId")]
     pub group_id: String,
     #[doc="<p>A set of IP permissions. You can't specify a destination security group and a CIDR IP address range.</p>"]
+    #[serde(rename="IpPermissions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_permissions: Option<Vec<IpPermission>>,
     #[doc="<p>The IP protocol name or number. We recommend that you specify the protocol in a set of IP permissions instead.</p>"]
+    #[serde(rename="IpProtocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_protocol: Option<String>,
     #[doc="<p>The name of a destination security group. To revoke outbound access to a destination security group, we recommend that you use a set of IP permissions instead.</p>"]
+    #[serde(rename="SourceSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_security_group_name: Option<String>,
     #[doc="<p>The AWS account number for a destination security group. To revoke outbound access to a destination security group, we recommend that you use a set of IP permissions instead.</p>"]
+    #[serde(rename="SourceSecurityGroupOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_security_group_owner_id: Option<String>,
     #[doc="<p>The end of port range for the TCP and UDP protocols, or an ICMP type number. We recommend that you specify the port range in a set of IP permissions instead.</p>"]
+    #[serde(rename="ToPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub to_port: Option<i64>,
 }
 
@@ -34075,27 +37423,47 @@ impl RevokeSecurityGroupEgressRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for RevokeSecurityGroupIngress.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevokeSecurityGroupIngressRequest {
     #[doc="<p>The CIDR IP address range. You can't specify this parameter when specifying a source security group.</p>"]
+    #[serde(rename="CidrIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_ip: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The start of port range for the TCP and UDP protocols, or an ICMP type number. For the ICMP type number, use <code>-1</code> to specify all ICMP types.</p>"]
+    #[serde(rename="FromPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub from_port: Option<i64>,
     #[doc="<p>The ID of the security group. Required for a security group in a nondefault VPC.</p>"]
+    #[serde(rename="GroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_id: Option<String>,
     #[doc="<p>[EC2-Classic, default VPC] The name of the security group.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>A set of IP permissions. You can't specify a source security group and a CIDR IP address range.</p>"]
+    #[serde(rename="IpPermissions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_permissions: Option<Vec<IpPermission>>,
     #[doc="<p>The IP protocol name (<code>tcp</code>, <code>udp</code>, <code>icmp</code>) or number (see <a href=\"http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml\">Protocol Numbers</a>). Use <code>-1</code> to specify all.</p>"]
+    #[serde(rename="IpProtocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_protocol: Option<String>,
     #[doc="<p>[EC2-Classic, default VPC] The name of the source security group. You can't specify this parameter in combination with the following parameters: the CIDR IP address range, the start of the port range, the IP protocol, and the end of the port range. For EC2-VPC, the source security group must be in the same VPC. To revoke a specific rule for an IP protocol and port range, use a set of IP permissions instead.</p>"]
+    #[serde(rename="SourceSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_security_group_name: Option<String>,
     #[doc="<p>[EC2-Classic] The AWS account ID of the source security group, if the source security group is in a different account. You can't specify this parameter in combination with the following parameters: the CIDR IP address range, the IP protocol, the start of the port range, and the end of the port range. To revoke a specific rule for an IP protocol and port range, use a set of IP permissions instead.</p>"]
+    #[serde(rename="SourceSecurityGroupOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_security_group_owner_id: Option<String>,
     #[doc="<p>The end of port range for the TCP and UDP protocols, or an ICMP code number. For the ICMP code number, use <code>-1</code> to specify all ICMP codes for the ICMP type.</p>"]
+    #[serde(rename="ToPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub to_port: Option<i64>,
 }
 
@@ -34155,31 +37523,55 @@ impl RevokeSecurityGroupIngressRequestSerializer {
 }
 
 #[doc="<p>Describes a route in a route table.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Route {
     #[doc="<p>The IPv4 CIDR block used for the destination match.</p>"]
+    #[serde(rename="DestinationCidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_cidr_block: Option<String>,
     #[doc="<p>The IPv6 CIDR block used for the destination match.</p>"]
+    #[serde(rename="DestinationIpv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_ipv_6_cidr_block: Option<String>,
     #[doc="<p>The prefix of the AWS service.</p>"]
+    #[serde(rename="DestinationPrefixListId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_prefix_list_id: Option<String>,
     #[doc="<p>The ID of the egress-only Internet gateway.</p>"]
+    #[serde(rename="EgressOnlyInternetGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub egress_only_internet_gateway_id: Option<String>,
     #[doc="<p>The ID of a gateway attached to your VPC.</p>"]
+    #[serde(rename="GatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub gateway_id: Option<String>,
     #[doc="<p>The ID of a NAT instance in your VPC.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The AWS account ID of the owner of the instance.</p>"]
+    #[serde(rename="InstanceOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_owner_id: Option<String>,
     #[doc="<p>The ID of a NAT gateway.</p>"]
+    #[serde(rename="NatGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nat_gateway_id: Option<String>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>Describes how the route was created.</p> <ul> <li> <p> <code>CreateRouteTable</code> - The route was automatically created when the route table was created.</p> </li> <li> <p> <code>CreateRoute</code> - The route was manually added to the route table.</p> </li> <li> <p> <code>EnableVgwRoutePropagation</code> - The route was propagated by route propagation.</p> </li> </ul>"]
+    #[serde(rename="Origin")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub origin: Option<String>,
     #[doc="<p>The state of the route. The <code>blackhole</code> state indicates that the route's target isn't available (for example, the specified gateway isn't attached to the VPC, or the specified NAT instance has been terminated).</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The ID of the VPC peering connection.</p>"]
+    #[serde(rename="VpcPeeringConnectionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_peering_connection_id: Option<String>,
 }
 
@@ -34346,19 +37738,31 @@ impl RouteStateDeserializer {
     }
 }
 #[doc="<p>Describes a route table.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RouteTable {
     #[doc="<p>The associations between the route table and one or more subnets.</p>"]
+    #[serde(rename="Associations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub associations: Option<Vec<RouteTableAssociation>>,
     #[doc="<p>Any virtual private gateway (VGW) propagating routes.</p>"]
+    #[serde(rename="PropagatingVgws")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub propagating_vgws: Option<Vec<PropagatingVgw>>,
     #[doc="<p>The ID of the route table.</p>"]
+    #[serde(rename="RouteTableId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub route_table_id: Option<String>,
     #[doc="<p>The routes in the route table.</p>"]
+    #[serde(rename="Routes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub routes: Option<Vec<Route>>,
     #[doc="<p>Any tags assigned to the route table.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -34425,15 +37829,23 @@ impl RouteTableDeserializer {
     }
 }
 #[doc="<p>Describes an association between a route table and a subnet.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RouteTableAssociation {
     #[doc="<p>Indicates whether this is the main route table.</p>"]
+    #[serde(rename="Main")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub main: Option<bool>,
     #[doc="<p>The ID of the association between a route table and a subnet.</p>"]
+    #[serde(rename="RouteTableAssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub route_table_association_id: Option<String>,
     #[doc="<p>The ID of the route table.</p>"]
+    #[serde(rename="RouteTableId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub route_table_id: Option<String>,
     #[doc="<p>The ID of the subnet. A subnet ID is not returned for an implicit association.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
 }
 
@@ -34589,9 +38001,10 @@ impl RuleActionDeserializer {
     }
 }
 #[doc="<p>Describes the monitoring of an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RunInstancesMonitoringEnabled {
     #[doc="<p>Indicates whether detailed monitoring is enabled. Otherwise, basic monitoring is enabled.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
 }
 
@@ -34653,61 +38066,112 @@ impl RunInstancesMonitoringEnabledSerializer {
 }
 
 #[doc="<p>Contains the parameters for RunInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RunInstancesRequest {
     #[doc="<p>Reserved.</p>"]
+    #[serde(rename="AdditionalInfo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub additional_info: Option<String>,
     #[doc="<p>The block device mapping.</p> <important> <p>Supplying both a snapshot ID and an encryption value as arguments for block-device mapping results in an error. This is because only blank volumes can be encrypted on start, and these are not created from a snapshot. If a snapshot is the basis for the volume, it contains data by definition and its encryption status cannot be changed using this action.</p> </important>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html\">Ensuring Idempotency</a>.</p> <p>Constraints: Maximum 64 ASCII characters</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>If you set this parameter to <code>true</code>, you can't terminate the instance using the Amazon EC2 console, CLI, or API; otherwise, you can. To change this attribute to <code>false</code> after launch, use <a>ModifyInstanceAttribute</a>. Alternatively, if you set <code>InstanceInitiatedShutdownBehavior</code> to <code>terminate</code>, you can terminate the instance by running the shutdown command from the instance.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="DisableApiTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disable_api_termination: Option<bool>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Indicates whether the instance is optimized for EBS I/O. This optimization provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal EBS I/O performance. This optimization isn't available with all instance types. Additional usage charges apply when using an EBS-optimized instance.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EbsOptimized")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs_optimized: Option<bool>,
     #[doc="<p>An Elastic GPU to associate with the instance.</p>"]
+    #[serde(rename="ElasticGpuSpecification")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_gpu_specification: Option<Vec<ElasticGpuSpecification>>,
     #[doc="<p>The IAM instance profile.</p>"]
+    #[serde(rename="IamInstanceProfile")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile: Option<IamInstanceProfileSpecification>,
     #[doc="<p>The ID of the AMI, which you can get by calling <a>DescribeImages</a>.</p>"]
+    #[serde(rename="ImageId")]
     pub image_id: String,
     #[doc="<p>Indicates whether an instance stops or terminates when you initiate shutdown from the instance (using the operating system command for system shutdown).</p> <p>Default: <code>stop</code> </p>"]
+    #[serde(rename="InstanceInitiatedShutdownBehavior")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_initiated_shutdown_behavior: Option<String>,
     #[doc="<p>The instance type. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html\">Instance Types</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p> <p>Default: <code>m1.small</code> </p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>[EC2-VPC] A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet. You cannot specify this option and the option to assign specific IPv6 addresses in the same request. You can specify this option if you've specified a minimum number of instances to launch.</p>"]
+    #[serde(rename="Ipv6AddressCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_address_count: Option<i64>,
     #[doc="<p>[EC2-VPC] Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface. You cannot specify this option and the option to assign a number of IPv6 addresses in the same request. You cannot specify this option if you've specified a minimum number of instances to launch.</p>"]
+    #[serde(rename="Ipv6Addresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_addresses: Option<Vec<InstanceIpv6Address>>,
     #[doc="<p>The ID of the kernel.</p> <important> <p>We recommend that you use PV-GRUB instead of kernels and RAM disks. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedkernels.html\"> PV-GRUB</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p> </important>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<String>,
     #[doc="<p>The name of the key pair. You can create a key pair using <a>CreateKeyPair</a> or <a>ImportKeyPair</a>.</p> <important> <p>If you do not specify a key pair, you can't connect to the instance unless you choose an AMI that is configured to allow users another way to log in.</p> </important>"]
+    #[serde(rename="KeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_name: Option<String>,
     #[doc="<p>The maximum number of instances to launch. If you specify more instances than Amazon EC2 can launch in the target Availability Zone, Amazon EC2 launches the largest possible number of instances above <code>MinCount</code>.</p> <p>Constraints: Between 1 and the maximum number you're allowed for the specified instance type. For more information about the default limits, and how to request an increase, see <a href=\"http://aws.amazon.com/ec2/faqs/#How_many_instances_can_I_run_in_Amazon_EC2\">How many instances can I run in Amazon EC2</a> in the Amazon EC2 FAQ.</p>"]
+    #[serde(rename="MaxCount")]
     pub max_count: i64,
     #[doc="<p>The minimum number of instances to launch. If you specify a minimum that is more instances than Amazon EC2 can launch in the target Availability Zone, Amazon EC2 launches no instances.</p> <p>Constraints: Between 1 and the maximum number you're allowed for the specified instance type. For more information about the default limits, and how to request an increase, see <a href=\"http://aws.amazon.com/ec2/faqs/#How_many_instances_can_I_run_in_Amazon_EC2\">How many instances can I run in Amazon EC2</a> in the Amazon EC2 General FAQ.</p>"]
+    #[serde(rename="MinCount")]
     pub min_count: i64,
     #[doc="<p>The monitoring for the instance.</p>"]
+    #[serde(rename="Monitoring")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring: Option<RunInstancesMonitoringEnabled>,
     #[doc="<p>One or more network interfaces.</p>"]
+    #[serde(rename="NetworkInterfaces")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interfaces: Option<Vec<InstanceNetworkInterfaceSpecification>>,
     #[doc="<p>The placement for the instance.</p>"]
+    #[serde(rename="Placement")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement: Option<Placement>,
     #[doc="<p>[EC2-VPC] The primary IPv4 address. You must specify a value from the IPv4 address range of the subnet.</p> <p>Only one private IP address can be designated as primary. You can't specify this option if you've specified the option to designate a private IP address as the primary IP address in a network interface specification. You cannot specify this option if you're launching more than one instance in the request.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
     #[doc="<p>The ID of the RAM disk.</p> <important> <p>We recommend that you use PV-GRUB instead of kernels and RAM disks. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedkernels.html\"> PV-GRUB</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p> </important>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<String>,
     #[doc="<p>One or more security group IDs. You can create a security group using <a>CreateSecurityGroup</a>.</p> <p>Default: Amazon EC2 uses the default security group.</p>"]
+    #[serde(rename="SecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_group_ids: Option<Vec<String>>,
     #[doc="<p>[EC2-Classic, default VPC] One or more security group names. For a nondefault VPC, you must use security group IDs instead.</p> <p>Default: Amazon EC2 uses the default security group.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<String>>,
     #[doc="<p>[EC2-VPC] The ID of the subnet to launch the instance into.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>The tags to apply to the resources during launch. You can tag instances and volumes. The specified tags are applied to all instances or volumes that are created during launch.</p>"]
+    #[serde(rename="TagSpecifications")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_specifications: Option<Vec<TagSpecification>>,
     #[doc="<p>The user data to make available to the instance. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html\">Running Commands on Your Linux Instance at Launch</a> (Linux) and <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-instance-metadata.html#instancedata-add-user-data\">Adding User Data</a> (Windows). If you are using an AWS SDK or command line tool, Base64-encoding is performed for you, and you can load the text from a file. Otherwise, you must provide Base64-encoded text.</p>"]
+    #[serde(rename="UserData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_data: Option<String>,
 }
 
@@ -34850,17 +38314,25 @@ impl RunInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for RunScheduledInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RunScheduledInstancesRequest {
     #[doc="<p>Unique, case-sensitive identifier that ensures the idempotency of the request. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html\">Ensuring Idempotency</a>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>The number of instances.</p> <p>Default: 1</p>"]
+    #[serde(rename="InstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_count: Option<i64>,
     #[doc="<p>The launch specification. You must match the instance type, Availability Zone, network, and platform of the schedule that you purchased.</p>"]
+    #[serde(rename="LaunchSpecification")]
     pub launch_specification: ScheduledInstancesLaunchSpecification,
     #[doc="<p>The Scheduled Instance ID.</p>"]
+    #[serde(rename="ScheduledInstanceId")]
     pub scheduled_instance_id: String,
 }
 
@@ -34898,9 +38370,11 @@ impl RunScheduledInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of RunScheduledInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RunScheduledInstancesResult {
     #[doc="<p>The IDs of the newly launched instances.</p>"]
+    #[serde(rename="InstanceIdSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id_set: Option<Vec<String>>,
 }
 
@@ -34948,17 +38422,31 @@ impl RunScheduledInstancesResultDeserializer {
     }
 }
 #[doc="<p>Describes the storage parameters for S3 and S3 buckets for an instance store-backed AMI.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3Storage {
     #[doc="<p>The access key ID of the owner of the bucket. Before you specify a value for your access key ID, review and follow the guidance in <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html\">Best Practices for Managing AWS Access Keys</a>.</p>"]
+    #[serde(rename="AWSAccessKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub aws_access_key_id: Option<String>,
     #[doc="<p>The bucket in which to store the AMI. You can specify a bucket that you already own or a new bucket that Amazon EC2 creates on your behalf. If you specify a bucket that belongs to someone else, Amazon EC2 returns an error.</p>"]
+    #[serde(rename="Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bucket: Option<String>,
     #[doc="<p>The beginning of the file name of the AMI.</p>"]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="<p>An Amazon S3 upload policy that gives Amazon EC2 permission to upload items into Amazon S3 on your behalf.</p>"]
+    #[serde(rename="UploadPolicy")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub upload_policy: Option<Vec<u8>>,
     #[doc="<p>The signature of the JSON document.</p>"]
+    #[serde(rename="UploadPolicySignature")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_policy_signature: Option<String>,
 }
 
@@ -35059,37 +38547,67 @@ impl S3StorageSerializer {
 }
 
 #[doc="<p>Describes a Scheduled Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstance {
     #[doc="<p>The Availability Zone.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The date when the Scheduled Instance was purchased.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>The hourly price for a single instance.</p>"]
+    #[serde(rename="HourlyPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hourly_price: Option<String>,
     #[doc="<p>The number of instances.</p>"]
+    #[serde(rename="InstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_count: Option<i64>,
     #[doc="<p>The instance type.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The network platform (<code>EC2-Classic</code> or <code>EC2-VPC</code>).</p>"]
+    #[serde(rename="NetworkPlatform")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_platform: Option<String>,
     #[doc="<p>The time for the next schedule to start.</p>"]
+    #[serde(rename="NextSlotStartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_slot_start_time: Option<String>,
     #[doc="<p>The platform (<code>Linux/UNIX</code> or <code>Windows</code>).</p>"]
+    #[serde(rename="Platform")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform: Option<String>,
     #[doc="<p>The time that the previous schedule ended or will end.</p>"]
+    #[serde(rename="PreviousSlotEndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub previous_slot_end_time: Option<String>,
     #[doc="<p>The schedule recurrence.</p>"]
+    #[serde(rename="Recurrence")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurrence: Option<ScheduledInstanceRecurrence>,
     #[doc="<p>The Scheduled Instance ID.</p>"]
+    #[serde(rename="ScheduledInstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheduled_instance_id: Option<String>,
     #[doc="<p>The number of hours in the schedule.</p>"]
+    #[serde(rename="SlotDurationInHours")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub slot_duration_in_hours: Option<i64>,
     #[doc="<p>The end date for the Scheduled Instance.</p>"]
+    #[serde(rename="TermEndDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub term_end_date: Option<String>,
     #[doc="<p>The start date for the Scheduled Instance.</p>"]
+    #[serde(rename="TermStartDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub term_start_date: Option<String>,
     #[doc="<p>The total number of hours for a single instance for the entire term.</p>"]
+    #[serde(rename="TotalScheduledInstanceHours")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub total_scheduled_instance_hours: Option<i64>,
 }
 
@@ -35200,33 +38718,59 @@ impl ScheduledInstanceDeserializer {
     }
 }
 #[doc="<p>Describes a schedule that is available for your Scheduled Instances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstanceAvailability {
     #[doc="<p>The Availability Zone.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The number of available instances.</p>"]
+    #[serde(rename="AvailableInstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub available_instance_count: Option<i64>,
     #[doc="<p>The time period for the first schedule to start.</p>"]
+    #[serde(rename="FirstSlotStartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub first_slot_start_time: Option<String>,
     #[doc="<p>The hourly price for a single instance.</p>"]
+    #[serde(rename="HourlyPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hourly_price: Option<String>,
     #[doc="<p>The instance type. You can specify one of the C3, C4, M4, or R3 instance types.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The maximum term. The only possible value is 365 days.</p>"]
+    #[serde(rename="MaxTermDurationInDays")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_term_duration_in_days: Option<i64>,
     #[doc="<p>The minimum term. The only possible value is 365 days.</p>"]
+    #[serde(rename="MinTermDurationInDays")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_term_duration_in_days: Option<i64>,
     #[doc="<p>The network platform (<code>EC2-Classic</code> or <code>EC2-VPC</code>).</p>"]
+    #[serde(rename="NetworkPlatform")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_platform: Option<String>,
     #[doc="<p>The platform (<code>Linux/UNIX</code> or <code>Windows</code>).</p>"]
+    #[serde(rename="Platform")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform: Option<String>,
     #[doc="<p>The purchase token. This token expires in two hours.</p>"]
+    #[serde(rename="PurchaseToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub purchase_token: Option<String>,
     #[doc="<p>The schedule recurrence.</p>"]
+    #[serde(rename="Recurrence")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurrence: Option<ScheduledInstanceRecurrence>,
     #[doc="<p>The number of hours in the schedule.</p>"]
+    #[serde(rename="SlotDurationInHours")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub slot_duration_in_hours: Option<i64>,
     #[doc="<p>The total number of hours for a single instance for the entire term.</p>"]
+    #[serde(rename="TotalScheduledInstanceHours")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub total_scheduled_instance_hours: Option<i64>,
 }
 
@@ -35382,17 +38926,27 @@ impl ScheduledInstanceIdRequestSetSerializer {
 }
 
 #[doc="<p>Describes the recurring schedule for a Scheduled Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstanceRecurrence {
     #[doc="<p>The frequency (<code>Daily</code>, <code>Weekly</code>, or <code>Monthly</code>).</p>"]
+    #[serde(rename="Frequency")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub frequency: Option<String>,
     #[doc="<p>The interval quantity. The interval unit depends on the value of <code>frequency</code>. For example, every 2 weeks or every 2 months.</p>"]
+    #[serde(rename="Interval")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub interval: Option<i64>,
     #[doc="<p>The days. For a monthly schedule, this is one or more days of the month (1-31). For a weekly schedule, this is one or more days of the week (1-7, where 1 is Sunday).</p>"]
+    #[serde(rename="OccurrenceDaySet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub occurrence_day_set: Option<Vec<i64>>,
     #[doc="<p>Indicates whether the occurrence is relative to the end of the specified week or month.</p>"]
+    #[serde(rename="OccurrenceRelativeToEnd")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub occurrence_relative_to_end: Option<bool>,
     #[doc="<p>The unit for <code>occurrenceDaySet</code> (<code>DayOfWeek</code> or <code>DayOfMonth</code>).</p>"]
+    #[serde(rename="OccurrenceUnit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub occurrence_unit: Option<String>,
 }
 
@@ -35458,17 +39012,27 @@ impl ScheduledInstanceRecurrenceDeserializer {
     }
 }
 #[doc="<p>Describes the recurring schedule for a Scheduled Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstanceRecurrenceRequest {
     #[doc="<p>The frequency (<code>Daily</code>, <code>Weekly</code>, or <code>Monthly</code>).</p>"]
+    #[serde(rename="Frequency")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub frequency: Option<String>,
     #[doc="<p>The interval quantity. The interval unit depends on the value of <code>Frequency</code>. For example, every 2 weeks or every 2 months.</p>"]
+    #[serde(rename="Interval")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub interval: Option<i64>,
     #[doc="<p>The days. For a monthly schedule, this is one or more days of the month (1-31). For a weekly schedule, this is one or more days of the week (1-7, where 1 is Sunday). You can't specify this value with a daily schedule. If the occurrence is relative to the end of the month, you can specify only a single day.</p>"]
+    #[serde(rename="OccurrenceDays")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub occurrence_days: Option<Vec<i64>>,
     #[doc="<p>Indicates whether the occurrence is relative to the end of the specified week or month. You can't specify this value with a daily schedule.</p>"]
+    #[serde(rename="OccurrenceRelativeToEnd")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub occurrence_relative_to_end: Option<bool>,
     #[doc="<p>The unit for <code>OccurrenceDays</code> (<code>DayOfWeek</code> or <code>DayOfMonth</code>). This value is required for a monthly schedule. You can't specify <code>DayOfWeek</code> with a weekly schedule. You can't specify this value with a daily schedule.</p>"]
+    #[serde(rename="OccurrenceUnit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub occurrence_unit: Option<String>,
 }
 
@@ -35549,15 +39113,23 @@ impl ScheduledInstanceSetDeserializer {
     }
 }
 #[doc="<p>Describes a block device mapping for a Scheduled Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstancesBlockDeviceMapping {
     #[doc="<p>The device name exposed to the instance (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>"]
+    #[serde(rename="DeviceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device_name: Option<String>,
     #[doc="<p>Parameters used to set up EBS volumes automatically when the instance is launched.</p>"]
+    #[serde(rename="Ebs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs: Option<ScheduledInstancesEbs>,
     #[doc="<p>Suppresses the specified device included in the block device mapping of the AMI.</p>"]
+    #[serde(rename="NoDevice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub no_device: Option<String>,
     #[doc="<p>The virtual device name (<code>ephemeral</code>N). Instance store volumes are numbered starting from 0. An instance type with two available instance store volumes can specify mappings for <code>ephemeral0</code> and <code>ephemeral1</code>.The number of available instance store volumes depends on the instance type. After you connect to the instance, you must mount the volume.</p> <p>Constraints: For M3 instances, you must specify instance store volumes in the block device mapping for the instance. When you launch an M3 instance, we ignore any instance store volumes specified in the block device mapping for the AMI.</p>"]
+    #[serde(rename="VirtualName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub virtual_name: Option<String>,
 }
 
@@ -35607,19 +39179,31 @@ impl ScheduledInstancesBlockDeviceMappingSetSerializer {
 }
 
 #[doc="<p>Describes an EBS volume for a Scheduled Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstancesEbs {
     #[doc="<p>Indicates whether the volume is deleted on instance termination.</p>"]
+    #[serde(rename="DeleteOnTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_on_termination: Option<bool>,
     #[doc="<p>Indicates whether the volume is encrypted. You can attached encrypted volumes only to instances that support them.</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>The number of I/O operations per second (IOPS) that the volume supports. For io1 volumes, this represents the number of IOPS that are provisioned for the volume. For <code>gp2</code> volumes, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting. For more information about <code>gp2</code> baseline performance, I/O credits, and bursting, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html\">Amazon EBS Volume Types</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p> <p>Constraint: Range is 100-20000 IOPS for <code>io1</code> volumes and 100-10000 IOPS for <code>gp2</code> volumes.</p> <p>Condition: This parameter is required for requests to create <code>io1</code>volumes; it is not used in requests to create <code>gp2</code>, <code>st1</code>, <code>sc1</code>, or <code>standard</code> volumes.</p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>The ID of the snapshot.</p>"]
+    #[serde(rename="SnapshotId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_id: Option<String>,
     #[doc="<p>The size of the volume, in GiB.</p> <p>Default: If you're creating the volume from a snapshot and don't specify a volume size, the default is the snapshot size.</p>"]
+    #[serde(rename="VolumeSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_size: Option<i64>,
     #[doc="<p>The volume type. <code>gp2</code> for General Purpose SSD, <code>io1</code> for Provisioned IOPS SSD, Throughput Optimized HDD for <code>st1</code>, Cold HDD for <code>sc1</code>, or <code>standard</code> for Magnetic.</p> <p>Default: <code>standard</code> </p>"]
+    #[serde(rename="VolumeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_type: Option<String>,
 }
 
@@ -35662,11 +39246,15 @@ impl ScheduledInstancesEbsSerializer {
 }
 
 #[doc="<p>Describes an IAM instance profile for a Scheduled Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstancesIamInstanceProfile {
     #[doc="<p>The Amazon Resource Name (ARN).</p>"]
+    #[serde(rename="Arn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
     #[doc="<p>The name.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -35693,9 +39281,11 @@ impl ScheduledInstancesIamInstanceProfileSerializer {
 }
 
 #[doc="<p>Describes an IPv6 address.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstancesIpv6Address {
     #[doc="<p>The IPv6 address.</p>"]
+    #[serde(rename="Ipv6Address")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_address: Option<String>,
 }
 
@@ -35730,35 +39320,62 @@ impl ScheduledInstancesIpv6AddressListSerializer {
 }
 
 #[doc="<p>Describes the launch specification for a Scheduled Instance.</p> <p>If you are launching the Scheduled Instance in EC2-VPC, you must specify the ID of the subnet. You can specify the subnet using either <code>SubnetId</code> or <code>NetworkInterface</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstancesLaunchSpecification {
     #[doc="<p>One or more block device mapping entries.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<ScheduledInstancesBlockDeviceMapping>>,
     #[doc="<p>Indicates whether the instances are optimized for EBS I/O. This optimization provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal EBS I/O performance. This optimization isn't available with all instance types. Additional usage charges apply when using an EBS-optimized instance.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EbsOptimized")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs_optimized: Option<bool>,
     #[doc="<p>The IAM instance profile.</p>"]
+    #[serde(rename="IamInstanceProfile")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile: Option<ScheduledInstancesIamInstanceProfile>,
     #[doc="<p>The ID of the Amazon Machine Image (AMI).</p>"]
+    #[serde(rename="ImageId")]
     pub image_id: String,
     #[doc="<p>The instance type.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The ID of the kernel.</p>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<String>,
     #[doc="<p>The name of the key pair.</p>"]
+    #[serde(rename="KeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_name: Option<String>,
     #[doc="<p>Enable or disable monitoring for the instances.</p>"]
+    #[serde(rename="Monitoring")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring: Option<ScheduledInstancesMonitoring>,
     #[doc="<p>One or more network interfaces.</p>"]
+    #[serde(rename="NetworkInterfaces")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interfaces: Option<Vec<ScheduledInstancesNetworkInterface>>,
     #[doc="<p>The placement information.</p>"]
+    #[serde(rename="Placement")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement: Option<ScheduledInstancesPlacement>,
     #[doc="<p>The ID of the RAM disk.</p>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<String>,
     #[doc="<p>The IDs of one or more security groups.</p>"]
+    #[serde(rename="SecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_group_ids: Option<Vec<String>>,
     #[doc="<p>The ID of the subnet in which to launch the instances.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>The base64-encoded MIME user data.</p>"]
+    #[serde(rename="UserData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_data: Option<String>,
 }
 
@@ -35847,9 +39464,11 @@ impl ScheduledInstancesLaunchSpecificationSerializer {
 }
 
 #[doc="<p>Describes whether monitoring is enabled for a Scheduled Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstancesMonitoring {
     #[doc="<p>Indicates whether monitoring is enabled.</p>"]
+    #[serde(rename="Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled: Option<bool>,
 }
 
@@ -35872,31 +39491,55 @@ impl ScheduledInstancesMonitoringSerializer {
 }
 
 #[doc="<p>Describes a network interface for a Scheduled Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstancesNetworkInterface {
     #[doc="<p>Indicates whether to assign a public IPv4 address to instances launched in a VPC. The public IPv4 address can only be assigned to a network interface for eth0, and can only be assigned to a new network interface, not an existing one. You cannot specify more than one network interface in the request. If launching into a default subnet, the default value is <code>true</code>.</p>"]
+    #[serde(rename="AssociatePublicIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub associate_public_ip_address: Option<bool>,
     #[doc="<p>Indicates whether to delete the interface when the instance is terminated.</p>"]
+    #[serde(rename="DeleteOnTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_on_termination: Option<bool>,
     #[doc="<p>The description.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The index of the device for the network interface attachment.</p>"]
+    #[serde(rename="DeviceIndex")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device_index: Option<i64>,
     #[doc="<p>The IDs of one or more security groups.</p>"]
+    #[serde(rename="Groups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub groups: Option<Vec<String>>,
     #[doc="<p>The number of IPv6 addresses to assign to the network interface. The IPv6 addresses are automatically selected from the subnet range.</p>"]
+    #[serde(rename="Ipv6AddressCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_address_count: Option<i64>,
     #[doc="<p>One or more specific IPv6 addresses from the subnet range.</p>"]
+    #[serde(rename="Ipv6Addresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_addresses: Option<Vec<ScheduledInstancesIpv6Address>>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>The IPv4 address of the network interface within the subnet.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
     #[doc="<p>The private IPv4 addresses.</p>"]
+    #[serde(rename="PrivateIpAddressConfigs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address_configs: Option<Vec<ScheduledInstancesPrivateIpAddressConfig>>,
     #[doc="<p>The number of secondary private IPv4 addresses.</p>"]
+    #[serde(rename="SecondaryPrivateIpAddressCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub secondary_private_ip_address_count: Option<i64>,
     #[doc="<p>The ID of the subnet.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
 }
 
@@ -35984,11 +39627,15 @@ impl ScheduledInstancesNetworkInterfaceSetSerializer {
 }
 
 #[doc="<p>Describes the placement for a Scheduled Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstancesPlacement {
     #[doc="<p>The Availability Zone.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The name of the placement group.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
 }
 
@@ -36015,11 +39662,15 @@ impl ScheduledInstancesPlacementSerializer {
 }
 
 #[doc="<p>Describes a private IPv4 address for a Scheduled Instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduledInstancesPrivateIpAddressConfig {
     #[doc="<p>Indicates whether this is a primary IPv4 address. Otherwise, this is a secondary IPv4 address.</p>"]
+    #[serde(rename="Primary")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub primary: Option<bool>,
     #[doc="<p>The IPv4 address.</p>"]
+    #[serde(rename="PrivateIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
 }
 
@@ -36072,23 +39723,39 @@ impl ScopeDeserializer {
     }
 }
 #[doc="<p>Describes a security group</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SecurityGroup {
     #[doc="<p>A description of the security group.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of the security group.</p>"]
+    #[serde(rename="GroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_id: Option<String>,
     #[doc="<p>The name of the security group.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>One or more inbound rules associated with the security group.</p>"]
+    #[serde(rename="IpPermissions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_permissions: Option<Vec<IpPermission>>,
     #[doc="<p>[EC2-VPC] One or more outbound rules associated with the security group.</p>"]
+    #[serde(rename="IpPermissionsEgress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_permissions_egress: Option<Vec<IpPermission>>,
     #[doc="<p>The AWS account ID of the owner of the security group.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
     #[doc="<p>Any tags assigned to the security group.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>[EC2-VPC] The ID of the VPC for the security group.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -36259,13 +39926,17 @@ impl SecurityGroupListDeserializer {
     }
 }
 #[doc="<p>Describes a VPC with a security group that references your security group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SecurityGroupReference {
     #[doc="<p>The ID of your security group.</p>"]
+    #[serde(rename="GroupId")]
     pub group_id: String,
     #[doc="<p>The ID of the VPC with the referencing security group.</p>"]
+    #[serde(rename="ReferencingVpcId")]
     pub referencing_vpc_id: String,
     #[doc="<p>The ID of the VPC peering connection.</p>"]
+    #[serde(rename="VpcPeeringConnectionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_peering_connection_id: Option<String>,
 }
 
@@ -36374,11 +40045,13 @@ impl SecurityGroupStringListSerializer {
 }
 
 #[doc="<p>Describes the time period for a Scheduled Instance to start its first schedule. The time period must span less than one day.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SlotDateTimeRangeRequest {
     #[doc="<p>The earliest date and time, in UTC, for the Scheduled Instance to start.</p>"]
+    #[serde(rename="EarliestTime")]
     pub earliest_time: String,
     #[doc="<p>The latest date and time, in UTC, for the Scheduled Instance to start. This value must be later than or equal to the earliest date and at most three months in the future.</p>"]
+    #[serde(rename="LatestTime")]
     pub latest_time: String,
 }
 
@@ -36401,11 +40074,15 @@ impl SlotDateTimeRangeRequestSerializer {
 }
 
 #[doc="<p>Describes the time period for a Scheduled Instance to start its first schedule.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SlotStartTimeRangeRequest {
     #[doc="<p>The earliest date and time, in UTC, for the Scheduled Instance to start.</p>"]
+    #[serde(rename="EarliestTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub earliest_time: Option<String>,
     #[doc="<p>The latest date and time, in UTC, for the Scheduled Instance to start.</p>"]
+    #[serde(rename="LatestTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub latest_time: Option<String>,
 }
 
@@ -36432,35 +40109,63 @@ impl SlotStartTimeRangeRequestSerializer {
 }
 
 #[doc="<p>Describes a snapshot.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Snapshot {
     #[doc="<p>The data encryption key identifier for the snapshot. This value is a unique identifier that corresponds to the data encryption key that was used to encrypt the original volume or snapshot copy. Because data encryption keys are inherited by volumes created from snapshots, and vice versa, if snapshots share the same data encryption key identifier, then they belong to the same volume/snapshot lineage. This parameter is only returned by the <a>DescribeSnapshots</a> API operation.</p>"]
+    #[serde(rename="DataEncryptionKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub data_encryption_key_id: Option<String>,
     #[doc="<p>The description for the snapshot.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Indicates whether the snapshot is encrypted.</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to protect the volume encryption key for the parent volume.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p> Value from an Amazon-maintained list (<code>amazon</code> | <code>aws-marketplace</code> | <code>microsoft</code>) of snapshot owners. Not to be confused with the user-configured AWS account alias, which is set from the IAM console. </p>"]
+    #[serde(rename="OwnerAlias")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_alias: Option<String>,
     #[doc="<p>The AWS account ID of the EBS snapshot owner.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
     #[doc="<p>The progress of the snapshot, as a percentage.</p>"]
+    #[serde(rename="Progress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress: Option<String>,
     #[doc="<p>The ID of the snapshot. Each snapshot receives a unique identifier when it is created.</p>"]
+    #[serde(rename="SnapshotId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_id: Option<String>,
     #[doc="<p>The time stamp when the snapshot was initiated.</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
     #[doc="<p>The snapshot state.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>Encrypted Amazon EBS snapshots are copied asynchronously. If a snapshot copy operation fails (for example, if the proper AWS Key Management Service (AWS KMS) permissions are not obtained) this field displays error state details to help you diagnose why the error occurred. This parameter is only returned by the <a>DescribeSnapshots</a> API operation.</p>"]
+    #[serde(rename="StateMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state_message: Option<String>,
     #[doc="<p>Any tags assigned to the snapshot.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The ID of the volume that was used to create the snapshot. Snapshots created by the <a>CopySnapshot</a> action have an arbitrary volume ID that should not be used for any purpose.</p>"]
+    #[serde(rename="VolumeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_id: Option<String>,
     #[doc="<p>The size of the volume, in GiB.</p>"]
+    #[serde(rename="VolumeSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_size: Option<i64>,
 }
 
@@ -36560,27 +40265,47 @@ impl SnapshotDeserializer {
     }
 }
 #[doc="<p>Describes the snapshot created from the imported disk.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SnapshotDetail {
     #[doc="<p>A description for the snapshot.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The block device mapping for the snapshot.</p>"]
+    #[serde(rename="DeviceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device_name: Option<String>,
     #[doc="<p>The size of the disk in the snapshot, in GiB.</p>"]
+    #[serde(rename="DiskImageSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disk_image_size: Option<f64>,
     #[doc="<p>The format of the disk image from which the snapshot is created.</p>"]
+    #[serde(rename="Format")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub format: Option<String>,
     #[doc="<p>The percentage of progress for the task.</p>"]
+    #[serde(rename="Progress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress: Option<String>,
     #[doc="<p>The snapshot ID of the disk being imported.</p>"]
+    #[serde(rename="SnapshotId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_id: Option<String>,
     #[doc="<p>A brief status of the snapshot creation.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>A detailed status message for the snapshot creation.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
     #[doc="<p>The URL used to access the disk image.</p>"]
+    #[serde(rename="Url")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
     #[doc="<p>The S3 bucket for the disk image.</p>"]
+    #[serde(rename="UserBucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_bucket: Option<UserBucketDetails>,
 }
 
@@ -36704,15 +40429,23 @@ impl SnapshotDetailListDeserializer {
     }
 }
 #[doc="<p>The disk container object for the import snapshot request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SnapshotDiskContainer {
     #[doc="<p>The description of the disk image being imported.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The format of the disk image being imported.</p> <p>Valid values: <code>RAW</code> | <code>VHD</code> | <code>VMDK</code> | <code>OVA</code> </p>"]
+    #[serde(rename="Format")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub format: Option<String>,
     #[doc="<p>The URL to the Amazon S3-based disk image being imported. It can either be a https URL (https://..) or an Amazon S3 URL (s3://..).</p>"]
+    #[serde(rename="Url")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
     #[doc="<p>The S3 bucket for the disk image.</p>"]
+    #[serde(rename="UserBucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_bucket: Option<UserBucket>,
 }
 
@@ -36815,25 +40548,43 @@ impl SnapshotStateDeserializer {
     }
 }
 #[doc="<p>Details about the import snapshot task.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SnapshotTaskDetail {
     #[doc="<p>The description of the snapshot.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The size of the disk in the snapshot, in GiB.</p>"]
+    #[serde(rename="DiskImageSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub disk_image_size: Option<f64>,
     #[doc="<p>The format of the disk image from which the snapshot is created.</p>"]
+    #[serde(rename="Format")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub format: Option<String>,
     #[doc="<p>The percentage of completion for the import snapshot task.</p>"]
+    #[serde(rename="Progress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress: Option<String>,
     #[doc="<p>The snapshot ID of the disk being imported.</p>"]
+    #[serde(rename="SnapshotId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_id: Option<String>,
     #[doc="<p>A brief status for the import snapshot task.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>A detailed status message for the import snapshot task.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
     #[doc="<p>The URL of the disk image from which the snapshot is created.</p>"]
+    #[serde(rename="Url")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
     #[doc="<p>The S3 bucket for the disk image.</p>"]
+    #[serde(rename="UserBucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_bucket: Option<UserBucketDetails>,
 }
 
@@ -36912,17 +40663,27 @@ impl SnapshotTaskDetailDeserializer {
     }
 }
 #[doc="<p>Describes the data feed for a Spot instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SpotDatafeedSubscription {
     #[doc="<p>The Amazon S3 bucket where the Spot instance data feed is located.</p>"]
+    #[serde(rename="Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bucket: Option<String>,
     #[doc="<p>The fault codes for the Spot instance request, if any.</p>"]
+    #[serde(rename="Fault")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fault: Option<SpotInstanceStateFault>,
     #[doc="<p>The AWS account ID of the account.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
     #[doc="<p>The prefix that is prepended to data feed files.</p>"]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="<p>The state of the Spot instance data feed subscription.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -36985,43 +40746,79 @@ impl SpotDatafeedSubscriptionDeserializer {
     }
 }
 #[doc="<p>Describes the launch specification for one or more Spot instances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SpotFleetLaunchSpecification {
     #[doc="<p>Deprecated.</p>"]
+    #[serde(rename="AddressingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub addressing_type: Option<String>,
     #[doc="<p>One or more block device mapping entries.</p>"]
+    #[serde(rename="BlockDeviceMappings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
     #[doc="<p>Indicates whether the instances are optimized for EBS I/O. This optimization provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal EBS I/O performance. This optimization isn't available with all instance types. Additional usage charges apply when using an EBS Optimized instance.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EbsOptimized")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ebs_optimized: Option<bool>,
     #[doc="<p>The IAM instance profile.</p>"]
+    #[serde(rename="IamInstanceProfile")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_instance_profile: Option<IamInstanceProfileSpecification>,
     #[doc="<p>The ID of the AMI.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
     #[doc="<p>The instance type. Note that T2 and HS1 instance types are not supported.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The ID of the kernel.</p>"]
+    #[serde(rename="KernelId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kernel_id: Option<String>,
     #[doc="<p>The name of the key pair.</p>"]
+    #[serde(rename="KeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_name: Option<String>,
     #[doc="<p>Enable or disable monitoring for the instances.</p>"]
+    #[serde(rename="Monitoring")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring: Option<SpotFleetMonitoring>,
     #[doc="<p>One or more network interfaces. If you specify a network interface, you must specify subnet IDs and security group IDs using the network interface.</p>"]
+    #[serde(rename="NetworkInterfaces")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interfaces: Option<Vec<InstanceNetworkInterfaceSpecification>>,
     #[doc="<p>The placement information.</p>"]
+    #[serde(rename="Placement")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub placement: Option<SpotPlacement>,
     #[doc="<p>The ID of the RAM disk.</p>"]
+    #[serde(rename="RamdiskId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ramdisk_id: Option<String>,
     #[doc="<p>One or more security groups. When requesting instances in a VPC, you must specify the IDs of the security groups. When requesting instances in EC2-Classic, you can specify the names or the IDs of the security groups.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<GroupIdentifier>>,
     #[doc="<p>The bid price per unit hour for the specified instance type. If this value is not specified, the default is the Spot bid price specified for the fleet. To determine the bid price per unit hour, divide the Spot bid price by the value of <code>WeightedCapacity</code>.</p>"]
+    #[serde(rename="SpotPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_price: Option<String>,
     #[doc="<p>The ID of the subnet in which to launch the instances. To specify multiple subnets, separate them using commas; for example, \"subnet-a61dafcf, subnet-65ea5f08\".</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>The tags to apply during creation.</p>"]
+    #[serde(rename="TagSpecifications")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_specifications: Option<Vec<SpotFleetTagSpecification>>,
     #[doc="<p>The user data to make available to the instances. If you are using an AWS SDK or command line tool, Base64-encoding is performed for you, and you can load the text from a file. Otherwise, you must provide Base64-encoded text.</p>"]
+    #[serde(rename="UserData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_data: Option<String>,
     #[doc="<p>The number of units provided by the specified instance type. These are the same units that you chose to set the target capacity in terms (instances or a performance characteristic such as vCPUs, memory, or I/O).</p> <p>If the target capacity divided by this value is not a whole number, we round the number of instances to the next whole number. If this value is not specified, the default is 1.</p>"]
+    #[serde(rename="WeightedCapacity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub weighted_capacity: Option<f64>,
 }
 
@@ -37241,9 +41038,11 @@ impl SpotFleetLaunchSpecificationSerializer {
 }
 
 #[doc="<p>Describes whether monitoring is enabled.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SpotFleetMonitoring {
     #[doc="<p>Enables monitoring for the instance.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled: Option<bool>,
 }
 
@@ -37308,17 +41107,23 @@ impl SpotFleetMonitoringSerializer {
 }
 
 #[doc="<p>Describes a Spot fleet request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SpotFleetRequestConfig {
     #[doc="<p>The progress of the Spot fleet request. If there is an error, the status is <code>error</code>. After all bids are placed, the status is <code>pending_fulfillment</code>. If the size of the fleet is equal to or greater than its target capacity, the status is <code>fulfilled</code>. If the size of the fleet is decreased, the status is <code>pending_termination</code> while Spot instances are terminating.</p>"]
+    #[serde(rename="ActivityStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub activity_status: Option<String>,
     #[doc="<p>The creation date and time of the request.</p>"]
+    #[serde(rename="CreateTime")]
     pub create_time: String,
     #[doc="<p>Information about the configuration of the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestConfig")]
     pub spot_fleet_request_config: SpotFleetRequestConfigData,
     #[doc="<p>The ID of the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestId")]
     pub spot_fleet_request_id: String,
     #[doc="<p>The state of the Spot fleet request.</p>"]
+    #[serde(rename="SpotFleetRequestState")]
     pub spot_fleet_request_state: String,
 }
 
@@ -37384,33 +41189,55 @@ impl SpotFleetRequestConfigDeserializer {
     }
 }
 #[doc="<p>Describes the configuration of a Spot fleet request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SpotFleetRequestConfigData {
     #[doc="<p>Indicates how to allocate the target capacity across the Spot pools specified by the Spot fleet request. The default is <code>lowestPrice</code>.</p>"]
+    #[serde(rename="AllocationStrategy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocation_strategy: Option<String>,
     #[doc="<p>A unique, case-sensitive identifier you provide to ensure idempotency of your listings. This helps avoid duplicate listings. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html\">Ensuring Idempotency</a>.</p>"]
+    #[serde(rename="ClientToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_token: Option<String>,
     #[doc="<p>Indicates whether running Spot instances should be terminated if the target capacity of the Spot fleet request is decreased below the current size of the Spot fleet.</p>"]
+    #[serde(rename="ExcessCapacityTerminationPolicy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub excess_capacity_termination_policy: Option<String>,
     #[doc="<p>The number of units fulfilled by this request compared to the set target capacity.</p>"]
+    #[serde(rename="FulfilledCapacity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fulfilled_capacity: Option<f64>,
     #[doc="<p>Grants the Spot fleet permission to terminate Spot instances on your behalf when you cancel its Spot fleet request using <a>CancelSpotFleetRequests</a> or when the Spot fleet request expires, if you set <code>terminateInstancesWithExpiration</code>.</p>"]
+    #[serde(rename="IamFleetRole")]
     pub iam_fleet_role: String,
     #[doc="<p>Information about the launch specifications for the Spot fleet request.</p>"]
+    #[serde(rename="LaunchSpecifications")]
     pub launch_specifications: Vec<SpotFleetLaunchSpecification>,
     #[doc="<p>Indicates whether Spot fleet should replace unhealthy instances.</p>"]
+    #[serde(rename="ReplaceUnhealthyInstances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replace_unhealthy_instances: Option<bool>,
     #[doc="<p>The bid price per unit hour.</p>"]
+    #[serde(rename="SpotPrice")]
     pub spot_price: String,
     #[doc="<p>The number of units to request. You can choose to set the target capacity in terms of instances or a performance characteristic that is important to your application workload, such as vCPUs, memory, or I/O.</p>"]
+    #[serde(rename="TargetCapacity")]
     pub target_capacity: i64,
     #[doc="<p>Indicates whether running Spot instances should be terminated when the Spot fleet request expires.</p>"]
+    #[serde(rename="TerminateInstancesWithExpiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub terminate_instances_with_expiration: Option<bool>,
     #[doc="<p>The type of request. Indicates whether the fleet will only <code>request</code> the target capacity or also attempt to <code>maintain</code> it. When you <code>request</code> a certain target capacity, the fleet will only place the required bids. It will not attempt to replenish Spot instances if capacity is diminished, nor will it submit bids in alternative Spot pools if capacity is not available. When you want to <code>maintain</code> a certain target capacity, fleet will place the required bids to meet this target capacity. It will also automatically replenish any interrupted instances. Default: <code>maintain</code>.</p>"]
+    #[serde(rename="Type")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
     #[doc="<p>The start date and time of the request, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z). The default is to start fulfilling the request immediately.</p>"]
+    #[serde(rename="ValidFrom")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub valid_from: Option<String>,
     #[doc="<p>The end date and time of the request, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z). At this point, no new Spot instance requests are placed or enabled to fulfill the request.</p>"]
+    #[serde(rename="ValidUntil")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub valid_until: Option<String>,
 }
 
@@ -37610,11 +41437,15 @@ impl SpotFleetRequestConfigSetDeserializer {
     }
 }
 #[doc="<p>The tags for a Spot fleet resource.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SpotFleetTagSpecification {
     #[doc="<p>The type of resource. Currently, the only resource type that is supported is <code>instance</code>.</p>"]
+    #[serde(rename="ResourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
     #[doc="<p>The tags.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -37740,43 +41571,79 @@ impl SpotFleetTagSpecificationListSerializer {
 }
 
 #[doc="<p>Describes a Spot instance request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SpotInstanceRequest {
     #[doc="<p>If you specified a duration and your Spot instance request was fulfilled, this is the fixed hourly price in effect for the Spot instance while it runs.</p>"]
+    #[serde(rename="ActualBlockHourlyPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub actual_block_hourly_price: Option<String>,
     #[doc="<p>The Availability Zone group. If you specify the same Availability Zone group for all Spot instance requests, all Spot instances are launched in the same Availability Zone.</p>"]
+    #[serde(rename="AvailabilityZoneGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone_group: Option<String>,
     #[doc="<p>The duration for the Spot instance, in minutes.</p>"]
+    #[serde(rename="BlockDurationMinutes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub block_duration_minutes: Option<i64>,
     #[doc="<p>The date and time when the Spot instance request was created, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z).</p>"]
+    #[serde(rename="CreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_time: Option<String>,
     #[doc="<p>The fault codes for the Spot instance request, if any.</p>"]
+    #[serde(rename="Fault")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fault: Option<SpotInstanceStateFault>,
     #[doc="<p>The instance ID, if an instance has been launched to fulfill the Spot instance request.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The instance launch group. Launch groups are Spot instances that launch together and terminate together.</p>"]
+    #[serde(rename="LaunchGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_group: Option<String>,
     #[doc="<p>Additional information for launching instances.</p>"]
+    #[serde(rename="LaunchSpecification")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_specification: Option<LaunchSpecification>,
     #[doc="<p>The Availability Zone in which the bid is launched.</p>"]
+    #[serde(rename="LaunchedAvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launched_availability_zone: Option<String>,
     #[doc="<p>The product description associated with the Spot instance.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The ID of the Spot instance request.</p>"]
+    #[serde(rename="SpotInstanceRequestId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_instance_request_id: Option<String>,
     #[doc="<p>The maximum hourly price (bid) for the Spot instance launched to fulfill the request.</p>"]
+    #[serde(rename="SpotPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_price: Option<String>,
     #[doc="<p>The state of the Spot instance request. Spot bid status information can help you track your Spot instance requests. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html\">Spot Bid Status</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The status code and status message describing the Spot instance request.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<SpotInstanceStatus>,
     #[doc="<p>Any tags assigned to the resource.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The Spot instance request type.</p>"]
+    #[serde(rename="Type")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
     #[doc="<p>The start date of the request, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z). The request becomes active at this date and time.</p>"]
+    #[serde(rename="ValidFrom")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub valid_from: Option<String>,
     #[doc="<p>The end date of the request, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z). If this is a one-time request, it remains active until all instances launch, the request is canceled, or this date is reached. If the request is persistent, it remains active until it is canceled or this date is reached.</p>"]
+    #[serde(rename="ValidUntil")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub valid_until: Option<String>,
 }
 
@@ -37969,11 +41836,15 @@ impl SpotInstanceStateDeserializer {
     }
 }
 #[doc="<p>Describes a Spot instance state change.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SpotInstanceStateFault {
     #[doc="<p>The reason code for the Spot instance state change.</p>"]
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<String>,
     #[doc="<p>The message for the Spot instance state change.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
 }
 
@@ -38023,13 +41894,19 @@ impl SpotInstanceStateFaultDeserializer {
     }
 }
 #[doc="<p>Describes the status of a Spot instance request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SpotInstanceStatus {
     #[doc="<p>The status code. For a list of status codes, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html#spot-instance-bid-status-understand\">Spot Bid Status Codes</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>"]
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<String>,
     #[doc="<p>The description for the status code.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
     #[doc="<p>The date and time of the most recent status update, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z).</p>"]
+    #[serde(rename="UpdateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub update_time: Option<String>,
 }
 
@@ -38097,13 +41974,19 @@ impl SpotInstanceTypeDeserializer {
     }
 }
 #[doc="<p>Describes Spot instance placement.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SpotPlacement {
     #[doc="<p>The Availability Zone.</p> <p>[Spot fleet only] To specify multiple Availability Zones, separate them using commas; for example, \"us-west-2a, us-west-2b\".</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The name of the placement group (for cluster instances).</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of <code>dedicated</code> runs on single-tenant hardware. The <code>host</code> tenancy is not supported for Spot instances.</p>"]
+    #[serde(rename="Tenancy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tenancy: Option<String>,
 }
 
@@ -38185,17 +42068,27 @@ impl SpotPlacementSerializer {
 }
 
 #[doc="<p>Describes the maximum hourly price (bid) for any Spot instance launched to fulfill the request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SpotPrice {
     #[doc="<p>The Availability Zone.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The instance type. Note that T2 and HS1 instance types are not supported.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>A general description of the AMI.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The maximum price (bid) that you are willing to pay for a Spot instance.</p>"]
+    #[serde(rename="SpotPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub spot_price: Option<String>,
     #[doc="<p>The date and time the request was created, in UTC format (for example, <i>YYYY</i>-<i>MM</i>-<i>DD</i>T<i>HH</i>:<i>MM</i>:<i>SS</i>Z).</p>"]
+    #[serde(rename="Timestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timestamp: Option<String>,
 }
 
@@ -38302,19 +42195,31 @@ impl SpotPriceHistoryListDeserializer {
     }
 }
 #[doc="<p>Describes a stale rule in a security group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StaleIpPermission {
     #[doc="<p>The start of the port range for the TCP and UDP protocols, or an ICMP type number. A value of <code>-1</code> indicates all ICMP types. </p>"]
+    #[serde(rename="FromPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub from_port: Option<i64>,
     #[doc="<p>The IP protocol name (for <code>tcp</code>, <code>udp</code>, and <code>icmp</code>) or number (see <a href=\"http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml\">Protocol Numbers)</a>.</p>"]
+    #[serde(rename="IpProtocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_protocol: Option<String>,
     #[doc="<p>One or more IP ranges. Not applicable for stale security group rules.</p>"]
+    #[serde(rename="IpRanges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_ranges: Option<Vec<String>>,
     #[doc="<p>One or more prefix list IDs for an AWS service. Not applicable for stale security group rules.</p>"]
+    #[serde(rename="PrefixListIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix_list_ids: Option<Vec<String>>,
     #[doc="<p>The end of the port range for the TCP and UDP protocols, or an ICMP type number. A value of <code>-1</code> indicates all ICMP types. </p>"]
+    #[serde(rename="ToPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub to_port: Option<i64>,
     #[doc="<p>One or more security group pairs. Returns the ID of the referenced security group and VPC, and the ID and status of the VPC peering connection.</p>"]
+    #[serde(rename="UserIdGroupPairs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_id_group_pairs: Option<Vec<UserIdGroupPair>>,
 }
 
@@ -38424,19 +42329,30 @@ impl StaleIpPermissionSetDeserializer {
     }
 }
 #[doc="<p>Describes a stale security group (a security group that contains stale rules).</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StaleSecurityGroup {
     #[doc="<p>The description of the security group.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of the security group.</p>"]
+    #[serde(rename="GroupId")]
     pub group_id: String,
     #[doc="<p>The name of the security group.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>Information about the stale inbound rules in the security group.</p>"]
+    #[serde(rename="StaleIpPermissions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stale_ip_permissions: Option<Vec<StaleIpPermission>>,
     #[doc="<p>Information about the stale outbound rules in the security group.</p>"]
+    #[serde(rename="StaleIpPermissionsEgress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stale_ip_permissions_egress: Option<Vec<StaleIpPermission>>,
     #[doc="<p>The ID of the VPC for the security group.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -38545,13 +42461,18 @@ impl StaleSecurityGroupSetDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for StartInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartInstancesRequest {
     #[doc="<p>Reserved.</p>"]
+    #[serde(rename="AdditionalInfo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub additional_info: Option<String>,
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more instance IDs.</p>"]
+    #[serde(rename="InstanceIds")]
     pub instance_ids: Vec<String>,
 }
 
@@ -38581,9 +42502,11 @@ impl StartInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of StartInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartInstancesResult {
     #[doc="<p>Information about one or more started instances.</p>"]
+    #[serde(rename="StartingInstances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub starting_instances: Option<Vec<InstanceStateChange>>,
 }
 
@@ -38645,11 +42568,15 @@ impl StateDeserializer {
     }
 }
 #[doc="<p>Describes a state change.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StateReason {
     #[doc="<p>The reason code for the state change.</p>"]
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<String>,
     #[doc="<p>The message for the state change.</p> <ul> <li> <p> <code>Server.InsufficientInstanceCapacity</code>: There was insufficient instance capacity to satisfy the launch request.</p> </li> <li> <p> <code>Server.InternalError</code>: An internal error occurred during instance launch, resulting in termination.</p> </li> <li> <p> <code>Server.ScheduledStop</code>: The instance was stopped due to a scheduled retirement.</p> </li> <li> <p> <code>Server.SpotInstanceTermination</code>: A Spot instance was terminated due to an increase in the market price.</p> </li> <li> <p> <code>Client.InternalError</code>: A client error caused the instance to terminate on launch.</p> </li> <li> <p> <code>Client.InstanceInitiatedShutdown</code>: The instance was shut down using the <code>shutdown -h</code> command from the instance.</p> </li> <li> <p> <code>Client.UserInitiatedShutdown</code>: The instance was shut down using the Amazon EC2 API.</p> </li> <li> <p> <code>Client.VolumeLimitExceeded</code>: The limit on the number of EBS volumes or total storage was exceeded. Decrease usage or request an increase in your limits.</p> </li> <li> <p> <code>Client.InvalidSnapshot.NotFound</code>: The specified snapshot was not found.</p> </li> </ul>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
 }
 
@@ -38741,13 +42668,18 @@ impl StatusTypeDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for StopInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopInstancesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>Forces the instances to stop. The instances do not have an opportunity to flush file system caches or file system metadata. If you use this option, you must perform file system check and repair procedures. This option is not recommended for Windows instances.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="Force")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub force: Option<bool>,
     #[doc="<p>One or more instance IDs.</p>"]
+    #[serde(rename="InstanceIds")]
     pub instance_ids: Vec<String>,
 }
 
@@ -38777,9 +42709,11 @@ impl StopInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of StopInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopInstancesResult {
     #[doc="<p>Information about one or more stopped instances.</p>"]
+    #[serde(rename="StoppingInstances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stopping_instances: Option<Vec<InstanceStateChange>>,
 }
 
@@ -38827,9 +42761,11 @@ impl StopInstancesResultDeserializer {
     }
 }
 #[doc="<p>Describes the storage location for an instance store-backed AMI.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Storage {
     #[doc="<p>An Amazon S3 storage location.</p>"]
+    #[serde(rename="S3")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3: Option<S3Storage>,
 }
 
@@ -38892,11 +42828,15 @@ impl StorageSerializer {
 }
 
 #[doc="<p>Describes a storage location in Amazon S3.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StorageLocation {
     #[doc="<p>The name of the S3 bucket.</p>"]
+    #[serde(rename="Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bucket: Option<String>,
     #[doc="<p>The key.</p>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
 }
 
@@ -38937,29 +42877,51 @@ impl StringDeserializer {
     }
 }
 #[doc="<p>Describes a subnet.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Subnet {
     #[doc="<p>Indicates whether a network interface created in this subnet (including a network interface created by <a>RunInstances</a>) receives an IPv6 address.</p>"]
+    #[serde(rename="AssignIpv6AddressOnCreation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub assign_ipv_6_address_on_creation: Option<bool>,
     #[doc="<p>The Availability Zone of the subnet.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The number of unused private IPv4 addresses in the subnet. Note that the IPv4 addresses for any stopped instances are considered unavailable.</p>"]
+    #[serde(rename="AvailableIpAddressCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub available_ip_address_count: Option<i64>,
     #[doc="<p>The IPv4 CIDR block assigned to the subnet.</p>"]
+    #[serde(rename="CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_block: Option<String>,
     #[doc="<p>Indicates whether this is the default subnet for the Availability Zone.</p>"]
+    #[serde(rename="DefaultForAz")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_for_az: Option<bool>,
     #[doc="<p>Information about the IPv6 CIDR blocks associated with the subnet.</p>"]
+    #[serde(rename="Ipv6CidrBlockAssociationSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block_association_set: Option<Vec<SubnetIpv6CidrBlockAssociation>>,
     #[doc="<p>Indicates whether instances launched in this subnet receive a public IPv4 address.</p>"]
+    #[serde(rename="MapPublicIpOnLaunch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub map_public_ip_on_launch: Option<bool>,
     #[doc="<p>The current state of the subnet.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The ID of the subnet.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>Any tags assigned to the subnet.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The ID of the VPC the subnet is in.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -39049,11 +43011,15 @@ impl SubnetDeserializer {
     }
 }
 #[doc="<p>Describes the state of a CIDR block.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubnetCidrBlockState {
     #[doc="<p>The state of a CIDR block.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>A message about the status of the CIDR block, if applicable.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
 }
 
@@ -39129,13 +43095,19 @@ impl SubnetIdStringListSerializer {
 }
 
 #[doc="<p>Describes an IPv6 CIDR block associated with a subnet.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubnetIpv6CidrBlockAssociation {
     #[doc="<p>The association ID for the CIDR block.</p>"]
+    #[serde(rename="AssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association_id: Option<String>,
     #[doc="<p>The IPv6 CIDR block.</p>"]
+    #[serde(rename="Ipv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block: Option<String>,
     #[doc="<p>Information about the state of the CIDR block.</p>"]
+    #[serde(rename="Ipv6CidrBlockState")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block_state: Option<SubnetCidrBlockState>,
 }
 
@@ -39302,11 +43274,15 @@ impl SummaryStatusDeserializer {
     }
 }
 #[doc="<p>Describes a tag.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>The key of the tag.</p> <p>Constraints: Tag keys are case-sensitive and accept a maximum of 127 Unicode characters. May not begin with <code>aws:</code> </p>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>The value of the tag.</p> <p>Constraints: Tag values are case-sensitive and accept a maximum of 255 Unicode characters.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -39377,15 +43353,23 @@ impl TagSerializer {
 }
 
 #[doc="<p>Describes a tag.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagDescription {
     #[doc="<p>The tag key.</p>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>The ID of the resource. For example, <code>ami-1a2b3c4d</code>.</p>"]
+    #[serde(rename="ResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_id: Option<String>,
     #[doc="<p>The resource type.</p>"]
+    #[serde(rename="ResourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
     #[doc="<p>The tag value.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -39537,11 +43521,15 @@ impl TagListSerializer {
 }
 
 #[doc="<p>The tags to apply to a resource when the resource is being created.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagSpecification {
     #[doc="<p>The type of resource to tag. Currently, the resource types that support tagging on creation are <code>instance</code> and <code>volume</code>. </p>"]
+    #[serde(rename="ResourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
     #[doc="<p>The tags to apply to the resource.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -39579,11 +43567,15 @@ impl TagSpecificationListSerializer {
 }
 
 #[doc="<p>Information about the Convertible Reserved Instance offering.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TargetConfiguration {
     #[doc="<p>The number of instances the Convertible Reserved Instance offering can be applied to. This parameter is reserved and cannot be specified in a request</p>"]
+    #[serde(rename="InstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_count: Option<i64>,
     #[doc="<p>The ID of the Convertible Reserved Instance offering.</p>"]
+    #[serde(rename="OfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_id: Option<String>,
 }
 
@@ -39635,11 +43627,14 @@ impl TargetConfigurationDeserializer {
     }
 }
 #[doc="<p>Details about the target configuration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TargetConfigurationRequest {
     #[doc="<p>The number of instances the Covertible Reserved Instance offering can be applied to. This parameter is reserved and cannot be specified in a request</p>"]
+    #[serde(rename="InstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_count: Option<i64>,
     #[doc="<p>The Convertible Reserved Instance offering ID.</p>"]
+    #[serde(rename="OfferingId")]
     pub offering_id: String,
 }
 
@@ -39676,11 +43671,15 @@ impl TargetConfigurationRequestSetSerializer {
 }
 
 #[doc="<p>The total value of the new Convertible Reserved Instances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TargetReservationValue {
     #[doc="<p>The total value of the Convertible Reserved Instances that make up the exchange. This is the sum of the list value, remaining upfront price, and additional upfront cost of the exchange.</p>"]
+    #[serde(rename="ReservationValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reservation_value: Option<ReservationValue>,
     #[doc="<p>The configuration of the Convertible Reserved Instances that make up the exchange.</p>"]
+    #[serde(rename="TargetConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_configuration: Option<TargetConfiguration>,
 }
 
@@ -39803,11 +43802,14 @@ impl TenancyDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for TerminateInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateInstancesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more instance IDs.</p> <p>Constraints: Up to 1000 instance IDs. We recommend breaking up this request into smaller batches.</p>"]
+    #[serde(rename="InstanceIds")]
     pub instance_ids: Vec<String>,
 }
 
@@ -39833,9 +43835,11 @@ impl TerminateInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of TerminateInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateInstancesResult {
     #[doc="<p>Information about one or more terminated instances.</p>"]
+    #[serde(rename="TerminatingInstances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub terminating_instances: Option<Vec<InstanceStateChange>>,
 }
 
@@ -39896,11 +43900,13 @@ impl TrafficTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnassignIpv6AddressesRequest {
     #[doc="<p>The IPv6 addresses to unassign from the network interface.</p>"]
+    #[serde(rename="Ipv6Addresses")]
     pub ipv_6_addresses: Vec<String>,
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
     pub network_interface_id: String,
 }
 
@@ -39923,11 +43929,15 @@ impl UnassignIpv6AddressesRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnassignIpv6AddressesResult {
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub network_interface_id: Option<String>,
     #[doc="<p>The IPv6 addresses that have been unassigned from the network interface.</p>"]
+    #[serde(rename="UnassignedIpv6Addresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unassigned_ipv_6_addresses: Option<Vec<String>>,
 }
 
@@ -39980,11 +43990,13 @@ impl UnassignIpv6AddressesResultDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for UnassignPrivateIpAddresses.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnassignPrivateIpAddressesRequest {
     #[doc="<p>The ID of the network interface.</p>"]
+    #[serde(rename="NetworkInterfaceId")]
     pub network_interface_id: String,
     #[doc="<p>The secondary private IP addresses to unassign from the network interface. You can specify this option multiple times to unassign more than one IP address.</p>"]
+    #[serde(rename="PrivateIpAddresses")]
     pub private_ip_addresses: Vec<String>,
 }
 
@@ -40010,11 +44022,14 @@ impl UnassignPrivateIpAddressesRequestSerializer {
 }
 
 #[doc="<p>Contains the parameters for UnmonitorInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnmonitorInstancesRequest {
     #[doc="<p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>"]
+    #[serde(rename="DryRun")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dry_run: Option<bool>,
     #[doc="<p>One or more instance IDs.</p>"]
+    #[serde(rename="InstanceIds")]
     pub instance_ids: Vec<String>,
 }
 
@@ -40040,9 +44055,11 @@ impl UnmonitorInstancesRequestSerializer {
 }
 
 #[doc="<p>Contains the output of UnmonitorInstances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnmonitorInstancesResult {
     #[doc="<p>The monitoring information.</p>"]
+    #[serde(rename="InstanceMonitorings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_monitorings: Option<Vec<InstanceMonitoring>>,
 }
 
@@ -40090,11 +44107,14 @@ impl UnmonitorInstancesResultDeserializer {
     }
 }
 #[doc="<p>Information about items that were not successfully processed in a batch call.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnsuccessfulItem {
     #[doc="<p>Information about the error.</p>"]
+    #[serde(rename="Error")]
     pub error: UnsuccessfulItemError,
     #[doc="<p>The ID of the resource.</p>"]
+    #[serde(rename="ResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_id: Option<String>,
 }
 
@@ -40145,11 +44165,13 @@ impl UnsuccessfulItemDeserializer {
     }
 }
 #[doc="<p>Information about the error that occurred. For more information about errors, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html\">Error Codes</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnsuccessfulItemError {
     #[doc="<p>The error code.</p>"]
+    #[serde(rename="Code")]
     pub code: String,
     #[doc="<p>The error message accompanying the error code.</p>"]
+    #[serde(rename="Message")]
     pub message: String,
 }
 
@@ -40280,11 +44302,15 @@ impl UnsuccessfulItemSetDeserializer {
     }
 }
 #[doc="<p>Describes the S3 bucket for the disk image.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserBucket {
     #[doc="<p>The name of the S3 bucket where the disk image is located.</p>"]
+    #[serde(rename="S3Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_bucket: Option<String>,
     #[doc="<p>The file name of the disk image.</p>"]
+    #[serde(rename="S3Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_key: Option<String>,
 }
 
@@ -40311,11 +44337,15 @@ impl UserBucketSerializer {
 }
 
 #[doc="<p>Describes the S3 bucket for the disk image.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserBucketDetails {
     #[doc="<p>The S3 bucket from which the disk image was created.</p>"]
+    #[serde(rename="S3Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_bucket: Option<String>,
     #[doc="<p>The file name of the disk image.</p>"]
+    #[serde(rename="S3Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_key: Option<String>,
 }
 
@@ -40366,9 +44396,11 @@ impl UserBucketDetailsDeserializer {
     }
 }
 #[doc="<p>Describes the user data for an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserData {
     #[doc="<p>The user data. If you are using an AWS SDK or command line tool, Base64-encoding is performed for you, and you can load the text from a file. Otherwise, you must provide Base64-encoded text.</p>"]
+    #[serde(rename="Data")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub data: Option<String>,
 }
 
@@ -40403,19 +44435,31 @@ impl UserGroupStringListSerializer {
 }
 
 #[doc="<p>Describes a security group and AWS account ID pair.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserIdGroupPair {
     #[doc="<p>The ID of the security group.</p>"]
+    #[serde(rename="GroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_id: Option<String>,
     #[doc="<p>The name of the security group. In a request, use this parameter for a security group in EC2-Classic or a default VPC only. For a security group in a nondefault VPC, use the security group ID.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>The status of a VPC peering connection, if applicable.</p>"]
+    #[serde(rename="PeeringStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub peering_status: Option<String>,
     #[doc="<p>The ID of an AWS account. For a referenced security group in another VPC, the account ID of the referenced security group is returned.</p> <p>[EC2-Classic] Required when adding or removing rules that reference a security group in another AWS account.</p>"]
+    #[serde(rename="UserId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_id: Option<String>,
     #[doc="<p>The ID of the VPC for the referenced security group, if applicable.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
     #[doc="<p>The ID of the VPC peering connection, if applicable.</p>"]
+    #[serde(rename="VpcPeeringConnectionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_peering_connection_id: Option<String>,
 }
 
@@ -40680,17 +44724,27 @@ impl ValueStringListSerializer {
 }
 
 #[doc="<p>Describes telemetry for a VPN tunnel.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VgwTelemetry {
     #[doc="<p>The number of accepted routes.</p>"]
+    #[serde(rename="AcceptedRouteCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub accepted_route_count: Option<i64>,
     #[doc="<p>The date and time of the last change in status.</p>"]
+    #[serde(rename="LastStatusChange")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_status_change: Option<String>,
     #[doc="<p>The Internet-routable IP address of the virtual private gateway's outside interface.</p>"]
+    #[serde(rename="OutsideIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub outside_ip_address: Option<String>,
     #[doc="<p>The status of the VPN tunnel.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>If an error occurs, a description of the error.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
 }
 
@@ -40812,31 +44866,55 @@ impl VirtualizationTypeDeserializer {
     }
 }
 #[doc="<p>Describes a volume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Volume {
     #[doc="<p>Information about the volume attachments.</p>"]
+    #[serde(rename="Attachments")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachments: Option<Vec<VolumeAttachment>>,
     #[doc="<p>The Availability Zone for the volume.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The time stamp when volume creation was initiated.</p>"]
+    #[serde(rename="CreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_time: Option<String>,
     #[doc="<p>Indicates whether the volume will be encrypted.</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>The number of I/O operations per second (IOPS) that the volume supports. For Provisioned IOPS SSD volumes, this represents the number of IOPS that are provisioned for the volume. For General Purpose SSD volumes, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting. For more information on General Purpose SSD baseline performance, I/O credits, and bursting, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html\">Amazon EBS Volume Types</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p> <p>Constraint: Range is 100-20000 IOPS for io1 volumes and 100-10000 IOPS for <code>gp2</code> volumes.</p> <p>Condition: This parameter is required for requests to create <code>io1</code> volumes; it is not used in requests to create <code>gp2</code>, <code>st1</code>, <code>sc1</code>, or <code>standard</code> volumes.</p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to protect the volume encryption key for the volume.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The size of the volume, in GiBs.</p>"]
+    #[serde(rename="Size")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub size: Option<i64>,
     #[doc="<p>The snapshot from which the volume was created, if applicable.</p>"]
+    #[serde(rename="SnapshotId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_id: Option<String>,
     #[doc="<p>The volume state.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>Any tags assigned to the volume.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The ID of the volume.</p>"]
+    #[serde(rename="VolumeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_id: Option<String>,
     #[doc="<p>The volume type. This can be <code>gp2</code> for General Purpose SSD, <code>io1</code> for Provisioned IOPS SSD, <code>st1</code> for Throughput Optimized HDD, <code>sc1</code> for Cold HDD, or <code>standard</code> for Magnetic volumes.</p>"]
+    #[serde(rename="VolumeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_type: Option<String>,
 }
 
@@ -40928,19 +45006,31 @@ impl VolumeDeserializer {
     }
 }
 #[doc="<p>Describes volume attachment details.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VolumeAttachment {
     #[doc="<p>The time stamp when the attachment initiated.</p>"]
+    #[serde(rename="AttachTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attach_time: Option<String>,
     #[doc="<p>Indicates whether the EBS volume is deleted on instance termination.</p>"]
+    #[serde(rename="DeleteOnTermination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_on_termination: Option<bool>,
     #[doc="<p>The device name.</p>"]
+    #[serde(rename="Device")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub device: Option<String>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The attachment state of the volume.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The ID of the volume.</p>"]
+    #[serde(rename="VolumeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_id: Option<String>,
 }
 
@@ -41064,9 +45154,10 @@ impl VolumeAttachmentStateDeserializer {
     }
 }
 #[doc="<p>Describes an EBS volume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VolumeDetail {
     #[doc="<p>The size of the volume, in GiB.</p>"]
+    #[serde(rename="Size")]
     pub size: i64,
 }
 
@@ -41140,31 +45231,55 @@ impl VolumeListDeserializer {
     }
 }
 #[doc="<p>Describes the modification status of an EBS volume.</p> <p>If the volume has never been modified, some element values will be null.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VolumeModification {
     #[doc="<p>Modification completion or failure time.</p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>Current state of modification. Modification state is null for unmodified volumes. </p>"]
+    #[serde(rename="ModificationState")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub modification_state: Option<String>,
     #[doc="<p>Original IOPS rate of the volume being modified.</p>"]
+    #[serde(rename="OriginalIops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub original_iops: Option<i64>,
     #[doc="<p>Original size of the volume being modified.</p>"]
+    #[serde(rename="OriginalSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub original_size: Option<i64>,
     #[doc="<p>Original EBS volume type of the volume being modified.</p>"]
+    #[serde(rename="OriginalVolumeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub original_volume_type: Option<String>,
     #[doc="<p>Modification progress from 0 to 100%.</p>"]
+    #[serde(rename="Progress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress: Option<i64>,
     #[doc="<p>Modification start time </p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
     #[doc="<p>Generic status message on modification progress or failure.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
     #[doc="<p>Target IOPS rate of the volume being modified.</p>"]
+    #[serde(rename="TargetIops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_iops: Option<i64>,
     #[doc="<p>Target size of the volume being modified.</p>"]
+    #[serde(rename="TargetSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_size: Option<i64>,
     #[doc="<p>Target EBS volume type of the volume being modified.</p>"]
+    #[serde(rename="TargetVolumeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_volume_type: Option<String>,
     #[doc="<p>ID of the volume being modified.</p>"]
+    #[serde(rename="VolumeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_id: Option<String>,
 }
 
@@ -41327,15 +45442,23 @@ impl VolumeStateDeserializer {
     }
 }
 #[doc="<p>Describes a volume status operation code.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VolumeStatusAction {
     #[doc="<p>The code identifying the operation, for example, <code>enable-volume-io</code>.</p>"]
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<String>,
     #[doc="<p>A description of the operation.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of the event associated with this operation.</p>"]
+    #[serde(rename="EventId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_id: Option<String>,
     #[doc="<p>The event type associated with this operation.</p>"]
+    #[serde(rename="EventType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_type: Option<String>,
 }
 
@@ -41434,11 +45557,15 @@ impl VolumeStatusActionsListDeserializer {
     }
 }
 #[doc="<p>Describes a volume status.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VolumeStatusDetails {
     #[doc="<p>The name of the volume status.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The intended status of the volume status.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -41530,17 +45657,27 @@ impl VolumeStatusDetailsListDeserializer {
     }
 }
 #[doc="<p>Describes a volume status event.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VolumeStatusEvent {
     #[doc="<p>A description of the event.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of this event.</p>"]
+    #[serde(rename="EventId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_id: Option<String>,
     #[doc="<p>The type of this event.</p>"]
+    #[serde(rename="EventType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_type: Option<String>,
     #[doc="<p>The latest end time of the event.</p>"]
+    #[serde(rename="NotAfter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub not_after: Option<String>,
     #[doc="<p>The earliest start time of the event.</p>"]
+    #[serde(rename="NotBefore")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub not_before: Option<String>,
 }
 
@@ -41644,11 +45781,15 @@ impl VolumeStatusEventsListDeserializer {
     }
 }
 #[doc="<p>Describes the status of a volume.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VolumeStatusInfo {
     #[doc="<p>The details of the volume status.</p>"]
+    #[serde(rename="Details")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub details: Option<Vec<VolumeStatusDetails>>,
     #[doc="<p>The status of the volume.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -41715,17 +45856,27 @@ impl VolumeStatusInfoStatusDeserializer {
     }
 }
 #[doc="<p>Describes the volume status.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VolumeStatusItem {
     #[doc="<p>The details of the operation.</p>"]
+    #[serde(rename="Actions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub actions: Option<Vec<VolumeStatusAction>>,
     #[doc="<p>The Availability Zone of the volume.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>A list of events associated with the volume.</p>"]
+    #[serde(rename="Events")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<VolumeStatusEvent>>,
     #[doc="<p>The volume ID.</p>"]
+    #[serde(rename="VolumeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_id: Option<String>,
     #[doc="<p>The volume status.</p>"]
+    #[serde(rename="VolumeStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub volume_status: Option<VolumeStatusInfo>,
 }
 
@@ -41861,23 +46012,39 @@ impl VolumeTypeDeserializer {
     }
 }
 #[doc="<p>Describes a VPC.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Vpc {
     #[doc="<p>The IPv4 CIDR block for the VPC.</p>"]
+    #[serde(rename="CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_block: Option<String>,
     #[doc="<p>The ID of the set of DHCP options you've associated with the VPC (or <code>default</code> if the default options are associated with the VPC).</p>"]
+    #[serde(rename="DhcpOptionsId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dhcp_options_id: Option<String>,
     #[doc="<p>The allowed tenancy of instances launched into the VPC.</p>"]
+    #[serde(rename="InstanceTenancy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_tenancy: Option<String>,
     #[doc="<p>Information about the IPv6 CIDR blocks associated with the VPC.</p>"]
+    #[serde(rename="Ipv6CidrBlockAssociationSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block_association_set: Option<Vec<VpcIpv6CidrBlockAssociation>>,
     #[doc="<p>Indicates whether the VPC is the default VPC.</p>"]
+    #[serde(rename="IsDefault")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_default: Option<bool>,
     #[doc="<p>The current state of the VPC.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>Any tags assigned to the VPC.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -41952,11 +46119,15 @@ impl VpcDeserializer {
     }
 }
 #[doc="<p>Describes an attachment between a virtual private gateway and a VPC.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcAttachment {
     #[doc="<p>The current state of the attachment.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -42049,11 +46220,15 @@ impl VpcAttachmentListDeserializer {
     }
 }
 #[doc="<p>Describes the state of a CIDR block.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcCidrBlockState {
     #[doc="<p>The state of the CIDR block.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>A message about the status of the CIDR block, if applicable.</p>"]
+    #[serde(rename="StatusMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_message: Option<String>,
 }
 
@@ -42119,13 +46294,19 @@ impl VpcCidrBlockStateCodeDeserializer {
     }
 }
 #[doc="<p>Describes whether a VPC is enabled for ClassicLink.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcClassicLink {
     #[doc="<p>Indicates whether the VPC is enabled for ClassicLink.</p>"]
+    #[serde(rename="ClassicLinkEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub classic_link_enabled: Option<bool>,
     #[doc="<p>Any tags assigned to the VPC.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -42234,21 +46415,35 @@ impl VpcClassicLinkListDeserializer {
     }
 }
 #[doc="<p>Describes a VPC endpoint.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcEndpoint {
     #[doc="<p>The date and time the VPC endpoint was created.</p>"]
+    #[serde(rename="CreationTimestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub creation_timestamp: Option<String>,
     #[doc="<p>The policy document associated with the endpoint.</p>"]
+    #[serde(rename="PolicyDocument")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_document: Option<String>,
     #[doc="<p>One or more route tables associated with the endpoint.</p>"]
+    #[serde(rename="RouteTableIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub route_table_ids: Option<Vec<String>>,
     #[doc="<p>The name of the AWS service to which the endpoint is associated.</p>"]
+    #[serde(rename="ServiceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub service_name: Option<String>,
     #[doc="<p>The state of the VPC endpoint.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The ID of the VPC endpoint.</p>"]
+    #[serde(rename="VpcEndpointId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_endpoint_id: Option<String>,
     #[doc="<p>The ID of the VPC to which the endpoint is associated.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -42374,13 +46569,19 @@ impl VpcIdStringListSerializer {
 }
 
 #[doc="<p>Describes an IPv6 CIDR block associated with a VPC.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcIpv6CidrBlockAssociation {
     #[doc="<p>The association ID for the IPv6 CIDR block.</p>"]
+    #[serde(rename="AssociationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub association_id: Option<String>,
     #[doc="<p>The IPv6 CIDR block.</p>"]
+    #[serde(rename="Ipv6CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block: Option<String>,
     #[doc="<p>Information about the state of the CIDR block.</p>"]
+    #[serde(rename="Ipv6CidrBlockState")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block_state: Option<VpcCidrBlockState>,
 }
 
@@ -42520,19 +46721,31 @@ impl VpcListDeserializer {
     }
 }
 #[doc="<p>Describes a VPC peering connection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcPeeringConnection {
     #[doc="<p>Information about the accepter VPC. CIDR block information is only returned when describing an active VPC peering connection.</p>"]
+    #[serde(rename="AccepterVpcInfo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub accepter_vpc_info: Option<VpcPeeringConnectionVpcInfo>,
     #[doc="<p>The time that an unaccepted VPC peering connection will expire.</p>"]
+    #[serde(rename="ExpirationTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expiration_time: Option<String>,
     #[doc="<p>Information about the requester VPC. CIDR block information is only returned when describing an active VPC peering connection.</p>"]
+    #[serde(rename="RequesterVpcInfo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub requester_vpc_info: Option<VpcPeeringConnectionVpcInfo>,
     #[doc="<p>The status of the VPC peering connection.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<VpcPeeringConnectionStateReason>,
     #[doc="<p>Any tags assigned to the resource.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The ID of the VPC peering connection.</p>"]
+    #[serde(rename="VpcPeeringConnectionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_peering_connection_id: Option<String>,
 }
 
@@ -42640,13 +46853,19 @@ impl VpcPeeringConnectionListDeserializer {
     }
 }
 #[doc="<p>Describes the VPC peering connection options.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcPeeringConnectionOptionsDescription {
     #[doc="<p>Indicates whether a local VPC can resolve public DNS hostnames to private IP addresses when queried from instances in a peer VPC.</p>"]
+    #[serde(rename="AllowDnsResolutionFromRemoteVpc")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_dns_resolution_from_remote_vpc: Option<bool>,
     #[doc="<p>Indicates whether a local ClassicLink connection can communicate with the peer VPC over the VPC peering connection.</p>"]
+    #[serde(rename="AllowEgressFromLocalClassicLinkToRemoteVpc")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_egress_from_local_classic_link_to_remote_vpc: Option<bool>,
     #[doc="<p>Indicates whether a local VPC can communicate with a ClassicLink connection in the peer VPC over the VPC peering connection.</p>"]
+    #[serde(rename="AllowEgressFromLocalVpcToRemoteClassicLink")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_egress_from_local_vpc_to_remote_classic_link: Option<bool>,
 }
 
@@ -42705,11 +46924,15 @@ impl VpcPeeringConnectionOptionsDescriptionDeserializer {
     }
 }
 #[doc="<p>Describes the status of a VPC peering connection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcPeeringConnectionStateReason {
     #[doc="<p>The status of the VPC peering connection.</p>"]
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<String>,
     #[doc="<p>A message that provides more information about the status, if applicable.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
 }
 
@@ -42774,17 +46997,27 @@ impl VpcPeeringConnectionStateReasonCodeDeserializer {
     }
 }
 #[doc="<p>Describes a VPC in a VPC peering connection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcPeeringConnectionVpcInfo {
     #[doc="<p>The IPv4 CIDR block for the VPC.</p>"]
+    #[serde(rename="CidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidr_block: Option<String>,
     #[doc="<p>The IPv6 CIDR block for the VPC.</p>"]
+    #[serde(rename="Ipv6CidrBlockSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ipv_6_cidr_block_set: Option<Vec<Ipv6CidrBlock>>,
     #[doc="<p>The AWS account ID of the VPC owner.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
     #[doc="<p>Information about the VPC peering connection options for the accepter or requester VPC.</p>"]
+    #[serde(rename="PeeringOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub peering_options: Option<VpcPeeringConnectionOptionsDescription>,
     #[doc="<p>The ID of the VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -42861,27 +47094,47 @@ impl VpcStateDeserializer {
     }
 }
 #[doc="<p>Describes a VPN connection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpnConnection {
     #[doc="<p>The configuration information for the VPN connection's customer gateway (in the native XML format). This element is always present in the <a>CreateVpnConnection</a> response; however, it's present in the <a>DescribeVpnConnections</a> response only if the VPN connection is in the <code>pending</code> or <code>available</code> state.</p>"]
+    #[serde(rename="CustomerGatewayConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub customer_gateway_configuration: Option<String>,
     #[doc="<p>The ID of the customer gateway at your end of the VPN connection.</p>"]
+    #[serde(rename="CustomerGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub customer_gateway_id: Option<String>,
     #[doc="<p>The VPN connection options.</p>"]
+    #[serde(rename="Options")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options: Option<VpnConnectionOptions>,
     #[doc="<p>The static routes associated with the VPN connection.</p>"]
+    #[serde(rename="Routes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub routes: Option<Vec<VpnStaticRoute>>,
     #[doc="<p>The current state of the VPN connection.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>Any tags assigned to the VPN connection.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The type of VPN connection.</p>"]
+    #[serde(rename="Type")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
     #[doc="<p>Information about the VPN tunnel.</p>"]
+    #[serde(rename="VgwTelemetry")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vgw_telemetry: Option<Vec<VgwTelemetry>>,
     #[doc="<p>The ID of the VPN connection.</p>"]
+    #[serde(rename="VpnConnectionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpn_connection_id: Option<String>,
     #[doc="<p>The ID of the virtual private gateway at the AWS side of the VPN connection.</p>"]
+    #[serde(rename="VpnGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpn_gateway_id: Option<String>,
 }
 
@@ -43023,9 +47276,11 @@ impl VpnConnectionListDeserializer {
     }
 }
 #[doc="<p>Describes VPN connection options.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpnConnectionOptions {
     #[doc="<p>Indicates whether the VPN connection uses static routes only. Static routes must be used for devices that don't support BGP.</p>"]
+    #[serde(rename="StaticRoutesOnly")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub static_routes_only: Option<bool>,
 }
 
@@ -43073,9 +47328,11 @@ impl VpnConnectionOptionsDeserializer {
     }
 }
 #[doc="<p>Describes VPN connection options.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpnConnectionOptionsSpecification {
     #[doc="<p>Indicates whether the VPN connection uses static routes only. Static routes must be used for devices that don't support BGP.</p>"]
+    #[serde(rename="StaticRoutesOnly")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub static_routes_only: Option<bool>,
 }
 
@@ -43098,19 +47355,31 @@ impl VpnConnectionOptionsSpecificationSerializer {
 }
 
 #[doc="<p>Describes a virtual private gateway.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpnGateway {
     #[doc="<p>The Availability Zone where the virtual private gateway was created, if applicable. This field may be empty or not returned.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The current state of the virtual private gateway.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>Any tags assigned to the virtual private gateway.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The type of VPN connection the virtual private gateway supports.</p>"]
+    #[serde(rename="Type")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
     #[doc="<p>Any VPCs attached to the virtual private gateway.</p>"]
+    #[serde(rename="VpcAttachments")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_attachments: Option<Vec<VpcAttachment>>,
     #[doc="<p>The ID of the virtual private gateway.</p>"]
+    #[serde(rename="VpnGatewayId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpn_gateway_id: Option<String>,
 }
 
@@ -43246,13 +47515,19 @@ impl VpnStateDeserializer {
     }
 }
 #[doc="<p>Describes a static route for a VPN connection.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpnStaticRoute {
     #[doc="<p>The CIDR block associated with the local subnet of the customer data center.</p>"]
+    #[serde(rename="DestinationCidrBlock")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_cidr_block: Option<String>,
     #[doc="<p>Indicates how the routes were provided.</p>"]
+    #[serde(rename="Source")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source: Option<String>,
     #[doc="<p>The current state of the static route.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>An object representing authorization data for an Amazon ECR registry.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthorizationData {
     #[doc="<p>A base64-encoded string that contains authorization data for the specified Amazon ECR registry. When the string is decoded, it is presented in the format <code>user:password</code> for private registry authentication using <code>docker login</code>.</p>"]
     #[serde(rename="authorizationToken")]
@@ -45,7 +45,7 @@ pub struct AuthorizationData {
     pub proxy_endpoint: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchCheckLayerAvailabilityRequest {
     #[doc="<p>The digests of the image layers to check.</p>"]
     #[serde(rename="layerDigests")]
@@ -59,7 +59,7 @@ pub struct BatchCheckLayerAvailabilityRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchCheckLayerAvailabilityResponse {
     #[doc="<p>Any failures associated with the call.</p>"]
     #[serde(rename="failures")]
@@ -72,7 +72,7 @@ pub struct BatchCheckLayerAvailabilityResponse {
 }
 
 #[doc="<p>Deletes specified images within a specified repository. Images are specified with either the <code>imageTag</code> or <code>imageDigest</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDeleteImageRequest {
     #[doc="<p>A list of image ID references that correspond to images to delete. The format of the <code>imageIds</code> reference is <code>imageTag=tag</code> or <code>imageDigest=digest</code>.</p>"]
     #[serde(rename="imageIds")]
@@ -86,7 +86,7 @@ pub struct BatchDeleteImageRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDeleteImageResponse {
     #[doc="<p>Any failures associated with the call.</p>"]
     #[serde(rename="failures")]
@@ -98,7 +98,7 @@ pub struct BatchDeleteImageResponse {
     pub image_ids: Option<Vec<ImageIdentifier>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetImageRequest {
     #[doc="<p>The accepted media types for the request.</p> <p>Valid values: <code>application/vnd.docker.distribution.manifest.v1+json</code> | <code>application/vnd.docker.distribution.manifest.v2+json</code> | <code>application/vnd.oci.image.manifest.v1+json</code> </p>"]
     #[serde(rename="acceptedMediaTypes")]
@@ -116,7 +116,7 @@ pub struct BatchGetImageRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetImageResponse {
     #[doc="<p>Any failures associated with the call.</p>"]
     #[serde(rename="failures")]
@@ -128,7 +128,7 @@ pub struct BatchGetImageResponse {
     pub images: Option<Vec<Image>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompleteLayerUploadRequest {
     #[doc="<p>The <code>sha256</code> digest of the image layer.</p>"]
     #[serde(rename="layerDigests")]
@@ -145,7 +145,7 @@ pub struct CompleteLayerUploadRequest {
     pub upload_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompleteLayerUploadResponse {
     #[doc="<p>The <code>sha256</code> digest of the image layer.</p>"]
     #[serde(rename="layerDigest")]
@@ -165,14 +165,14 @@ pub struct CompleteLayerUploadResponse {
     pub upload_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRepositoryRequest {
     #[doc="<p>The name to use for the repository. The repository name may be specified on its own (such as <code>nginx-web-app</code>) or it can be prepended with a namespace to group the repository into a category (such as <code>project-a/nginx-web-app</code>).</p>"]
     #[serde(rename="repositoryName")]
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRepositoryResponse {
     #[doc="<p>The repository that was created.</p>"]
     #[serde(rename="repository")]
@@ -180,7 +180,7 @@ pub struct CreateRepositoryResponse {
     pub repository: Option<Repository>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRepositoryPolicyRequest {
     #[doc="<p>The AWS account ID associated with the registry that contains the repository policy to delete. If you do not specify a registry, the default registry is assumed.</p>"]
     #[serde(rename="registryId")]
@@ -191,7 +191,7 @@ pub struct DeleteRepositoryPolicyRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRepositoryPolicyResponse {
     #[doc="<p>The JSON repository policy that was deleted from the repository.</p>"]
     #[serde(rename="policyText")]
@@ -207,7 +207,7 @@ pub struct DeleteRepositoryPolicyResponse {
     pub repository_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRepositoryRequest {
     #[doc="<p>Force the deletion of the repository if it contains images.</p>"]
     #[serde(rename="force")]
@@ -222,7 +222,7 @@ pub struct DeleteRepositoryRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRepositoryResponse {
     #[doc="<p>The repository that was deleted.</p>"]
     #[serde(rename="repository")]
@@ -231,7 +231,7 @@ pub struct DeleteRepositoryResponse {
 }
 
 #[doc="<p>An object representing a filter on a <a>DescribeImages</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImagesFilter {
     #[doc="<p>The tag status with which to filter your <a>DescribeImages</a> results. You can filter results based on whether they are <code>TAGGED</code> or <code>UNTAGGED</code>.</p>"]
     #[serde(rename="tagStatus")]
@@ -239,7 +239,7 @@ pub struct DescribeImagesFilter {
     pub tag_status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImagesRequest {
     #[doc="<p>The filter key and value with which to filter your <code>DescribeImages</code> results.</p>"]
     #[serde(rename="filter")]
@@ -266,7 +266,7 @@ pub struct DescribeImagesRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeImagesResponse {
     #[doc="<p>A list of <a>ImageDetail</a> objects that contain data about the image.</p>"]
     #[serde(rename="imageDetails")]
@@ -278,7 +278,7 @@ pub struct DescribeImagesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRepositoriesRequest {
     #[doc="<p>The maximum number of repository results returned by <code>DescribeRepositories</code> in paginated output. When this parameter is used, <code>DescribeRepositories</code> only returns <code>maxResults</code> results in a single page along with a <code>nextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>DescribeRepositories</code> request with the returned <code>nextToken</code> value. This value can be between 1 and 100. If this parameter is not used, then <code>DescribeRepositories</code> returns up to 100 results and a <code>nextToken</code> value, if applicable.</p>"]
     #[serde(rename="maxResults")]
@@ -298,7 +298,7 @@ pub struct DescribeRepositoriesRequest {
     pub repository_names: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRepositoriesResponse {
     #[doc="<p>The <code>nextToken</code> value to include in a future <code>DescribeRepositories</code> request. When the results of a <code>DescribeRepositories</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
     #[serde(rename="nextToken")]
@@ -310,7 +310,7 @@ pub struct DescribeRepositoriesResponse {
     pub repositories: Option<Vec<Repository>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAuthorizationTokenRequest {
     #[doc="<p>A list of AWS account IDs that are associated with the registries for which to get authorization tokens. If you do not specify a registry, the default registry is assumed.</p>"]
     #[serde(rename="registryIds")]
@@ -318,7 +318,7 @@ pub struct GetAuthorizationTokenRequest {
     pub registry_ids: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAuthorizationTokenResponse {
     #[doc="<p>A list of authorization token data objects that correspond to the <code>registryIds</code> values in the request.</p>"]
     #[serde(rename="authorizationData")]
@@ -326,7 +326,7 @@ pub struct GetAuthorizationTokenResponse {
     pub authorization_data: Option<Vec<AuthorizationData>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDownloadUrlForLayerRequest {
     #[doc="<p>The digest of the image layer to download.</p>"]
     #[serde(rename="layerDigest")]
@@ -340,7 +340,7 @@ pub struct GetDownloadUrlForLayerRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDownloadUrlForLayerResponse {
     #[doc="<p>The pre-signed Amazon S3 download URL for the requested layer.</p>"]
     #[serde(rename="downloadUrl")]
@@ -352,7 +352,7 @@ pub struct GetDownloadUrlForLayerResponse {
     pub layer_digest: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRepositoryPolicyRequest {
     #[doc="<p>The AWS account ID associated with the registry that contains the repository. If you do not specify a registry, the default registry is assumed.</p>"]
     #[serde(rename="registryId")]
@@ -363,7 +363,7 @@ pub struct GetRepositoryPolicyRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRepositoryPolicyResponse {
     #[doc="<p>The JSON repository policy text associated with the repository.</p>"]
     #[serde(rename="policyText")]
@@ -380,7 +380,7 @@ pub struct GetRepositoryPolicyResponse {
 }
 
 #[doc="<p>An object representing an Amazon ECR image.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Image {
     #[doc="<p>An object containing the image tag and image digest associated with an image.</p>"]
     #[serde(rename="imageId")]
@@ -401,7 +401,7 @@ pub struct Image {
 }
 
 #[doc="<p>An object that describes an image returned by a <a>DescribeImages</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImageDetail {
     #[doc="<p>The <code>sha256</code> digest of the image manifest.</p>"]
     #[serde(rename="imageDigest")]
@@ -430,7 +430,7 @@ pub struct ImageDetail {
 }
 
 #[doc="<p>An object representing an Amazon ECR image failure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImageFailure {
     #[doc="<p>The code associated with the failure.</p>"]
     #[serde(rename="failureCode")]
@@ -459,7 +459,7 @@ pub struct ImageIdentifier {
     pub image_tag: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateLayerUploadRequest {
     #[doc="<p>The AWS account ID associated with the registry that you intend to upload layers to. If you do not specify a registry, the default registry is assumed.</p>"]
     #[serde(rename="registryId")]
@@ -470,7 +470,7 @@ pub struct InitiateLayerUploadRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateLayerUploadResponse {
     #[doc="<p>The size, in bytes, that Amazon ECR expects future layer part uploads to be.</p>"]
     #[serde(rename="partSize")]
@@ -483,7 +483,7 @@ pub struct InitiateLayerUploadResponse {
 }
 
 #[doc="<p>An object representing an Amazon ECR image layer.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Layer {
     #[doc="<p>The availability status of the image layer.</p>"]
     #[serde(rename="layerAvailability")]
@@ -504,7 +504,7 @@ pub struct Layer {
 }
 
 #[doc="<p>An object representing an Amazon ECR image layer failure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LayerFailure {
     #[doc="<p>The failure code associated with the failure.</p>"]
     #[serde(rename="failureCode")]
@@ -521,7 +521,7 @@ pub struct LayerFailure {
 }
 
 #[doc="<p>An object representing a filter on a <a>ListImages</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListImagesFilter {
     #[doc="<p>The tag status with which to filter your <a>ListImages</a> results. You can filter results based on whether they are <code>TAGGED</code> or <code>UNTAGGED</code>.</p>"]
     #[serde(rename="tagStatus")]
@@ -529,7 +529,7 @@ pub struct ListImagesFilter {
     pub tag_status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListImagesRequest {
     #[doc="<p>The filter key and value with which to filter your <code>ListImages</code> results.</p>"]
     #[serde(rename="filter")]
@@ -552,7 +552,7 @@ pub struct ListImagesRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListImagesResponse {
     #[doc="<p>The list of image IDs for the requested repository.</p>"]
     #[serde(rename="imageIds")]
@@ -564,7 +564,7 @@ pub struct ListImagesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutImageRequest {
     #[doc="<p>The image manifest corresponding to the image to be uploaded.</p>"]
     #[serde(rename="imageManifest")]
@@ -582,7 +582,7 @@ pub struct PutImageRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutImageResponse {
     #[doc="<p>Details of the image uploaded.</p>"]
     #[serde(rename="image")]
@@ -591,7 +591,7 @@ pub struct PutImageResponse {
 }
 
 #[doc="<p>An object representing a repository.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Repository {
     #[doc="<p>The date and time, in JavaScript date/time format, when the repository was created.</p>"]
     #[serde(rename="createdAt")]
@@ -615,7 +615,7 @@ pub struct Repository {
     pub repository_uri: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetRepositoryPolicyRequest {
     #[doc="<p>If the policy you are attempting to set on a repository policy would prevent you from setting another policy in the future, you must force the <a>SetRepositoryPolicy</a> operation. This is intended to prevent accidental repository lock outs.</p>"]
     #[serde(rename="force")]
@@ -633,7 +633,7 @@ pub struct SetRepositoryPolicyRequest {
     pub repository_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetRepositoryPolicyResponse {
     #[doc="<p>The JSON repository policy text applied to the repository.</p>"]
     #[serde(rename="policyText")]
@@ -649,7 +649,7 @@ pub struct SetRepositoryPolicyResponse {
     pub repository_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadLayerPartRequest {
     #[doc="<p>The base64-encoded layer part payload.</p>"]
     #[serde(rename="layerPartBlob")]
@@ -677,7 +677,7 @@ pub struct UploadLayerPartRequest {
     pub upload_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadLayerPartResponse {
     #[doc="<p>The integer value of the last byte received in the request.</p>"]
     #[serde(rename="lastByteReceived")]

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -49,7 +49,7 @@ pub struct Attribute {
 }
 
 #[doc="<p>A regional grouping of one or more container instances on which you can run task requests. Each account receives a default cluster the first time you use the Amazon ECS service, but you may also create other clusters. Clusters may contain more than one instance type simultaneously.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Cluster {
     #[doc="<p>The number of services that are running on the cluster in an <code>ACTIVE</code> state. You can view these services with <a>ListServices</a>.</p>"]
     #[serde(rename="activeServicesCount")]
@@ -82,7 +82,7 @@ pub struct Cluster {
 }
 
 #[doc="<p>A Docker container that is part of a task.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Container {
     #[doc="<p>The Amazon Resource Name (ARN) of the container.</p>"]
     #[serde(rename="containerArn")]
@@ -224,7 +224,7 @@ pub struct ContainerDefinition {
 }
 
 #[doc="<p>An EC2 instance that is running the Amazon ECS agent and has been registered with a cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ContainerInstance {
     #[doc="<p>This parameter returns <code>true</code> if the agent is actually connected to Amazon ECS. Registered instances with an agent that may be unhealthy or stopped return <code>false</code>, and instances without a connected agent cannot accept placement requests.</p>"]
     #[serde(rename="agentConnected")]
@@ -309,7 +309,7 @@ pub struct ContainerOverride {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterRequest {
     #[doc="<p>The name of your cluster. If you do not specify a name for your cluster, you create a cluster named <code>default</code>. Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.</p>"]
     #[serde(rename="clusterName")]
@@ -317,7 +317,7 @@ pub struct CreateClusterRequest {
     pub cluster_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterResponse {
     #[doc="<p>The full description of your new cluster.</p>"]
     #[serde(rename="cluster")]
@@ -325,7 +325,7 @@ pub struct CreateClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateServiceRequest {
     #[doc="<p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. Up to 32 ASCII characters are allowed.</p>"]
     #[serde(rename="clientToken")]
@@ -366,7 +366,7 @@ pub struct CreateServiceRequest {
     pub task_definition: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateServiceResponse {
     #[doc="<p>The full description of your service following the create call.</p>"]
     #[serde(rename="service")]
@@ -374,7 +374,7 @@ pub struct CreateServiceResponse {
     pub service: Option<Service>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAttributesRequest {
     #[doc="<p>The attributes to delete from your resource. You can specify up to 10 attributes per request. For custom attributes, specify the attribute name and target ID, but do not specify the value. If you specify the target ID using the short form, you must also specify the target type.</p>"]
     #[serde(rename="attributes")]
@@ -385,7 +385,7 @@ pub struct DeleteAttributesRequest {
     pub cluster: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAttributesResponse {
     #[doc="<p>A list of attribute objects that were successfully deleted from your resource.</p>"]
     #[serde(rename="attributes")]
@@ -393,14 +393,14 @@ pub struct DeleteAttributesResponse {
     pub attributes: Option<Vec<Attribute>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster to delete.</p>"]
     #[serde(rename="cluster")]
     pub cluster: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterResponse {
     #[doc="<p>The full description of the deleted cluster.</p>"]
     #[serde(rename="cluster")]
@@ -408,7 +408,7 @@ pub struct DeleteClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteServiceRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the service to delete. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -419,7 +419,7 @@ pub struct DeleteServiceRequest {
     pub service: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteServiceResponse {
     #[doc="<p>The full description of the deleted service.</p>"]
     #[serde(rename="service")]
@@ -428,7 +428,7 @@ pub struct DeleteServiceResponse {
 }
 
 #[doc="<p>The details of an Amazon ECS service deployment.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Deployment {
     #[doc="<p>The Unix timestamp for when the service was created.</p>"]
     #[serde(rename="createdAt")]
@@ -477,7 +477,7 @@ pub struct DeploymentConfiguration {
     pub minimum_healthy_percent: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterContainerInstanceRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the container instance to deregister. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -492,7 +492,7 @@ pub struct DeregisterContainerInstanceRequest {
     pub force: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterContainerInstanceResponse {
     #[doc="<p>The container instance that was deregistered.</p>"]
     #[serde(rename="containerInstance")]
@@ -500,14 +500,14 @@ pub struct DeregisterContainerInstanceResponse {
     pub container_instance: Option<ContainerInstance>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterTaskDefinitionRequest {
     #[doc="<p>The <code>family</code> and <code>revision</code> (<code>family:revision</code>) or full Amazon Resource Name (ARN) of the task definition to deregister. You must specify a <code>revision</code>.</p>"]
     #[serde(rename="taskDefinition")]
     pub task_definition: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterTaskDefinitionResponse {
     #[doc="<p>The full description of the deregistered task.</p>"]
     #[serde(rename="taskDefinition")]
@@ -515,7 +515,7 @@ pub struct DeregisterTaskDefinitionResponse {
     pub task_definition: Option<TaskDefinition>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClustersRequest {
     #[doc="<p>A list of up to 100 cluster names or full cluster Amazon Resource Name (ARN) entries. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="clusters")]
@@ -523,7 +523,7 @@ pub struct DescribeClustersRequest {
     pub clusters: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClustersResponse {
     #[doc="<p>The list of clusters.</p>"]
     #[serde(rename="clusters")]
@@ -535,7 +535,7 @@ pub struct DescribeClustersResponse {
     pub failures: Option<Vec<Failure>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeContainerInstancesRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the container instances to describe. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -546,7 +546,7 @@ pub struct DescribeContainerInstancesRequest {
     pub container_instances: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeContainerInstancesResponse {
     #[doc="<p>The list of container instances.</p>"]
     #[serde(rename="containerInstances")]
@@ -558,7 +558,7 @@ pub struct DescribeContainerInstancesResponse {
     pub failures: Option<Vec<Failure>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeServicesRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN)the cluster that hosts the service to describe. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -569,7 +569,7 @@ pub struct DescribeServicesRequest {
     pub services: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeServicesResponse {
     #[doc="<p>Any failures associated with the call.</p>"]
     #[serde(rename="failures")]
@@ -581,14 +581,14 @@ pub struct DescribeServicesResponse {
     pub services: Option<Vec<Service>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTaskDefinitionRequest {
     #[doc="<p>The <code>family</code> for the latest <code>ACTIVE</code> revision, <code>family</code> and <code>revision</code> (<code>family:revision</code>) for a specific revision in the family, or full Amazon Resource Name (ARN) of the task definition to describe.</p>"]
     #[serde(rename="taskDefinition")]
     pub task_definition: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTaskDefinitionResponse {
     #[doc="<p>The full task definition description.</p>"]
     #[serde(rename="taskDefinition")]
@@ -596,7 +596,7 @@ pub struct DescribeTaskDefinitionResponse {
     pub task_definition: Option<TaskDefinition>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTasksRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the task to describe. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -607,7 +607,7 @@ pub struct DescribeTasksRequest {
     pub tasks: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTasksResponse {
     #[doc="<p>Any failures associated with the call.</p>"]
     #[serde(rename="failures")]
@@ -619,7 +619,7 @@ pub struct DescribeTasksResponse {
     pub tasks: Option<Vec<Task>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DiscoverPollEndpointRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that the container instance belongs to.</p>"]
     #[serde(rename="cluster")]
@@ -631,7 +631,7 @@ pub struct DiscoverPollEndpointRequest {
     pub container_instance: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DiscoverPollEndpointResponse {
     #[doc="<p>The endpoint for the Amazon ECS agent to poll.</p>"]
     #[serde(rename="endpoint")]
@@ -644,7 +644,7 @@ pub struct DiscoverPollEndpointResponse {
 }
 
 #[doc="<p>A failed resource.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Failure {
     #[doc="<p>The Amazon Resource Name (ARN) of the failed resource.</p>"]
     #[serde(rename="arn")]
@@ -689,7 +689,7 @@ pub struct KeyValuePair {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttributesRequest {
     #[doc="<p>The name of the attribute with which to filter the results. </p>"]
     #[serde(rename="attributeName")]
@@ -716,7 +716,7 @@ pub struct ListAttributesRequest {
     pub target_type: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttributesResponse {
     #[doc="<p>A list of attribute objects that meet the criteria of the request.</p>"]
     #[serde(rename="attributes")]
@@ -728,7 +728,7 @@ pub struct ListAttributesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListClustersRequest {
     #[doc="<p>The maximum number of cluster results returned by <code>ListClusters</code> in paginated output. When this parameter is used, <code>ListClusters</code> only returns <code>maxResults</code> results in a single page along with a <code>nextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>ListClusters</code> request with the returned <code>nextToken</code> value. This value can be between 1 and 100. If this parameter is not used, then <code>ListClusters</code> returns up to 100 results and a <code>nextToken</code> value if applicable.</p>"]
     #[serde(rename="maxResults")]
@@ -740,7 +740,7 @@ pub struct ListClustersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListClustersResponse {
     #[doc="<p>The list of full Amazon Resource Name (ARN) entries for each cluster associated with your account.</p>"]
     #[serde(rename="clusterArns")]
@@ -752,7 +752,7 @@ pub struct ListClustersResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListContainerInstancesRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the container instances to list. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -776,7 +776,7 @@ pub struct ListContainerInstancesRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListContainerInstancesResponse {
     #[doc="<p>The list of container instances with full Amazon Resource Name (ARN) entries for each container instance associated with the specified cluster.</p>"]
     #[serde(rename="containerInstanceArns")]
@@ -788,7 +788,7 @@ pub struct ListContainerInstancesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListServicesRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the services to list. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -804,7 +804,7 @@ pub struct ListServicesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListServicesResponse {
     #[doc="<p>The <code>nextToken</code> value to include in a future <code>ListServices</code> request. When the results of a <code>ListServices</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
     #[serde(rename="nextToken")]
@@ -816,7 +816,7 @@ pub struct ListServicesResponse {
     pub service_arns: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTaskDefinitionFamiliesRequest {
     #[doc="<p>The <code>familyPrefix</code> is a string that is used to filter the results of <code>ListTaskDefinitionFamilies</code>. If you specify a <code>familyPrefix</code>, only task definition family names that begin with the <code>familyPrefix</code> string are returned.</p>"]
     #[serde(rename="familyPrefix")]
@@ -836,7 +836,7 @@ pub struct ListTaskDefinitionFamiliesRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTaskDefinitionFamiliesResponse {
     #[doc="<p>The list of task definition family names that match the <code>ListTaskDefinitionFamilies</code> request.</p>"]
     #[serde(rename="families")]
@@ -848,7 +848,7 @@ pub struct ListTaskDefinitionFamiliesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTaskDefinitionsRequest {
     #[doc="<p>The full family name with which to filter the <code>ListTaskDefinitions</code> results. Specifying a <code>familyPrefix</code> limits the listed task definitions to task definition revisions that belong to that family.</p>"]
     #[serde(rename="familyPrefix")]
@@ -872,7 +872,7 @@ pub struct ListTaskDefinitionsRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTaskDefinitionsResponse {
     #[doc="<p>The <code>nextToken</code> value to include in a future <code>ListTaskDefinitions</code> request. When the results of a <code>ListTaskDefinitions</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
     #[serde(rename="nextToken")]
@@ -884,7 +884,7 @@ pub struct ListTaskDefinitionsResponse {
     pub task_definition_arns: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTasksRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the tasks to list. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -920,7 +920,7 @@ pub struct ListTasksRequest {
     pub started_by: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTasksResponse {
     #[doc="<p>The <code>nextToken</code> value to include in a future <code>ListTasks</code> request. When the results of a <code>ListTasks</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>"]
     #[serde(rename="nextToken")]
@@ -1046,7 +1046,7 @@ pub struct PortMapping {
     pub protocol: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutAttributesRequest {
     #[doc="<p>The attributes to apply to your resource. You can specify up to 10 custom attributes per resource. You can specify up to 10 attributes in a single call.</p>"]
     #[serde(rename="attributes")]
@@ -1057,7 +1057,7 @@ pub struct PutAttributesRequest {
     pub cluster: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutAttributesResponse {
     #[doc="<p>The attributes applied to your resource.</p>"]
     #[serde(rename="attributes")]
@@ -1065,7 +1065,7 @@ pub struct PutAttributesResponse {
     pub attributes: Option<Vec<Attribute>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterContainerInstanceRequest {
     #[doc="<p>The container instance attributes that this container instance supports.</p>"]
     #[serde(rename="attributes")]
@@ -1097,7 +1097,7 @@ pub struct RegisterContainerInstanceRequest {
     pub version_info: Option<VersionInfo>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterContainerInstanceResponse {
     #[doc="<p>The container instance that was registered.</p>"]
     #[serde(rename="containerInstance")]
@@ -1105,7 +1105,7 @@ pub struct RegisterContainerInstanceResponse {
     pub container_instance: Option<ContainerInstance>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterTaskDefinitionRequest {
     #[doc="<p>A list of container definitions in JSON format that describe the different containers that make up your task.</p>"]
     #[serde(rename="containerDefinitions")]
@@ -1131,7 +1131,7 @@ pub struct RegisterTaskDefinitionRequest {
     pub volumes: Option<Vec<Volume>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterTaskDefinitionResponse {
     #[doc="<p>The full description of the registered task definition.</p>"]
     #[serde(rename="taskDefinition")]
@@ -1168,7 +1168,7 @@ pub struct Resource {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RunTaskRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster on which to run your task. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -1203,7 +1203,7 @@ pub struct RunTaskRequest {
     pub task_definition: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RunTaskResponse {
     #[doc="<p>Any failures associated with the call.</p>"]
     #[serde(rename="failures")]
@@ -1216,7 +1216,7 @@ pub struct RunTaskResponse {
 }
 
 #[doc="<p>Details on a service within a cluster</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Service {
     #[doc="<p>The Amazon Resource Name (ARN) of the cluster that hosts the service.</p>"]
     #[serde(rename="clusterArn")]
@@ -1285,7 +1285,7 @@ pub struct Service {
 }
 
 #[doc="<p>Details on an event associated with a service.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ServiceEvent {
     #[doc="<p>The Unix timestamp for when the event was triggered.</p>"]
     #[serde(rename="createdAt")]
@@ -1301,7 +1301,7 @@ pub struct ServiceEvent {
     pub message: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartTaskRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster on which to start your task. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -1327,7 +1327,7 @@ pub struct StartTaskRequest {
     pub task_definition: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartTaskResponse {
     #[doc="<p>Any failures associated with the call.</p>"]
     #[serde(rename="failures")]
@@ -1339,7 +1339,7 @@ pub struct StartTaskResponse {
     pub tasks: Option<Vec<Task>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopTaskRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the task to stop. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -1354,7 +1354,7 @@ pub struct StopTaskRequest {
     pub task: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopTaskResponse {
     #[doc="<p>The task that was stopped.</p>"]
     #[serde(rename="task")]
@@ -1362,7 +1362,7 @@ pub struct StopTaskResponse {
     pub task: Option<Task>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubmitContainerStateChangeRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the container.</p>"]
     #[serde(rename="cluster")]
@@ -1394,7 +1394,7 @@ pub struct SubmitContainerStateChangeRequest {
     pub task: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubmitContainerStateChangeResponse {
     #[doc="<p>Acknowledgement of the state change.</p>"]
     #[serde(rename="acknowledgment")]
@@ -1402,7 +1402,7 @@ pub struct SubmitContainerStateChangeResponse {
     pub acknowledgment: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubmitTaskStateChangeRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the task.</p>"]
     #[serde(rename="cluster")]
@@ -1422,7 +1422,7 @@ pub struct SubmitTaskStateChangeRequest {
     pub task: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubmitTaskStateChangeResponse {
     #[doc="<p>Acknowledgement of the state change.</p>"]
     #[serde(rename="acknowledgment")]
@@ -1431,7 +1431,7 @@ pub struct SubmitTaskStateChangeResponse {
 }
 
 #[doc="<p>Details on a task in a cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Task {
     #[doc="<p>The Amazon Resource Name (ARN) of the cluster that hosts the task.</p>"]
     #[serde(rename="clusterArn")]
@@ -1496,7 +1496,7 @@ pub struct Task {
 }
 
 #[doc="<p>Details of a task definition.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TaskDefinition {
     #[doc="<p>A list of container definitions in JSON format that describe the different containers that make up your task. For more information about container definition parameters and defaults, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html\">Amazon ECS Task Definitions</a> in the <i>Amazon EC2 Container Service Developer Guide</i>.</p>"]
     #[serde(rename="containerDefinitions")]
@@ -1580,7 +1580,7 @@ pub struct Ulimit {
     pub soft_limit: i64,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateContainerAgentRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that your container instance is running on. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -1591,7 +1591,7 @@ pub struct UpdateContainerAgentRequest {
     pub container_instance: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateContainerAgentResponse {
     #[doc="<p>The container instance for which the container agent was updated.</p>"]
     #[serde(rename="containerInstance")]
@@ -1599,7 +1599,7 @@ pub struct UpdateContainerAgentResponse {
     pub container_instance: Option<ContainerInstance>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateContainerInstancesStateRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the container instance to update. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -1613,7 +1613,7 @@ pub struct UpdateContainerInstancesStateRequest {
     pub status: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateContainerInstancesStateResponse {
     #[doc="<p>The list of container instances.</p>"]
     #[serde(rename="containerInstances")]
@@ -1625,7 +1625,7 @@ pub struct UpdateContainerInstancesStateResponse {
     pub failures: Option<Vec<Failure>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateServiceRequest {
     #[doc="<p>The short name or full Amazon Resource Name (ARN) of the cluster that your service is running on. If you do not specify a cluster, the default cluster is assumed.</p>"]
     #[serde(rename="cluster")]
@@ -1648,7 +1648,7 @@ pub struct UpdateServiceRequest {
     pub task_definition: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateServiceResponse {
     #[doc="<p>The full description of your service following the update call.</p>"]
     #[serde(rename="service")]

--- a/rusoto/services/efs/src/generated.rs
+++ b/rusoto/services/efs/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFileSystemRequest {
     #[doc="<p>String of up to 64 ASCII characters. Amazon EFS uses this to ensure idempotent creation.</p>"]
     #[serde(rename="CreationToken")]
@@ -49,7 +49,7 @@ pub struct CreateFileSystemRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateMountTargetRequest {
     #[doc="<p>ID of the file system for which to create the mount target.</p>"]
     #[serde(rename="FileSystemId")]
@@ -68,7 +68,7 @@ pub struct CreateMountTargetRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTagsRequest {
     #[doc="<p>ID of the file system whose tags you want to modify (String). This operation modifies the tags only, not the file system.</p>"]
     #[serde(rename="FileSystemId")]
@@ -79,7 +79,7 @@ pub struct CreateTagsRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFileSystemRequest {
     #[doc="<p>ID of the file system you want to delete.</p>"]
     #[serde(rename="FileSystemId")]
@@ -87,7 +87,7 @@ pub struct DeleteFileSystemRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMountTargetRequest {
     #[doc="<p>ID of the mount target to delete (String).</p>"]
     #[serde(rename="MountTargetId")]
@@ -95,7 +95,7 @@ pub struct DeleteMountTargetRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsRequest {
     #[doc="<p>ID of the file system whose tags you want to delete (String).</p>"]
     #[serde(rename="FileSystemId")]
@@ -106,7 +106,7 @@ pub struct DeleteTagsRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFileSystemsRequest {
     #[doc="<p>(Optional) Restricts the list to the file system with this creation token (String). You specify a creation token when you create an Amazon EFS file system.</p>"]
     #[serde(rename="CreationToken")]
@@ -126,7 +126,7 @@ pub struct DescribeFileSystemsRequest {
     pub max_items: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFileSystemsResponse {
     #[doc="<p>Array of file system descriptions.</p>"]
     #[serde(rename="FileSystems")]
@@ -143,14 +143,14 @@ pub struct DescribeFileSystemsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMountTargetSecurityGroupsRequest {
     #[doc="<p>ID of the mount target whose security groups you want to retrieve.</p>"]
     #[serde(rename="MountTargetId")]
     pub mount_target_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMountTargetSecurityGroupsResponse {
     #[doc="<p>Array of security groups.</p>"]
     #[serde(rename="SecurityGroups")]
@@ -158,7 +158,7 @@ pub struct DescribeMountTargetSecurityGroupsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMountTargetsRequest {
     #[doc="<p>(Optional) ID of the file system whose mount targets you want to list (String). It must be included in your request if <code>MountTargetId</code> is not included.</p>"]
     #[serde(rename="FileSystemId")]
@@ -179,7 +179,7 @@ pub struct DescribeMountTargetsRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMountTargetsResponse {
     #[doc="<p>If the request included the <code>Marker</code>, the response returns that value in this field.</p>"]
     #[serde(rename="Marker")]
@@ -196,7 +196,7 @@ pub struct DescribeMountTargetsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsRequest {
     #[doc="<p>ID of the file system whose tag set you want to retrieve.</p>"]
     #[serde(rename="FileSystemId")]
@@ -212,7 +212,7 @@ pub struct DescribeTagsRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsResponse {
     #[doc="<p>If the request included a <code>Marker</code>, the response returns that value in this field.</p>"]
     #[serde(rename="Marker")]
@@ -228,7 +228,7 @@ pub struct DescribeTagsResponse {
 }
 
 #[doc="<p>Description of the file system.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FileSystemDescription {
     #[doc="<p>Time that the file system was created, in seconds (since 1970-01-01T00:00:00Z).</p>"]
     #[serde(rename="CreationTime")]
@@ -269,7 +269,7 @@ pub struct FileSystemDescription {
 }
 
 #[doc="<p>Latest known metered size (in bytes) of data stored in the file system, in its <code>Value</code> field, and the time at which that size was determined in its <code>Timestamp</code> field. Note that the value does not represent the size of a consistent snapshot of the file system, but it is eventually consistent when there are no writes to the file system. That is, the value will represent the actual size only if the file system is not modified for a period longer than a couple of hours. Otherwise, the value is not necessarily the exact size the file system was at any instant in time.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FileSystemSize {
     #[doc="<p>Time at which the size of data, returned in the <code>Value</code> field, was determined. The value is the integer number of seconds since 1970-01-01T00:00:00Z.</p>"]
     #[serde(rename="Timestamp")]
@@ -281,7 +281,7 @@ pub struct FileSystemSize {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyMountTargetSecurityGroupsRequest {
     #[doc="<p>ID of the mount target whose security groups you want to modify.</p>"]
     #[serde(rename="MountTargetId")]
@@ -293,7 +293,7 @@ pub struct ModifyMountTargetSecurityGroupsRequest {
 }
 
 #[doc="<p>Provides a description of a mount target.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MountTargetDescription {
     #[doc="<p>ID of the file system for which the mount target is intended.</p>"]
     #[serde(rename="FileSystemId")]

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -40,11 +40,13 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>Represents the input of an AddTagsToResource operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceMessage {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource to which the tags are to be added, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>"]
+    #[serde(rename="ResourceName")]
     pub resource_name: String,
     #[doc="<p>A list of cost allocation tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value.</p>"]
+    #[serde(rename="Tags")]
     pub tags: Vec<Tag>,
 }
 
@@ -66,9 +68,11 @@ impl AddTagsToResourceMessageSerializer {
 }
 
 #[doc="<p>Represents the allowed node types you can use to modify your cache cluster or replication group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AllowedNodeTypeModificationsMessage {
     #[doc="<p>A string list, each element of which specifies a cache node type which you can use to scale your cache cluster or replication group.</p> <p>When scaling up a Redis cluster or replication group using <code>ModifyCacheCluster</code> or <code>ModifyReplicationGroup</code>, use a value from this list for the <code>CacheNodeType</code> parameter.</p>"]
+    #[serde(rename="ScaleUpModifications")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scale_up_modifications: Option<Vec<String>>,
 }
 
@@ -117,13 +121,16 @@ impl AllowedNodeTypeModificationsMessageDeserializer {
     }
 }
 #[doc="<p>Represents the input of an AuthorizeCacheSecurityGroupIngress operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthorizeCacheSecurityGroupIngressMessage {
     #[doc="<p>The cache security group that allows network ingress.</p>"]
+    #[serde(rename="CacheSecurityGroupName")]
     pub cache_security_group_name: String,
     #[doc="<p>The Amazon EC2 security group to be authorized for ingress to the cache security group.</p>"]
+    #[serde(rename="EC2SecurityGroupName")]
     pub ec2_security_group_name: String,
     #[doc="<p>The AWS account number of the Amazon EC2 security group owner. Note that this is not the same thing as an AWS access key ID - you must provide a valid AWS account number for this parameter.</p>"]
+    #[serde(rename="EC2SecurityGroupOwnerId")]
     pub ec2_security_group_owner_id: String,
 }
 
@@ -149,8 +156,10 @@ impl AuthorizeCacheSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthorizeCacheSecurityGroupIngressResult {
+    #[serde(rename="CacheSecurityGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_group: Option<CacheSecurityGroup>,
 }
 
@@ -213,9 +222,11 @@ impl AutomaticFailoverStatusDeserializer {
     }
 }
 #[doc="<p>Describes an Availability Zone in which the cache cluster is launched.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AvailabilityZone {
     #[doc="<p>The name of the Availability Zone.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -342,48 +353,92 @@ impl BooleanOptionalDeserializer {
     }
 }
 #[doc="<p>Contains all of the attributes of a specific cache cluster.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheCluster {
     #[doc="<p>This parameter is currently disabled.</p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p>The date and time when the cache cluster was created.</p>"]
+    #[serde(rename="CacheClusterCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster_create_time: Option<String>,
     #[doc="<p>The user-supplied identifier of the cache cluster. This identifier is a unique key that identifies a cache cluster.</p>"]
+    #[serde(rename="CacheClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster_id: Option<String>,
     #[doc="<p>The current state of this cache cluster, one of the following values: <code>available</code>, <code>creating</code>, <code>deleted</code>, <code>deleting</code>, <code>incompatible-network</code>, <code>modifying</code>, <code>rebooting cache cluster nodes</code>, <code>restore-failed</code>, or <code>snapshotting</code>.</p>"]
+    #[serde(rename="CacheClusterStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster_status: Option<String>,
     #[doc="<p>The name of the compute and memory capacity node type for the cache cluster.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>A list of cache nodes that are members of the cache cluster.</p>"]
+    #[serde(rename="CacheNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_nodes: Option<Vec<CacheNode>>,
+    #[serde(rename="CacheParameterGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group: Option<CacheParameterGroupStatus>,
     #[doc="<p>A list of cache security group elements, composed of name and status sub-elements.</p>"]
+    #[serde(rename="CacheSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_groups: Option<Vec<CacheSecurityGroupMembership>>,
     #[doc="<p>The name of the cache subnet group associated with the cache cluster.</p>"]
+    #[serde(rename="CacheSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_subnet_group_name: Option<String>,
     #[doc="<p>The URL of the web page where you can download the latest ElastiCache client library.</p>"]
+    #[serde(rename="ClientDownloadLandingPage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_download_landing_page: Option<String>,
     #[doc="<p>Represents a Memcached cluster endpoint which, if Automatic Discovery is enabled on the cluster, can be used by an application to connect to any node in the cluster. The configuration endpoint will always have <code>.cfg</code> in it.</p> <p>Example: <code>mem-3.9dvc4r<u>.cfg</u>.usw2.cache.amazonaws.com:11211</code> </p>"]
+    #[serde(rename="ConfigurationEndpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub configuration_endpoint: Option<Endpoint>,
     #[doc="<p>The name of the cache engine (<code>memcached</code> or <code>redis</code>) to be used for this cache cluster.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>The version of the cache engine that is used in this cache cluster.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
+    #[serde(rename="NotificationConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_configuration: Option<NotificationConfiguration>,
     #[doc="<p>The number of cache nodes in the cache cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p>"]
+    #[serde(rename="NumCacheNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub num_cache_nodes: Option<i64>,
+    #[serde(rename="PendingModifiedValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pending_modified_values: Option<PendingModifiedValues>,
     #[doc="<p>The name of the Availability Zone in which the cache cluster is located or \"Multiple\" if the cache nodes are located in different Availability Zones.</p>"]
+    #[serde(rename="PreferredAvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_availability_zone: Option<String>,
     #[doc="<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>The replication group to which this cache cluster belongs. If this field is empty, the cache cluster is not associated with any replication group.</p>"]
+    #[serde(rename="ReplicationGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group_id: Option<String>,
     #[doc="<p>A list of VPC Security Groups associated with the cache cluster.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<SecurityGroupMembership>>,
     #[doc="<p>The number of days for which ElastiCache retains automatic cache cluster snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <important> <p> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p> </important>"]
+    #[serde(rename="SnapshotRetentionLimit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_retention_limit: Option<i64>,
     #[doc="<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your cache cluster.</p> <p>Example: <code>05:00-09:00</code> </p>"]
+    #[serde(rename="SnapshotWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_window: Option<String>,
 }
 
@@ -567,11 +622,15 @@ impl CacheClusterListDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>DescribeCacheClusters</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheClusterMessage {
     #[doc="<p>A list of cache clusters. Each item in the list contains detailed information about one cache cluster.</p>"]
+    #[serde(rename="CacheClusters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_clusters: Option<Vec<CacheCluster>>,
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -623,17 +682,27 @@ impl CacheClusterMessageDeserializer {
     }
 }
 #[doc="<p>Provides all of the details about a particular cache engine version.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheEngineVersion {
     #[doc="<p>The description of the cache engine.</p>"]
+    #[serde(rename="CacheEngineDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_engine_description: Option<String>,
     #[doc="<p>The description of the cache engine version.</p>"]
+    #[serde(rename="CacheEngineVersionDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_engine_version_description: Option<String>,
     #[doc="<p>The name of the cache parameter group family associated with this cache engine.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>"]
+    #[serde(rename="CacheParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_family: Option<String>,
     #[doc="<p>The name of the cache engine.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>The version number of the cache engine.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
 }
 
@@ -740,11 +809,15 @@ impl CacheEngineVersionListDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <a>DescribeCacheEngineVersions</a> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheEngineVersionMessage {
     #[doc="<p>A list of cache engine version details. Each element in the list contains detailed information about one cache engine version.</p>"]
+    #[serde(rename="CacheEngineVersions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_engine_versions: Option<Vec<CacheEngineVersion>>,
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -796,21 +869,35 @@ impl CacheEngineVersionMessageDeserializer {
     }
 }
 #[doc="<p>Represents an individual cache node within a cache cluster. Each cache node runs its own instance of the cluster's protocol-compliant caching software - either Memcached or Redis.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheNode {
     #[doc="<p>The date and time when the cache node was created.</p>"]
+    #[serde(rename="CacheNodeCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_create_time: Option<String>,
     #[doc="<p>The cache node identifier. A node ID is a numeric identifier (0001, 0002, etc.). The combination of cluster ID and node ID uniquely identifies every cache node used in a customer's AWS account.</p>"]
+    #[serde(rename="CacheNodeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_id: Option<String>,
     #[doc="<p>The current state of this cache node.</p>"]
+    #[serde(rename="CacheNodeStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_status: Option<String>,
     #[doc="<p>The Availability Zone where this node was created and now resides.</p>"]
+    #[serde(rename="CustomerAvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub customer_availability_zone: Option<String>,
     #[doc="<p>The hostname for connecting to this cache node.</p>"]
+    #[serde(rename="Endpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoint: Option<Endpoint>,
     #[doc="<p>The status of the parameter group applied to this cache node.</p>"]
+    #[serde(rename="ParameterGroupStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_group_status: Option<String>,
     #[doc="<p>The ID of the primary node to which this read replica node is synchronized. If this field is empty, this node is not associated with a primary cache cluster.</p>"]
+    #[serde(rename="SourceCacheNodeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_cache_node_id: Option<String>,
 }
 
@@ -980,25 +1067,43 @@ impl CacheNodeListDeserializer {
     }
 }
 #[doc="<p>A parameter that has a different value for each cache node type it is applied to. For example, in a Redis cache cluster, a <code>cache.m1.large</code> cache node type would have a larger <code>maxmemory</code> value than a <code>cache.m1.small</code> type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheNodeTypeSpecificParameter {
     #[doc="<p>The valid range of values for the parameter.</p>"]
+    #[serde(rename="AllowedValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allowed_values: Option<String>,
     #[doc="<p>A list of cache node types and their corresponding values for this parameter.</p>"]
+    #[serde(rename="CacheNodeTypeSpecificValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type_specific_values: Option<Vec<CacheNodeTypeSpecificValue>>,
     #[doc="<p>Indicates whether a change to the parameter is applied immediately or requires a reboot for the change to be applied. You can force a reboot or wait until the next maintenance window's reboot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Rebooting.html\">Rebooting a Cluster</a>.</p>"]
+    #[serde(rename="ChangeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub change_type: Option<String>,
     #[doc="<p>The valid data type for the parameter.</p>"]
+    #[serde(rename="DataType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub data_type: Option<String>,
     #[doc="<p>A description of the parameter.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Indicates whether (<code>true</code>) or not (<code>false</code>) the parameter can be modified. Some parameters have security or operational implications that prevent them from being changed.</p>"]
+    #[serde(rename="IsModifiable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_modifiable: Option<bool>,
     #[doc="<p>The earliest cache engine version to which the parameter can apply.</p>"]
+    #[serde(rename="MinimumEngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub minimum_engine_version: Option<String>,
     #[doc="<p>The name of the parameter.</p>"]
+    #[serde(rename="ParameterName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_name: Option<String>,
     #[doc="<p>The source of the parameter value.</p>"]
+    #[serde(rename="Source")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source: Option<String>,
 }
 
@@ -1120,11 +1225,15 @@ impl CacheNodeTypeSpecificParametersListDeserializer {
     }
 }
 #[doc="<p>A value that applies only to a certain cache node type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheNodeTypeSpecificValue {
     #[doc="<p>The cache node type for which this value applies.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>The value for the cache node type.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -1216,13 +1325,19 @@ impl CacheNodeTypeSpecificValueListDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>CreateCacheParameterGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheParameterGroup {
     #[doc="<p>The name of the cache parameter group family that this cache parameter group is compatible with.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>"]
+    #[serde(rename="CacheParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_family: Option<String>,
     #[doc="<p>The name of the cache parameter group.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_name: Option<String>,
     #[doc="<p>The description for this cache parameter group.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
 }
 
@@ -1279,13 +1394,19 @@ impl CacheParameterGroupDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>DescribeCacheParameters</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheParameterGroupDetails {
     #[doc="<p>A list of parameters specific to a particular cache node type. Each element in the list contains detailed information about one parameter.</p>"]
+    #[serde(rename="CacheNodeTypeSpecificParameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type_specific_parameters: Option<Vec<CacheNodeTypeSpecificParameter>>,
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of <a>Parameter</a> instances.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
 }
 
@@ -1381,9 +1502,11 @@ impl CacheParameterGroupListDeserializer {
     }
 }
 #[doc="<p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>ModifyCacheParameterGroup</code> </p> </li> <li> <p> <code>ResetCacheParameterGroup</code> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheParameterGroupNameMessage {
     #[doc="<p>The name of the cache parameter group.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_name: Option<String>,
 }
 
@@ -1431,13 +1554,19 @@ impl CacheParameterGroupNameMessageDeserializer {
     }
 }
 #[doc="<p>Status of the cache parameter group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheParameterGroupStatus {
     #[doc="<p>A list of the cache node IDs which need to be rebooted for parameter changes to be applied. A node ID is a numeric identifier (0001, 0002, etc.).</p>"]
+    #[serde(rename="CacheNodeIdsToReboot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_ids_to_reboot: Option<Vec<String>>,
     #[doc="<p>The name of the cache parameter group.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_name: Option<String>,
     #[doc="<p>The status of parameter updates.</p>"]
+    #[serde(rename="ParameterApplyStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_apply_status: Option<String>,
 }
 
@@ -1495,11 +1624,15 @@ impl CacheParameterGroupStatusDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>DescribeCacheParameterGroups</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheParameterGroupsMessage {
     #[doc="<p>A list of cache parameter groups. Each element in the list contains detailed information about one cache parameter group.</p>"]
+    #[serde(rename="CacheParameterGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_groups: Option<Vec<CacheParameterGroup>>,
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -1551,15 +1684,23 @@ impl CacheParameterGroupsMessageDeserializer {
     }
 }
 #[doc="<p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>AuthorizeCacheSecurityGroupIngress</code> </p> </li> <li> <p> <code>CreateCacheSecurityGroup</code> </p> </li> <li> <p> <code>RevokeCacheSecurityGroupIngress</code> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheSecurityGroup {
     #[doc="<p>The name of the cache security group.</p>"]
+    #[serde(rename="CacheSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_group_name: Option<String>,
     #[doc="<p>The description of the cache security group.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>A list of Amazon EC2 security groups that are associated with this cache security group.</p>"]
+    #[serde(rename="EC2SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_groups: Option<Vec<EC2SecurityGroup>>,
     #[doc="<p>The AWS account ID of the cache security group owner.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
 }
 
@@ -1620,11 +1761,15 @@ impl CacheSecurityGroupDeserializer {
     }
 }
 #[doc="<p>Represents a cache cluster's status within a particular cache security group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheSecurityGroupMembership {
     #[doc="<p>The name of the cache security group.</p>"]
+    #[serde(rename="CacheSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_group_name: Option<String>,
     #[doc="<p>The membership status in the cache security group. The status changes when a cache security group is modified, or when the cache security groups assigned to a cache cluster are modified.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -1718,11 +1863,15 @@ impl CacheSecurityGroupMembershipListDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>DescribeCacheSecurityGroups</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheSecurityGroupMessage {
     #[doc="<p>A list of cache security groups. Each element in the list contains detailed information about one group.</p>"]
+    #[serde(rename="CacheSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_groups: Option<Vec<CacheSecurityGroup>>,
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -1827,15 +1976,23 @@ impl CacheSecurityGroupsDeserializer {
     }
 }
 #[doc="<p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>CreateCacheSubnetGroup</code> </p> </li> <li> <p> <code>ModifyCacheSubnetGroup</code> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheSubnetGroup {
     #[doc="<p>The description of the cache subnet group.</p>"]
+    #[serde(rename="CacheSubnetGroupDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_subnet_group_description: Option<String>,
     #[doc="<p>The name of the cache subnet group.</p>"]
+    #[serde(rename="CacheSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_subnet_group_name: Option<String>,
     #[doc="<p>A list of subnets associated with the cache subnet group.</p>"]
+    #[serde(rename="Subnets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnets: Option<Vec<Subnet>>,
     #[doc="<p>The Amazon Virtual Private Cloud identifier (VPC ID) of the cache subnet group.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -1896,11 +2053,15 @@ impl CacheSubnetGroupDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>DescribeCacheSubnetGroups</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CacheSubnetGroupMessage {
     #[doc="<p>A list of cache subnet groups. Each element in the list contains detailed information about one group.</p>"]
+    #[serde(rename="CacheSubnetGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_subnet_groups: Option<Vec<CacheSubnetGroup>>,
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -2049,13 +2210,17 @@ impl ClusterIdListDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>CopySnapshotMessage</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopySnapshotMessage {
     #[doc="<p>The name of an existing snapshot from which to make a copy.</p>"]
+    #[serde(rename="SourceSnapshotName")]
     pub source_snapshot_name: String,
     #[doc="<p>The Amazon S3 bucket to which the snapshot is exported. This parameter is used only when exporting a snapshot for external access.</p> <p>When using this parameter to export a snapshot, be sure Amazon ElastiCache has the needed permissions to this S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html#Snapshots.Exporting.GrantAccess\">Step 2: Grant ElastiCache Access to Your Amazon S3 Bucket</a> in the <i>Amazon ElastiCache User Guide</i>.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Snapshots.Exporting.html\">Exporting a Snapshot</a> in the <i>Amazon ElastiCache User Guide</i>.</p>"]
+    #[serde(rename="TargetBucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_bucket: Option<String>,
     #[doc="<p>A name for the snapshot copy. ElastiCache does not permit overwriting a snapshot, therefore this name must be unique within its context - ElastiCache or an Amazon S3 bucket if exporting.</p>"]
+    #[serde(rename="TargetSnapshotName")]
     pub target_snapshot_name: String,
 }
 
@@ -2081,8 +2246,10 @@ impl CopySnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopySnapshotResult {
+    #[serde(rename="Snapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot: Option<Snapshot>,
 }
 
@@ -2129,53 +2296,98 @@ impl CopySnapshotResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a CreateCacheCluster operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCacheClusterMessage {
     #[doc="<p>Specifies whether the nodes in this Memcached cluster are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region.</p> <p>This parameter is only supported for Memcached cache clusters.</p> <p>If the <code>AZMode</code> and <code>PreferredAvailabilityZones</code> are not specified, ElastiCache assumes <code>single-az</code> mode.</p>"]
+    #[serde(rename="AZMode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub az_mode: Option<String>,
     #[doc="<p> <b>Reserved parameter.</b> The password used to access a password protected server.</p> <p>Password constraints:</p> <ul> <li> <p>Must be only printable ASCII characters.</p> </li> <li> <p>Must be at least 16 characters and no more than 128 characters in length.</p> </li> <li> <p>Cannot contain any of the following characters: '/', '\"', or \"@\". </p> </li> </ul> <p>For more information, see <a href=\"http://redis.io/commands/AUTH\">AUTH password</a> at Redis.</p>"]
+    #[serde(rename="AuthToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auth_token: Option<String>,
     #[doc="<p>This parameter is currently disabled.</p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p>The node group (shard) identifier. This parameter is stored as a lowercase string.</p> <p> <b>Constraints:</b> </p> <ul> <li> <p>A name must contain from 1 to 20 alphanumeric characters or hyphens.</p> </li> <li> <p>The first character must be a letter.</p> </li> <li> <p>A name cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>"]
+    #[serde(rename="CacheClusterId")]
     pub cache_cluster_id: String,
     #[doc="<p>The compute and memory capacity of the nodes in the node group (shard).</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>The name of the parameter group to associate with this cache cluster. If this argument is omitted, the default parameter group for the specified engine is used. You cannot use any parameter group which has <code>cluster-enabled='yes'</code> when creating a cluster.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_name: Option<String>,
     #[doc="<p>A list of security group names to associate with this cache cluster.</p> <p>Use this parameter only when you are creating a cache cluster outside of an Amazon Virtual Private Cloud (Amazon VPC).</p>"]
+    #[serde(rename="CacheSecurityGroupNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_group_names: Option<Vec<String>>,
     #[doc="<p>The name of the subnet group to be used for the cache cluster.</p> <p>Use this parameter only when you are creating a cache cluster in an Amazon Virtual Private Cloud (Amazon VPC).</p> <important> <p>If you're going to launch your cluster in an Amazon VPC, you need to create a subnet group before you start creating a cluster. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SubnetGroups.html\">Subnets and Subnet Groups</a>.</p> </important>"]
+    #[serde(rename="CacheSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_subnet_group_name: Option<String>,
     #[doc="<p>The name of the cache engine to be used for this cache cluster.</p> <p>Valid values for this parameter are: <code>memcached</code> | <code>redis</code> </p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>The version number of the cache engine to be used for this cache cluster. To view the supported cache engine versions, use the DescribeCacheEngineVersions operation.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>), but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing cache cluster or replication group and create it anew with the earlier engine version. </p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic to which notifications are sent.</p> <note> <p>The Amazon SNS topic owner must be the same as the cache cluster owner.</p> </note>"]
+    #[serde(rename="NotificationTopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_topic_arn: Option<String>,
     #[doc="<p>The initial number of cache nodes that the cache cluster has.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p> <p>If you need more than 20 nodes for your Memcached cluster, please fill out the ElastiCache Limit Increase Request form at <a href=\"http://aws.amazon.com/contact-us/elasticache-node-limit-request/\">http://aws.amazon.com/contact-us/elasticache-node-limit-request/</a>.</p>"]
+    #[serde(rename="NumCacheNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub num_cache_nodes: Option<i64>,
     #[doc="<p>The port number on which each of the cache nodes accepts connections.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The EC2 Availability Zone in which the cache cluster is created.</p> <p>All nodes belonging to this Memcached cache cluster are placed in the preferred Availability Zone. If you want to create your nodes across multiple Availability Zones, use <code>PreferredAvailabilityZones</code>.</p> <p>Default: System chosen Availability Zone.</p>"]
+    #[serde(rename="PreferredAvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_availability_zone: Option<String>,
     #[doc="<p>A list of the Availability Zones in which cache nodes are created. The order of the zones in the list is not important.</p> <p>This option is only supported on Memcached.</p> <note> <p>If you are creating your cache cluster in an Amazon VPC (recommended) you can only locate nodes in Availability Zones that are associated with the subnets in the selected subnet group.</p> <p>The number of Availability Zones listed must equal the value of <code>NumCacheNodes</code>.</p> </note> <p>If you want all the nodes in the same Availability Zone, use <code>PreferredAvailabilityZone</code> instead, or repeat the Availability Zone multiple times in the list.</p> <p>Default: System chosen Availability Zones.</p>"]
+    #[serde(rename="PreferredAvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_availability_zones: Option<Vec<String>>,
     #[doc="<p>Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<important> <p>Due to current limitations on Redis (cluster mode disabled), this operation or parameter is not supported on Redis (cluster mode enabled) replication groups.</p> </important> <p>The ID of the replication group to which this cache cluster should belong. If this parameter is specified, the cache cluster is added to the specified replication group as a read replica; otherwise, the cache cluster is a standalone primary that is not part of any replication group.</p> <p>If the specified replication group is Multi-AZ enabled and the Availability Zone is not specified, the cache cluster is created in Availability Zones that provide the best spread of read replicas across Availability Zones.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>"]
+    #[serde(rename="ReplicationGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group_id: Option<String>,
     #[doc="<p>One or more VPC security groups associated with the cache cluster.</p> <p>Use this parameter only when you are creating a cache cluster in an Amazon Virtual Private Cloud (Amazon VPC).</p>"]
+    #[serde(rename="SecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_group_ids: Option<Vec<String>>,
     #[doc="<p>A single-element string list containing an Amazon Resource Name (ARN) that uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot file is used to populate the node group (shard). The Amazon S3 object name in the ARN cannot contain any commas.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Example of an Amazon S3 ARN: <code>arn:aws:s3:::my_bucket/snapshot1.rdb</code> </p>"]
+    #[serde(rename="SnapshotArns")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_arns: Option<Vec<String>>,
     #[doc="<p>The name of a Redis snapshot from which to restore data into the new node group (shard). The snapshot status changes to <code>restoring</code> while the new node group (shard) is being created.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>"]
+    #[serde(rename="SnapshotName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_name: Option<String>,
     #[doc="<p>The number of days for which ElastiCache retains automatic snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot taken today is retained for 5 days before being deleted.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Default: 0 (i.e., automatic backups are disabled for this cache cluster).</p>"]
+    #[serde(rename="SnapshotRetentionLimit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_retention_limit: Option<i64>,
     #[doc="<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard).</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.</p> <p> <b>Note:</b> This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p>"]
+    #[serde(rename="SnapshotWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_window: Option<String>,
     #[doc="<p>A list of cost allocation tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2290,8 +2502,10 @@ impl CreateCacheClusterMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCacheClusterResult {
+    #[serde(rename="CacheCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster: Option<CacheCluster>,
 }
 
@@ -2339,13 +2553,16 @@ impl CreateCacheClusterResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>CreateCacheParameterGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCacheParameterGroupMessage {
     #[doc="<p>The name of the cache parameter group family that the cache parameter group can be used with.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>"]
+    #[serde(rename="CacheParameterGroupFamily")]
     pub cache_parameter_group_family: String,
     #[doc="<p>A user-specified name for the cache parameter group.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
     pub cache_parameter_group_name: String,
     #[doc="<p>A user-specified description for the cache parameter group.</p>"]
+    #[serde(rename="Description")]
     pub description: String,
 }
 
@@ -2369,8 +2586,10 @@ impl CreateCacheParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCacheParameterGroupResult {
+    #[serde(rename="CacheParameterGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group: Option<CacheParameterGroup>,
 }
 
@@ -2419,11 +2638,13 @@ impl CreateCacheParameterGroupResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>CreateCacheSecurityGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCacheSecurityGroupMessage {
     #[doc="<p>A name for the cache security group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters. Cannot be the word \"Default\".</p> <p>Example: <code>mysecuritygroup</code> </p>"]
+    #[serde(rename="CacheSecurityGroupName")]
     pub cache_security_group_name: String,
     #[doc="<p>A description for the cache security group.</p>"]
+    #[serde(rename="Description")]
     pub description: String,
 }
 
@@ -2445,8 +2666,10 @@ impl CreateCacheSecurityGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCacheSecurityGroupResult {
+    #[serde(rename="CacheSecurityGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_group: Option<CacheSecurityGroup>,
 }
 
@@ -2494,13 +2717,16 @@ impl CreateCacheSecurityGroupResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>CreateCacheSubnetGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCacheSubnetGroupMessage {
     #[doc="<p>A description for the cache subnet group.</p>"]
+    #[serde(rename="CacheSubnetGroupDescription")]
     pub cache_subnet_group_description: String,
     #[doc="<p>A name for the cache subnet group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters or hyphens.</p> <p>Example: <code>mysubnetgroup</code> </p>"]
+    #[serde(rename="CacheSubnetGroupName")]
     pub cache_subnet_group_name: String,
     #[doc="<p>A list of VPC subnet IDs for the cache subnet group.</p>"]
+    #[serde(rename="SubnetIds")]
     pub subnet_ids: Vec<String>,
 }
 
@@ -2525,8 +2751,10 @@ impl CreateCacheSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCacheSubnetGroupResult {
+    #[serde(rename="CacheSubnetGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_subnet_group: Option<CacheSubnetGroup>,
 }
 
@@ -2574,59 +2802,109 @@ impl CreateCacheSubnetGroupResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>CreateReplicationGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReplicationGroupMessage {
     #[doc="<p> <b>Reserved parameter.</b> The password used to access a password protected server.</p> <p>Password constraints:</p> <ul> <li> <p>Must be only printable ASCII characters.</p> </li> <li> <p>Must be at least 16 characters and no more than 128 characters in length.</p> </li> <li> <p>Cannot contain any of the following characters: '/', '\"', or \"@\". </p> </li> </ul> <p>For more information, see <a href=\"http://redis.io/commands/AUTH\">AUTH password</a> at Redis.</p>"]
+    #[serde(rename="AuthToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auth_token: Option<String>,
     #[doc="<p>This parameter is currently disabled.</p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p>Specifies whether a read-only replica is automatically promoted to read/write primary if the existing primary fails.</p> <p>If <code>true</code>, Multi-AZ is enabled for this replication group. If <code>false</code>, Multi-AZ is disabled for this replication group.</p> <p> <code>AutomaticFailoverEnabled</code> must be enabled for Redis (cluster mode enabled) replication groups.</p> <p>Default: false</p> <note> <p>ElastiCache Multi-AZ replication groups is not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled): T1 and T2 node types.</p> <p>Redis (cluster mode enabled): T2 node types.</p> </li> </ul> </note>"]
+    #[serde(rename="AutomaticFailoverEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub automatic_failover_enabled: Option<bool>,
     #[doc="<p>The compute and memory capacity of the nodes in the node group (shard).</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used.</p> <p>If you are running Redis version 3.2.4 or later, only one node group (shard), and want to use a default parameter group, we recommend that you specify the parameter group by name. </p> <ul> <li> <p>To create a Redis (cluster mode disabled) replication group, use <code>CacheParameterGroupName=default.redis3.2</code>.</p> </li> <li> <p>To create a Redis (cluster mode enabled) replication group, use <code>CacheParameterGroupName=default.redis3.2.cluster.on</code>.</p> </li> </ul>"]
+    #[serde(rename="CacheParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_name: Option<String>,
     #[doc="<p>A list of cache security group names to associate with this replication group.</p>"]
+    #[serde(rename="CacheSecurityGroupNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_group_names: Option<Vec<String>>,
     #[doc="<p>The name of the cache subnet group to be used for the replication group.</p> <important> <p>If you're going to launch your cluster in an Amazon VPC, you need to create a subnet group before you start creating a cluster. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SubnetGroups.html\">Subnets and Subnet Groups</a>.</p> </important>"]
+    #[serde(rename="CacheSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_subnet_group_name: Option<String>,
     #[doc="<p>The name of the cache engine to be used for the cache clusters in this replication group.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>The version number of the cache engine to be used for the cache clusters in this replication group. To view the supported cache engine versions, use the <code>DescribeCacheEngineVersions</code> operation.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>) in the <i>ElastiCache User Guide</i>, but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing cache cluster or replication group and create it anew with the earlier engine version. </p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>A list of node group (shard) configuration options. Each node group (shard) configuration has the following: Slots, PrimaryAvailabilityZone, ReplicaAvailabilityZones, ReplicaCount.</p> <p>If you're creating a Redis (cluster mode disabled) or a Redis (cluster mode enabled) replication group, you can use this parameter to individually configure each node group (shard), or you can omit this parameter.</p>"]
+    #[serde(rename="NodeGroupConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_group_configuration: Option<Vec<NodeGroupConfiguration>>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS) topic to which notifications are sent.</p> <note> <p>The Amazon SNS topic owner must be the same as the cache cluster owner.</p> </note>"]
+    #[serde(rename="NotificationTopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_topic_arn: Option<String>,
     #[doc="<p>The number of clusters this replication group initially has.</p> <p>This parameter is not used if there is more than one node group (shard). You should use <code>ReplicasPerNodeGroup</code> instead.</p> <p>If <code>AutomaticFailoverEnabled</code> is <code>true</code>, the value of this parameter must be at least 2. If <code>AutomaticFailoverEnabled</code> is <code>false</code> you can omit this parameter (it will default to 1), or you can explicitly set it to a value between 2 and 6.</p> <p>The maximum permitted value for <code>NumCacheClusters</code> is 6 (primary plus 5 replicas).</p>"]
+    #[serde(rename="NumCacheClusters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub num_cache_clusters: Option<i64>,
     #[doc="<p>An optional parameter that specifies the number of node groups (shards) for this Redis (cluster mode enabled) replication group. For Redis (cluster mode disabled) either omit this parameter or set it to 1.</p> <p>Default: 1</p>"]
+    #[serde(rename="NumNodeGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub num_node_groups: Option<i64>,
     #[doc="<p>The port number on which each member of the replication group accepts connections.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>A list of EC2 Availability Zones in which the replication group's cache clusters are created. The order of the Availability Zones in the list is the order in which clusters are allocated. The primary cluster is created in the first AZ in the list.</p> <p>This parameter is not used if there is more than one node group (shard). You should use <code>NodeGroupConfiguration</code> instead.</p> <note> <p>If you are creating your replication group in an Amazon VPC (recommended), you can only locate cache clusters in Availability Zones associated with the subnets in the selected subnet group.</p> <p>The number of Availability Zones listed must equal the value of <code>NumCacheClusters</code>.</p> </note> <p>Default: system chosen Availability Zones.</p>"]
+    #[serde(rename="PreferredCacheClusterAZs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_cache_cluster_a_zs: Option<Vec<String>>,
     #[doc="<p>Specifies the weekly time range during which maintenance on the cache cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid values for <code>ddd</code> are:</p> <p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>The identifier of the cache cluster that serves as the primary for this replication group. This cache cluster must already exist and have a status of <code>available</code>.</p> <p>This parameter is not required if <code>NumCacheClusters</code>, <code>NumNodeGroups</code>, or <code>ReplicasPerNodeGroup</code> is specified.</p>"]
+    #[serde(rename="PrimaryClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub primary_cluster_id: Option<String>,
     #[doc="<p>An optional parameter that specifies the number of replica nodes in each node group (shard). Valid values are 0 to 5.</p>"]
+    #[serde(rename="ReplicasPerNodeGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replicas_per_node_group: Option<i64>,
     #[doc="<p>A user-created description for the replication group.</p>"]
+    #[serde(rename="ReplicationGroupDescription")]
     pub replication_group_description: String,
     #[doc="<p>The replication group identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>A name must contain from 1 to 20 alphanumeric characters or hyphens.</p> </li> <li> <p>The first character must be a letter.</p> </li> <li> <p>A name cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>"]
+    #[serde(rename="ReplicationGroupId")]
     pub replication_group_id: String,
     #[doc="<p>One or more Amazon VPC security groups associated with this replication group.</p> <p>Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud (Amazon VPC).</p>"]
+    #[serde(rename="SecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_group_ids: Option<Vec<String>>,
     #[doc="<p>A list of Amazon Resource Names (ARN) that uniquely identify the Redis RDB snapshot files stored in Amazon S3. The snapshot files are used to populate the new replication group. The Amazon S3 object name in the ARN cannot contain any commas. The new replication group will have the number of node groups (console: shards) specified by the parameter <i>NumNodeGroups</i> or the number of node groups configured by <i>NodeGroupConfiguration</i> regardless of the number of ARNs specified here.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Example of an Amazon S3 ARN: <code>arn:aws:s3:::my_bucket/snapshot1.rdb</code> </p>"]
+    #[serde(rename="SnapshotArns")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_arns: Option<Vec<String>>,
     #[doc="<p>The name of a snapshot from which to restore data into the new replication group. The snapshot status changes to <code>restoring</code> while the new replication group is being created.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>"]
+    #[serde(rename="SnapshotName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_name: Option<String>,
     #[doc="<p>The number of days for which ElastiCache retains automatic snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note> <p>Default: 0 (i.e., automatic backups are disabled for this cache cluster).</p>"]
+    #[serde(rename="SnapshotRetentionLimit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_retention_limit: Option<i64>,
     #[doc="<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard).</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.</p> <note> <p>This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p> </note>"]
+    #[serde(rename="SnapshotWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_window: Option<String>,
     #[doc="<p>A list of cost allocation tags to be added to this resource. A tag is a key-value pair. A tag key must be accompanied by a tag value.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2754,8 +3032,10 @@ impl CreateReplicationGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReplicationGroupResult {
+    #[serde(rename="ReplicationGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group: Option<ReplicationGroup>,
 }
 
@@ -2803,13 +3083,18 @@ impl CreateReplicationGroupResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>CreateSnapshot</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSnapshotMessage {
     #[doc="<p>The identifier of an existing cache cluster. The snapshot is created from this cache cluster.</p>"]
+    #[serde(rename="CacheClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster_id: Option<String>,
     #[doc="<p>The identifier of an existing replication group. The snapshot is created from this replication group.</p>"]
+    #[serde(rename="ReplicationGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group_id: Option<String>,
     #[doc="<p>A name for the snapshot being created.</p>"]
+    #[serde(rename="SnapshotName")]
     pub snapshot_name: String,
 }
 
@@ -2837,8 +3122,10 @@ impl CreateSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSnapshotResult {
+    #[serde(rename="Snapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot: Option<Snapshot>,
 }
 
@@ -2885,11 +3172,14 @@ impl CreateSnapshotResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>DeleteCacheCluster</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCacheClusterMessage {
     #[doc="<p>The cache cluster identifier for the cluster to be deleted. This parameter is not case sensitive.</p>"]
+    #[serde(rename="CacheClusterId")]
     pub cache_cluster_id: String,
     #[doc="<p>The user-supplied name of a final cache cluster snapshot. This is the unique name that identifies the snapshot. ElastiCache creates the snapshot, and then deletes the cache cluster immediately afterward.</p>"]
+    #[serde(rename="FinalSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub final_snapshot_identifier: Option<String>,
 }
 
@@ -2913,8 +3203,10 @@ impl DeleteCacheClusterMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCacheClusterResult {
+    #[serde(rename="CacheCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster: Option<CacheCluster>,
 }
 
@@ -2962,9 +3254,10 @@ impl DeleteCacheClusterResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>DeleteCacheParameterGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCacheParameterGroupMessage {
     #[doc="<p>The name of the cache parameter group to delete.</p> <note> <p>The specified cache security group must not be associated with any cache clusters.</p> </note>"]
+    #[serde(rename="CacheParameterGroupName")]
     pub cache_parameter_group_name: String,
 }
 
@@ -2985,9 +3278,10 @@ impl DeleteCacheParameterGroupMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DeleteCacheSecurityGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCacheSecurityGroupMessage {
     #[doc="<p>The name of the cache security group to delete.</p> <note> <p>You cannot delete the default security group.</p> </note>"]
+    #[serde(rename="CacheSecurityGroupName")]
     pub cache_security_group_name: String,
 }
 
@@ -3008,9 +3302,10 @@ impl DeleteCacheSecurityGroupMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DeleteCacheSubnetGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCacheSubnetGroupMessage {
     #[doc="<p>The name of the cache subnet group to delete.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters or hyphens.</p>"]
+    #[serde(rename="CacheSubnetGroupName")]
     pub cache_subnet_group_name: String,
 }
 
@@ -3031,13 +3326,18 @@ impl DeleteCacheSubnetGroupMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DeleteReplicationGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReplicationGroupMessage {
     #[doc="<p>The name of a final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster, rather than one of the replicas; this is to ensure that it captures the freshest data. After the final snapshot is taken, the replication group is immediately deleted.</p>"]
+    #[serde(rename="FinalSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub final_snapshot_identifier: Option<String>,
     #[doc="<p>The identifier for the cluster to be deleted. This parameter is not case sensitive.</p>"]
+    #[serde(rename="ReplicationGroupId")]
     pub replication_group_id: String,
     #[doc="<p>If set to <code>true</code>, all of the read replicas are deleted, but the primary node is retained.</p>"]
+    #[serde(rename="RetainPrimaryCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub retain_primary_cluster: Option<bool>,
 }
 
@@ -3065,8 +3365,10 @@ impl DeleteReplicationGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReplicationGroupResult {
+    #[serde(rename="ReplicationGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group: Option<ReplicationGroup>,
 }
 
@@ -3114,9 +3416,10 @@ impl DeleteReplicationGroupResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>DeleteSnapshot</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSnapshotMessage {
     #[doc="<p>The name of the snapshot to be deleted.</p>"]
+    #[serde(rename="SnapshotName")]
     pub snapshot_name: String,
 }
 
@@ -3136,8 +3439,10 @@ impl DeleteSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSnapshotResult {
+    #[serde(rename="Snapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot: Option<Snapshot>,
 }
 
@@ -3184,17 +3489,27 @@ impl DeleteSnapshotResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>DescribeCacheClusters</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCacheClustersMessage {
     #[doc="<p>The user-supplied cluster identifier. If this parameter is specified, only information about that specific cache cluster is returned. This parameter isn't case sensitive.</p>"]
+    #[serde(rename="CacheClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster_id: Option<String>,
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>An optional flag that can be included in the <code>DescribeCacheCluster</code> request to show only nodes (API/CLI: clusters) that are not members of a replication group. In practice, this mean Memcached and single node Redis clusters.</p>"]
+    #[serde(rename="ShowCacheClustersNotInReplicationGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub show_cache_clusters_not_in_replication_groups: Option<bool>,
     #[doc="<p>An optional flag that can be included in the <code>DescribeCacheCluster</code> request to retrieve information about the individual cache nodes.</p>"]
+    #[serde(rename="ShowCacheNodeInfo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub show_cache_node_info: Option<bool>,
 }
 
@@ -3233,19 +3548,31 @@ impl DescribeCacheClustersMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeCacheEngineVersions</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCacheEngineVersionsMessage {
     #[doc="<p>The name of a specific cache parameter group family to return details for.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="CacheParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_family: Option<String>,
     #[doc="<p>If <code>true</code>, specifies that only the default version of the specified engine or engine and major version combination is to be returned.</p>"]
+    #[serde(rename="DefaultOnly")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_only: Option<bool>,
     #[doc="<p>The cache engine to return. Valid values: <code>memcached</code> | <code>redis</code> </p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>The cache engine version to return.</p> <p>Example: <code>1.4.14</code> </p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -3288,13 +3615,19 @@ impl DescribeCacheEngineVersionsMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeCacheParameterGroups</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCacheParameterGroupsMessage {
     #[doc="<p>The name of a specific cache parameter group to return details for.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_name: Option<String>,
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -3325,15 +3658,22 @@ impl DescribeCacheParameterGroupsMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeCacheParameters</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCacheParametersMessage {
     #[doc="<p>The name of a specific cache parameter group to return details for.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
     pub cache_parameter_group_name: String,
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The parameter types to return.</p> <p>Valid values: <code>user</code> | <code>system</code> | <code>engine-default</code> </p>"]
+    #[serde(rename="Source")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source: Option<String>,
 }
 
@@ -3366,13 +3706,19 @@ impl DescribeCacheParametersMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeCacheSecurityGroups</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCacheSecurityGroupsMessage {
     #[doc="<p>The name of the cache security group to return details for.</p>"]
+    #[serde(rename="CacheSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_group_name: Option<String>,
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -3403,13 +3749,19 @@ impl DescribeCacheSecurityGroupsMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeCacheSubnetGroups</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCacheSubnetGroupsMessage {
     #[doc="<p>The name of the cache subnet group to return details for.</p>"]
+    #[serde(rename="CacheSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_subnet_group_name: Option<String>,
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -3440,13 +3792,18 @@ impl DescribeCacheSubnetGroupsMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeEngineDefaultParameters</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEngineDefaultParametersMessage {
     #[doc="<p>The name of the cache parameter group family.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>"]
+    #[serde(rename="CacheParameterGroupFamily")]
     pub cache_parameter_group_family: String,
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -3474,8 +3831,10 @@ impl DescribeEngineDefaultParametersMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEngineDefaultParametersResult {
+    #[serde(rename="EngineDefaults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_defaults: Option<EngineDefaults>,
 }
 
@@ -3524,21 +3883,35 @@ impl DescribeEngineDefaultParametersResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>DescribeEvents</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsMessage {
     #[doc="<p>The number of minutes worth of events to retrieve.</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The end of the time interval for which to retrieve events, specified in ISO 8601 format.</p> <p> <b>Example:</b> 2017-03-30T07:03:49.555Z</p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The identifier of the event source for which events are returned. If not specified, all sources are included in the response.</p>"]
+    #[serde(rename="SourceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_identifier: Option<String>,
     #[doc="<p>The event source to retrieve events for. If no value is specified, all events are returned.</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
     #[doc="<p>The beginning of the time interval to retrieve events for, specified in ISO 8601 format.</p> <p> <b>Example:</b> 2017-03-30T07:03:49.555Z</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
 }
 
@@ -3585,13 +3958,19 @@ impl DescribeEventsMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeReplicationGroups</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReplicationGroupsMessage {
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The identifier for the replication group to be described. This parameter is not case sensitive.</p> <p>If you do not specify this parameter, information about all replication groups is returned.</p>"]
+    #[serde(rename="ReplicationGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group_id: Option<String>,
 }
 
@@ -3622,23 +4001,39 @@ impl DescribeReplicationGroupsMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeReservedCacheNodes</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedCacheNodesMessage {
     #[doc="<p>The cache node type filter value. Use this parameter to show only those reservations matching the specified cache node type.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>The duration filter value, specified in years or seconds. Use this parameter to show only reservations for this duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<String>,
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The offering type filter value. Use this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid values: <code>\"Light Utilization\"|\"Medium Utilization\"|\"Heavy Utilization\"</code> </p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The product description filter value. Use this parameter to show only those reservations matching the specified product description.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The reserved cache node identifier filter value. Use this parameter to show only the reservation that matches the specified reservation ID.</p>"]
+    #[serde(rename="ReservedCacheNodeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_cache_node_id: Option<String>,
     #[doc="<p>The offering identifier filter value. Use this parameter to show only purchased reservations matching the specified offering identifier.</p>"]
+    #[serde(rename="ReservedCacheNodesOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_cache_nodes_offering_id: Option<String>,
 }
 
@@ -3689,21 +4084,35 @@ impl DescribeReservedCacheNodesMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>DescribeReservedCacheNodesOfferings</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedCacheNodesOfferingsMessage {
     #[doc="<p>The cache node type filter value. Use this parameter to show only the available offerings matching the specified cache node type.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>Duration filter value, specified in years or seconds. Use this parameter to show only reservations for a given duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<String>,
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 100</p> <p>Constraints: minimum 20; maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The offering type filter value. Use this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid Values: <code>\"Light Utilization\"|\"Medium Utilization\"|\"Heavy Utilization\"</code> </p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The product description filter value. Use this parameter to show only the available offerings matching the specified product description.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The offering identifier filter value. Use this parameter to show only the available offering that matches the specified reservation identifier.</p> <p>Example: <code>438012d3-4052-4cc7-b2e3-8d3372e0e706</code> </p>"]
+    #[serde(rename="ReservedCacheNodesOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_cache_nodes_offering_id: Option<String>,
 }
 
@@ -3752,11 +4161,15 @@ impl DescribeReservedCacheNodesOfferingsMessageSerializer {
 }
 
 #[doc="<p>Represents the output of a <code>DescribeSnapshots</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSnapshotsListMessage {
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of snapshots. Each item in the list contains detailed information about one snapshot.</p>"]
+    #[serde(rename="Snapshots")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshots: Option<Vec<Snapshot>>,
 }
 
@@ -3808,21 +4221,35 @@ impl DescribeSnapshotsListMessageDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>DescribeSnapshotsMessage</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSnapshotsMessage {
     #[doc="<p>A user-supplied cluster identifier. If this parameter is specified, only snapshots associated with that specific cache cluster are described.</p>"]
+    #[serde(rename="CacheClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster_id: Option<String>,
     #[doc="<p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a marker is included in the response so that the remaining results can be retrieved.</p> <p>Default: 50</p> <p>Constraints: minimum 20; maximum 50.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>A user-supplied replication group identifier. If this parameter is specified, only snapshots associated with that specific replication group are described.</p>"]
+    #[serde(rename="ReplicationGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group_id: Option<String>,
     #[doc="<p>A Boolean value which if true, the node group (shard) configuration is included in the snapshot description.</p>"]
+    #[serde(rename="ShowNodeGroupConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub show_node_group_config: Option<bool>,
     #[doc="<p>A user-supplied name of the snapshot. If this parameter is specified, only this snapshot are described.</p>"]
+    #[serde(rename="SnapshotName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_name: Option<String>,
     #[doc="<p>If set to <code>system</code>, the output shows snapshots that were automatically created by ElastiCache. If set to <code>user</code> the output shows snapshots that were manually created. If omitted, the output shows both automatically and manually created snapshots.</p>"]
+    #[serde(rename="SnapshotSource")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_source: Option<String>,
 }
 
@@ -3883,13 +4310,19 @@ impl DoubleDeserializer {
     }
 }
 #[doc="<p>Provides ownership and status information for an Amazon EC2 security group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EC2SecurityGroup {
     #[doc="<p>The name of the Amazon EC2 security group.</p>"]
+    #[serde(rename="EC2SecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_name: Option<String>,
     #[doc="<p>The AWS account ID of the Amazon EC2 security group owner.</p>"]
+    #[serde(rename="EC2SecurityGroupOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_owner_id: Option<String>,
     #[doc="<p>The status of the Amazon EC2 security group.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -3988,11 +4421,15 @@ impl EC2SecurityGroupListDeserializer {
     }
 }
 #[doc="<p>Represents the information required for client programs to connect to a cache node.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Endpoint {
     #[doc="<p>The DNS hostname of the cache node.</p>"]
+    #[serde(rename="Address")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub address: Option<String>,
     #[doc="<p>The port number that the cache engine is listening on.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
 }
 
@@ -4042,15 +4479,23 @@ impl EndpointDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>DescribeEngineDefaultParameters</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EngineDefaults {
     #[doc="<p>A list of parameters specific to a particular cache node type. Each element in the list contains detailed information about one parameter.</p>"]
+    #[serde(rename="CacheNodeTypeSpecificParameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type_specific_parameters: Option<Vec<CacheNodeTypeSpecificParameter>>,
     #[doc="<p>Specifies the name of the cache parameter group family to which the engine default parameters apply.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>"]
+    #[serde(rename="CacheParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_family: Option<String>,
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>Contains a list of engine default parameters.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
 }
 
@@ -4110,15 +4555,23 @@ impl EngineDefaultsDeserializer {
     }
 }
 #[doc="<p>Represents a single occurrence of something interesting within the system. Some examples of events are creating a cache cluster, adding or removing a cache node, or rebooting a node.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Event {
     #[doc="<p>The date and time when the event occurred.</p>"]
+    #[serde(rename="Date")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date: Option<String>,
     #[doc="<p>The text of the event.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
     #[doc="<p>The identifier for the source of the event. For example, if the event occurred at the cache cluster level, the identifier would be the name of the cache cluster.</p>"]
+    #[serde(rename="SourceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_identifier: Option<String>,
     #[doc="<p>Specifies the origin of this event - a cache cluster, a parameter group, a security group, etc.</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
 }
 
@@ -4219,11 +4672,15 @@ impl EventListDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>DescribeEvents</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventsMessage {
     #[doc="<p>A list of events. Each element in the list contains detailed information about one event.</p>"]
+    #[serde(rename="Events")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<Event>>,
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -4314,11 +4771,15 @@ impl KeyListSerializer {
 }
 
 #[doc="<p>The input parameters for the <code>ListAllowedNodeTypeModifications</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAllowedNodeTypeModificationsMessage {
     #[doc="<p>The name of the cache cluster you want to scale up to a larger node instanced type. ElastiCache uses the cluster id to identify the current node type of this cluster and from that to create a list of node types you can scale up to.</p> <important> <p>You must provide a value for either the <code>CacheClusterId</code> or the <code>ReplicationGroupId</code>.</p> </important>"]
+    #[serde(rename="CacheClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster_id: Option<String>,
     #[doc="<p>The name of the replication group want to scale up to a larger node type. ElastiCache uses the replication group id to identify the current node type being used by this replication group, and from that to create a list of node types you can scale up to.</p> <important> <p>You must provide a value for either the <code>CacheClusterId</code> or the <code>ReplicationGroupId</code>.</p> </important>"]
+    #[serde(rename="ReplicationGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group_id: Option<String>,
 }
 
@@ -4345,9 +4806,10 @@ impl ListAllowedNodeTypeModificationsMessageSerializer {
 }
 
 #[doc="<p>The input parameters for the <code>ListTagsForResource</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceMessage {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource for which you want the list of tags, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>"]
+    #[serde(rename="ResourceName")]
     pub resource_name: String,
 }
 
@@ -4368,41 +4830,74 @@ impl ListTagsForResourceMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>ModifyCacheCluster</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyCacheClusterMessage {
     #[doc="<p>Specifies whether the new nodes in this Memcached cache cluster are all created in a single Availability Zone or created across multiple Availability Zones.</p> <p>Valid values: <code>single-az</code> | <code>cross-az</code>.</p> <p>This option is only supported for Memcached cache clusters.</p> <note> <p>You cannot specify <code>single-az</code> if the Memcached cache cluster already has cache nodes in different Availability Zones. If <code>cross-az</code> is specified, existing Memcached nodes remain in their current Availability Zone.</p> <p>Only newly created nodes are located in different Availability Zones. For instructions on how to move existing Memcached nodes to different Availability Zones, see the <b>Availability Zone Considerations</b> section of <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheNode.Memcached.html\">Cache Node Considerations for Memcached</a>.</p> </note>"]
+    #[serde(rename="AZMode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub az_mode: Option<String>,
     #[doc="<p>If <code>true</code>, this parameter causes the modifications in this request and any pending modifications to be applied, asynchronously and as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the cache cluster.</p> <p>If <code>false</code>, changes to the cache cluster are applied on the next maintenance reboot, or the next failure reboot, whichever occurs first.</p> <important> <p>If you perform a <code>ModifyCacheCluster</code> before a pending modification is applied, the pending modification is replaced by the newer modification.</p> </important> <p>Valid values: <code>true</code> | <code>false</code> </p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="ApplyImmediately")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub apply_immediately: Option<bool>,
     #[doc="<p>This parameter is currently disabled.</p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p>The cache cluster identifier. This value is stored as a lowercase string.</p>"]
+    #[serde(rename="CacheClusterId")]
     pub cache_cluster_id: String,
     #[doc="<p>A list of cache node IDs to be removed. A node ID is a numeric identifier (0001, 0002, etc.). This parameter is only valid when <code>NumCacheNodes</code> is less than the existing number of cache nodes. The number of cache node IDs supplied in this parameter must match the difference between the existing number of cache nodes in the cluster or pending cache nodes, whichever is greater, and the value of <code>NumCacheNodes</code> in the request.</p> <p>For example: If you have 3 active cache nodes, 7 pending cache nodes, and the number of cache nodes in this <code>ModifyCacheCluser</code> call is 5, you must list 2 (7 - 5) cache node IDs to remove.</p>"]
+    #[serde(rename="CacheNodeIdsToRemove")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_ids_to_remove: Option<Vec<String>>,
     #[doc="<p>A valid cache node type that you want to scale this cache cluster up to.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>The name of the cache parameter group to apply to this cache cluster. This change is asynchronously applied as soon as possible for parameters when the <code>ApplyImmediately</code> parameter is specified as <code>true</code> for this request.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_name: Option<String>,
     #[doc="<p>A list of cache security group names to authorize on this cache cluster. This change is asynchronously applied as soon as possible.</p> <p>You can use this parameter only with clusters that are created outside of an Amazon Virtual Private Cloud (Amazon VPC).</p> <p>Constraints: Must contain no more than 255 alphanumeric characters. Must not be \"Default\".</p>"]
+    #[serde(rename="CacheSecurityGroupNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_group_names: Option<Vec<String>>,
     #[doc="<p>The upgraded version of the cache engine to be run on the cache nodes.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>), but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing cache cluster and create it anew with the earlier engine version. </p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>The list of Availability Zones where the new Memcached cache nodes are created.</p> <p>This parameter is only valid when <code>NumCacheNodes</code> in the request is greater than the sum of the number of active cache nodes and the number of cache nodes pending creation (which may be zero). The number of Availability Zones supplied in this list must match the cache nodes being added in this request.</p> <p>This option is only supported on Memcached clusters.</p> <p>Scenarios:</p> <ul> <li> <p> <b>Scenario 1:</b> You have 3 active nodes and wish to add 2 nodes. Specify <code>NumCacheNodes=5</code> (3 + 2) and optionally specify two Availability Zones for the two new nodes.</p> </li> <li> <p> <b>Scenario 2:</b> You have 3 active nodes and 2 nodes pending creation (from the scenario 1 call) and want to add 1 more node. Specify <code>NumCacheNodes=6</code> ((3 + 2) + 1) and optionally specify an Availability Zone for the new node.</p> </li> <li> <p> <b>Scenario 3:</b> You want to cancel all pending operations. Specify <code>NumCacheNodes=3</code> to cancel all pending operations.</p> </li> </ul> <p>The Availability Zone placement of nodes pending creation cannot be modified. If you wish to cancel any nodes pending creation, add 0 nodes by setting <code>NumCacheNodes</code> to the number of current nodes.</p> <p>If <code>cross-az</code> is specified, existing Memcached nodes remain in their current Availability Zone. Only newly created nodes can be located in different Availability Zones. For guidance on how to move existing Memcached nodes to different Availability Zones, see the <b>Availability Zone Considerations</b> section of <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheNode.Memcached.html\">Cache Node Considerations for Memcached</a>.</p> <p> <b>Impact of new add/remove requests upon pending requests</b> </p> <ul> <li> <p>Scenario-1</p> <ul> <li> <p>Pending Action: Delete</p> </li> <li> <p>New Request: Delete</p> </li> <li> <p>Result: The new delete, pending or immediate, replaces the pending delete.</p> </li> </ul> </li> <li> <p>Scenario-2</p> <ul> <li> <p>Pending Action: Delete</p> </li> <li> <p>New Request: Create</p> </li> <li> <p>Result: The new create, pending or immediate, replaces the pending delete.</p> </li> </ul> </li> <li> <p>Scenario-3</p> <ul> <li> <p>Pending Action: Create</p> </li> <li> <p>New Request: Delete</p> </li> <li> <p>Result: The new delete, pending or immediate, replaces the pending create.</p> </li> </ul> </li> <li> <p>Scenario-4</p> <ul> <li> <p>Pending Action: Create</p> </li> <li> <p>New Request: Create</p> </li> <li> <p>Result: The new create is added to the pending create.</p> <important> <p> <b>Important:</b> If the new create request is <b>Apply Immediately - Yes</b>, all creates are performed immediately. If the new create request is <b>Apply Immediately - No</b>, all creates are pending.</p> </important> </li> </ul> </li> </ul>"]
+    #[serde(rename="NewAvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_availability_zones: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications are sent.</p> <note> <p>The Amazon SNS topic owner must be same as the cache cluster owner.</p> </note>"]
+    #[serde(rename="NotificationTopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_topic_arn: Option<String>,
     #[doc="<p>The status of the Amazon SNS notification topic. Notifications are sent only if the status is <code>active</code>.</p> <p>Valid values: <code>active</code> | <code>inactive</code> </p>"]
+    #[serde(rename="NotificationTopicStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_topic_status: Option<String>,
     #[doc="<p>The number of cache nodes that the cache cluster should have. If the value for <code>NumCacheNodes</code> is greater than the sum of the number of current cache nodes and the number of cache nodes pending creation (which may be zero), more nodes are added. If the value is less than the number of existing cache nodes, nodes are removed. If the value is equal to the number of current cache nodes, any pending add or remove requests are canceled.</p> <p>If you are removing cache nodes, you must use the <code>CacheNodeIdsToRemove</code> parameter to provide the IDs of the specific cache nodes to remove.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p> <note> <p>Adding or removing Memcached cache nodes can be applied immediately or as a pending operation (see <code>ApplyImmediately</code>).</p> <p>A pending operation to modify the number of cache nodes in a cluster during its maintenance window, whether by adding or removing nodes in accordance with the scale out architecture, is not queued. The customer's latest request to add or remove nodes to the cluster overrides any previous pending operations to modify the number of cache nodes in the cluster. For example, a request to remove 2 nodes would override a previous pending operation to remove 3 nodes. Similarly, a request to add 2 nodes would override a previous pending operation to remove 3 nodes and vice versa. As Memcached cache nodes may now be provisioned in different Availability Zones with flexible cache node placement, a request to add nodes does not automatically override a previous pending operation to add nodes. The customer can modify the previous pending operation to add more nodes or explicitly cancel the pending request and retry the new request. To cancel pending operations to modify the number of cache nodes in a cluster, use the <code>ModifyCacheCluster</code> request and set <code>NumCacheNodes</code> equal to the number of cache nodes currently in the cache cluster.</p> </note>"]
+    #[serde(rename="NumCacheNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub num_cache_nodes: Option<i64>,
     #[doc="<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>Specifies the VPC Security Groups associated with the cache cluster.</p> <p>This parameter can be used only with clusters that are created in an Amazon Virtual Private Cloud (Amazon VPC).</p>"]
+    #[serde(rename="SecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_group_ids: Option<Vec<String>>,
     #[doc="<p>The number of days for which ElastiCache retains automatic cache cluster snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <note> <p>If the value of <code>SnapshotRetentionLimit</code> is set to zero (0), backups are turned off.</p> </note>"]
+    #[serde(rename="SnapshotRetentionLimit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_retention_limit: Option<i64>,
     #[doc="<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your cache cluster. </p>"]
+    #[serde(rename="SnapshotWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_window: Option<String>,
 }
 
@@ -4494,8 +4989,10 @@ impl ModifyCacheClusterMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyCacheClusterResult {
+    #[serde(rename="CacheCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster: Option<CacheCluster>,
 }
 
@@ -4543,11 +5040,13 @@ impl ModifyCacheClusterResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>ModifyCacheParameterGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyCacheParameterGroupMessage {
     #[doc="<p>The name of the cache parameter group to modify.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
     pub cache_parameter_group_name: String,
     #[doc="<p>An array of parameter names and values for the parameter update. You must supply at least one parameter name and value; subsequent arguments are optional. A maximum of 20 parameters may be modified per request.</p>"]
+    #[serde(rename="ParameterNameValues")]
     pub parameter_name_values: Vec<ParameterNameValue>,
 }
 
@@ -4573,13 +5072,18 @@ impl ModifyCacheParameterGroupMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>ModifyCacheSubnetGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyCacheSubnetGroupMessage {
     #[doc="<p>A description of the cache subnet group.</p>"]
+    #[serde(rename="CacheSubnetGroupDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_subnet_group_description: Option<String>,
     #[doc="<p>The name for the cache subnet group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters or hyphens.</p> <p>Example: <code>mysubnetgroup</code> </p>"]
+    #[serde(rename="CacheSubnetGroupName")]
     pub cache_subnet_group_name: String,
     #[doc="<p>The EC2 subnet IDs for the cache subnet group.</p>"]
+    #[serde(rename="SubnetIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_ids: Option<Vec<String>>,
 }
 
@@ -4608,8 +5112,10 @@ impl ModifyCacheSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyCacheSubnetGroupResult {
+    #[serde(rename="CacheSubnetGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_subnet_group: Option<CacheSubnetGroup>,
 }
 
@@ -4657,43 +5163,78 @@ impl ModifyCacheSubnetGroupResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>ModifyReplicationGroups</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyReplicationGroupMessage {
     #[doc="<p>If <code>true</code>, this parameter causes the modifications in this request and any pending modifications to be applied, asynchronously and as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the replication group.</p> <p>If <code>false</code>, changes to the nodes in the replication group are applied on the next maintenance reboot, or the next failure reboot, whichever occurs first.</p> <p>Valid values: <code>true</code> | <code>false</code> </p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="ApplyImmediately")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub apply_immediately: Option<bool>,
     #[doc="<p>This parameter is currently disabled.</p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p>Determines whether a read replica is automatically promoted to read/write primary if the existing primary encounters a failure.</p> <p>Valid values: <code>true</code> | <code>false</code> </p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled):T1 and T2 cache node types.</p> <p>Redis (cluster mode enabled): T1 node types.</p> </li> </ul> </note>"]
+    #[serde(rename="AutomaticFailoverEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub automatic_failover_enabled: Option<bool>,
     #[doc="<p>A valid cache node type that you want to scale this replication group to.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>The name of the cache parameter group to apply to all of the clusters in this replication group. This change is asynchronously applied as soon as possible for parameters when the <code>ApplyImmediately</code> parameter is specified as <code>true</code> for this request.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_name: Option<String>,
     #[doc="<p>A list of cache security group names to authorize for the clusters in this replication group. This change is asynchronously applied as soon as possible.</p> <p>This parameter can be used only with replication group containing cache clusters running outside of an Amazon Virtual Private Cloud (Amazon VPC).</p> <p>Constraints: Must contain no more than 255 alphanumeric characters. Must not be <code>Default</code>.</p>"]
+    #[serde(rename="CacheSecurityGroupNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_group_names: Option<Vec<String>>,
     #[doc="<p>The upgraded version of the cache engine to be run on the cache clusters in the replication group.</p> <p> <b>Important:</b> You can upgrade to a newer engine version (see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/SelectEngine.html#VersionManagement\">Selecting a Cache Engine and Version</a>), but you cannot downgrade to an earlier engine version. If you want to use an earlier engine version, you must delete the existing replication group and create it anew with the earlier engine version. </p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>The name of the Node Group (called shard in the console).</p>"]
+    #[serde(rename="NodeGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_group_id: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications are sent.</p> <note> <p>The Amazon SNS topic owner must be same as the replication group owner. </p> </note>"]
+    #[serde(rename="NotificationTopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_topic_arn: Option<String>,
     #[doc="<p>The status of the Amazon SNS notification topic for the replication group. Notifications are sent only if the status is <code>active</code>.</p> <p>Valid values: <code>active</code> | <code>inactive</code> </p>"]
+    #[serde(rename="NotificationTopicStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub notification_topic_status: Option<String>,
     #[doc="<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>For replication groups with a single primary, if this parameter is specified, ElastiCache promotes the specified cluster in the specified replication group to the primary role. The nodes of all other clusters in the replication group are read replicas.</p>"]
+    #[serde(rename="PrimaryClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub primary_cluster_id: Option<String>,
     #[doc="<p>A description for the replication group. Maximum length is 255 characters.</p>"]
+    #[serde(rename="ReplicationGroupDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group_description: Option<String>,
     #[doc="<p>The identifier of the replication group to modify.</p>"]
+    #[serde(rename="ReplicationGroupId")]
     pub replication_group_id: String,
     #[doc="<p>Specifies the VPC Security Groups associated with the cache clusters in the replication group.</p> <p>This parameter can be used only with replication group containing cache clusters running in an Amazon Virtual Private Cloud (Amazon VPC).</p>"]
+    #[serde(rename="SecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_group_ids: Option<Vec<String>>,
     #[doc="<p>The number of days for which ElastiCache retains automatic node group (shard) snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <p> <b>Important</b> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p>"]
+    #[serde(rename="SnapshotRetentionLimit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_retention_limit: Option<i64>,
     #[doc="<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of the node group (shard) specified by <code>SnapshottingClusterId</code>.</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.</p>"]
+    #[serde(rename="SnapshotWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_window: Option<String>,
     #[doc="<p>The cache cluster ID that is used as the daily snapshot source for the replication group. This parameter cannot be set for Redis (cluster mode enabled) replication groups.</p>"]
+    #[serde(rename="SnapshottingClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshotting_cluster_id: Option<String>,
 }
 
@@ -4785,8 +5326,10 @@ impl ModifyReplicationGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyReplicationGroupResult {
+    #[serde(rename="ReplicationGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group: Option<ReplicationGroup>,
 }
 
@@ -4834,17 +5377,27 @@ impl ModifyReplicationGroupResultDeserializer {
     }
 }
 #[doc="<p>Represents a collection of cache nodes in a replication group. One node in the node group is the read/write primary node. All the other nodes are read-only Replica nodes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NodeGroup {
     #[doc="<p>The identifier for the node group (shard). A Redis (cluster mode disabled) replication group contains only 1 node group; therefore, the node group ID is 0001. A Redis (cluster mode enabled) replication group contains 1 to 15 node groups numbered 0001 to 0015. </p>"]
+    #[serde(rename="NodeGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_group_id: Option<String>,
     #[doc="<p>A list containing information about individual nodes within the node group (shard).</p>"]
+    #[serde(rename="NodeGroupMembers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_group_members: Option<Vec<NodeGroupMember>>,
     #[doc="<p>The endpoint of the primary node in this node group (shard).</p>"]
+    #[serde(rename="PrimaryEndpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub primary_endpoint: Option<Endpoint>,
     #[doc="<p>The keyspace for this node group (shard).</p>"]
+    #[serde(rename="Slots")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub slots: Option<String>,
     #[doc="<p>The current state of this replication group - <code>creating</code>, <code>available</code>, etc.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -4908,15 +5461,23 @@ impl NodeGroupDeserializer {
     }
 }
 #[doc="<p>node group (shard) configuration options. Each node group (shard) configuration has the following: <code>Slots</code>, <code>PrimaryAvailabilityZone</code>, <code>ReplicaAvailabilityZones</code>, <code>ReplicaCount</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NodeGroupConfiguration {
     #[doc="<p>The Availability Zone where the primary node of this node group (shard) is launched.</p>"]
+    #[serde(rename="PrimaryAvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub primary_availability_zone: Option<String>,
     #[doc="<p>A list of Availability Zones to be used for the read replicas. The number of Availability Zones in this list must match the value of <code>ReplicaCount</code> or <code>ReplicasPerNodeGroup</code> if not specified.</p>"]
+    #[serde(rename="ReplicaAvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replica_availability_zones: Option<Vec<String>>,
     #[doc="<p>The number of read replica nodes in this node group (shard).</p>"]
+    #[serde(rename="ReplicaCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replica_count: Option<i64>,
     #[doc="<p>A string that specifies the keyspace for a particular node group. Keyspaces range from 0 to 16,383. The string is in the format <code>startkey-endkey</code>.</p> <p>Example: <code>\"0-3999\"</code> </p>"]
+    #[serde(rename="Slots")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub slots: Option<String>,
 }
 
@@ -5063,16 +5624,26 @@ impl NodeGroupListDeserializer {
     }
 }
 #[doc="<p>Represents a single node within a node group (shard).</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NodeGroupMember {
     #[doc="<p>The ID of the cache cluster to which the node belongs.</p>"]
+    #[serde(rename="CacheClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster_id: Option<String>,
     #[doc="<p>The ID of the node within its cache cluster. A node ID is a numeric identifier (0001, 0002, etc.).</p>"]
+    #[serde(rename="CacheNodeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_id: Option<String>,
     #[doc="<p>The role that is currently assigned to the node - <code>primary</code> or <code>replica</code>.</p>"]
+    #[serde(rename="CurrentRole")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub current_role: Option<String>,
     #[doc="<p>The name of the Availability Zone in which the node is located.</p>"]
+    #[serde(rename="PreferredAvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_availability_zone: Option<String>,
+    #[serde(rename="ReadEndpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub read_endpoint: Option<Endpoint>,
 }
 
@@ -5180,21 +5751,35 @@ impl NodeGroupMemberListDeserializer {
     }
 }
 #[doc="<p>Represents an individual cache node in a snapshot of a cache cluster.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NodeSnapshot {
     #[doc="<p>A unique identifier for the source cache cluster.</p>"]
+    #[serde(rename="CacheClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster_id: Option<String>,
     #[doc="<p>The date and time when the cache node was created in the source cache cluster.</p>"]
+    #[serde(rename="CacheNodeCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_create_time: Option<String>,
     #[doc="<p>The cache node identifier for the node in the source cache cluster.</p>"]
+    #[serde(rename="CacheNodeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_id: Option<String>,
     #[doc="<p>The size of the cache on the source cache node.</p>"]
+    #[serde(rename="CacheSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_size: Option<String>,
     #[doc="<p>The configuration for the source node group (shard).</p>"]
+    #[serde(rename="NodeGroupConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_group_configuration: Option<NodeGroupConfiguration>,
     #[doc="<p>A unique identifier for the source node group (shard).</p>"]
+    #[serde(rename="NodeGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_group_id: Option<String>,
     #[doc="<p>The date and time when the source node's metadata and cache data set was obtained for the snapshot.</p>"]
+    #[serde(rename="SnapshotCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_create_time: Option<String>,
 }
 
@@ -5352,11 +5937,15 @@ impl NodeTypeListDeserializer {
     }
 }
 #[doc="<p>Describes a notification topic and its status. Notification topics are used for publishing ElastiCache events to subscribers using Amazon Simple Notification Service (SNS).</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotificationConfiguration {
     #[doc="<p>The Amazon Resource Name (ARN) that identifies the topic.</p>"]
+    #[serde(rename="TopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
     #[doc="<p>The current state of the topic.</p>"]
+    #[serde(rename="TopicStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_status: Option<String>,
 }
 
@@ -5407,25 +5996,43 @@ impl NotificationConfigurationDeserializer {
     }
 }
 #[doc="<p>Describes an individual setting that controls some aspect of ElastiCache behavior.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Parameter {
     #[doc="<p>The valid range of values for the parameter.</p>"]
+    #[serde(rename="AllowedValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allowed_values: Option<String>,
     #[doc="<p>Indicates whether a change to the parameter is applied immediately or requires a reboot for the change to be applied. You can force a reboot or wait until the next maintenance window's reboot. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Rebooting.html\">Rebooting a Cluster</a>.</p>"]
+    #[serde(rename="ChangeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub change_type: Option<String>,
     #[doc="<p>The valid data type for the parameter.</p>"]
+    #[serde(rename="DataType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub data_type: Option<String>,
     #[doc="<p>A description of the parameter.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Indicates whether (<code>true</code>) or not (<code>false</code>) the parameter can be modified. Some parameters have security or operational implications that prevent them from being changed.</p>"]
+    #[serde(rename="IsModifiable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_modifiable: Option<bool>,
     #[doc="<p>The earliest cache engine version to which the parameter can apply.</p>"]
+    #[serde(rename="MinimumEngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub minimum_engine_version: Option<String>,
     #[doc="<p>The name of the parameter.</p>"]
+    #[serde(rename="ParameterName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_name: Option<String>,
     #[doc="<p>The value of the parameter.</p>"]
+    #[serde(rename="ParameterValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_value: Option<String>,
     #[doc="<p>The source of the parameter.</p>"]
+    #[serde(rename="Source")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source: Option<String>,
 }
 
@@ -5507,11 +6114,15 @@ impl ParameterDeserializer {
     }
 }
 #[doc="<p>Describes a name-value pair that is used to update the value of a parameter.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ParameterNameValue {
     #[doc="<p>The name of the parameter.</p>"]
+    #[serde(rename="ParameterName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_name: Option<String>,
     #[doc="<p>The value of the parameter.</p>"]
+    #[serde(rename="ParameterValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_value: Option<String>,
 }
 
@@ -5605,15 +6216,23 @@ impl PendingAutomaticFailoverStatusDeserializer {
     }
 }
 #[doc="<p>A group of settings that are applied to the cache cluster in the future, or that are currently being applied.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PendingModifiedValues {
     #[doc="<p>A list of cache node IDs that are being removed (or will be removed) from the cache cluster. A node ID is a numeric identifier (0001, 0002, etc.).</p>"]
+    #[serde(rename="CacheNodeIdsToRemove")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_ids_to_remove: Option<Vec<String>>,
     #[doc="<p>The cache node type that this cache cluster or replication group is scaled to.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>The new cache engine version that the cache cluster runs.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>The new number of cache nodes for the cache cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p>"]
+    #[serde(rename="NumCacheNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub num_cache_nodes: Option<i64>,
 }
 
@@ -5686,13 +6305,18 @@ impl PreferredAvailabilityZoneListSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>PurchaseReservedCacheNodesOffering</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseReservedCacheNodesOfferingMessage {
     #[doc="<p>The number of cache node instances to reserve.</p> <p>Default: <code>1</code> </p>"]
+    #[serde(rename="CacheNodeCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_count: Option<i64>,
     #[doc="<p>A customer-specified identifier to track this reservation.</p> <note> <p>The Reserved Cache Node ID is an unique customer-specified identifier to track this reservation. If this parameter is not specified, ElastiCache automatically generates an identifier for the reservation.</p> </note> <p>Example: myreservationID</p>"]
+    #[serde(rename="ReservedCacheNodeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_cache_node_id: Option<String>,
     #[doc="<p>The ID of the reserved cache node offering to purchase.</p> <p>Example: <code>438012d3-4052-4cc7-b2e3-8d3372e0e706</code> </p>"]
+    #[serde(rename="ReservedCacheNodesOfferingId")]
     pub reserved_cache_nodes_offering_id: String,
 }
 
@@ -5722,8 +6346,10 @@ impl PurchaseReservedCacheNodesOfferingMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseReservedCacheNodesOfferingResult {
+    #[serde(rename="ReservedCacheNode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_cache_node: Option<ReservedCacheNode>,
 }
 
@@ -5772,11 +6398,13 @@ impl PurchaseReservedCacheNodesOfferingResultDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>RebootCacheCluster</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootCacheClusterMessage {
     #[doc="<p>The cache cluster identifier. This parameter is stored as a lowercase string.</p>"]
+    #[serde(rename="CacheClusterId")]
     pub cache_cluster_id: String,
     #[doc="<p>A list of cache node IDs to reboot. A node ID is a numeric identifier (0001, 0002, etc.). To reboot an entire cache cluster, specify all of the cache node IDs.</p>"]
+    #[serde(rename="CacheNodeIdsToReboot")]
     pub cache_node_ids_to_reboot: Vec<String>,
 }
 
@@ -5799,8 +6427,10 @@ impl RebootCacheClusterMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootCacheClusterResult {
+    #[serde(rename="CacheCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster: Option<CacheCluster>,
 }
 
@@ -5848,11 +6478,15 @@ impl RebootCacheClusterResultDeserializer {
     }
 }
 #[doc="<p>Contains the specific price and frequency of a recurring charges for a reserved cache node, or for a reserved cache node offering.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecurringCharge {
     #[doc="<p>The monetary amount of the recurring charge.</p>"]
+    #[serde(rename="RecurringChargeAmount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charge_amount: Option<f64>,
     #[doc="<p>The frequency of the recurring charge.</p>"]
+    #[serde(rename="RecurringChargeFrequency")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charge_frequency: Option<String>,
 }
 
@@ -5947,11 +6581,13 @@ impl RecurringChargeListDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>RemoveTagsFromResource</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceMessage {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource from which you want the tags removed, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>"]
+    #[serde(rename="ResourceName")]
     pub resource_name: String,
     #[doc="<p>A list of <code>TagKeys</code> identifying the tags you want removed from the named resource.</p>"]
+    #[serde(rename="TagKeys")]
     pub tag_keys: Vec<String>,
 }
 
@@ -5973,33 +6609,59 @@ impl RemoveTagsFromResourceMessageSerializer {
 }
 
 #[doc="<p>Contains all of the attributes of a specific Redis replication group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplicationGroup {
     #[doc="<p>Indicates the status of Multi-AZ for this replication group.</p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled):T1 and T2 cache node types.</p> <p>Redis (cluster mode enabled): T1 node types.</p> </li> </ul> </note>"]
+    #[serde(rename="AutomaticFailover")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub automatic_failover: Option<String>,
     #[doc="<p>The name of the compute and memory capacity node type for each node in the replication group.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>A flag indicating whether or not this replication group is cluster enabled; i.e., whether its data can be partitioned across multiple shards (API/CLI: node groups).</p> <p>Valid values: <code>true</code> | <code>false</code> </p>"]
+    #[serde(rename="ClusterEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_enabled: Option<bool>,
     #[doc="<p>The configuration endpoint for this replicaiton group. Use the configuration endpoint to connect to this replication group.</p>"]
+    #[serde(rename="ConfigurationEndpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub configuration_endpoint: Option<Endpoint>,
     #[doc="<p>The description of the replication group.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The names of all the cache clusters that are part of this replication group.</p>"]
+    #[serde(rename="MemberClusters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub member_clusters: Option<Vec<String>>,
     #[doc="<p>A single element list with information about the nodes in the replication group.</p>"]
+    #[serde(rename="NodeGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_groups: Option<Vec<NodeGroup>>,
     #[doc="<p>A group of settings to be applied to the replication group, either immediately or during the next maintenance window.</p>"]
+    #[serde(rename="PendingModifiedValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pending_modified_values: Option<ReplicationGroupPendingModifiedValues>,
     #[doc="<p>The identifier for the replication group.</p>"]
+    #[serde(rename="ReplicationGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group_id: Option<String>,
     #[doc="<p>The number of days for which ElastiCache retains automatic cache cluster snapshots before deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a snapshot that was taken today is retained for 5 days before being deleted.</p> <important> <p> If the value of <code>SnapshotRetentionLimit</code> is set to zero (0), backups are turned off.</p> </important>"]
+    #[serde(rename="SnapshotRetentionLimit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_retention_limit: Option<i64>,
     #[doc="<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard).</p> <p>Example: <code>05:00-09:00</code> </p> <p>If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.</p> <p> <b>Note:</b> This parameter is only valid if the <code>Engine</code> parameter is <code>redis</code>.</p>"]
+    #[serde(rename="SnapshotWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_window: Option<String>,
     #[doc="<p>The cache cluster ID that is used as the daily snapshot source for the replication group.</p>"]
+    #[serde(rename="SnapshottingClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshotting_cluster_id: Option<String>,
     #[doc="<p>The current state of this replication group - <code>creating</code>, <code>available</code>, <code>modifying</code>, <code>deleting</code>, <code>create-failed</code>, <code>snapshotting</code>.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -6144,11 +6806,15 @@ impl ReplicationGroupListDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>DescribeReplicationGroups</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplicationGroupMessage {
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of replication groups. Each item in the list contains detailed information about one replication group.</p>"]
+    #[serde(rename="ReplicationGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_groups: Option<Vec<ReplicationGroup>>,
 }
 
@@ -6200,11 +6866,15 @@ impl ReplicationGroupMessageDeserializer {
     }
 }
 #[doc="<p>The settings to be applied to the Redis replication group, either immediately or during the next maintenance window.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplicationGroupPendingModifiedValues {
     #[doc="<p>Indicates the status of Multi-AZ for this Redis replication group.</p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled):T1 and T2 cache node types.</p> <p>Redis (cluster mode enabled): T1 node types.</p> </li> </ul> </note>"]
+    #[serde(rename="AutomaticFailoverStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub automatic_failover_status: Option<String>,
     #[doc="<p>The primary cluster ID that is applied immediately (if <code>--apply-immediately</code> was specified), or during the next maintenance window.</p>"]
+    #[serde(rename="PrimaryClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub primary_cluster_id: Option<String>,
 }
 
@@ -6256,31 +6926,55 @@ impl ReplicationGroupPendingModifiedValuesDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>PurchaseReservedCacheNodesOffering</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedCacheNode {
     #[doc="<p>The number of cache nodes that have been reserved.</p>"]
+    #[serde(rename="CacheNodeCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_count: Option<i64>,
     #[doc="<p>The cache node type for the reserved cache nodes.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>The duration of the reservation in seconds.</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The fixed price charged for this reserved cache node.</p>"]
+    #[serde(rename="FixedPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fixed_price: Option<f64>,
     #[doc="<p>The offering type of this reserved cache node.</p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The description of the reserved cache node.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The recurring price charged to run this reserved cache node.</p>"]
+    #[serde(rename="RecurringCharges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charges: Option<Vec<RecurringCharge>>,
     #[doc="<p>The unique identifier for the reservation.</p>"]
+    #[serde(rename="ReservedCacheNodeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_cache_node_id: Option<String>,
     #[doc="<p>The offering identifier.</p>"]
+    #[serde(rename="ReservedCacheNodesOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_cache_nodes_offering_id: Option<String>,
     #[doc="<p>The time the reservation started.</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
     #[doc="<p>The state of the reserved cache node.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The hourly price charged for this reserved cache node.</p>"]
+    #[serde(rename="UsagePrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub usage_price: Option<f64>,
 }
 
@@ -6416,11 +7110,15 @@ impl ReservedCacheNodeListDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>DescribeReservedCacheNodes</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedCacheNodeMessage {
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of reserved cache nodes. Each element in the list contains detailed information about one node.</p>"]
+    #[serde(rename="ReservedCacheNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_cache_nodes: Option<Vec<ReservedCacheNode>>,
 }
 
@@ -6472,23 +7170,39 @@ impl ReservedCacheNodeMessageDeserializer {
     }
 }
 #[doc="<p>Describes all of the attributes of a reserved cache node offering.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedCacheNodesOffering {
     #[doc="<p>The cache node type for the reserved cache node.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>The duration of the offering. in seconds.</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The fixed price charged for this offering.</p>"]
+    #[serde(rename="FixedPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fixed_price: Option<f64>,
     #[doc="<p>The offering type.</p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The cache engine used by the offering.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The recurring price charged to run this reserved cache node.</p>"]
+    #[serde(rename="RecurringCharges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charges: Option<Vec<RecurringCharge>>,
     #[doc="<p>A unique identifier for the reserved cache node offering.</p>"]
+    #[serde(rename="ReservedCacheNodesOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_cache_nodes_offering_id: Option<String>,
     #[doc="<p>The hourly price charged for this offering.</p>"]
+    #[serde(rename="UsagePrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub usage_price: Option<f64>,
 }
 
@@ -6608,11 +7322,15 @@ impl ReservedCacheNodesOfferingListDeserializer {
     }
 }
 #[doc="<p>Represents the output of a <code>DescribeReservedCacheNodesOfferings</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedCacheNodesOfferingMessage {
     #[doc="<p>Provides an identifier to allow retrieval of paginated results.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of reserved cache node offerings. Each element in the list contains detailed information about one offering.</p>"]
+    #[serde(rename="ReservedCacheNodesOfferings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_cache_nodes_offerings: Option<Vec<ReservedCacheNodesOffering>>,
 }
 
@@ -6663,13 +7381,18 @@ impl ReservedCacheNodesOfferingMessageDeserializer {
     }
 }
 #[doc="<p>Represents the input of a <code>ResetCacheParameterGroup</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetCacheParameterGroupMessage {
     #[doc="<p>The name of the cache parameter group to reset.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
     pub cache_parameter_group_name: String,
     #[doc="<p>An array of parameter names to reset to their default values. If <code>ResetAllParameters</code> is <code>true</code>, do not use <code>ParameterNameValues</code>. If <code>ResetAllParameters</code> is <code>false</code>, you must specify the name of at least one parameter to reset.</p>"]
+    #[serde(rename="ParameterNameValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_name_values: Option<Vec<ParameterNameValue>>,
     #[doc="<p>If <code>true</code>, all parameters in the cache parameter group are reset to their default values. If <code>false</code>, only the parameters listed by <code>ParameterNameValues</code> are reset to their default values.</p> <p>Valid values: <code>true</code> | <code>false</code> </p>"]
+    #[serde(rename="ResetAllParameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reset_all_parameters: Option<bool>,
 }
 
@@ -6701,13 +7424,16 @@ impl ResetCacheParameterGroupMessageSerializer {
 }
 
 #[doc="<p>Represents the input of a <code>RevokeCacheSecurityGroupIngress</code> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevokeCacheSecurityGroupIngressMessage {
     #[doc="<p>The name of the cache security group to revoke ingress from.</p>"]
+    #[serde(rename="CacheSecurityGroupName")]
     pub cache_security_group_name: String,
     #[doc="<p>The name of the Amazon EC2 security group to revoke access from.</p>"]
+    #[serde(rename="EC2SecurityGroupName")]
     pub ec2_security_group_name: String,
     #[doc="<p>The AWS account number of the Amazon EC2 security group owner. Note that this is not the same thing as an AWS access key ID - you must provide a valid AWS account number for this parameter.</p>"]
+    #[serde(rename="EC2SecurityGroupOwnerId")]
     pub ec2_security_group_owner_id: String,
 }
 
@@ -6731,8 +7457,10 @@ impl RevokeCacheSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevokeCacheSecurityGroupIngressResult {
+    #[serde(rename="CacheSecurityGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_security_group: Option<CacheSecurityGroup>,
 }
 
@@ -6793,11 +7521,15 @@ impl SecurityGroupIdsListSerializer {
 }
 
 #[doc="<p>Represents a single cache security group and its status.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SecurityGroupMembership {
     #[doc="<p>The identifier of the cache security group.</p>"]
+    #[serde(rename="SecurityGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_group_id: Option<String>,
     #[doc="<p>The status of the cache security group membership. The status changes whenever a cache security group is modified, or when the cache security groups assigned to a cache cluster are modified.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -6891,55 +7623,103 @@ impl SecurityGroupMembershipListDeserializer {
     }
 }
 #[doc="<p>Represents a copy of an entire Redis cache cluster as of the time when the snapshot was taken.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Snapshot {
     #[doc="<p>This parameter is currently disabled.</p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p>Indicates the status of Multi-AZ for the source replication group.</p> <note> <p>ElastiCache Multi-AZ replication groups are not supported on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled):T1 and T2 cache node types.</p> <p>Redis (cluster mode enabled): T1 node types.</p> </li> </ul> </note>"]
+    #[serde(rename="AutomaticFailover")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub automatic_failover: Option<String>,
     #[doc="<p>The date and time when the source cache cluster was created.</p>"]
+    #[serde(rename="CacheClusterCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster_create_time: Option<String>,
     #[doc="<p>The user-supplied identifier of the source cache cluster.</p>"]
+    #[serde(rename="CacheClusterId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_cluster_id: Option<String>,
     #[doc="<p>The name of the compute and memory capacity node type for the source cache cluster.</p> <p>Valid node types are as follows:</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code>, <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized: <code>cache.c1.xlarge</code> </p> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis backup/restore is not supported for Redis (cluster mode disabled) T1 and T2 instances. Backup/restore is supported on Redis (cluster mode enabled) T2 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and either <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>.</p>"]
+    #[serde(rename="CacheNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_node_type: Option<String>,
     #[doc="<p>The cache parameter group that is associated with the source cache cluster.</p>"]
+    #[serde(rename="CacheParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_parameter_group_name: Option<String>,
     #[doc="<p>The name of the cache subnet group associated with the source cache cluster.</p>"]
+    #[serde(rename="CacheSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_subnet_group_name: Option<String>,
     #[doc="<p>The name of the cache engine (<code>memcached</code> or <code>redis</code>) used by the source cache cluster.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>The version of the cache engine version that is used by the source cache cluster.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>A list of the cache nodes in the source cache cluster.</p>"]
+    #[serde(rename="NodeSnapshots")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_snapshots: Option<Vec<NodeSnapshot>>,
     #[doc="<p>The number of cache nodes in the source cache cluster.</p> <p>For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.</p>"]
+    #[serde(rename="NumCacheNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub num_cache_nodes: Option<i64>,
     #[doc="<p>The number of node groups (shards) in this snapshot. When restoring from a snapshot, the number of node groups (shards) in the snapshot and in the restored replication group must be the same.</p>"]
+    #[serde(rename="NumNodeGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub num_node_groups: Option<i64>,
     #[doc="<p>The port number used by each cache nodes in the source cache cluster.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The name of the Availability Zone in which the source cache cluster is located.</p>"]
+    #[serde(rename="PreferredAvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_availability_zone: Option<String>,
     #[doc="<p>Specifies the weekly time range during which maintenance on the cluster is performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.</p> <p>Valid values for <code>ddd</code> are:</p> <ul> <li> <p> <code>sun</code> </p> </li> <li> <p> <code>mon</code> </p> </li> <li> <p> <code>tue</code> </p> </li> <li> <p> <code>wed</code> </p> </li> <li> <p> <code>thu</code> </p> </li> <li> <p> <code>fri</code> </p> </li> <li> <p> <code>sat</code> </p> </li> </ul> <p>Example: <code>sun:23:00-mon:01:30</code> </p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>A description of the source replication group.</p>"]
+    #[serde(rename="ReplicationGroupDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group_description: Option<String>,
     #[doc="<p>The unique identifier of the source replication group.</p>"]
+    #[serde(rename="ReplicationGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group_id: Option<String>,
     #[doc="<p>The name of a snapshot. For an automatic snapshot, the name is system-generated. For a manual snapshot, this is the user-provided name.</p>"]
+    #[serde(rename="SnapshotName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_name: Option<String>,
     #[doc="<p>For an automatic snapshot, the number of days for which ElastiCache retains the snapshot before deleting it.</p> <p>For manual snapshots, this field reflects the <code>SnapshotRetentionLimit</code> for the source cache cluster when the snapshot was created. This field is otherwise ignored: Manual snapshots do not expire, and can only be deleted using the <code>DeleteSnapshot</code> operation. </p> <p> <b>Important</b> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off.</p>"]
+    #[serde(rename="SnapshotRetentionLimit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_retention_limit: Option<i64>,
     #[doc="<p>Indicates whether the snapshot is from an automatic backup (<code>automated</code>) or was created manually (<code>manual</code>).</p>"]
+    #[serde(rename="SnapshotSource")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_source: Option<String>,
     #[doc="<p>The status of the snapshot. Valid values: <code>creating</code> | <code>available</code> | <code>restoring</code> | <code>copying</code> | <code>deleting</code>.</p>"]
+    #[serde(rename="SnapshotStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_status: Option<String>,
     #[doc="<p>The daily time range during which ElastiCache takes daily snapshots of the source cache cluster.</p>"]
+    #[serde(rename="SnapshotWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_window: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) for the topic used by the source cache cluster for publishing notifications.</p>"]
+    #[serde(rename="TopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
     #[doc="<p>The Amazon Virtual Private Cloud identifier (VPC ID) of the cache subnet group for the source cache cluster.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -7176,11 +7956,15 @@ impl StringDeserializer {
     }
 }
 #[doc="<p>Represents the subnet associated with a cache cluster. This parameter refers to subnets defined in Amazon Virtual Private Cloud (Amazon VPC) and used with ElastiCache.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Subnet {
     #[doc="<p>The Availability Zone associated with the subnet.</p>"]
+    #[serde(rename="SubnetAvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_availability_zone: Option<AvailabilityZone>,
     #[doc="<p>The unique identifier for the subnet.</p>"]
+    #[serde(rename="SubnetIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_identifier: Option<String>,
 }
 
@@ -7300,11 +8084,15 @@ impl TStampDeserializer {
     }
 }
 #[doc="<p>A cost allocation Tag that can be added to an ElastiCache cluster or replication group. Tags are composed of a Key/Value pair. A tag with a null Value is permitted.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>The key for the tag. May not be null.</p>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>The tag's value. May be null.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -7428,9 +8216,11 @@ impl TagListSerializer {
 }
 
 #[doc="<p>Represents the output from the <code>AddTagsToResource</code>, <code>ListTagsForResource</code>, and <code>RemoveTagsFromResource</code> operations.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagListMessage {
     #[doc="<p>A list of cost allocation tags as key-value pairs.</p>"]
+    #[serde(rename="TagList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_list: Option<Vec<Tag>>,
 }
 
@@ -7476,11 +8266,13 @@ impl TagListMessageDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestFailoverMessage {
     #[doc="<p>The name of the node group (called shard in the console) in this replication group on which automatic failover is to be tested. You may test automatic failover on up to 5 node groups in any rolling 24-hour period.</p>"]
+    #[serde(rename="NodeGroupId")]
     pub node_group_id: String,
     #[doc="<p>The name of the replication group (console: cluster) whose automatic failover is being tested by this operation.</p>"]
+    #[serde(rename="ReplicationGroupId")]
     pub replication_group_id: String,
 }
 
@@ -7502,8 +8294,10 @@ impl TestFailoverMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestFailoverResult {
+    #[serde(rename="ReplicationGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_group: Option<ReplicationGroup>,
 }
 

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -54,11 +54,15 @@ impl ARNDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AbortEnvironmentUpdateMessage {
     #[doc="<p>This specifies the ID of the environment with the in-progress update that you want to cancel.</p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>This specifies the name of the environment with the in-progress update that you want to cancel.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
 }
 
@@ -141,21 +145,35 @@ impl ActionTypeDeserializer {
     }
 }
 #[doc="<p>Describes the properties of an application.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationDescription {
     #[doc="<p>The name of the application.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>The names of the configuration templates associated with this application.</p>"]
+    #[serde(rename="ConfigurationTemplates")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub configuration_templates: Option<Vec<String>>,
     #[doc="<p>The date when the application was created.</p>"]
+    #[serde(rename="DateCreated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_created: Option<String>,
     #[doc="<p>The date when the application was last modified.</p>"]
+    #[serde(rename="DateUpdated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_updated: Option<String>,
     #[doc="<p>User-defined description of the application.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The lifecycle settings for the application.</p>"]
+    #[serde(rename="ResourceLifecycleConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_lifecycle_config: Option<ApplicationResourceLifecycleConfig>,
     #[doc="<p>The names of the versions for this application.</p>"]
+    #[serde(rename="Versions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub versions: Option<Vec<String>>,
 }
 
@@ -271,9 +289,11 @@ impl ApplicationDescriptionListDeserializer {
     }
 }
 #[doc="<p>Result message containing a single description of an application.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationDescriptionMessage {
     #[doc="<p> The <a>ApplicationDescription</a> of the application. </p>"]
+    #[serde(rename="Application")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application: Option<ApplicationDescription>,
 }
 
@@ -321,9 +341,11 @@ impl ApplicationDescriptionMessageDeserializer {
     }
 }
 #[doc="<p>Result message containing a list of application descriptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationDescriptionsMessage {
     #[doc="<p>This parameter contains a list of <a>ApplicationDescription</a>.</p>"]
+    #[serde(rename="Applications")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub applications: Option<Vec<ApplicationDescription>>,
 }
 
@@ -369,15 +391,23 @@ impl ApplicationDescriptionsMessageDeserializer {
     }
 }
 #[doc="<p>Application request metrics for an AWS Elastic Beanstalk environment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationMetrics {
     #[doc="<p>The amount of time that the metrics cover (usually 10 seconds). For example, you might have 5 requests (<code>request_count</code>) within the most recent time slice of 10 seconds (<code>duration</code>).</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>Represents the average latency for the slowest X percent of requests over the last 10 seconds. Latencies are in seconds with one millisecond resolution.</p>"]
+    #[serde(rename="Latency")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub latency: Option<Latency>,
     #[doc="<p>Average number of requests handled by the web server per second over the last 10 seconds.</p>"]
+    #[serde(rename="RequestCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_count: Option<i64>,
     #[doc="<p>Represents the percentage of requests over the last 10 seconds that resulted in each type of status code response.</p>"]
+    #[serde(rename="StatusCodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_codes: Option<StatusCodes>,
 }
 
@@ -465,11 +495,15 @@ impl ApplicationNamesListSerializer {
 }
 
 #[doc="<p>The resource lifecycle configuration for an application. Defines lifecycle settings for resources that belong to the application, and the service role that Elastic Beanstalk assumes in order to apply lifecycle settings. The version lifecycle configuration defines lifecycle settings for application versions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationResourceLifecycleConfig {
     #[doc="<p>The ARN of an IAM service role that Elastic Beanstalk has permission to assume.</p>"]
+    #[serde(rename="ServiceRole")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub service_role: Option<String>,
     #[doc="<p>The application version lifecycle configuration.</p>"]
+    #[serde(rename="VersionLifecycleConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_lifecycle_config: Option<ApplicationVersionLifecycleConfig>,
 }
 
@@ -544,11 +578,15 @@ impl ApplicationResourceLifecycleConfigSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationResourceLifecycleDescriptionMessage {
     #[doc="<p>The name of the application.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>The lifecycle configuration.</p>"]
+    #[serde(rename="ResourceLifecycleConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_lifecycle_config: Option<ApplicationResourceLifecycleConfig>,
 }
 
@@ -600,25 +638,43 @@ impl ApplicationResourceLifecycleDescriptionMessageDeserializer {
     }
 }
 #[doc="<p>Describes the properties of an application version.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationVersionDescription {
     #[doc="<p>The name of the application to which the application version belongs.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>Reference to the artifact from the AWS CodeBuild build.</p>"]
+    #[serde(rename="BuildArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub build_arn: Option<String>,
     #[doc="<p>The creation date of the application version.</p>"]
+    #[serde(rename="DateCreated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_created: Option<String>,
     #[doc="<p>The last modified date of the application version.</p>"]
+    #[serde(rename="DateUpdated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_updated: Option<String>,
     #[doc="<p>The description of the application version.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>If the version's source code was retrieved from AWS CodeCommit, the location of the source code for the application version.</p>"]
+    #[serde(rename="SourceBuildInformation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_build_information: Option<SourceBuildInformation>,
     #[doc="<p>The storage location of the application version's source bundle in Amazon S3.</p>"]
+    #[serde(rename="SourceBundle")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_bundle: Option<S3Location>,
     #[doc="<p>The processing status of the application version.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>A unique identifier for the application version.</p>"]
+    #[serde(rename="VersionLabel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_label: Option<String>,
 }
 
@@ -745,9 +801,11 @@ impl ApplicationVersionDescriptionListDeserializer {
     }
 }
 #[doc="<p>Result message wrapping a single description of an application version.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationVersionDescriptionMessage {
     #[doc="<p> The <a>ApplicationVersionDescription</a> of the application version. </p>"]
+    #[serde(rename="ApplicationVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_version: Option<ApplicationVersionDescription>,
 }
 
@@ -794,11 +852,15 @@ impl ApplicationVersionDescriptionMessageDeserializer {
     }
 }
 #[doc="<p>Result message wrapping a list of application version descriptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationVersionDescriptionsMessage {
     #[doc="<p>List of <code>ApplicationVersionDescription</code> objects sorted in order of creation.</p>"]
+    #[serde(rename="ApplicationVersions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_versions: Option<Vec<ApplicationVersionDescription>>,
     #[doc="<p>In a paginated request, the token that you can pass in a subsequent request to get the next response page.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -849,11 +911,15 @@ impl ApplicationVersionDescriptionsMessageDeserializer {
     }
 }
 #[doc="<p>The application version lifecycle settings for an application. Defines the rules that Elastic Beanstalk applies to an application's versions in order to avoid hitting the per-region limit for application versions.</p> <p>When Elastic Beanstalk deletes an application version from its database, you can no longer deploy that version to an environment. The source bundle remains in S3 unless you configure the rule to delete it.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationVersionLifecycleConfig {
     #[doc="<p>Specify a max age rule to restrict the length of time that application versions are retained for an application.</p>"]
+    #[serde(rename="MaxAgeRule")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_age_rule: Option<MaxAgeRule>,
     #[doc="<p>Specify a max count rule to restrict the number of application versions that are retained for an application.</p>"]
+    #[serde(rename="MaxCountRule")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_count_rule: Option<MaxCountRule>,
 }
 
@@ -945,13 +1011,18 @@ impl ApplicationVersionStatusDeserializer {
     }
 }
 #[doc="<p>Request to execute a scheduled managed action immediately.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplyEnvironmentManagedActionRequest {
     #[doc="<p>The action ID of the scheduled managed action to execute.</p>"]
+    #[serde(rename="ActionId")]
     pub action_id: String,
     #[doc="<p>The environment ID of the target environment.</p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>The name of the target environment.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
 }
 
@@ -980,15 +1051,23 @@ impl ApplyEnvironmentManagedActionRequestSerializer {
 }
 
 #[doc="<p>The result message containing information about the managed action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplyEnvironmentManagedActionResult {
     #[doc="<p>A description of the managed action.</p>"]
+    #[serde(rename="ActionDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action_description: Option<String>,
     #[doc="<p>The action ID of the managed action.</p>"]
+    #[serde(rename="ActionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action_id: Option<String>,
     #[doc="<p>The type of managed action.</p>"]
+    #[serde(rename="ActionType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action_type: Option<String>,
     #[doc="<p>The status of the managed action.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -1050,9 +1129,11 @@ impl ApplyEnvironmentManagedActionResultDeserializer {
     }
 }
 #[doc="<p>Describes an Auto Scaling launch configuration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoScalingGroup {
     #[doc="<p>The name of the <code>AutoScalingGroup</code> . </p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -1251,17 +1332,25 @@ impl BoxedIntDeserializer {
     }
 }
 #[doc="<p>Settings for an AWS CodeBuild build.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BuildConfiguration {
     #[doc="<p>The name of the artifact of the CodeBuild build. If provided, Elastic Beanstalk stores the build artifact in the S3 location <i>S3-bucket</i>/resources/<i>application-name</i>/codebuild/codebuild-<i>version-label</i>-<i>artifact-name</i>.zip. If not provided, Elastic Beanstalk stores the build artifact in the S3 location <i>S3-bucket</i>/resources/<i>application-name</i>/codebuild/codebuild-<i>version-label</i>.zip. </p>"]
+    #[serde(rename="ArtifactName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub artifact_name: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that enables AWS CodeBuild to interact with dependent AWS services on behalf of the AWS account.</p>"]
+    #[serde(rename="CodeBuildServiceRole")]
     pub code_build_service_role: String,
     #[doc="<p>Information about the compute resources the build project will use.</p> <ul> <li> <p> <code>BUILD_GENERAL1_SMALL: Use up to 3 GB memory and 2 vCPUs for builds</code> </p> </li> <li> <p> <code>BUILD_GENERAL1_MEDIUM: Use up to 7 GB memory and 4 vCPUs for builds</code> </p> </li> <li> <p> <code>BUILD_GENERAL1_LARGE: Use up to 15 GB memory and 8 vCPUs for builds</code> </p> </li> </ul>"]
+    #[serde(rename="ComputeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub compute_type: Option<String>,
     #[doc="<p>The ID of the Docker image to use for this build project.</p>"]
+    #[serde(rename="Image")]
     pub image: String,
     #[doc="<p>How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes.</p>"]
+    #[serde(rename="TimeoutInMinutes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timeout_in_minutes: Option<i64>,
 }
 
@@ -1296,9 +1385,11 @@ impl BuildConfigurationSerializer {
 }
 
 #[doc="<p>The builder used to build the custom platform.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Builder {
     #[doc="<p>The ARN of the builder.</p>"]
+    #[serde(rename="ARN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
 }
 
@@ -1344,21 +1435,35 @@ impl BuilderDeserializer {
     }
 }
 #[doc="<p>CPU utilization metrics for an instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CPUUtilization {
     #[doc="<p>Percentage of time that the CPU has spent in the <code>I/O Wait</code> state over the last 10 seconds.</p>"]
+    #[serde(rename="IOWait")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub io_wait: Option<f64>,
     #[doc="<p>Percentage of time that the CPU has spent in the <code>IRQ</code> state over the last 10 seconds.</p>"]
+    #[serde(rename="IRQ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub irq: Option<f64>,
     #[doc="<p>Percentage of time that the CPU has spent in the <code>Idle</code> state over the last 10 seconds.</p>"]
+    #[serde(rename="Idle")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub idle: Option<f64>,
     #[doc="<p>Percentage of time that the CPU has spent in the <code>Nice</code> state over the last 10 seconds.</p>"]
+    #[serde(rename="Nice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub nice: Option<f64>,
     #[doc="<p>Percentage of time that the CPU has spent in the <code>SoftIRQ</code> state over the last 10 seconds.</p>"]
+    #[serde(rename="SoftIRQ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub soft_irq: Option<f64>,
     #[doc="<p>Percentage of time that the CPU has spent in the <code>System</code> state over the last 10 seconds.</p>"]
+    #[serde(rename="System")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub system: Option<f64>,
     #[doc="<p>Percentage of time that the CPU has spent in the <code>User</code> state over the last 10 seconds.</p>"]
+    #[serde(rename="User")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user: Option<f64>,
 }
 
@@ -1486,9 +1591,10 @@ impl CausesDeserializer {
     }
 }
 #[doc="<p>Results message indicating whether a CNAME is available.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CheckDNSAvailabilityMessage {
     #[doc="<p>The prefix used when this CNAME is reserved.</p>"]
+    #[serde(rename="CNAMEPrefix")]
     pub cname_prefix: String,
 }
 
@@ -1509,11 +1615,15 @@ impl CheckDNSAvailabilityMessageSerializer {
 }
 
 #[doc="<p>Indicates if the specified CNAME is available.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CheckDNSAvailabilityResultMessage {
     #[doc="<p>Indicates if the specified CNAME is available:</p> <ul> <li> <p> <code>true</code> : The CNAME is available.</p> </li> <li> <p> <code>false</code> : The CNAME is not available.</p> </li> </ul>"]
+    #[serde(rename="Available")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub available: Option<bool>,
     #[doc="<p>The fully qualified CNAME to reserve when <a>CreateEnvironment</a> is called with the provided prefix.</p>"]
+    #[serde(rename="FullyQualifiedCNAME")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fully_qualified_cname: Option<String>,
 }
 
@@ -1581,13 +1691,19 @@ impl CnameAvailabilityDeserializer {
     }
 }
 #[doc="<p>Request to create or update a group of environments.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComposeEnvironmentsMessage {
     #[doc="<p>The name of the application to which the specified source bundles belong.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>The name of the group to which the target environments belong. Specify a group name only if the environment name defined in each target environment's manifest ends with a + (plus) character. See <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-cfg-manifest.html\">Environment Manifest (env.yaml)</a> for details.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>A list of version labels, specifying one or more application source bundles that belong to the target application. Each source bundle must include an environment manifest that specifies the name of the environment and the name of the solution stack to use, and optionally can specify environment links to create.</p>"]
+    #[serde(rename="VersionLabels")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_labels: Option<Vec<String>>,
 }
 
@@ -1647,29 +1763,51 @@ impl ConfigurationOptionDefaultValueDeserializer {
     }
 }
 #[doc="<p>Describes the possible values for a configuration option.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigurationOptionDescription {
     #[doc="<p>An indication of which action is required if the value for this configuration option changes:</p> <ul> <li> <p> <code>NoInterruption</code> : There is no interruption to the environment or application availability.</p> </li> <li> <p> <code>RestartEnvironment</code> : The environment is entirely restarted, all AWS resources are deleted and recreated, and the environment is unavailable during the process.</p> </li> <li> <p> <code>RestartApplicationServer</code> : The environment is available the entire time. However, a short application outage occurs when the application servers on the running Amazon EC2 instances are restarted.</p> </li> </ul>"]
+    #[serde(rename="ChangeSeverity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub change_severity: Option<String>,
     #[doc="<p>The default value for this configuration option.</p>"]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>If specified, the configuration option must be a string value no longer than this value.</p>"]
+    #[serde(rename="MaxLength")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_length: Option<i64>,
     #[doc="<p>If specified, the configuration option must be a numeric value less than this value.</p>"]
+    #[serde(rename="MaxValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_value: Option<i64>,
     #[doc="<p>If specified, the configuration option must be a numeric value greater than this value.</p>"]
+    #[serde(rename="MinValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub min_value: Option<i64>,
     #[doc="<p>The name of the configuration option.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>A unique namespace identifying the option's associated AWS resource.</p>"]
+    #[serde(rename="Namespace")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub namespace: Option<String>,
     #[doc="<p>If specified, the configuration option must be a string value that satisfies this regular expression.</p>"]
+    #[serde(rename="Regex")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub regex: Option<OptionRestrictionRegex>,
     #[doc="<p>An indication of whether the user defined this configuration option:</p> <ul> <li> <p> <code>true</code> : This configuration option was defined by the user. It is a valid choice for specifying if this as an <code>Option to Remove</code> when updating configuration settings. </p> </li> <li> <p> <code>false</code> : This configuration was not defined by the user.</p> </li> </ul> <p> Constraint: You can remove only <code>UserDefined</code> options from a configuration. </p> <p> Valid Values: <code>true</code> | <code>false</code> </p>"]
+    #[serde(rename="UserDefined")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_defined: Option<bool>,
     #[doc="<p>If specified, values for the configuration option are selected from this list.</p>"]
+    #[serde(rename="ValueOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value_options: Option<Vec<String>>,
     #[doc="<p>An indication of which type of values this option has and whether it is allowable to select one or more than one of the possible values:</p> <ul> <li> <p> <code>Scalar</code> : Values for this option are a single selection from the possible values, or an unformatted string, or numeric value governed by the <code>MIN/MAX/Regex</code> constraints.</p> </li> <li> <p> <code>List</code> : Values for this option are multiple selections from the possible values.</p> </li> <li> <p> <code>Boolean</code> : Values for this option are either <code>true</code> or <code>false</code> .</p> </li> <li> <p> <code>Json</code> : Values for this option are a JSON representation of a <code>ConfigDocument</code>.</p> </li> </ul>"]
+    #[serde(rename="ValueType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value_type: Option<String>,
 }
 
@@ -1864,15 +2002,23 @@ impl ConfigurationOptionPossibleValuesDeserializer {
     }
 }
 #[doc="<p> A specification identifying an individual configuration option along with its current value. For a list of possible option values, go to <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html\">Option Values</a> in the <i>AWS Elastic Beanstalk Developer Guide</i>. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigurationOptionSetting {
     #[doc="<p>A unique namespace identifying the option's associated AWS resource.</p>"]
+    #[serde(rename="Namespace")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub namespace: Option<String>,
     #[doc="<p>The name of the configuration option.</p>"]
+    #[serde(rename="OptionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_name: Option<String>,
     #[doc="<p>A unique resource name for a time-based scaling configuration option.</p>"]
+    #[serde(rename="ResourceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_name: Option<String>,
     #[doc="<p>The current value for the configuration option.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -2060,13 +2206,19 @@ impl ConfigurationOptionValueTypeDeserializer {
     }
 }
 #[doc="<p>Describes the settings for a specified configuration set.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigurationOptionsDescription {
     #[doc="<p> A list of <a>ConfigurationOptionDescription</a>. </p>"]
+    #[serde(rename="Options")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options: Option<Vec<ConfigurationOptionDescription>>,
     #[doc="<p>The ARN of the platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
     #[doc="<p>The name of the solution stack these configuration options belong to.</p>"]
+    #[serde(rename="SolutionStackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub solution_stack_name: Option<String>,
 }
 
@@ -2123,27 +2275,47 @@ impl ConfigurationOptionsDescriptionDeserializer {
     }
 }
 #[doc="<p>Describes the settings for a configuration set.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigurationSettingsDescription {
     #[doc="<p>The name of the application associated with this configuration set.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>The date (in UTC time) when this configuration set was created.</p>"]
+    #[serde(rename="DateCreated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_created: Option<String>,
     #[doc="<p>The date (in UTC time) when this configuration set was last modified.</p>"]
+    #[serde(rename="DateUpdated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_updated: Option<String>,
     #[doc="<p> If this configuration set is associated with an environment, the <code>DeploymentStatus</code> parameter indicates the deployment status of this configuration set: </p> <ul> <li> <p> <code>null</code>: This configuration is not associated with a running environment.</p> </li> <li> <p> <code>pending</code>: This is a draft configuration that is not deployed to the associated environment but is in the process of deploying.</p> </li> <li> <p> <code>deployed</code>: This is the configuration that is currently deployed to the associated running environment.</p> </li> <li> <p> <code>failed</code>: This is a draft configuration that failed to successfully deploy.</p> </li> </ul>"]
+    #[serde(rename="DeploymentStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deployment_status: Option<String>,
     #[doc="<p>Describes this configuration set.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p> If not <code>null</code>, the name of the environment for this configuration set. </p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>A list of the configuration options and their values in this configuration set.</p>"]
+    #[serde(rename="OptionSettings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_settings: Option<Vec<ConfigurationOptionSetting>>,
     #[doc="<p>The ARN of the platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
     #[doc="<p>The name of the solution stack this configuration set uses.</p>"]
+    #[serde(rename="SolutionStackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub solution_stack_name: Option<String>,
     #[doc="<p> If not <code>null</code>, the name of the configuration template for this configuration set. </p>"]
+    #[serde(rename="TemplateName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_name: Option<String>,
 }
 
@@ -2273,9 +2445,11 @@ impl ConfigurationSettingsDescriptionListDeserializer {
     }
 }
 #[doc="<p>The results from a request to change the configuration settings of an environment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigurationSettingsDescriptions {
     #[doc="<p> A list of <a>ConfigurationSettingsDescription</a>. </p>"]
+    #[serde(rename="ConfigurationSettings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub configuration_settings: Option<Vec<ConfigurationSettingsDescription>>,
 }
 
@@ -2322,9 +2496,11 @@ impl ConfigurationSettingsDescriptionsDeserializer {
     }
 }
 #[doc="<p>Provides a list of validation messages.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigurationSettingsValidationMessages {
     #[doc="<p> A list of <a>ValidationMessage</a>. </p>"]
+    #[serde(rename="Messages")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub messages: Option<Vec<ValidationMessage>>,
 }
 
@@ -2429,13 +2605,18 @@ impl ConfigurationTemplateNamesListDeserializer {
     }
 }
 #[doc="<p>Request to create an application.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateApplicationMessage {
     #[doc="<p>The name of the application.</p> <p>Constraint: This name must be unique within your account. If the specified name already exists, the action returns an <code>InvalidParameterValue</code> error.</p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>Describes the application.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Specify an application resource lifecycle configuration to prevent your application from accumulating too many versions.</p>"]
+    #[serde(rename="ResourceLifecycleConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_lifecycle_config: Option<ApplicationResourceLifecycleConfig>,
 }
 
@@ -2467,23 +2648,37 @@ impl CreateApplicationMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateApplicationVersionMessage {
     #[doc="<p> The name of the application. If no application is found with this name, and <code>AutoCreateApplication</code> is <code>false</code>, returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>Set to <code>true</code> to create an application with the specified name if it doesn't already exist.</p>"]
+    #[serde(rename="AutoCreateApplication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_create_application: Option<bool>,
     #[doc="<p>Settings for an AWS CodeBuild build.</p>"]
+    #[serde(rename="BuildConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub build_configuration: Option<BuildConfiguration>,
     #[doc="<p>Describes this version.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Preprocesses and validates the environment manifest and configuration files in the source bundle. Validating configuration files can identify issues prior to deploying the application version to an environment.</p>"]
+    #[serde(rename="Process")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub process: Option<bool>,
     #[doc="<p>Specify a commit in an AWS CodeCommit Git repository to use as the source code for the application version.</p>"]
+    #[serde(rename="SourceBuildInformation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_build_information: Option<SourceBuildInformation>,
     #[doc="<p>The Amazon S3 bucket and key that identify the location of the source bundle for this version.</p> <note> <p>The Amazon S3 bucket must be in the same region as the environment.</p> </note> <p>Specify a source bundle in S3 or a commit in an AWS CodeCommit repository (with <code>SourceBuildInformation</code>), but not both. If neither <code>SourceBundle</code> nor <code>SourceBuildInformation</code> are provided, Elastic Beanstalk uses a sample application.</p>"]
+    #[serde(rename="SourceBundle")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_bundle: Option<S3Location>,
     #[doc="<p>A label identifying this version.</p> <p>Constraint: Must be unique per application. If an application version already exists with this label for the specified application, AWS Elastic Beanstalk returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="VersionLabel")]
     pub version_label: String,
 }
 
@@ -2535,23 +2730,37 @@ impl CreateApplicationVersionMessageSerializer {
 }
 
 #[doc="<p>Request to create a configuration template.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConfigurationTemplateMessage {
     #[doc="<p>The name of the application to associate with this configuration template. If no application is found with this name, AWS Elastic Beanstalk returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>Describes this configuration.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of the environment used with this configuration template.</p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk sets the specified configuration option to the requested value. The new value overrides the value obtained from the solution stack or the source configuration template.</p>"]
+    #[serde(rename="OptionSettings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_settings: Option<Vec<ConfigurationOptionSetting>>,
     #[doc="<p>The ARN of the custome platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
     #[doc="<p>The name of the solution stack used by this configuration. The solution stack specifies the operating system, architecture, and application server for a configuration template. It determines the set of configuration options as well as the possible and default values.</p> <p> Use <a>ListAvailableSolutionStacks</a> to obtain a list of available solution stacks. </p> <p> A solution stack name or a source configuration parameter must be specified, otherwise AWS Elastic Beanstalk returns an <code>InvalidParameterValue</code> error. </p> <p>If a solution stack name is not specified and the source configuration parameter is specified, AWS Elastic Beanstalk uses the same solution stack as the source configuration template.</p>"]
+    #[serde(rename="SolutionStackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub solution_stack_name: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk uses the configuration values from the specified configuration template to create a new configuration.</p> <p> Values specified in the <code>OptionSettings</code> parameter of this call overrides any values obtained from the <code>SourceConfiguration</code>. </p> <p> If no configuration template is found, returns an <code>InvalidParameterValue</code> error. </p> <p> Constraint: If both the solution stack name parameter and the source configuration parameters are specified, the solution stack of the source configuration template must match the specified solution stack name or else AWS Elastic Beanstalk returns an <code>InvalidParameterCombination</code> error. </p>"]
+    #[serde(rename="SourceConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_configuration: Option<SourceConfiguration>,
     #[doc="<p>The name of the configuration template.</p> <p>Constraint: This name must be unique per application.</p> <p>Default: If a configuration template already exists with this name, AWS Elastic Beanstalk returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="TemplateName")]
     pub template_name: String,
 }
 
@@ -2604,33 +2813,58 @@ impl CreateConfigurationTemplateMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEnvironmentMessage {
     #[doc="<p>The name of the application that contains the version to be deployed.</p> <p> If no application is found with this name, <code>CreateEnvironment</code> returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>If specified, the environment attempts to use this value as the prefix for the CNAME. If not specified, the CNAME is generated automatically by appending a random alphanumeric string to the environment name.</p>"]
+    #[serde(rename="CNAMEPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cname_prefix: Option<String>,
     #[doc="<p>Describes this environment.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>A unique name for the deployment environment. Used in the application URL.</p> <p>Constraint: Must be from 4 to 40 characters in length. The name can contain only letters, numbers, and hyphens. It cannot start or end with a hyphen. This name must be unique within a region in your account. If the specified name already exists in the region, AWS Elastic Beanstalk returns an <code>InvalidParameterValue</code> error. </p> <p>Default: If the CNAME parameter is not specified, the environment name becomes part of the CNAME, and therefore part of the visible URL for your application.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>The name of the group to which the target environment belongs. Specify a group name only if the environment's name is specified in an environment manifest and not with the environment name parameter. See <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-cfg-manifest.html\">Environment Manifest (env.yaml)</a> for details.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk sets the specified configuration options to the requested value in the configuration set for the new environment. These override the values obtained from the solution stack or the configuration template.</p>"]
+    #[serde(rename="OptionSettings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_settings: Option<Vec<ConfigurationOptionSetting>>,
     #[doc="<p>A list of custom user-defined configuration options to remove from the configuration set for this new environment.</p>"]
+    #[serde(rename="OptionsToRemove")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options_to_remove: Option<Vec<OptionSpecification>>,
     #[doc="<p>The ARN of the platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
     #[doc="<p>This is an alternative to specifying a template name. If specified, AWS Elastic Beanstalk sets the configuration values to the default values associated with the specified solution stack.</p>"]
+    #[serde(rename="SolutionStackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub solution_stack_name: Option<String>,
     #[doc="<p>This specifies the tags applied to resources in the environment.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p> The name of the configuration template to use in deployment. If no configuration template is found with this name, AWS Elastic Beanstalk returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="TemplateName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_name: Option<String>,
     #[doc="<p>This specifies the tier to use for creating this environment.</p>"]
+    #[serde(rename="Tier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tier: Option<EnvironmentTier>,
     #[doc="<p>The name of the application version to deploy.</p> <p> If the specified application has no associated application versions, AWS Elastic Beanstalk <code>UpdateEnvironment</code> returns an <code>InvalidParameterValue</code> error. </p> <p>Default: If not specified, AWS Elastic Beanstalk attempts to launch the sample application in the container.</p>"]
+    #[serde(rename="VersionLabel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_label: Option<String>,
 }
 
@@ -2703,17 +2937,24 @@ impl CreateEnvironmentMessageSerializer {
 }
 
 #[doc="<p>Request to create a new platform version.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePlatformVersionRequest {
     #[doc="<p>The name of the builder environment.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>The configuration option settings to apply to the builder environment.</p>"]
+    #[serde(rename="OptionSettings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_settings: Option<Vec<ConfigurationOptionSetting>>,
     #[doc="<p>The location of the platform definition archive in Amazon S3.</p>"]
+    #[serde(rename="PlatformDefinitionBundle")]
     pub platform_definition_bundle: S3Location,
     #[doc="<p>The name of your custom platform.</p>"]
+    #[serde(rename="PlatformName")]
     pub platform_name: String,
     #[doc="<p>The number, such as 1.0.2, for the new platform version.</p>"]
+    #[serde(rename="PlatformVersion")]
     pub platform_version: String,
 }
 
@@ -2749,11 +2990,15 @@ impl CreatePlatformVersionRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePlatformVersionResult {
     #[doc="<p>The builder used to create the custom platform.</p>"]
+    #[serde(rename="Builder")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub builder: Option<Builder>,
     #[doc="<p>Detailed information about the new version of the custom platform.</p>"]
+    #[serde(rename="PlatformSummary")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_summary: Option<PlatformSummary>,
 }
 
@@ -2805,9 +3050,11 @@ impl CreatePlatformVersionResultDeserializer {
     }
 }
 #[doc="<p>Results of a <a>CreateStorageLocationResult</a> call.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStorageLocationResultMessage {
     #[doc="<p>The name of the Amazon S3 bucket created.</p>"]
+    #[serde(rename="S3Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_bucket: Option<String>,
 }
 
@@ -2869,11 +3116,15 @@ impl CreationDateDeserializer {
     }
 }
 #[doc="<p>A custom AMI available to platforms.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CustomAmi {
     #[doc="<p>THe ID of the image used to create the custom AMI.</p>"]
+    #[serde(rename="ImageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub image_id: Option<String>,
     #[doc="<p>The type of virtualization used to create the custom AMI.</p>"]
+    #[serde(rename="VirtualizationType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub virtualization_type: Option<String>,
 }
 
@@ -2980,11 +3231,14 @@ impl DNSCnameDeserializer {
     }
 }
 #[doc="<p>Request to delete an application.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationMessage {
     #[doc="<p>The name of the application to delete.</p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>When set to true, running environments will be terminated before deleting the application.</p>"]
+    #[serde(rename="TerminateEnvByForce")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub terminate_env_by_force: Option<bool>,
 }
 
@@ -3009,13 +3263,17 @@ impl DeleteApplicationMessageSerializer {
 }
 
 #[doc="<p>Request to delete an application version.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationVersionMessage {
     #[doc="<p>The name of the application to which the version belongs.</p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>Set to <code>true</code> to delete the source bundle from your storage bucket. Otherwise, the application version is deleted only from Elastic Beanstalk and the source bundle remains in Amazon S3.</p>"]
+    #[serde(rename="DeleteSourceBundle")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_source_bundle: Option<bool>,
     #[doc="<p>The label of the version to delete.</p>"]
+    #[serde(rename="VersionLabel")]
     pub version_label: String,
 }
 
@@ -3042,11 +3300,13 @@ impl DeleteApplicationVersionMessageSerializer {
 }
 
 #[doc="<p>Request to delete a configuration template.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConfigurationTemplateMessage {
     #[doc="<p>The name of the application to delete the configuration template from.</p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>The name of the configuration template to delete.</p>"]
+    #[serde(rename="TemplateName")]
     pub template_name: String,
 }
 
@@ -3069,11 +3329,13 @@ impl DeleteConfigurationTemplateMessageSerializer {
 }
 
 #[doc="<p>Request to delete a draft environment configuration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEnvironmentConfigurationMessage {
     #[doc="<p>The name of the application the environment is associated with.</p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>The name of the environment to delete the draft configuration from.</p>"]
+    #[serde(rename="EnvironmentName")]
     pub environment_name: String,
 }
 
@@ -3095,9 +3357,11 @@ impl DeleteEnvironmentConfigurationMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePlatformVersionRequest {
     #[doc="<p>The ARN of the version of the custom platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
 }
 
@@ -3119,9 +3383,11 @@ impl DeletePlatformVersionRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePlatformVersionResult {
     #[doc="<p>Detailed information about the version of the custom platform.</p>"]
+    #[serde(rename="PlatformSummary")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_summary: Option<PlatformSummary>,
 }
 
@@ -3169,15 +3435,23 @@ impl DeletePlatformVersionResultDeserializer {
     }
 }
 #[doc="<p>Information about an application version deployment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Deployment {
     #[doc="<p>The ID of the deployment. This number increases by one each time that you deploy source code or change instance configuration settings.</p>"]
+    #[serde(rename="DeploymentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deployment_id: Option<i64>,
     #[doc="<p>For in-progress deployments, the time that the deployment started.</p> <p>For completed deployments, the time that the deployment ended.</p>"]
+    #[serde(rename="DeploymentTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deployment_time: Option<String>,
     #[doc="<p>The status of the deployment:</p> <ul> <li> <p> <code>In Progress</code> : The deployment is in progress.</p> </li> <li> <p> <code>Deployed</code> : The deployment succeeded.</p> </li> <li> <p> <code>Failed</code> : The deployment failed.</p> </li> </ul>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The version label of the application version in the deployment.</p>"]
+    #[serde(rename="VersionLabel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_label: Option<String>,
 }
 
@@ -3252,15 +3526,23 @@ impl DeploymentTimestampDeserializer {
     }
 }
 #[doc="<p>Request to describe application versions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeApplicationVersionsMessage {
     #[doc="<p>Specify an application name to show only application versions for that application.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>For a paginated request. Specify a maximum number of application versions to include in each response.</p> <p>If no <code>MaxRecords</code> is specified, all available application versions are retrieved in a single response.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>For a paginated request. Specify a token from a previous response page to retrieve the next response page. All other parameter values must be identical to the ones specified in the initial request.</p> <p>If no <code>NextToken</code> is specified, the first page is retrieved.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Specify a version label to show a specific application version.</p>"]
+    #[serde(rename="VersionLabels")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_labels: Option<Vec<String>>,
 }
 
@@ -3296,9 +3578,11 @@ impl DescribeApplicationVersionsMessageSerializer {
 }
 
 #[doc="<p>Request to describe one or more applications.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeApplicationsMessage {
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to only include those with the specified names.</p>"]
+    #[serde(rename="ApplicationNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_names: Option<Vec<String>>,
 }
 
@@ -3322,19 +3606,31 @@ impl DescribeApplicationsMessageSerializer {
 }
 
 #[doc="<p>Result message containing a list of application version descriptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigurationOptionsMessage {
     #[doc="<p>The name of the application associated with the configuration template or environment. Only needed if you want to describe the configuration options associated with either the configuration template or environment.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>The name of the environment whose configuration options you want to describe.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>If specified, restricts the descriptions to only the specified options.</p>"]
+    #[serde(rename="Options")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options: Option<Vec<OptionSpecification>>,
     #[doc="<p>The ARN of the custom platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
     #[doc="<p>The name of the solution stack whose configuration options you want to describe.</p>"]
+    #[serde(rename="SolutionStackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub solution_stack_name: Option<String>,
     #[doc="<p>The name of the configuration template whose configuration options you want to describe.</p>"]
+    #[serde(rename="TemplateName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_name: Option<String>,
 }
 
@@ -3378,13 +3674,18 @@ impl DescribeConfigurationOptionsMessageSerializer {
 }
 
 #[doc="<p>Result message containing all of the configuration settings for a specified solution stack or configuration template.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigurationSettingsMessage {
     #[doc="<p>The application for the environment or configuration template.</p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>The name of the environment to describe.</p> <p> Condition: You must specify either this or a TemplateName, but not both. If you specify both, AWS Elastic Beanstalk returns an <code>InvalidParameterCombination</code> error. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>The name of the configuration template to describe.</p> <p> Conditional: You must specify either this parameter or an EnvironmentName, but not both. If you specify both, AWS Elastic Beanstalk returns an <code>InvalidParameterCombination</code> error. If you do not specify either, AWS Elastic Beanstalk returns a <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="TemplateName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_name: Option<String>,
 }
 
@@ -3413,13 +3714,19 @@ impl DescribeConfigurationSettingsMessageSerializer {
 }
 
 #[doc="<p>See the example below to learn how to create a request body.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEnvironmentHealthRequest {
     #[doc="<p>Specify the response elements to return. To retrieve all attributes, set to <code>All</code>. If no attribute names are specified, returns the name of the environment.</p>"]
+    #[serde(rename="AttributeNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_names: Option<Vec<String>>,
     #[doc="<p>Specify the environment by ID.</p> <p>You must specify either this or an EnvironmentName, or both.</p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>Specify the environment by name.</p> <p>You must specify either this or an EnvironmentName, or both.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
 }
 
@@ -3453,23 +3760,39 @@ impl DescribeEnvironmentHealthRequestSerializer {
 }
 
 #[doc="<p>Health details for an AWS Elastic Beanstalk environment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEnvironmentHealthResult {
     #[doc="<p>Application request metrics for the environment.</p>"]
+    #[serde(rename="ApplicationMetrics")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_metrics: Option<ApplicationMetrics>,
     #[doc="<p>Descriptions of the data that contributed to the environment's current health status.</p>"]
+    #[serde(rename="Causes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub causes: Option<Vec<String>>,
     #[doc="<p>The <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-status.html\">health color</a> of the environment.</p>"]
+    #[serde(rename="Color")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub color: Option<String>,
     #[doc="<p>The environment's name.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>The <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-status.html\">health status</a> of the environment. For example, <code>Ok</code>.</p>"]
+    #[serde(rename="HealthStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_status: Option<String>,
     #[doc="<p>Summary health information for the instances in the environment.</p>"]
+    #[serde(rename="InstancesHealth")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instances_health: Option<InstanceHealthSummary>,
     #[doc="<p>The date and time that the health information was retrieved.</p>"]
+    #[serde(rename="RefreshedAt")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub refreshed_at: Option<String>,
     #[doc="<p>The environment's operational status. <code>Ready</code>, <code>Launching</code>, <code>Updating</code>, <code>Terminating</code>, or <code>Terminated</code>.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -3549,15 +3872,23 @@ impl DescribeEnvironmentHealthResultDeserializer {
     }
 }
 #[doc="<p>Request to list completed and failed managed actions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEnvironmentManagedActionHistoryRequest {
     #[doc="<p>The environment ID of the target environment.</p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>The name of the target environment.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>The maximum number of items to return for a single request.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The pagination token returned by a previous request.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3594,11 +3925,15 @@ impl DescribeEnvironmentManagedActionHistoryRequestSerializer {
 }
 
 #[doc="<p>A result message containing a list of completed and failed managed actions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEnvironmentManagedActionHistoryResult {
     #[doc="<p>A list of completed and failed managed actions.</p>"]
+    #[serde(rename="ManagedActionHistoryItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub managed_action_history_items: Option<Vec<ManagedActionHistoryItem>>,
     #[doc="<p>A pagination token that you pass to <a>DescribeEnvironmentManagedActionHistory</a> to get the next page of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3649,13 +3984,19 @@ impl DescribeEnvironmentManagedActionHistoryResultDeserializer {
     }
 }
 #[doc="<p>Request to list an environment's upcoming and in-progress managed actions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEnvironmentManagedActionsRequest {
     #[doc="<p>The environment ID of the target environment.</p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>The name of the target environment.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>To show only actions with a particular status, specify a status.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -3686,9 +4027,11 @@ impl DescribeEnvironmentManagedActionsRequestSerializer {
 }
 
 #[doc="<p>The result message containing a list of managed actions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEnvironmentManagedActionsResult {
     #[doc="<p>A list of upcoming and in-progress managed actions.</p>"]
+    #[serde(rename="ManagedActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub managed_actions: Option<Vec<ManagedAction>>,
 }
 
@@ -3737,11 +4080,15 @@ impl DescribeEnvironmentManagedActionsResultDeserializer {
     }
 }
 #[doc="<p>Request to describe the resources in an environment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEnvironmentResourcesMessage {
     #[doc="<p>The ID of the environment to retrieve AWS resource usage data.</p> <p> Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>The name of the environment to retrieve AWS resource usage data.</p> <p> Condition: You must specify either this or an EnvironmentId, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
 }
 
@@ -3768,23 +4115,39 @@ impl DescribeEnvironmentResourcesMessageSerializer {
 }
 
 #[doc="<p>Request to describe one or more environments.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEnvironmentsMessage {
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to include only those that are associated with this application.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to include only those that have the specified IDs.</p>"]
+    #[serde(rename="EnvironmentIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_ids: Option<Vec<String>>,
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to include only those that have the specified names.</p>"]
+    #[serde(rename="EnvironmentNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_names: Option<Vec<String>>,
     #[doc="<p>Indicates whether to include deleted environments:</p> <p> <code>true</code>: Environments that have been deleted after <code>IncludedDeletedBackTo</code> are displayed.</p> <p> <code>false</code>: Do not include deleted environments.</p>"]
+    #[serde(rename="IncludeDeleted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub include_deleted: Option<bool>,
     #[doc="<p> If specified when <code>IncludeDeleted</code> is set to <code>true</code>, then environments deleted after this date are displayed. </p>"]
+    #[serde(rename="IncludedDeletedBackTo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub included_deleted_back_to: Option<String>,
     #[doc="<p>For a paginated request. Specify a maximum number of environments to include in each response.</p> <p>If no <code>MaxRecords</code> is specified, all available environments are retrieved in a single response.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>For a paginated request. Specify a token from a previous response page to retrieve the next response page. All other parameter values must be identical to the ones specified in the initial request.</p> <p>If no <code>NextToken</code> is specified, the first page is retrieved.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to include only those that are associated with this application version.</p>"]
+    #[serde(rename="VersionLabel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_label: Option<String>,
 }
 
@@ -3837,31 +4200,55 @@ impl DescribeEnvironmentsMessageSerializer {
 }
 
 #[doc="<p>Request to retrieve a list of events for an environment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsMessage {
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to include only those associated with this application.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p> If specified, AWS Elastic Beanstalk restricts the returned descriptions to those that occur up to, but not including, the <code>EndTime</code>. </p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to those associated with this environment.</p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to those associated with this environment.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>Specifies the maximum number of events that can be returned, beginning with the most recent event.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>Pagination token. If specified, the events return the next batch of results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The ARN of the version of the custom platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the described events to include only those associated with this request ID.</p>"]
+    #[serde(rename="RequestId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_id: Option<String>,
     #[doc="<p>If specified, limits the events returned from this call to include only those with the specified severity or higher.</p>"]
+    #[serde(rename="Severity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub severity: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to those that occur on or after this time.</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to those that are associated with this environment configuration.</p>"]
+    #[serde(rename="TemplateName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_name: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to those associated with this application version.</p>"]
+    #[serde(rename="VersionLabel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_label: Option<String>,
 }
 
@@ -3928,15 +4315,23 @@ impl DescribeEventsMessageSerializer {
 }
 
 #[doc="<p>Parameters for a call to <code>DescribeInstancesHealth</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancesHealthRequest {
     #[doc="<p>Specifies the response elements you wish to receive. To retrieve all attributes, set to <code>All</code>. If no attribute names are specified, returns a list of instances.</p>"]
+    #[serde(rename="AttributeNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_names: Option<Vec<String>>,
     #[doc="<p>Specify the AWS Elastic Beanstalk environment by ID.</p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>Specify the AWS Elastic Beanstalk environment by name.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>Specify the pagination token returned by a previous call.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3974,13 +4369,19 @@ impl DescribeInstancesHealthRequestSerializer {
 }
 
 #[doc="<p>Detailed health information about the Amazon EC2 instances in an AWS Elastic Beanstalk environment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancesHealthResult {
     #[doc="<p>Detailed health information about each instance.</p>"]
+    #[serde(rename="InstanceHealthList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_health_list: Option<Vec<SingleInstanceHealth>>,
     #[doc="<p>Pagination token for the next page of results, if available.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The date and time that the health information was retrieved.</p>"]
+    #[serde(rename="RefreshedAt")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub refreshed_at: Option<String>,
 }
 
@@ -4036,9 +4437,11 @@ impl DescribeInstancesHealthResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePlatformVersionRequest {
     #[doc="<p>The ARN of the version of the platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
 }
 
@@ -4060,9 +4463,11 @@ impl DescribePlatformVersionRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePlatformVersionResult {
     #[doc="<p>Detailed information about the version of the platform.</p>"]
+    #[serde(rename="PlatformDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_description: Option<PlatformDescription>,
 }
 
@@ -4166,47 +4571,87 @@ impl EnvironmentArnDeserializer {
     }
 }
 #[doc="<p>Describes the properties of an environment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentDescription {
     #[doc="<p>Indicates if there is an in-progress environment configuration update or application version deployment that you can cancel.</p> <p> <code>true:</code> There is an update in progress. </p> <p> <code>false:</code> There are no updates currently in progress. </p>"]
+    #[serde(rename="AbortableOperationInProgress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub abortable_operation_in_progress: Option<bool>,
     #[doc="<p>The name of the application associated with this environment.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>The URL to the CNAME for this environment.</p>"]
+    #[serde(rename="CNAME")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cname: Option<String>,
     #[doc="<p>The creation date for this environment.</p>"]
+    #[serde(rename="DateCreated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_created: Option<String>,
     #[doc="<p>The last modified date for this environment.</p>"]
+    #[serde(rename="DateUpdated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_updated: Option<String>,
     #[doc="<p>Describes this environment.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>For load-balanced, autoscaling environments, the URL to the LoadBalancer. For single-instance environments, the IP address of the instance.</p>"]
+    #[serde(rename="EndpointURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoint_url: Option<String>,
     #[doc="<p>The environment's Amazon Resource Name (ARN), which can be used in other API reuqests that require an ARN.</p>"]
+    #[serde(rename="EnvironmentArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_arn: Option<String>,
     #[doc="<p>The ID of this environment.</p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>A list of links to other environments in the same group.</p>"]
+    #[serde(rename="EnvironmentLinks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_links: Option<Vec<EnvironmentLink>>,
     #[doc="<p>The name of this environment.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>Describes the health status of the environment. AWS Elastic Beanstalk indicates the failure levels for a running environment:</p> <ul> <li> <p> <code>Red</code>: Indicates the environment is not responsive. Occurs when three or more consecutive failures occur for an environment.</p> </li> <li> <p> <code>Yellow</code>: Indicates that something is wrong. Occurs when two consecutive failures occur for an environment.</p> </li> <li> <p> <code>Green</code>: Indicates the environment is healthy and fully functional.</p> </li> <li> <p> <code>Grey</code>: Default health for a new environment. The environment is not fully launched and health checks have not started or health checks are suspended during an <code>UpdateEnvironment</code> or <code>RestartEnvironement</code> request.</p> </li> </ul> <p> Default: <code>Grey</code> </p>"]
+    #[serde(rename="Health")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health: Option<String>,
     #[doc="<p>Returns the health status of the application running in your environment. For more information, see <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-status.html\">Health Colors and Statuses</a>.</p>"]
+    #[serde(rename="HealthStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_status: Option<String>,
     #[doc="<p>The ARN of the platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
     #[doc="<p>The description of the AWS resources used by this environment.</p>"]
+    #[serde(rename="Resources")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resources: Option<EnvironmentResourcesDescription>,
     #[doc="<p> The name of the <code>SolutionStack</code> deployed with this environment. </p>"]
+    #[serde(rename="SolutionStackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub solution_stack_name: Option<String>,
     #[doc="<p>The current operational status of the environment:</p> <ul> <li> <p> <code>Launching</code>: Environment is in the process of initial deployment.</p> </li> <li> <p> <code>Updating</code>: Environment is in the process of updating its configuration settings or application version.</p> </li> <li> <p> <code>Ready</code>: Environment is available to have an action performed on it, such as update or terminate.</p> </li> <li> <p> <code>Terminating</code>: Environment is in the shut-down process.</p> </li> <li> <p> <code>Terminated</code>: Environment is not running.</p> </li> </ul>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The name of the configuration template used to originally launch this environment.</p>"]
+    #[serde(rename="TemplateName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_name: Option<String>,
     #[doc="<p>Describes the current tier of this environment.</p>"]
+    #[serde(rename="Tier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tier: Option<EnvironmentTier>,
     #[doc="<p>The application version deployed in this environment.</p>"]
+    #[serde(rename="VersionLabel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_label: Option<String>,
 }
 
@@ -4383,11 +4828,15 @@ impl EnvironmentDescriptionsListDeserializer {
     }
 }
 #[doc="<p>Result message containing a list of environment descriptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentDescriptionsMessage {
     #[doc="<p> Returns an <a>EnvironmentDescription</a> list. </p>"]
+    #[serde(rename="Environments")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environments: Option<Vec<EnvironmentDescription>>,
     #[doc="<p>In a paginated request, the token that you can pass in a subsequent request to get the next response page.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -4503,15 +4952,23 @@ impl EnvironmentIdListSerializer {
 }
 
 #[doc="<p>The information retrieved from the Amazon EC2 instances.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentInfoDescription {
     #[doc="<p>The Amazon EC2 Instance ID for this information.</p>"]
+    #[serde(rename="Ec2InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec_2_instance_id: Option<String>,
     #[doc="<p>The type of information retrieved.</p>"]
+    #[serde(rename="InfoType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub info_type: Option<String>,
     #[doc="<p>The retrieved information.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
     #[doc="<p>The time stamp when this information was retrieved.</p>"]
+    #[serde(rename="SampleTimestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sample_timestamp: Option<String>,
 }
 
@@ -4630,11 +5087,15 @@ impl EnvironmentInfoTypeDeserializer {
     }
 }
 #[doc="<p>A link to another environment, defined in the environment's manifest. Links provide connection information in system properties that can be used to connect to another environment in the same group. See <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-cfg-manifest.html\">Environment Manifest (env.yaml)</a> for details.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentLink {
     #[doc="<p>The name of the linked environment (the dependency).</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>The name of the link.</p>"]
+    #[serde(rename="LinkName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub link_name: Option<String>,
 }
 
@@ -4753,21 +5214,35 @@ impl EnvironmentNamesListSerializer {
 }
 
 #[doc="<p>Describes the AWS resources in use by this environment. This data is live.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentResourceDescription {
     #[doc="<p> The <code>AutoScalingGroups</code> used by this environment. </p>"]
+    #[serde(rename="AutoScalingGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_scaling_groups: Option<Vec<AutoScalingGroup>>,
     #[doc="<p>The name of the environment.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>The Amazon EC2 instances used by this environment.</p>"]
+    #[serde(rename="Instances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instances: Option<Vec<Instance>>,
     #[doc="<p>The Auto Scaling launch configurations in use by this environment.</p>"]
+    #[serde(rename="LaunchConfigurations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launch_configurations: Option<Vec<LaunchConfiguration>>,
     #[doc="<p>The LoadBalancers in use by this environment.</p>"]
+    #[serde(rename="LoadBalancers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancers: Option<Vec<LoadBalancer>>,
     #[doc="<p>The queues used by this environment.</p>"]
+    #[serde(rename="Queues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub queues: Option<Vec<Queue>>,
     #[doc="<p>The <code>AutoScaling</code> triggers in use by this environment. </p>"]
+    #[serde(rename="Triggers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub triggers: Option<Vec<Trigger>>,
 }
 
@@ -4843,9 +5318,11 @@ impl EnvironmentResourceDescriptionDeserializer {
     }
 }
 #[doc="<p>Result message containing a list of environment resource descriptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentResourceDescriptionsMessage {
     #[doc="<p> A list of <a>EnvironmentResourceDescription</a>. </p>"]
+    #[serde(rename="EnvironmentResources")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_resources: Option<EnvironmentResourceDescription>,
 }
 
@@ -4892,9 +5369,11 @@ impl EnvironmentResourceDescriptionsMessageDeserializer {
     }
 }
 #[doc="<p>Describes the AWS resources in use by this environment. This data is not live data.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentResourcesDescription {
     #[doc="<p>Describes the LoadBalancer.</p>"]
+    #[serde(rename="LoadBalancer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer: Option<LoadBalancerDescription>,
 }
 
@@ -4957,13 +5436,19 @@ impl EnvironmentStatusDeserializer {
     }
 }
 #[doc="<p>Describes the properties of an environment tier</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentTier {
     #[doc="<p>The name of this environment tier.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The type of this environment tier.</p>"]
+    #[serde(rename="Type")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
     #[doc="<p>The version of this environment tier.</p>"]
+    #[serde(rename="Version")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version: Option<String>,
 }
 
@@ -5056,25 +5541,43 @@ impl EventDateDeserializer {
     }
 }
 #[doc="<p>Describes an event.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventDescription {
     #[doc="<p>The application associated with the event.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>The name of the environment associated with this event.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>The date when the event occurred.</p>"]
+    #[serde(rename="EventDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_date: Option<String>,
     #[doc="<p>The event message.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
     #[doc="<p>The ARN of the platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
     #[doc="<p>The web service request ID for the activity of this event.</p>"]
+    #[serde(rename="RequestId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_id: Option<String>,
     #[doc="<p>The severity level of this event.</p>"]
+    #[serde(rename="Severity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub severity: Option<String>,
     #[doc="<p>The name of the configuration associated with this event.</p>"]
+    #[serde(rename="TemplateName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_name: Option<String>,
     #[doc="<p>The release label for the application version associated with this event.</p>"]
+    #[serde(rename="VersionLabel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_label: Option<String>,
 }
 
@@ -5198,11 +5701,15 @@ impl EventDescriptionListDeserializer {
     }
 }
 #[doc="<p>Result message wrapping a list of event descriptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventDescriptionsMessage {
     #[doc="<p> A list of <a>EventDescription</a>. </p>"]
+    #[serde(rename="Events")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<EventDescription>>,
     #[doc="<p> If returned, this indicates that there are more results to obtain. Use this token in the next <a>DescribeEvents</a> call to get the next batch of events. </p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -5324,9 +5831,11 @@ impl ImageIdDeserializer {
     }
 }
 #[doc="<p>The description of an Amazon EC2 instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Instance {
     #[doc="<p>The ID of the Amazon EC2 instance.</p>"]
+    #[serde(rename="Id")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
 }
 
@@ -5414,23 +5923,39 @@ impl InstanceHealthListDeserializer {
     }
 }
 #[doc="<p>Represents summary information about the health of an instance. For more information, see <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-status.html\">Health Colors and Statuses</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceHealthSummary {
     #[doc="<p> <b>Red.</b> The health agent is reporting a high number of request failures or other issues for an instance or environment.</p>"]
+    #[serde(rename="Degraded")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub degraded: Option<i64>,
     #[doc="<p> <b>Green.</b> An operation is in progress on an instance.</p>"]
+    #[serde(rename="Info")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub info: Option<i64>,
     #[doc="<p> <b>Grey.</b> AWS Elastic Beanstalk and the health agent are reporting no data on an instance.</p>"]
+    #[serde(rename="NoData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub no_data: Option<i64>,
     #[doc="<p> <b>Green.</b> An instance is passing health checks and the health agent is not reporting any problems.</p>"]
+    #[serde(rename="Ok")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ok: Option<i64>,
     #[doc="<p> <b>Grey.</b> An operation is in progress on an instance within the command timeout.</p>"]
+    #[serde(rename="Pending")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pending: Option<i64>,
     #[doc="<p> <b>Red.</b> The health agent is reporting a very high number of request failures or other issues for an instance or environment.</p>"]
+    #[serde(rename="Severe")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub severe: Option<i64>,
     #[doc="<p> <b>Grey.</b> AWS Elastic Beanstalk and the health agent are reporting an insufficient amount of data on an instance.</p>"]
+    #[serde(rename="Unknown")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unknown: Option<i64>,
     #[doc="<p> <b>Yellow.</b> The health agent is reporting a moderate number of request failures or other issues for an instance or environment.</p>"]
+    #[serde(rename="Warning")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub warning: Option<i64>,
 }
 
@@ -5592,23 +6117,39 @@ impl IntegerDeserializer {
     }
 }
 #[doc="<p>Represents the average latency for the slowest X percent of requests over the last 10 seconds.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Latency {
     #[doc="<p>The average latency for the slowest 90 percent of requests over the last 10 seconds.</p>"]
+    #[serde(rename="P10")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub p10: Option<f64>,
     #[doc="<p>The average latency for the slowest 50 percent of requests over the last 10 seconds.</p>"]
+    #[serde(rename="P50")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub p50: Option<f64>,
     #[doc="<p>The average latency for the slowest 25 percent of requests over the last 10 seconds.</p>"]
+    #[serde(rename="P75")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub p75: Option<f64>,
     #[doc="<p>The average latency for the slowest 15 percent of requests over the last 10 seconds.</p>"]
+    #[serde(rename="P85")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub p85: Option<f64>,
     #[doc="<p>The average latency for the slowest 10 percent of requests over the last 10 seconds.</p>"]
+    #[serde(rename="P90")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub p90: Option<f64>,
     #[doc="<p>The average latency for the slowest 5 percent of requests over the last 10 seconds.</p>"]
+    #[serde(rename="P95")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub p95: Option<f64>,
     #[doc="<p>The average latency for the slowest 1 percent of requests over the last 10 seconds.</p>"]
+    #[serde(rename="P99")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub p99: Option<f64>,
     #[doc="<p>The average latency for the slowest 0.1 percent of requests over the last 10 seconds.</p>"]
+    #[serde(rename="P999")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub p999: Option<f64>,
 }
 
@@ -5683,9 +6224,11 @@ impl LatencyDeserializer {
     }
 }
 #[doc="<p>Describes an Auto Scaling launch configuration.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LaunchConfiguration {
     #[doc="<p>The name of the launch configuration.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -5788,11 +6331,15 @@ impl LaunchedAtDeserializer {
     }
 }
 #[doc="<p>A list of available AWS Elastic Beanstalk solution stacks.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAvailableSolutionStacksResultMessage {
     #[doc="<p> A list of available solution stacks and their <a>SolutionStackDescription</a>. </p>"]
+    #[serde(rename="SolutionStackDetails")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub solution_stack_details: Option<Vec<SolutionStackDescription>>,
     #[doc="<p>A list of available solution stacks.</p>"]
+    #[serde(rename="SolutionStacks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub solution_stacks: Option<Vec<String>>,
 }
 
@@ -5841,13 +6388,19 @@ impl ListAvailableSolutionStacksResultMessageDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPlatformVersionsRequest {
     #[doc="<p>List only the platforms where the platform member value relates to one of the supplied values.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<PlatformFilter>>,
     #[doc="<p>The maximum number of platform values returned in one call.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The starting index into the remaining list of platforms. Use the <code>NextToken</code> value from a previous <code>ListPlatformVersion</code> call.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -5878,11 +6431,15 @@ impl ListPlatformVersionsRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPlatformVersionsResult {
     #[doc="<p>The starting index into the remaining list of platforms. if this value is not <code>null</code>, you can use it in a subsequent <code>ListPlatformVersion</code> call. </p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Detailed information about the platforms.</p>"]
+    #[serde(rename="PlatformSummaryList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_summary_list: Option<Vec<PlatformSummary>>,
 }
 
@@ -5934,11 +6491,15 @@ impl ListPlatformVersionsResultDeserializer {
     }
 }
 #[doc="<p>Describes the properties of a Listener for the LoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Listener {
     #[doc="<p>The port that is used by the Listener.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The protocol that is used by the Listener.</p>"]
+    #[serde(rename="Protocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub protocol: Option<String>,
 }
 
@@ -6043,9 +6604,11 @@ impl LoadAverageValueDeserializer {
     }
 }
 #[doc="<p>Describes a LoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBalancer {
     #[doc="<p>The name of the LoadBalancer.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -6092,13 +6655,19 @@ impl LoadBalancerDeserializer {
     }
 }
 #[doc="<p>Describes the details of a LoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBalancerDescription {
     #[doc="<p>The domain name of the LoadBalancer.</p>"]
+    #[serde(rename="Domain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain: Option<String>,
     #[doc="<p>A list of Listeners used by the LoadBalancer.</p>"]
+    #[serde(rename="Listeners")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub listeners: Option<Vec<Listener>>,
     #[doc="<p>The name of the LoadBalancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_name: Option<String>,
 }
 
@@ -6249,17 +6818,27 @@ impl MaintainerDeserializer {
     }
 }
 #[doc="<p>The record of an upcoming or in-progress managed action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ManagedAction {
     #[doc="<p>A description of the managed action.</p>"]
+    #[serde(rename="ActionDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action_description: Option<String>,
     #[doc="<p>A unique identifier for the managed action.</p>"]
+    #[serde(rename="ActionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action_id: Option<String>,
     #[doc="<p>The type of managed action.</p>"]
+    #[serde(rename="ActionType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action_type: Option<String>,
     #[doc="<p>The status of the managed action. If the action is <code>Scheduled</code>, you can apply it immediately with <a>ApplyEnvironmentManagedAction</a>.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The start time of the maintenance window in which the managed action will execute.</p>"]
+    #[serde(rename="WindowStartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub window_start_time: Option<String>,
 }
 
@@ -6325,23 +6904,39 @@ impl ManagedActionDeserializer {
     }
 }
 #[doc="<p>The record of a completed or failed managed action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ManagedActionHistoryItem {
     #[doc="<p>A description of the managed action.</p>"]
+    #[serde(rename="ActionDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action_description: Option<String>,
     #[doc="<p>A unique identifier for the managed action.</p>"]
+    #[serde(rename="ActionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action_id: Option<String>,
     #[doc="<p>The type of the managed action.</p>"]
+    #[serde(rename="ActionType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action_type: Option<String>,
     #[doc="<p>The date and time that the action started executing.</p>"]
+    #[serde(rename="ExecutedTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub executed_time: Option<String>,
     #[doc="<p>If the action failed, a description of the failure.</p>"]
+    #[serde(rename="FailureDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub failure_description: Option<String>,
     #[doc="<p>If the action failed, the type of failure.</p>"]
+    #[serde(rename="FailureType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub failure_type: Option<String>,
     #[doc="<p>The date and time that the action finished executing.</p>"]
+    #[serde(rename="FinishedTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub finished_time: Option<String>,
     #[doc="<p>The status of the action.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -6506,13 +7101,18 @@ impl ManagedActionsDeserializer {
     }
 }
 #[doc="<p>A lifecycle rule that deletes application versions after the specified number of days.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MaxAgeRule {
     #[doc="<p>Set to <code>true</code> to delete a version's source bundle from Amazon S3 when Elastic Beanstalk deletes the application version.</p>"]
+    #[serde(rename="DeleteSourceFromS3")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_source_from_s3: Option<bool>,
     #[doc="<p>Specify <code>true</code> to apply the rule, or <code>false</code> to disable it.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p>Specify the number of days to retain an application versions.</p>"]
+    #[serde(rename="MaxAgeInDays")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_age_in_days: Option<i64>,
 }
 
@@ -6593,13 +7193,18 @@ impl MaxAgeRuleSerializer {
 }
 
 #[doc="<p>A lifecycle rule that deletes the oldest application version when the maximum count is exceeded.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MaxCountRule {
     #[doc="<p>Set to <code>true</code> to delete a version's source bundle from Amazon S3 when Elastic Beanstalk deletes the application version.</p>"]
+    #[serde(rename="DeleteSourceFromS3")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_source_from_s3: Option<bool>,
     #[doc="<p>Specify <code>true</code> to apply the rule, or <code>false</code> to disable it.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p>Specify the maximum number of application versions to retain.</p>"]
+    #[serde(rename="MaxCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_count: Option<i64>,
 }
 
@@ -6833,11 +7438,15 @@ impl OptionRestrictionMinValueDeserializer {
     }
 }
 #[doc="<p>A regular expression representing a restriction on a string configuration option value.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionRestrictionRegex {
     #[doc="<p>A unique name representing this regular expression.</p>"]
+    #[serde(rename="Label")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub label: Option<String>,
     #[doc="<p>The regular expression pattern that a string configuration option value with this restriction must match.</p>"]
+    #[serde(rename="Pattern")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pattern: Option<String>,
 }
 
@@ -6888,13 +7497,19 @@ impl OptionRestrictionRegexDeserializer {
     }
 }
 #[doc="<p>A specification identifying an individual configuration option.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionSpecification {
     #[doc="<p>A unique namespace identifying the option's associated AWS resource.</p>"]
+    #[serde(rename="Namespace")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub namespace: Option<String>,
     #[doc="<p>The name of the configuration option.</p>"]
+    #[serde(rename="OptionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_name: Option<String>,
     #[doc="<p>A unique resource name for a time-based scaling configuration option.</p>"]
+    #[serde(rename="ResourceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_name: Option<String>,
 }
 
@@ -6965,43 +7580,79 @@ impl PlatformCategoryDeserializer {
     }
 }
 #[doc="<p>Detailed information about a platform.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlatformDescription {
     #[doc="<p>The custom AMIs supported by the platform.</p>"]
+    #[serde(rename="CustomAmiList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub custom_ami_list: Option<Vec<CustomAmi>>,
     #[doc="<p>The date when the platform was created.</p>"]
+    #[serde(rename="DateCreated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_created: Option<String>,
     #[doc="<p>The date when the platform was last updated.</p>"]
+    #[serde(rename="DateUpdated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date_updated: Option<String>,
     #[doc="<p>The description of the platform.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The frameworks supported by the platform.</p>"]
+    #[serde(rename="Frameworks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub frameworks: Option<Vec<PlatformFramework>>,
     #[doc="<p>Information about the maintainer of the platform.</p>"]
+    #[serde(rename="Maintainer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub maintainer: Option<String>,
     #[doc="<p>The operating system used by the platform.</p>"]
+    #[serde(rename="OperatingSystemName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operating_system_name: Option<String>,
     #[doc="<p>The version of the operating system used by the platform.</p>"]
+    #[serde(rename="OperatingSystemVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operating_system_version: Option<String>,
     #[doc="<p>The ARN of the platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
     #[doc="<p>The category of the platform.</p>"]
+    #[serde(rename="PlatformCategory")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_category: Option<String>,
     #[doc="<p>The name of the platform.</p>"]
+    #[serde(rename="PlatformName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_name: Option<String>,
     #[doc="<p>The AWS account ID of the person who created the platform.</p>"]
+    #[serde(rename="PlatformOwner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_owner: Option<String>,
     #[doc="<p>The status of the platform.</p>"]
+    #[serde(rename="PlatformStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_status: Option<String>,
     #[doc="<p>The version of the platform.</p>"]
+    #[serde(rename="PlatformVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_version: Option<String>,
     #[doc="<p>The programming languages supported by the platform.</p>"]
+    #[serde(rename="ProgrammingLanguages")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub programming_languages: Option<Vec<PlatformProgrammingLanguage>>,
     #[doc="<p>The name of the solution stack used by the platform.</p>"]
+    #[serde(rename="SolutionStackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub solution_stack_name: Option<String>,
     #[doc="<p>The additions supported by the platform.</p>"]
+    #[serde(rename="SupportedAddonList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub supported_addon_list: Option<Vec<String>>,
     #[doc="<p>The tiers supported by the platform.</p>"]
+    #[serde(rename="SupportedTierList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub supported_tier_list: Option<Vec<String>>,
 }
 
@@ -7131,13 +7782,19 @@ impl PlatformDescriptionDeserializer {
     }
 }
 #[doc="<p>Specify criteria to restrict the results when listing custom platforms.</p> <p>The filter is evaluated as the expression:</p> <p> <code>Type</code> <code>Operator</code> <code>Values[i]</code> </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlatformFilter {
     #[doc="<p>The operator to apply to the <code>Type</code> with each of the <code>Values</code>.</p> <p> Valid Values: <code>=</code> (equal to) | <code>!=</code> (not equal to) | <code>&lt;</code> (less than) | <code>&lt;=</code> (less than or equal to) | <code>&gt;</code> (greater than) | <code>&gt;=</code> (greater than or equal to) | <code>contains</code> | <code>begins_with</code> | <code>ends_with</code> </p>"]
+    #[serde(rename="Operator")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operator: Option<String>,
     #[doc="<p>The custom platform attribute to which the filter values are applied.</p> <p>Valid Values: <code>PlatformName</code> | <code>PlatformVersion</code> | <code>PlatformStatus</code> | <code>PlatformOwner</code> </p>"]
+    #[serde(rename="Type")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
     #[doc="<p>The list of values applied to the custom platform attribute.</p>"]
+    #[serde(rename="Values")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub values: Option<Vec<String>>,
 }
 
@@ -7193,11 +7850,15 @@ impl PlatformFiltersSerializer {
 }
 
 #[doc="<p>A framework supported by the custom platform.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlatformFramework {
     #[doc="<p>The name of the framework.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The version of the framework.</p>"]
+    #[serde(rename="Version")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version: Option<String>,
 }
 
@@ -7316,11 +7977,15 @@ impl PlatformOwnerDeserializer {
     }
 }
 #[doc="<p>A programming language supported by the platform.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlatformProgrammingLanguage {
     #[doc="<p>The name of the programming language.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The version of the programming language.</p>"]
+    #[serde(rename="Version")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version: Option<String>,
 }
 
@@ -7426,23 +8091,39 @@ impl PlatformStatusDeserializer {
     }
 }
 #[doc="<p>Detailed information about a platform.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlatformSummary {
     #[doc="<p>The operating system used by the platform.</p>"]
+    #[serde(rename="OperatingSystemName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operating_system_name: Option<String>,
     #[doc="<p>The version of the operating system used by the platform.</p>"]
+    #[serde(rename="OperatingSystemVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub operating_system_version: Option<String>,
     #[doc="<p>The ARN of the platform.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
     #[doc="<p>The category of platform.</p>"]
+    #[serde(rename="PlatformCategory")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_category: Option<String>,
     #[doc="<p>The AWS account ID of the person who created the platform.</p>"]
+    #[serde(rename="PlatformOwner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_owner: Option<String>,
     #[doc="<p>The status of the platform. You can create an environment from the platform once it is ready.</p>"]
+    #[serde(rename="PlatformStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_status: Option<String>,
     #[doc="<p>The additions associated with the platform.</p>"]
+    #[serde(rename="SupportedAddonList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub supported_addon_list: Option<Vec<String>>,
     #[doc="<p>The tiers in which the platform runs.</p>"]
+    #[serde(rename="SupportedTierList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub supported_tier_list: Option<Vec<String>>,
 }
 
@@ -7580,11 +8261,15 @@ impl PlatformVersionDeserializer {
     }
 }
 #[doc="<p>Describes a queue.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Queue {
     #[doc="<p>The name of the queue.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The URL of the queue.</p>"]
+    #[serde(rename="URL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
 }
 
@@ -7674,11 +8359,15 @@ impl QueueListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebuildEnvironmentMessage {
     #[doc="<p>The ID of the environment to rebuild.</p> <p> Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>The name of the environment to rebuild.</p> <p> Condition: You must specify either this or an EnvironmentId, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
 }
 
@@ -7761,13 +8450,18 @@ impl RequestCountDeserializer {
     }
 }
 #[doc="<p>Request to retrieve logs from an environment and store them in your Elastic Beanstalk storage bucket.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestEnvironmentInfoMessage {
     #[doc="<p>The ID of the environment of the requested data.</p> <p>If no such environment is found, <code>RequestEnvironmentInfo</code> returns an <code>InvalidParameterValue</code> error. </p> <p>Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>The name of the environment of the requested data.</p> <p>If no such environment is found, <code>RequestEnvironmentInfo</code> returns an <code>InvalidParameterValue</code> error. </p> <p>Condition: You must specify either this or an EnvironmentId, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>The type of information to request.</p>"]
+    #[serde(rename="InfoType")]
     pub info_type: String,
 }
 
@@ -7838,11 +8532,15 @@ impl ResourceNameDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestartAppServerMessage {
     #[doc="<p>The ID of the environment to restart the server for.</p> <p> Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>The name of the environment to restart the server for.</p> <p> Condition: You must specify either this or an EnvironmentId, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
 }
 
@@ -7869,13 +8567,18 @@ impl RestartAppServerMessageSerializer {
 }
 
 #[doc="<p>Request to download logs retrieved with <a>RequestEnvironmentInfo</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RetrieveEnvironmentInfoMessage {
     #[doc="<p>The ID of the data's environment.</p> <p>If no such environment is found, returns an <code>InvalidParameterValue</code> error.</p> <p>Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error.</p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>The name of the data's environment.</p> <p> If no such environment is found, returns an <code>InvalidParameterValue</code> error. </p> <p> Condition: You must specify either this or an EnvironmentId, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>The type of information to retrieve.</p>"]
+    #[serde(rename="InfoType")]
     pub info_type: String,
 }
 
@@ -7904,9 +8607,11 @@ impl RetrieveEnvironmentInfoMessageSerializer {
 }
 
 #[doc="<p>Result message containing a description of the requested environment info.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RetrieveEnvironmentInfoResultMessage {
     #[doc="<p> The <a>EnvironmentInfoDescription</a> of the environment. </p>"]
+    #[serde(rename="EnvironmentInfo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_info: Option<Vec<EnvironmentInfoDescription>>,
 }
 
@@ -7981,11 +8686,15 @@ impl S3KeyDeserializer {
     }
 }
 #[doc="<p>The bucket and key of an item stored in Amazon S3.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3Location {
     #[doc="<p>The Amazon S3 bucket where the data is located.</p>"]
+    #[serde(rename="S3Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_bucket: Option<String>,
     #[doc="<p>The Amazon S3 key where the data is located.</p>"]
+    #[serde(rename="S3Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_key: Option<String>,
 }
 
@@ -8071,27 +8780,47 @@ impl SampleTimestampDeserializer {
     }
 }
 #[doc="<p>Detailed health information about an Amazon EC2 instance in your Elastic Beanstalk environment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SingleInstanceHealth {
     #[doc="<p>Request metrics from your application.</p>"]
+    #[serde(rename="ApplicationMetrics")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_metrics: Option<ApplicationMetrics>,
     #[doc="<p>The availability zone in which the instance runs.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>Represents the causes, which provide more information about the current health status.</p>"]
+    #[serde(rename="Causes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub causes: Option<Vec<String>>,
     #[doc="<p>Represents the color indicator that gives you information about the health of the EC2 instance. For more information, see <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-status.html\">Health Colors and Statuses</a>.</p>"]
+    #[serde(rename="Color")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub color: Option<String>,
     #[doc="<p>Information about the most recent deployment to an instance.</p>"]
+    #[serde(rename="Deployment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deployment: Option<Deployment>,
     #[doc="<p>Returns the health status of the specified instance. For more information, see <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-status.html\">Health Colors and Statuses</a>.</p>"]
+    #[serde(rename="HealthStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_status: Option<String>,
     #[doc="<p>The ID of the Amazon EC2 instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>The instance's type.</p>"]
+    #[serde(rename="InstanceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_type: Option<String>,
     #[doc="<p>The time at which the EC2 instance was launched.</p>"]
+    #[serde(rename="LaunchedAt")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub launched_at: Option<String>,
     #[doc="<p>Operating system metrics from the instance.</p>"]
+    #[serde(rename="System")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub system: Option<SystemStatus>,
 }
 
@@ -8177,11 +8906,15 @@ impl SingleInstanceHealthDeserializer {
     }
 }
 #[doc="<p>Describes the solution stack.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SolutionStackDescription {
     #[doc="<p>The permitted file types allowed for a solution stack.</p>"]
+    #[serde(rename="PermittedFileTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub permitted_file_types: Option<Vec<String>>,
     #[doc="<p>The name of the solution stack.</p>"]
+    #[serde(rename="SolutionStackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub solution_stack_name: Option<String>,
 }
 
@@ -8287,13 +9020,16 @@ impl SolutionStackNameDeserializer {
     }
 }
 #[doc="<p>Location of the source code for an application version.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SourceBuildInformation {
     #[doc="<p>The location of the source code, as a formatted string, depending on the value of <code>SourceRepository</code> </p> <ul> <li> <p>For <code>CodeCommit</code>, the format is the repository name and commit ID, separated by a forward slash. For example, <code>my-git-repo/265cfa0cf6af46153527f55d6503ec030551f57a</code>.</p> </li> <li> <p>For <code>S3</code>, the format is the S3 bucket name and object key, separated by a forward slash. For example, <code>my-s3-bucket/Folders/my-source-file</code>.</p> </li> </ul>"]
+    #[serde(rename="SourceLocation")]
     pub source_location: String,
     #[doc="<p>Location where the repository is stored.</p> <ul> <li> <p> <code>CodeCommit</code> </p> </li> <li> <p> <code>S3</code> </p> </li> </ul>"]
+    #[serde(rename="SourceRepository")]
     pub source_repository: String,
     #[doc="<p>The type of repository.</p> <ul> <li> <p> <code>Git</code> </p> </li> <li> <p> <code>Zip</code> </p> </li> </ul>"]
+    #[serde(rename="SourceType")]
     pub source_type: String,
 }
 
@@ -8370,11 +9106,15 @@ impl SourceBuildInformationSerializer {
 }
 
 #[doc="<p>A specification for an environment configuration</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SourceConfiguration {
     #[doc="<p>The name of the application associated with the configuration.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>The name of the configuration template.</p>"]
+    #[serde(rename="TemplateName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_name: Option<String>,
 }
 
@@ -8443,15 +9183,23 @@ impl SourceTypeDeserializer {
     }
 }
 #[doc="<p>Represents the percentage of requests over the last 10 seconds that resulted in each type of status code response. For more information, see <a href=\"http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\">Status Code Definitions</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StatusCodes {
     #[doc="<p>The percentage of requests over the last 10 seconds that resulted in a 2xx (200, 201, etc.) status code.</p>"]
+    #[serde(rename="Status2xx")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_2xx: Option<i64>,
     #[doc="<p>The percentage of requests over the last 10 seconds that resulted in a 3xx (300, 301, etc.) status code.</p>"]
+    #[serde(rename="Status3xx")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_3xx: Option<i64>,
     #[doc="<p>The percentage of requests over the last 10 seconds that resulted in a 4xx (400, 401, etc.) status code.</p>"]
+    #[serde(rename="Status4xx")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_4xx: Option<i64>,
     #[doc="<p>The percentage of requests over the last 10 seconds that resulted in a 5xx (500, 501, etc.) status code.</p>"]
+    #[serde(rename="Status5xx")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_5xx: Option<i64>,
 }
 
@@ -8638,15 +9386,23 @@ impl SupportedTierListDeserializer {
     }
 }
 #[doc="<p>Swaps the CNAMEs of two environments.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SwapEnvironmentCNAMEsMessage {
     #[doc="<p>The ID of the destination environment.</p> <p> Condition: You must specify at least the <code>DestinationEnvironmentID</code> or the <code>DestinationEnvironmentName</code>. You may also specify both. You must specify the <code>SourceEnvironmentId</code> with the <code>DestinationEnvironmentId</code>. </p>"]
+    #[serde(rename="DestinationEnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_environment_id: Option<String>,
     #[doc="<p>The name of the destination environment.</p> <p> Condition: You must specify at least the <code>DestinationEnvironmentID</code> or the <code>DestinationEnvironmentName</code>. You may also specify both. You must specify the <code>SourceEnvironmentName</code> with the <code>DestinationEnvironmentName</code>. </p>"]
+    #[serde(rename="DestinationEnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_environment_name: Option<String>,
     #[doc="<p>The ID of the source environment.</p> <p> Condition: You must specify at least the <code>SourceEnvironmentID</code> or the <code>SourceEnvironmentName</code>. You may also specify both. If you specify the <code>SourceEnvironmentId</code>, you must specify the <code>DestinationEnvironmentId</code>. </p>"]
+    #[serde(rename="SourceEnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_environment_id: Option<String>,
     #[doc="<p>The name of the source environment.</p> <p> Condition: You must specify at least the <code>SourceEnvironmentID</code> or the <code>SourceEnvironmentName</code>. You may also specify both. If you specify the <code>SourceEnvironmentName</code>, you must specify the <code>DestinationEnvironmentName</code>. </p>"]
+    #[serde(rename="SourceEnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_environment_name: Option<String>,
 }
 
@@ -8681,11 +9437,15 @@ impl SwapEnvironmentCNAMEsMessageSerializer {
 }
 
 #[doc="<p>CPU utilization and load average metrics for an Amazon EC2 instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SystemStatus {
     #[doc="<p>CPU utilization metrics for the instance.</p>"]
+    #[serde(rename="CPUUtilization")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cpu_utilization: Option<CPUUtilization>,
     #[doc="<p>Load average in the last 1-minute, 5-minute, and 15-minute periods. For more information, see <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-metrics.html#health-enhanced-metrics-os\">Operating System Metrics</a>.</p>"]
+    #[serde(rename="LoadAverage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_average: Option<Vec<f64>>,
 }
 
@@ -8738,11 +9498,15 @@ impl SystemStatusDeserializer {
     }
 }
 #[doc="<p>Describes a tag applied to a resource in an environment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>The key of the tag.</p>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>The value of the tag.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -8781,15 +9545,23 @@ impl TagsSerializer {
 }
 
 #[doc="<p>Request to terminate an environment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateEnvironmentMessage {
     #[doc="<p>The ID of the environment to terminate.</p> <p> Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>The name of the environment to terminate.</p> <p> Condition: You must specify either this or an EnvironmentId, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>Terminates the target environment even if another environment in the same group is dependent on it.</p>"]
+    #[serde(rename="ForceTerminate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub force_terminate: Option<bool>,
     #[doc="<p>Indicates whether the associated AWS resources should shut down when the environment is terminated:</p> <ul> <li> <p> <code>true</code>: The specified environment as well as the associated AWS resources, such as Auto Scaling group and LoadBalancer, are terminated.</p> </li> <li> <p> <code>false</code>: AWS Elastic Beanstalk resource management is removed from the environment, but the AWS resources continue to operate.</p> </li> </ul> <p> For more information, see the <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/ug/\"> AWS Elastic Beanstalk User Guide. </a> </p> <p> Default: <code>true</code> </p> <p> Valid Values: <code>true</code> | <code>false</code> </p>"]
+    #[serde(rename="TerminateResources")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub terminate_resources: Option<bool>,
 }
 
@@ -8852,9 +9624,11 @@ impl TokenDeserializer {
     }
 }
 #[doc="<p>Describes a trigger.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Trigger {
     #[doc="<p>The name of the trigger.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -8942,11 +9716,14 @@ impl TriggerListDeserializer {
     }
 }
 #[doc="<p>Request to update an application.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateApplicationMessage {
     #[doc="<p>The name of the application to update. If no such application is found, <code>UpdateApplication</code> returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>A new description for the application.</p> <p>Default: If not specified, AWS Elastic Beanstalk does not update the description.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
 }
 
@@ -8970,11 +9747,13 @@ impl UpdateApplicationMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateApplicationResourceLifecycleMessage {
     #[doc="<p>The name of the application.</p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>The lifecycle configuration.</p>"]
+    #[serde(rename="ResourceLifecycleConfig")]
     pub resource_lifecycle_config: ApplicationResourceLifecycleConfig,
 }
 
@@ -9002,13 +9781,17 @@ impl UpdateApplicationResourceLifecycleMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateApplicationVersionMessage {
     #[doc="<p>The name of the application associated with this version.</p> <p> If no application is found with this name, <code>UpdateApplication</code> returns an <code>InvalidParameterValue</code> error.</p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>A new description for this version.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The name of the version to update.</p> <p>If no application version is found with this label, <code>UpdateApplication</code> returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="VersionLabel")]
     pub version_label: String,
 }
 
@@ -9035,17 +9818,25 @@ impl UpdateApplicationVersionMessageSerializer {
 }
 
 #[doc="<p>The result message containing the options for the specified solution stack.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateConfigurationTemplateMessage {
     #[doc="<p>The name of the application associated with the configuration template to update.</p> <p> If no application is found with this name, <code>UpdateConfigurationTemplate</code> returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>A new description for the configuration.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>A list of configuration option settings to update with the new specified option value.</p>"]
+    #[serde(rename="OptionSettings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_settings: Option<Vec<ConfigurationOptionSetting>>,
     #[doc="<p>A list of configuration options to remove from the configuration set.</p> <p> Constraint: You can remove only <code>UserDefined</code> configuration options. </p>"]
+    #[serde(rename="OptionsToRemove")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options_to_remove: Option<Vec<OptionSpecification>>,
     #[doc="<p>The name of the configuration template to update.</p> <p> If no configuration template is found with this name, <code>UpdateConfigurationTemplate</code> returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="TemplateName")]
     pub template_name: String,
 }
 
@@ -9098,31 +9889,55 @@ impl UpdateDateDeserializer {
     }
 }
 #[doc="<p>Request to update an environment.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateEnvironmentMessage {
     #[doc="<p>The name of the application with which the environment is associated.</p>"]
+    #[serde(rename="ApplicationName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub application_name: Option<String>,
     #[doc="<p>If this parameter is specified, AWS Elastic Beanstalk updates the description of this environment.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of the environment to update.</p> <p>If no environment with this ID exists, AWS Elastic Beanstalk returns an <code>InvalidParameterValue</code> error.</p> <p>Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_id: Option<String>,
     #[doc="<p>The name of the environment to update. If no environment with this name exists, AWS Elastic Beanstalk returns an <code>InvalidParameterValue</code> error. </p> <p>Condition: You must specify either this or an EnvironmentId, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>The name of the group to which the target environment belongs. Specify a group name only if the environment's name is specified in an environment manifest and not with the environment name or environment ID parameters. See <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-cfg-manifest.html\">Environment Manifest (env.yaml)</a> for details.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>If specified, AWS Elastic Beanstalk updates the configuration set associated with the running environment and sets the specified configuration options to the requested value.</p>"]
+    #[serde(rename="OptionSettings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_settings: Option<Vec<ConfigurationOptionSetting>>,
     #[doc="<p>A list of custom user-defined configuration options to remove from the configuration set for this environment.</p>"]
+    #[serde(rename="OptionsToRemove")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options_to_remove: Option<Vec<OptionSpecification>>,
     #[doc="<p>The ARN of the platform, if used.</p>"]
+    #[serde(rename="PlatformArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_arn: Option<String>,
     #[doc="<p>This specifies the platform version that the environment will run after the environment is updated.</p>"]
+    #[serde(rename="SolutionStackName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub solution_stack_name: Option<String>,
     #[doc="<p>If this parameter is specified, AWS Elastic Beanstalk deploys this configuration template to the environment. If no such configuration template is found, AWS Elastic Beanstalk returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="TemplateName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_name: Option<String>,
     #[doc="<p>This specifies the tier to use to update the environment.</p> <p>Condition: At this time, if you change the tier version, name, or type, AWS Elastic Beanstalk returns <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="Tier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tier: Option<EnvironmentTier>,
     #[doc="<p>If this parameter is specified, AWS Elastic Beanstalk deploys the named application version to the environment. If no such application version is found, returns an <code>InvalidParameterValue</code> error. </p>"]
+    #[serde(rename="VersionLabel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_label: Option<String>,
 }
 
@@ -9208,15 +10023,21 @@ impl UserDefinedOptionDeserializer {
     }
 }
 #[doc="<p>A list of validation messages for a specified configuration template.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ValidateConfigurationSettingsMessage {
     #[doc="<p>The name of the application that the configuration template or environment belongs to.</p>"]
+    #[serde(rename="ApplicationName")]
     pub application_name: String,
     #[doc="<p>The name of the environment to validate the settings against.</p> <p>Condition: You cannot specify both this and a configuration template name.</p>"]
+    #[serde(rename="EnvironmentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub environment_name: Option<String>,
     #[doc="<p>A list of the options and desired values to evaluate.</p>"]
+    #[serde(rename="OptionSettings")]
     pub option_settings: Vec<ConfigurationOptionSetting>,
     #[doc="<p>The name of the configuration template to validate the settings against.</p> <p>Condition: You cannot specify both this and an environment name.</p>"]
+    #[serde(rename="TemplateName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub template_name: Option<String>,
 }
 
@@ -9250,15 +10071,23 @@ impl ValidateConfigurationSettingsMessageSerializer {
 }
 
 #[doc="<p>An error or warning for a desired configuration option value.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ValidationMessage {
     #[doc="<p>A message describing the error or warning.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
     #[doc="<p>The namespace to which the option belongs.</p>"]
+    #[serde(rename="Namespace")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub namespace: Option<String>,
     #[doc="<p>The name of the option.</p>"]
+    #[serde(rename="OptionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_name: Option<String>,
     #[doc="<p>An indication of the severity of this message:</p> <ul> <li> <p> <code>error</code>: This message indicates that this is not a valid setting for an option.</p> </li> <li> <p> <code>warning</code>: This message is providing information you should take into account.</p> </li> </ul>"]
+    #[serde(rename="Severity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub severity: Option<String>,
 }
 

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -113,7 +113,7 @@ pub struct AudioParameters {
 }
 
 #[doc="<p>The <code>CancelJobRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelJobRequest {
     #[doc="<p>The identifier of the job that you want to cancel.</p> <p>To get a list of the jobs (including their <code>jobId</code>) that have a status of <code>Submitted</code>, use the <a>ListJobsByStatus</a> API action.</p>"]
     #[serde(rename="Id")]
@@ -121,7 +121,7 @@ pub struct CancelJobRequest {
 }
 
 #[doc="<p>The response body contains a JSON object. If the job is successfully canceled, the value of <code>Success</code> is <code>true</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelJobResponse;
 
 #[doc="<p>The file format of the output captions. If you leave this value blank, Elastic Transcoder returns an error.</p>"]
@@ -176,14 +176,16 @@ pub struct Captions {
 }
 
 #[doc="<p>Settings for one clip in a composition. All jobs in a playlist must have the same clip settings.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Clip {
     #[doc="<p>Settings that determine when a clip begins and how long it lasts.</p>"]
+    #[serde(rename="TimeSpan")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub time_span: Option<TimeSpan>,
 }
 
 #[doc="<p>The <code>CreateJobOutput</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobOutput {
     #[doc="<p>Information about the album art that you want Elastic Transcoder to add to the file during transcoding. You can specify up to twenty album artworks for each output. Settings for each artwork must be defined in the job for the current output.</p>"]
     #[serde(rename="AlbumArt")]
@@ -228,7 +230,7 @@ pub struct CreateJobOutput {
 }
 
 #[doc="<p>Information about the master playlist.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobPlaylist {
     #[doc="<p>The format of the output playlist. Valid formats include <code>HLSv3</code>, <code>HLSv4</code>, and <code>Smooth</code>.</p>"]
     #[serde(rename="Format")]
@@ -253,7 +255,7 @@ pub struct CreateJobPlaylist {
 }
 
 #[doc="<p>The <code>CreateJobRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobRequest {
     #[doc="<p>A section of the request body that provides information about the file that is being transcoded.</p>"]
     #[serde(rename="Input")]
@@ -289,7 +291,7 @@ pub struct CreateJobRequest {
 }
 
 #[doc="<p>The CreateJobResponse structure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobResponse {
     #[doc="<p>A section of the response body that provides information about the job that is created.</p>"]
     #[serde(rename="Job")]
@@ -298,7 +300,7 @@ pub struct CreateJobResponse {
 }
 
 #[doc="<p>The <code>CreatePipelineRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePipelineRequest {
     #[doc="<p>The AWS Key Management Service (AWS KMS) key that you want to use with this pipeline.</p> <p>If you use either <code>S3</code> or <code>S3-AWS-KMS</code> as your <code>Encryption:Mode</code>, you don't need to provide a key with your job because a default key, known as an AWS-KMS key, is created for you automatically. You need to provide an AWS-KMS key only if you want to use a non-default AWS-KMS key, or if you are using an <code>Encryption:Mode</code> of <code>AES-PKCS7</code>, <code>AES-CTR</code>, or <code>AES-GCM</code>.</p>"]
     #[serde(rename="AwsKmsKeyArn")]
@@ -332,7 +334,7 @@ pub struct CreatePipelineRequest {
 }
 
 #[doc="<p>When you create a pipeline, Elastic Transcoder returns the values that you specified in the request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePipelineResponse {
     #[doc="<p>A section of the response body that provides information about the pipeline that is created.</p>"]
     #[serde(rename="Pipeline")]
@@ -345,7 +347,7 @@ pub struct CreatePipelineResponse {
 }
 
 #[doc="<p>The <code>CreatePresetRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePresetRequest {
     #[doc="<p>A section of the request body that specifies the audio parameters.</p>"]
     #[serde(rename="Audio")]
@@ -372,7 +374,7 @@ pub struct CreatePresetRequest {
 }
 
 #[doc="<p>The <code>CreatePresetResponse</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePresetResponse {
     #[doc="<p>A section of the response body that provides information about the preset that is created.</p>"]
     #[serde(rename="Preset")]
@@ -385,7 +387,7 @@ pub struct CreatePresetResponse {
 }
 
 #[doc="<p>The <code>DeletePipelineRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePipelineRequest {
     #[doc="<p>The identifier of the pipeline that you want to delete.</p>"]
     #[serde(rename="Id")]
@@ -393,11 +395,11 @@ pub struct DeletePipelineRequest {
 }
 
 #[doc="<p>The <code>DeletePipelineResponse</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePipelineResponse;
 
 #[doc="<p>The <code>DeletePresetRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePresetRequest {
     #[doc="<p>The identifier of the preset for which you want to get detailed information.</p>"]
     #[serde(rename="Id")]
@@ -405,7 +407,7 @@ pub struct DeletePresetRequest {
 }
 
 #[doc="<p>The <code>DeletePresetResponse</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePresetResponse;
 
 #[doc="<p>The detected properties of the input file. Elastic Transcoder identifies these values from the input file.</p>"]
@@ -497,7 +499,7 @@ pub struct InputCaptions {
 }
 
 #[doc="<p>A section of the response body that provides information about the job that is created.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Job {
     #[doc="<p>The Amazon Resource Name (ARN) for the job.</p>"]
     #[serde(rename="Arn")]
@@ -608,7 +610,7 @@ pub struct JobInput {
 }
 
 #[doc="<important> <p>Outputs recommended instead.</p> </important> <p>If you specified one output for a job, information about that output. If you specified multiple outputs for a job, the <code>Output</code> object lists information about the first output. This duplicates the information that is listed for the first output in the <code>Outputs</code> object.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobOutput {
     #[doc="<p>The album art to be associated with the output file, if any.</p>"]
     #[serde(rename="AlbumArt")]
@@ -710,7 +712,7 @@ pub struct JobWatermark {
 }
 
 #[doc="<p>The <code>ListJobsByPipelineRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsByPipelineRequest {
     #[doc="<p> To list jobs in chronological order by the date and time that they were submitted, enter <code>true</code>. To list jobs in reverse chronological order, enter <code>false</code>. </p>"]
     #[serde(rename="Ascending")]
@@ -726,7 +728,7 @@ pub struct ListJobsByPipelineRequest {
 }
 
 #[doc="<p>The <code>ListJobsByPipelineResponse</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsByPipelineResponse {
     #[doc="<p>An array of <code>Job</code> objects that are in the specified pipeline.</p>"]
     #[serde(rename="Jobs")]
@@ -739,7 +741,7 @@ pub struct ListJobsByPipelineResponse {
 }
 
 #[doc="<p>The <code>ListJobsByStatusRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsByStatusRequest {
     #[doc="<p> To list jobs in chronological order by the date and time that they were submitted, enter <code>true</code>. To list jobs in reverse chronological order, enter <code>false</code>. </p>"]
     #[serde(rename="Ascending")]
@@ -755,7 +757,7 @@ pub struct ListJobsByStatusRequest {
 }
 
 #[doc="<p> The <code>ListJobsByStatusResponse</code> structure. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsByStatusResponse {
     #[doc="<p>An array of <code>Job</code> objects that have the specified status.</p>"]
     #[serde(rename="Jobs")]
@@ -768,7 +770,7 @@ pub struct ListJobsByStatusResponse {
 }
 
 #[doc="<p>The <code>ListPipelineRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPipelinesRequest {
     #[doc="<p>To list pipelines in chronological order by the date and time that they were created, enter <code>true</code>. To list pipelines in reverse chronological order, enter <code>false</code>.</p>"]
     #[serde(rename="Ascending")]
@@ -781,7 +783,7 @@ pub struct ListPipelinesRequest {
 }
 
 #[doc="<p>A list of the pipelines associated with the current AWS account.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPipelinesResponse {
     #[doc="<p>A value that you use to access the second and subsequent pages of results, if any. When the pipelines fit on one page or when you've reached the last page of results, the value of <code>NextPageToken</code> is <code>null</code>.</p>"]
     #[serde(rename="NextPageToken")]
@@ -794,7 +796,7 @@ pub struct ListPipelinesResponse {
 }
 
 #[doc="<p>The <code>ListPresetsRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPresetsRequest {
     #[doc="<p>To list presets in chronological order by the date and time that they were created, enter <code>true</code>. To list presets in reverse chronological order, enter <code>false</code>.</p>"]
     #[serde(rename="Ascending")]
@@ -807,7 +809,7 @@ pub struct ListPresetsRequest {
 }
 
 #[doc="<p>The <code>ListPresetsResponse</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPresetsResponse {
     #[doc="<p>A value that you use to access the second and subsequent pages of results, if any. When the presets fit on one page or when you've reached the last page of results, the value of <code>NextPageToken</code> is <code>null</code>.</p>"]
     #[serde(rename="NextPageToken")]
@@ -858,7 +860,7 @@ pub struct Permission {
 }
 
 #[doc="<p>The pipeline (queue) that is used to manage jobs.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Pipeline {
     #[doc="<p>The Amazon Resource Name (ARN) for the pipeline.</p>"]
     #[serde(rename="Arn")]
@@ -953,7 +955,7 @@ pub struct PlayReadyDrm {
 }
 
 #[doc="<p> Use Only for Fragmented MP4 or MPEG-TS Outputs. If you specify a preset for which the value of Container is <code>fmp4</code> (Fragmented MP4) or <code>ts</code> (MPEG-TS), Playlists contains information about the master playlists that you want Elastic Transcoder to create. We recommend that you create only one master playlist per output format. The maximum number of master playlists in a job is 30. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Playlist {
     #[doc="<p>The format of the output playlist. Valid formats include <code>HLSv3</code>, <code>HLSv4</code>, and <code>Smooth</code>.</p>"]
     #[serde(rename="Format")]
@@ -986,7 +988,7 @@ pub struct Playlist {
 }
 
 #[doc="<p>Presets are templates that contain most of the settings for transcoding media files from one format to another. Elastic Transcoder includes some default presets for common formats, for example, several iPod and iPhone versions. You can also create your own presets for formats that aren't included among the default presets. You specify which preset you want to use when you create a job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Preset {
     #[doc="<p>The Amazon Resource Name (ARN) for the preset.</p>"]
     #[serde(rename="Arn")]
@@ -1072,7 +1074,7 @@ pub struct PresetWatermark {
 }
 
 #[doc="<p>The <code>ReadJobRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReadJobRequest {
     #[doc="<p>The identifier of the job for which you want to get detailed information.</p>"]
     #[serde(rename="Id")]
@@ -1080,7 +1082,7 @@ pub struct ReadJobRequest {
 }
 
 #[doc="<p>The <code>ReadJobResponse</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReadJobResponse {
     #[doc="<p>A section of the response body that provides information about the job.</p>"]
     #[serde(rename="Job")]
@@ -1089,7 +1091,7 @@ pub struct ReadJobResponse {
 }
 
 #[doc="<p>The <code>ReadPipelineRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReadPipelineRequest {
     #[doc="<p>The identifier of the pipeline to read.</p>"]
     #[serde(rename="Id")]
@@ -1097,7 +1099,7 @@ pub struct ReadPipelineRequest {
 }
 
 #[doc="<p>The <code>ReadPipelineResponse</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReadPipelineResponse {
     #[doc="<p>A section of the response body that provides information about the pipeline.</p>"]
     #[serde(rename="Pipeline")]
@@ -1110,7 +1112,7 @@ pub struct ReadPipelineResponse {
 }
 
 #[doc="<p>The <code>ReadPresetRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReadPresetRequest {
     #[doc="<p>The identifier of the preset for which you want to get detailed information.</p>"]
     #[serde(rename="Id")]
@@ -1118,7 +1120,7 @@ pub struct ReadPresetRequest {
 }
 
 #[doc="<p>The <code>ReadPresetResponse</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReadPresetResponse {
     #[doc="<p>A section of the response body that provides information about the preset.</p>"]
     #[serde(rename="Preset")]
@@ -1127,7 +1129,7 @@ pub struct ReadPresetResponse {
 }
 
 #[doc="<p> The <code>TestRoleRequest</code> structure. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestRoleRequest {
     #[doc="<p>The Amazon S3 bucket that contains media files to be transcoded. The action attempts to read from this bucket.</p>"]
     #[serde(rename="InputBucket")]
@@ -1144,7 +1146,7 @@ pub struct TestRoleRequest {
 }
 
 #[doc="<p>The <code>TestRoleResponse</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestRoleResponse {
     #[doc="<p>If the <code>Success</code> element contains <code>false</code>, this value is an array of one or more error messages that were generated during the test process.</p>"]
     #[serde(rename="Messages")]
@@ -1207,7 +1209,7 @@ pub struct TimeSpan {
 }
 
 #[doc="<p>Details about the timing of a job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Timing {
     #[doc="<p>The time the job finished transcoding, in epoch milliseconds.</p>"]
     #[serde(rename="FinishTimeMillis")]
@@ -1224,7 +1226,7 @@ pub struct Timing {
 }
 
 #[doc="<p>The <code>UpdatePipelineNotificationsRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePipelineNotificationsRequest {
     #[doc="<p>The identifier of the pipeline for which you want to change notification settings.</p>"]
     #[serde(rename="Id")]
@@ -1235,7 +1237,7 @@ pub struct UpdatePipelineNotificationsRequest {
 }
 
 #[doc="<p>The <code>UpdatePipelineNotificationsResponse</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePipelineNotificationsResponse {
     #[doc="<p>A section of the response body that provides information about the pipeline associated with this notification.</p>"]
     #[serde(rename="Pipeline")]
@@ -1244,7 +1246,7 @@ pub struct UpdatePipelineNotificationsResponse {
 }
 
 #[doc="<p>The <code>UpdatePipelineRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePipelineRequest {
     #[doc="<p>The AWS Key Management Service (AWS KMS) key that you want to use with this pipeline.</p> <p>If you use either <code>S3</code> or <code>S3-AWS-KMS</code> as your <code>Encryption:Mode</code>, you don't need to provide a key with your job because a default key, known as an AWS-KMS key, is created for you automatically. You need to provide an AWS-KMS key only if you want to use a non-default AWS-KMS key, or if you are using an <code>Encryption:Mode</code> of <code>AES-PKCS7</code>, <code>AES-CTR</code>, or <code>AES-GCM</code>.</p>"]
     #[serde(rename="AwsKmsKeyArn")]
@@ -1280,7 +1282,7 @@ pub struct UpdatePipelineRequest {
 }
 
 #[doc="<p>When you update a pipeline, Elastic Transcoder returns the values that you specified in the request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePipelineResponse {
     #[doc="<p>The pipeline updated by this <code>UpdatePipelineResponse</code> call.</p>"]
     #[serde(rename="Pipeline")]
@@ -1293,7 +1295,7 @@ pub struct UpdatePipelineResponse {
 }
 
 #[doc="<p>The <code>UpdatePipelineStatusRequest</code> structure.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePipelineStatusRequest {
     #[doc="<p>The identifier of the pipeline to update.</p>"]
     #[serde(rename="Id")]
@@ -1304,7 +1306,7 @@ pub struct UpdatePipelineStatusRequest {
 }
 
 #[doc="<p>When you update status for a pipeline, Elastic Transcoder returns the values that you specified in the request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePipelineStatusResponse {
     #[doc="<p>A section of the response body that provides information about the pipeline.</p>"]
     #[serde(rename="Pipeline")]
@@ -1378,7 +1380,7 @@ pub struct VideoParameters {
 }
 
 #[doc="<p>Elastic Transcoder returns a warning if the resources used by your pipeline are not in the same region as the pipeline.</p> <p>Using resources in the same region, such as your Amazon S3 buckets, Amazon SNS notification topics, and AWS KMS key, reduces processing time and prevents cross-regional charges.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Warning {
     #[doc="<p>The code of the cross-regional warning.</p>"]
     #[serde(rename="Code")]

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -40,15 +40,22 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>Information about the <code>AccessLog</code> attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccessLog {
     #[doc="<p>The interval for publishing the access logs. You can specify an interval of either 5 minutes or 60 minutes.</p> <p>Default: 60 minutes</p>"]
+    #[serde(rename="EmitInterval")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub emit_interval: Option<i64>,
     #[doc="<p>Specifies whether access logs are enabled for the load balancer.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p>The name of the Amazon S3 bucket where the access logs are stored.</p>"]
+    #[serde(rename="S3BucketName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_bucket_name: Option<String>,
     #[doc="<p>The logical hierarchy you created for your Amazon S3 bucket, for example <code>my-bucket-prefix/prod</code>. If the prefix is not provided, the log is placed at the root level of the bucket.</p>"]
+    #[serde(rename="S3BucketPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_bucket_prefix: Option<String>,
 }
 
@@ -208,11 +215,13 @@ impl AccessPointPortDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for EnableAvailabilityZonesForLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddAvailabilityZonesInput {
     #[doc="<p>The Availability Zones. These must be in the same region as the load balancer.</p>"]
+    #[serde(rename="AvailabilityZones")]
     pub availability_zones: Vec<String>,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
 }
 
@@ -236,9 +245,11 @@ impl AddAvailabilityZonesInputSerializer {
 }
 
 #[doc="<p>Contains the output of EnableAvailabilityZonesForLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddAvailabilityZonesOutput {
     #[doc="<p>The updated list of Availability Zones for the load balancer.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<String>>,
 }
 
@@ -286,11 +297,13 @@ impl AddAvailabilityZonesOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AddTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsInput {
     #[doc="<p>The name of the load balancer. You can specify one load balancer only.</p>"]
+    #[serde(rename="LoadBalancerNames")]
     pub load_balancer_names: Vec<String>,
     #[doc="<p>The tags.</p>"]
+    #[serde(rename="Tags")]
     pub tags: Vec<Tag>,
 }
 
@@ -313,7 +326,7 @@ impl AddTagsInputSerializer {
 }
 
 #[doc="<p>Contains the output of AddTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsOutput;
 
 struct AddTagsOutputDeserializer;
@@ -333,11 +346,15 @@ impl AddTagsOutputDeserializer {
     }
 }
 #[doc="<p>This data type is reserved.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AdditionalAttribute {
     #[doc="<p>This parameter is reserved.</p>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>This parameter is reserved.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -534,11 +551,15 @@ impl AppCookieStickinessPoliciesDeserializer {
     }
 }
 #[doc="<p>Information about a policy for application-controlled session stickiness.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AppCookieStickinessPolicy {
     #[doc="<p>The name of the application cookie used for stickiness.</p>"]
+    #[serde(rename="CookieName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cookie_name: Option<String>,
     #[doc="<p>The mnemonic name for the policy being created. The name must be unique within a set of policies for this load balancer.</p>"]
+    #[serde(rename="PolicyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_name: Option<String>,
 }
 
@@ -591,11 +612,13 @@ impl AppCookieStickinessPolicyDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ApplySecurityGroupsToLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplySecurityGroupsToLoadBalancerInput {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The IDs of the security groups to associate with the load balancer. Note that you cannot specify the name of the security group.</p>"]
+    #[serde(rename="SecurityGroups")]
     pub security_groups: Vec<String>,
 }
 
@@ -619,9 +642,11 @@ impl ApplySecurityGroupsToLoadBalancerInputSerializer {
 }
 
 #[doc="<p>Contains the output of ApplySecurityGroupsToLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplySecurityGroupsToLoadBalancerOutput {
     #[doc="<p>The IDs of the security groups associated with the load balancer.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<String>>,
 }
 
@@ -670,11 +695,13 @@ impl ApplySecurityGroupsToLoadBalancerOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for AttachLoaBalancerToSubnets.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachLoadBalancerToSubnetsInput {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The IDs of the subnets to add. You can add only one subnet per Availability Zone.</p>"]
+    #[serde(rename="Subnets")]
     pub subnets: Vec<String>,
 }
 
@@ -696,9 +723,11 @@ impl AttachLoadBalancerToSubnetsInputSerializer {
 }
 
 #[doc="<p>Contains the output of AttachLoadBalancerToSubnets.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachLoadBalancerToSubnetsOutput {
     #[doc="<p>The IDs of the subnets attached to the load balancer.</p>"]
+    #[serde(rename="Subnets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnets: Option<Vec<String>>,
 }
 
@@ -855,11 +884,15 @@ impl AvailabilityZonesSerializer {
 }
 
 #[doc="<p>Information about the configuration of an EC2 instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BackendServerDescription {
     #[doc="<p>The port on which the EC2 instance is listening.</p>"]
+    #[serde(rename="InstancePort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_port: Option<i64>,
     #[doc="<p>The names of the policies enabled for the EC2 instance.</p>"]
+    #[serde(rename="PolicyNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_names: Option<Vec<String>>,
 }
 
@@ -968,11 +1001,13 @@ impl CardinalityDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ConfigureHealthCheck.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigureHealthCheckInput {
     #[doc="<p>The configuration information.</p>"]
+    #[serde(rename="HealthCheck")]
     pub health_check: HealthCheck,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
 }
 
@@ -996,9 +1031,11 @@ impl ConfigureHealthCheckInputSerializer {
 }
 
 #[doc="<p>Contains the output of ConfigureHealthCheck.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigureHealthCheckOutput {
     #[doc="<p>The updated health check.</p>"]
+    #[serde(rename="HealthCheck")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check: Option<HealthCheck>,
 }
 
@@ -1046,11 +1083,14 @@ impl ConfigureHealthCheckOutputDeserializer {
     }
 }
 #[doc="<p>Information about the <code>ConnectionDraining</code> attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConnectionDraining {
     #[doc="<p>Specifies whether connection draining is enabled for the load balancer.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p>The maximum time, in seconds, to keep the existing connections open before deregistering the instances.</p>"]
+    #[serde(rename="Timeout")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timeout: Option<i64>,
 }
 
@@ -1149,9 +1189,10 @@ impl ConnectionDrainingTimeoutDeserializer {
     }
 }
 #[doc="<p>Information about the <code>ConnectionSettings</code> attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConnectionSettings {
     #[doc="<p>The time, in seconds, that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.</p>"]
+    #[serde(rename="IdleTimeout")]
     pub idle_timeout: i64,
 }
 
@@ -1242,21 +1283,33 @@ impl CookieNameDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAccessPointInput {
     #[doc="<p>One or more Availability Zones from the same region as the load balancer.</p> <p>You must specify at least one Availability Zone.</p> <p>You can add more Availability Zones after you create the load balancer using <a>EnableAvailabilityZonesForLoadBalancer</a>.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<String>>,
     #[doc="<p>The listeners.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-listener-config.html\">Listeners for Your Classic Load Balancer</a> in the <i>Classic Load Balancer Guide</i>.</p>"]
+    #[serde(rename="Listeners")]
     pub listeners: Vec<Listener>,
     #[doc="<p>The name of the load balancer.</p> <p>This name must be unique within your set of load balancers for the region, must have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The type of a load balancer. Valid only for load balancers in a VPC.</p> <p>By default, Elastic Load Balancing creates an Internet-facing load balancer with a DNS name that resolves to public IP addresses. For more information about Internet-facing and Internal load balancers, see <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html#load-balancer-scheme\">Load Balancer Scheme</a> in the <i>Elastic Load Balancing User Guide</i>.</p> <p>Specify <code>internal</code> to create a load balancer with a DNS name that resolves to private IP addresses.</p>"]
+    #[serde(rename="Scheme")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheme: Option<String>,
     #[doc="<p>The IDs of the security groups to assign to the load balancer.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<String>>,
     #[doc="<p>The IDs of the subnets in your VPC to attach to the load balancer. Specify one subnet per Availability Zone specified in <code>AvailabilityZones</code>.</p>"]
+    #[serde(rename="Subnets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnets: Option<Vec<String>>,
     #[doc="<p>A list of tags to assign to the load balancer.</p> <p>For more information about tagging your load balancer, see <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/add-remove-tags.html\">Tag Your Classic Load Balancer</a> in the <i>Classic Load Balancer Guide</i>.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -1300,9 +1353,11 @@ impl CreateAccessPointInputSerializer {
 }
 
 #[doc="<p>Contains the output for CreateLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAccessPointOutput {
     #[doc="<p>The DNS name of the load balancer.</p>"]
+    #[serde(rename="DNSName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dns_name: Option<String>,
 }
 
@@ -1349,13 +1404,16 @@ impl CreateAccessPointOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateAppCookieStickinessPolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAppCookieStickinessPolicyInput {
     #[doc="<p>The name of the application cookie used for stickiness.</p>"]
+    #[serde(rename="CookieName")]
     pub cookie_name: String,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The name of the policy being created. Policy names must consist of alphanumeric characters and dashes (-). This name must be unique within the set of policies for this load balancer.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -1380,7 +1438,7 @@ impl CreateAppCookieStickinessPolicyInputSerializer {
 }
 
 #[doc="<p>Contains the output for CreateAppCookieStickinessPolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAppCookieStickinessPolicyOutput;
 
 struct CreateAppCookieStickinessPolicyOutputDeserializer;
@@ -1401,13 +1459,17 @@ impl CreateAppCookieStickinessPolicyOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateLBCookieStickinessPolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLBCookieStickinessPolicyInput {
     #[doc="<p>The time period, in seconds, after which the cookie should be considered stale. If you do not specify this parameter, the default value is 0, which indicates that the sticky session should last for the duration of the browser session.</p>"]
+    #[serde(rename="CookieExpirationPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cookie_expiration_period: Option<i64>,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The name of the policy being created. Policy names must consist of alphanumeric characters and dashes (-). This name must be unique within the set of policies for this load balancer.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -1434,7 +1496,7 @@ impl CreateLBCookieStickinessPolicyInputSerializer {
 }
 
 #[doc="<p>Contains the output for CreateLBCookieStickinessPolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLBCookieStickinessPolicyOutput;
 
 struct CreateLBCookieStickinessPolicyOutputDeserializer;
@@ -1455,11 +1517,13 @@ impl CreateLBCookieStickinessPolicyOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateLoadBalancerListeners.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoadBalancerListenerInput {
     #[doc="<p>The listeners.</p>"]
+    #[serde(rename="Listeners")]
     pub listeners: Vec<Listener>,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
 }
 
@@ -1483,7 +1547,7 @@ impl CreateLoadBalancerListenerInputSerializer {
 }
 
 #[doc="<p>Contains the parameters for CreateLoadBalancerListener.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoadBalancerListenerOutput;
 
 struct CreateLoadBalancerListenerOutputDeserializer;
@@ -1504,15 +1568,20 @@ impl CreateLoadBalancerListenerOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for CreateLoadBalancerPolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoadBalancerPolicyInput {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The policy attributes.</p>"]
+    #[serde(rename="PolicyAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_attributes: Option<Vec<PolicyAttribute>>,
     #[doc="<p>The name of the load balancer policy to be created. This name must be unique within the set of policies for this load balancer.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
     #[doc="<p>The name of the base policy type. To get the list of policy types, use <a>DescribeLoadBalancerPolicyTypes</a>.</p>"]
+    #[serde(rename="PolicyTypeName")]
     pub policy_type_name: String,
 }
 
@@ -1542,7 +1611,7 @@ impl CreateLoadBalancerPolicyInputSerializer {
 }
 
 #[doc="<p>Contains the output of CreateLoadBalancerPolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoadBalancerPolicyOutput;
 
 struct CreateLoadBalancerPolicyOutputDeserializer;
@@ -1576,9 +1645,10 @@ impl CreatedTimeDeserializer {
     }
 }
 #[doc="<p>Information about the <code>CrossZoneLoadBalancing</code> attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CrossZoneLoadBalancing {
     #[doc="<p>Specifies whether cross-zone load balancing is enabled for the load balancer.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
 }
 
@@ -1684,9 +1754,10 @@ impl DefaultValueDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAccessPointInput {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
 }
 
@@ -1707,7 +1778,7 @@ impl DeleteAccessPointInputSerializer {
 }
 
 #[doc="<p>Contains the output of DeleteLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAccessPointOutput;
 
 struct DeleteAccessPointOutputDeserializer;
@@ -1727,11 +1798,13 @@ impl DeleteAccessPointOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteLoadBalancerListeners.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLoadBalancerListenerInput {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The client port numbers of the listeners.</p>"]
+    #[serde(rename="LoadBalancerPorts")]
     pub load_balancer_ports: Vec<i64>,
 }
 
@@ -1755,7 +1828,7 @@ impl DeleteLoadBalancerListenerInputSerializer {
 }
 
 #[doc="<p>Contains the output of DeleteLoadBalancerListeners.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLoadBalancerListenerOutput;
 
 struct DeleteLoadBalancerListenerOutputDeserializer;
@@ -1776,11 +1849,13 @@ impl DeleteLoadBalancerListenerOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeleteLoadBalancerPolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLoadBalancerPolicyInput {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The name of the policy.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -1803,7 +1878,7 @@ impl DeleteLoadBalancerPolicyInputSerializer {
 }
 
 #[doc="<p>Contains the output of DeleteLoadBalancerPolicy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLoadBalancerPolicyOutput;
 
 struct DeleteLoadBalancerPolicyOutputDeserializer;
@@ -1823,11 +1898,13 @@ impl DeleteLoadBalancerPolicyOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DeregisterInstancesFromLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterEndPointsInput {
     #[doc="<p>The IDs of the instances.</p>"]
+    #[serde(rename="Instances")]
     pub instances: Vec<Instance>,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
 }
 
@@ -1851,9 +1928,11 @@ impl DeregisterEndPointsInputSerializer {
 }
 
 #[doc="<p>Contains the output of DeregisterInstancesFromLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterEndPointsOutput {
     #[doc="<p>The remaining instances registered with the load balancer.</p>"]
+    #[serde(rename="Instances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instances: Option<Vec<Instance>>,
 }
 
@@ -1900,13 +1979,19 @@ impl DeregisterEndPointsOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeLoadBalancers.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccessPointsInput {
     #[doc="<p>The names of the load balancers.</p>"]
+    #[serde(rename="LoadBalancerNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_names: Option<Vec<String>>,
     #[doc="<p>The marker for the next set of results. (You received this marker from a previous call.)</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of results to return with this call (a number from 1 to 400). The default is 400.</p>"]
+    #[serde(rename="PageSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub page_size: Option<i64>,
 }
 
@@ -1938,11 +2023,15 @@ impl DescribeAccessPointsInputSerializer {
 }
 
 #[doc="<p>Contains the parameters for DescribeLoadBalancers.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccessPointsOutput {
     #[doc="<p>Information about the load balancers.</p>"]
+    #[serde(rename="LoadBalancerDescriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_descriptions: Option<Vec<LoadBalancerDescription>>,
     #[doc="<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
 }
 
@@ -1991,11 +2080,15 @@ impl DescribeAccessPointsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountLimitsInput {
     #[doc="<p>The marker for the next set of results. (You received this marker from a previous call.)</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of results to return with this call.</p>"]
+    #[serde(rename="PageSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub page_size: Option<i64>,
 }
 
@@ -2021,11 +2114,15 @@ impl DescribeAccountLimitsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountLimitsOutput {
     #[doc="<p>Information about the limits.</p>"]
+    #[serde(rename="Limits")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub limits: Option<Vec<Limit>>,
     #[doc="<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
 }
 
@@ -2076,11 +2173,14 @@ impl DescribeAccountLimitsOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeInstanceHealth.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEndPointStateInput {
     #[doc="<p>The IDs of the instances.</p>"]
+    #[serde(rename="Instances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instances: Option<Vec<Instance>>,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
 }
 
@@ -2106,9 +2206,11 @@ impl DescribeEndPointStateInputSerializer {
 }
 
 #[doc="<p>Contains the output for DescribeInstanceHealth.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEndPointStateOutput {
     #[doc="<p>Information about the health of the instances.</p>"]
+    #[serde(rename="InstanceStates")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_states: Option<Vec<InstanceState>>,
 }
 
@@ -2156,9 +2258,10 @@ impl DescribeEndPointStateOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeLoadBalancerAttributes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancerAttributesInput {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
 }
 
@@ -2179,9 +2282,11 @@ impl DescribeLoadBalancerAttributesInputSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeLoadBalancerAttributes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancerAttributesOutput {
     #[doc="<p>Information about the load balancer attributes.</p>"]
+    #[serde(rename="LoadBalancerAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_attributes: Option<LoadBalancerAttributes>,
 }
 
@@ -2230,11 +2335,15 @@ impl DescribeLoadBalancerAttributesOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeLoadBalancerPolicies.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancerPoliciesInput {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_name: Option<String>,
     #[doc="<p>The names of the policies.</p>"]
+    #[serde(rename="PolicyNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_names: Option<Vec<String>>,
 }
 
@@ -2262,9 +2371,11 @@ impl DescribeLoadBalancerPoliciesInputSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeLoadBalancerPolicies.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancerPoliciesOutput {
     #[doc="<p>Information about the policies.</p>"]
+    #[serde(rename="PolicyDescriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_descriptions: Option<Vec<PolicyDescription>>,
 }
 
@@ -2313,9 +2424,11 @@ impl DescribeLoadBalancerPoliciesOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeLoadBalancerPolicyTypes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancerPolicyTypesInput {
     #[doc="<p>The names of the policy types. If no names are specified, describes all policy types defined by Elastic Load Balancing.</p>"]
+    #[serde(rename="PolicyTypeNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_type_names: Option<Vec<String>>,
 }
 
@@ -2339,9 +2452,11 @@ impl DescribeLoadBalancerPolicyTypesInputSerializer {
 }
 
 #[doc="<p>Contains the output of DescribeLoadBalancerPolicyTypes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancerPolicyTypesOutput {
     #[doc="<p>Information about the policy types.</p>"]
+    #[serde(rename="PolicyTypeDescriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_type_descriptions: Option<Vec<PolicyTypeDescription>>,
 }
 
@@ -2390,9 +2505,10 @@ impl DescribeLoadBalancerPolicyTypesOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DescribeTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsInput {
     #[doc="<p>The names of the load balancers.</p>"]
+    #[serde(rename="LoadBalancerNames")]
     pub load_balancer_names: Vec<String>,
 }
 
@@ -2414,9 +2530,11 @@ impl DescribeTagsInputSerializer {
 }
 
 #[doc="<p>Contains the output for DescribeTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsOutput {
     #[doc="<p>Information about the tags.</p>"]
+    #[serde(rename="TagDescriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_descriptions: Option<Vec<TagDescription>>,
 }
 
@@ -2478,11 +2596,13 @@ impl DescriptionDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DetachLoadBalancerFromSubnets.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachLoadBalancerFromSubnetsInput {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The IDs of the subnets.</p>"]
+    #[serde(rename="Subnets")]
     pub subnets: Vec<String>,
 }
 
@@ -2504,9 +2624,11 @@ impl DetachLoadBalancerFromSubnetsInputSerializer {
 }
 
 #[doc="<p>Contains the output of DetachLoadBalancerFromSubnets.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachLoadBalancerFromSubnetsOutput {
     #[doc="<p>The IDs of the remaining subnets for the load balancer.</p>"]
+    #[serde(rename="Subnets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnets: Option<Vec<String>>,
 }
 
@@ -2554,17 +2676,22 @@ impl DetachLoadBalancerFromSubnetsOutputDeserializer {
     }
 }
 #[doc="<p>Information about a health check.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HealthCheck {
     #[doc="<p>The number of consecutive health checks successes required before moving the instance to the <code>Healthy</code> state.</p>"]
+    #[serde(rename="HealthyThreshold")]
     pub healthy_threshold: i64,
     #[doc="<p>The approximate interval, in seconds, between health checks of an individual instance.</p>"]
+    #[serde(rename="Interval")]
     pub interval: i64,
     #[doc="<p>The instance being checked. The protocol is either TCP, HTTP, HTTPS, or SSL. The range of valid ports is one (1) through 65535.</p> <p>TCP is the default, specified as a TCP: port pair, for example \"TCP:5000\". In this case, a health check simply attempts to open a TCP connection to the instance on the specified port. Failure to connect within the configured timeout is considered unhealthy.</p> <p>SSL is also specified as SSL: port pair, for example, SSL:5000.</p> <p>For HTTP/HTTPS, you must include a ping path in the string. HTTP is specified as a HTTP:port;/;PathToPing; grouping, for example \"HTTP:80/weather/us/wa/seattle\". In this case, a HTTP GET request is issued to the instance on the given port and path. Any answer other than \"200 OK\" within the timeout period is considered unhealthy.</p> <p>The total length of the HTTP ping target must be 1024 16-bit Unicode characters or less.</p>"]
+    #[serde(rename="Target")]
     pub target: String,
     #[doc="<p>The amount of time, in seconds, during which no response means a failed health check.</p> <p>This value must be less than the <code>Interval</code> value.</p>"]
+    #[serde(rename="Timeout")]
     pub timeout: i64,
     #[doc="<p>The number of consecutive health check failures required before moving the instance to the <code>Unhealthy</code> state.</p>"]
+    #[serde(rename="UnhealthyThreshold")]
     pub unhealthy_threshold: i64,
 }
 
@@ -2724,9 +2851,11 @@ impl IdleTimeoutDeserializer {
     }
 }
 #[doc="<p>The ID of an EC2 instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Instance {
     #[doc="<p>The instance ID.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
 }
 
@@ -2820,15 +2949,23 @@ impl InstancePortDeserializer {
     }
 }
 #[doc="<p>Information about the state of an EC2 instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceState {
     #[doc="<p>A description of the instance state. This string can contain one or more of the following messages.</p> <ul> <li> <p> <code>N/A</code> </p> </li> <li> <p> <code>A transient error occurred. Please try again later.</code> </p> </li> <li> <p> <code>Instance has failed at least the UnhealthyThreshold number of health checks consecutively.</code> </p> </li> <li> <p> <code>Instance has not passed the configured HealthyThreshold number of health checks consecutively.</code> </p> </li> <li> <p> <code>Instance registration is still in progress.</code> </p> </li> <li> <p> <code>Instance is in the EC2 Availability Zone for which LoadBalancer is not configured to route traffic to.</code> </p> </li> <li> <p> <code>Instance is not currently registered with the LoadBalancer.</code> </p> </li> <li> <p> <code>Instance deregistration currently in progress.</code> </p> </li> <li> <p> <code>Disable Availability Zone is currently in progress.</code> </p> </li> <li> <p> <code>Instance is in pending state.</code> </p> </li> <li> <p> <code>Instance is in stopped state.</code> </p> </li> <li> <p> <code>Instance is in terminated state.</code> </p> </li> </ul>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The ID of the instance.</p>"]
+    #[serde(rename="InstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_id: Option<String>,
     #[doc="<p>Information about the cause of <code>OutOfService</code> instances. Specifically, whether the cause is Elastic Load Balancing or the instance.</p> <p>Valid values: <code>ELB</code> | <code>Instance</code> | <code>N/A</code> </p>"]
+    #[serde(rename="ReasonCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reason_code: Option<String>,
     #[doc="<p>The current state of the instance.</p> <p>Valid values: <code>InService</code> | <code>OutOfService</code> | <code>Unknown</code> </p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -3025,11 +3162,15 @@ impl LBCookieStickinessPoliciesDeserializer {
     }
 }
 #[doc="<p>Information about a policy for duration-based session stickiness.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LBCookieStickinessPolicy {
     #[doc="<p>The time period, in seconds, after which the cookie should be considered stale. If this parameter is not specified, the stickiness session lasts for the duration of the browser session.</p>"]
+    #[serde(rename="CookieExpirationPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cookie_expiration_period: Option<i64>,
     #[doc="<p>The name of the policy. This name must be unique within the set of policies for this load balancer.</p>"]
+    #[serde(rename="PolicyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_name: Option<String>,
 }
 
@@ -3082,11 +3223,15 @@ impl LBCookieStickinessPolicyDeserializer {
     }
 }
 #[doc="<p>Information about an Elastic Load Balancing resource limit for your AWS account.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Limit {
     #[doc="<p>The maximum value of the limit.</p>"]
+    #[serde(rename="Max")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max: Option<String>,
     #[doc="<p>The name of the limit. The possible values are:</p> <ul> <li> <p>classic-listeners</p> </li> <li> <p>classic-load-balancers</p> </li> </ul>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -3176,17 +3321,24 @@ impl LimitsDeserializer {
     }
 }
 #[doc="<p>Information about a listener.</p> <p>For information about the protocols and the ports supported by Elastic Load Balancing, see <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-listener-config.html\">Listeners for Your Classic Load Balancer</a> in the <i>Classic Load Balancer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Listener {
     #[doc="<p>The port on which the instance is listening.</p>"]
+    #[serde(rename="InstancePort")]
     pub instance_port: i64,
     #[doc="<p>The protocol to use for routing traffic to instances: HTTP, HTTPS, TCP, or SSL.</p> <p>If the front-end protocol is HTTP, HTTPS, TCP, or SSL, <code>InstanceProtocol</code> must be at the same protocol.</p> <p>If there is another listener with the same <code>InstancePort</code> whose <code>InstanceProtocol</code> is secure, (HTTPS or SSL), the listener's <code>InstanceProtocol</code> must also be secure.</p> <p>If there is another listener with the same <code>InstancePort</code> whose <code>InstanceProtocol</code> is HTTP or TCP, the listener's <code>InstanceProtocol</code> must be HTTP or TCP.</p>"]
+    #[serde(rename="InstanceProtocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_protocol: Option<String>,
     #[doc="<p>The port on which the load balancer is listening. On EC2-VPC, you can specify any port from the range 1-65535. On EC2-Classic, you can specify any port from the following list: 25, 80, 443, 465, 587, 1024-65535.</p>"]
+    #[serde(rename="LoadBalancerPort")]
     pub load_balancer_port: i64,
     #[doc="<p>The load balancer transport protocol to use for routing: HTTP, HTTPS, TCP, or SSL.</p>"]
+    #[serde(rename="Protocol")]
     pub protocol: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the server certificate.</p>"]
+    #[serde(rename="SSLCertificateId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssl_certificate_id: Option<String>,
 }
 
@@ -3280,11 +3432,15 @@ impl ListenerSerializer {
 }
 
 #[doc="<p>The policies enabled for a listener.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListenerDescription {
     #[doc="<p>The listener.</p>"]
+    #[serde(rename="Listener")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub listener: Option<Listener>,
     #[doc="<p>The policies. If there are no policies enabled, the list is empty.</p>"]
+    #[serde(rename="PolicyNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_names: Option<Vec<String>>,
 }
 
@@ -3390,17 +3546,27 @@ impl ListenersSerializer {
 }
 
 #[doc="<p>The attributes for a load balancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBalancerAttributes {
     #[doc="<p>If enabled, the load balancer captures detailed information of all requests and delivers the information to the Amazon S3 bucket that you specify.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html\">Enable Access Logs</a> in the <i>Classic Load Balancer Guide</i>.</p>"]
+    #[serde(rename="AccessLog")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub access_log: Option<AccessLog>,
     #[doc="<p>This parameter is reserved.</p>"]
+    #[serde(rename="AdditionalAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub additional_attributes: Option<Vec<AdditionalAttribute>>,
     #[doc="<p>If enabled, the load balancer allows existing requests to complete before the load balancer shifts traffic away from a deregistered or unhealthy instance.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-conn-drain.html\">Configure Connection Draining</a> in the <i>Classic Load Balancer Guide</i>.</p>"]
+    #[serde(rename="ConnectionDraining")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub connection_draining: Option<ConnectionDraining>,
     #[doc="<p>If enabled, the load balancer allows the connections to remain idle (no data is sent over the connection) for the specified duration.</p> <p>By default, Elastic Load Balancing maintains a 60-second idle connection timeout for both front-end and back-end connections of your load balancer. For more information, see <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html\">Configure Idle Connection Timeout</a> in the <i>Classic Load Balancer Guide</i>.</p>"]
+    #[serde(rename="ConnectionSettings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub connection_settings: Option<ConnectionSettings>,
     #[doc="<p>If enabled, the load balancer routes the request traffic evenly across all instances regardless of the Availability Zones.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-crosszone-lb.html\">Configure Cross-Zone Load Balancing</a> in the <i>Classic Load Balancer Guide</i>.</p>"]
+    #[serde(rename="CrossZoneLoadBalancing")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cross_zone_load_balancing: Option<CrossZoneLoadBalancing>,
 }
 
@@ -3510,39 +3676,71 @@ impl LoadBalancerAttributesSerializer {
 }
 
 #[doc="<p>Information about a load balancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBalancerDescription {
     #[doc="<p>The Availability Zones for the load balancer.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<String>>,
     #[doc="<p>Information about your EC2 instances.</p>"]
+    #[serde(rename="BackendServerDescriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub backend_server_descriptions: Option<Vec<BackendServerDescription>>,
     #[doc="<p>The DNS name of the load balancer.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/using-domain-names-with-elb.html\">Configure a Custom Domain Name</a> in the <i>Classic Load Balancer Guide</i>.</p>"]
+    #[serde(rename="CanonicalHostedZoneName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub canonical_hosted_zone_name: Option<String>,
     #[doc="<p>The ID of the Amazon Route 53 hosted zone for the load balancer.</p>"]
+    #[serde(rename="CanonicalHostedZoneNameID")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub canonical_hosted_zone_name_id: Option<String>,
     #[doc="<p>The date and time the load balancer was created.</p>"]
+    #[serde(rename="CreatedTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub created_time: Option<String>,
     #[doc="<p>The DNS name of the load balancer.</p>"]
+    #[serde(rename="DNSName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dns_name: Option<String>,
     #[doc="<p>Information about the health checks conducted on the load balancer.</p>"]
+    #[serde(rename="HealthCheck")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check: Option<HealthCheck>,
     #[doc="<p>The IDs of the instances for the load balancer.</p>"]
+    #[serde(rename="Instances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instances: Option<Vec<Instance>>,
     #[doc="<p>The listeners for the load balancer.</p>"]
+    #[serde(rename="ListenerDescriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub listener_descriptions: Option<Vec<ListenerDescription>>,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_name: Option<String>,
     #[doc="<p>The policies defined for the load balancer.</p>"]
+    #[serde(rename="Policies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policies: Option<Policies>,
     #[doc="<p>The type of load balancer. Valid only for load balancers in a VPC.</p> <p>If <code>Scheme</code> is <code>internet-facing</code>, the load balancer has a public DNS name that resolves to a public IP address.</p> <p>If <code>Scheme</code> is <code>internal</code>, the load balancer has a public DNS name that resolves to a private IP address.</p>"]
+    #[serde(rename="Scheme")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheme: Option<String>,
     #[doc="<p>The security groups for the load balancer. Valid only for load balancers in a VPC.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<String>>,
     #[doc="<p>The security group for the load balancer, which you can use as part of your inbound rules for your registered instances. To only allow traffic from load balancers, add a security group rule that specifies this source security group as the inbound source.</p>"]
+    #[serde(rename="SourceSecurityGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_security_group: Option<SourceSecurityGroup>,
     #[doc="<p>The IDs of the subnets for the load balancer.</p>"]
+    #[serde(rename="Subnets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnets: Option<Vec<String>>,
     #[doc="<p>The ID of the VPC for the load balancer.</p>"]
+    #[serde(rename="VPCId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -3765,11 +3963,13 @@ impl MaxDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for ModifyLoadBalancerAttributes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyLoadBalancerAttributesInput {
     #[doc="<p>The attributes for the load balancer.</p>"]
+    #[serde(rename="LoadBalancerAttributes")]
     pub load_balancer_attributes: LoadBalancerAttributes,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
 }
 
@@ -3795,11 +3995,15 @@ impl ModifyLoadBalancerAttributesInputSerializer {
 }
 
 #[doc="<p>Contains the output of ModifyLoadBalancerAttributes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyLoadBalancerAttributesOutput {
     #[doc="<p>Information about the load balancer attributes.</p>"]
+    #[serde(rename="LoadBalancerAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_attributes: Option<LoadBalancerAttributes>,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_name: Option<String>,
 }
 
@@ -3867,13 +4071,19 @@ impl NameDeserializer {
     }
 }
 #[doc="<p>The policies for a load balancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Policies {
     #[doc="<p>The stickiness policies created using <a>CreateAppCookieStickinessPolicy</a>.</p>"]
+    #[serde(rename="AppCookieStickinessPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub app_cookie_stickiness_policies: Option<Vec<AppCookieStickinessPolicy>>,
     #[doc="<p>The stickiness policies created using <a>CreateLBCookieStickinessPolicy</a>.</p>"]
+    #[serde(rename="LBCookieStickinessPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lb_cookie_stickiness_policies: Option<Vec<LBCookieStickinessPolicy>>,
     #[doc="<p>The policies other than the stickiness policies.</p>"]
+    #[serde(rename="OtherPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub other_policies: Option<Vec<String>>,
 }
 
@@ -3927,11 +4137,15 @@ impl PoliciesDeserializer {
     }
 }
 #[doc="<p>Information about a policy attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyAttribute {
     #[doc="<p>The name of the attribute.</p>"]
+    #[serde(rename="AttributeName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_name: Option<String>,
     #[doc="<p>The value of the attribute.</p>"]
+    #[serde(rename="AttributeValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_value: Option<String>,
 }
 
@@ -3958,11 +4172,15 @@ impl PolicyAttributeSerializer {
 }
 
 #[doc="<p>Information about a policy attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyAttributeDescription {
     #[doc="<p>The name of the attribute.</p>"]
+    #[serde(rename="AttributeName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_name: Option<String>,
     #[doc="<p>The value of the attribute.</p>"]
+    #[serde(rename="AttributeValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_value: Option<String>,
 }
 
@@ -4058,17 +4276,27 @@ impl PolicyAttributeDescriptionsDeserializer {
     }
 }
 #[doc="<p>Information about a policy attribute type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyAttributeTypeDescription {
     #[doc="<p>The name of the attribute.</p>"]
+    #[serde(rename="AttributeName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_name: Option<String>,
     #[doc="<p>The type of the attribute. For example, <code>Boolean</code> or <code>Integer</code>.</p>"]
+    #[serde(rename="AttributeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_type: Option<String>,
     #[doc="<p>The cardinality of the attribute.</p> <p>Valid values:</p> <ul> <li> <p>ONE(1) : Single value required</p> </li> <li> <p>ZERO_OR_ONE(0..1) : Up to one value is allowed</p> </li> <li> <p>ZERO_OR_MORE(0..*) : Optional. Multiple values are allowed</p> </li> <li> <p>ONE_OR_MORE(1..*0) : Required. Multiple values are allowed</p> </li> </ul>"]
+    #[serde(rename="Cardinality")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cardinality: Option<String>,
     #[doc="<p>The default value of the attribute, if applicable.</p>"]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>A description of the attribute.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
 }
 
@@ -4190,13 +4418,19 @@ impl PolicyAttributesSerializer {
 }
 
 #[doc="<p>Information about a policy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyDescription {
     #[doc="<p>The policy attributes.</p>"]
+    #[serde(rename="PolicyAttributeDescriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_attribute_descriptions: Option<Vec<PolicyAttributeDescription>>,
     #[doc="<p>The name of the policy.</p>"]
+    #[serde(rename="PolicyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_name: Option<String>,
     #[doc="<p>The name of the policy type.</p>"]
+    #[serde(rename="PolicyTypeName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_type_name: Option<String>,
 }
 
@@ -4360,13 +4594,19 @@ impl PolicyNamesSerializer {
 }
 
 #[doc="<p>Information about a policy type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyTypeDescription {
     #[doc="<p>A description of the policy type.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The description of the policy attributes associated with the policies defined by Elastic Load Balancing.</p>"]
+    #[serde(rename="PolicyAttributeTypeDescriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_attribute_type_descriptions: Option<Vec<PolicyAttributeTypeDescription>>,
     #[doc="<p>The name of the policy type.</p>"]
+    #[serde(rename="PolicyTypeName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_type_name: Option<String>,
 }
 
@@ -4530,11 +4770,13 @@ impl ReasonCodeDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for RegisterInstancesWithLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterEndPointsInput {
     #[doc="<p>The IDs of the instances.</p>"]
+    #[serde(rename="Instances")]
     pub instances: Vec<Instance>,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
 }
 
@@ -4558,9 +4800,11 @@ impl RegisterEndPointsInputSerializer {
 }
 
 #[doc="<p>Contains the output of RegisterInstancesWithLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterEndPointsOutput {
     #[doc="<p>The updated list of instances for the load balancer.</p>"]
+    #[serde(rename="Instances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instances: Option<Vec<Instance>>,
 }
 
@@ -4607,11 +4851,13 @@ impl RegisterEndPointsOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for DisableAvailabilityZonesForLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveAvailabilityZonesInput {
     #[doc="<p>The Availability Zones.</p>"]
+    #[serde(rename="AvailabilityZones")]
     pub availability_zones: Vec<String>,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
 }
 
@@ -4635,9 +4881,11 @@ impl RemoveAvailabilityZonesInputSerializer {
 }
 
 #[doc="<p>Contains the output for DisableAvailabilityZonesForLoadBalancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveAvailabilityZonesOutput {
     #[doc="<p>The remaining Availability Zones for the load balancer.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<String>>,
 }
 
@@ -4685,11 +4933,13 @@ impl RemoveAvailabilityZonesOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for RemoveTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsInput {
     #[doc="<p>The name of the load balancer. You can specify a maximum of one load balancer name.</p>"]
+    #[serde(rename="LoadBalancerNames")]
     pub load_balancer_names: Vec<String>,
     #[doc="<p>The list of tag keys to remove.</p>"]
+    #[serde(rename="Tags")]
     pub tags: Vec<TagKeyOnly>,
 }
 
@@ -4712,7 +4962,7 @@ impl RemoveTagsInputSerializer {
 }
 
 #[doc="<p>Contains the output of RemoveTags.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsOutput;
 
 struct RemoveTagsOutputDeserializer;
@@ -4855,13 +5105,16 @@ impl SecurityGroupsSerializer {
 }
 
 #[doc="<p>Contains the parameters for SetLoadBalancerListenerSSLCertificate.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetLoadBalancerListenerSSLCertificateInput {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The port that uses the specified SSL certificate.</p>"]
+    #[serde(rename="LoadBalancerPort")]
     pub load_balancer_port: i64,
     #[doc="<p>The Amazon Resource Name (ARN) of the SSL certificate.</p>"]
+    #[serde(rename="SSLCertificateId")]
     pub ssl_certificate_id: String,
 }
 
@@ -4888,7 +5141,7 @@ impl SetLoadBalancerListenerSSLCertificateInputSerializer {
 }
 
 #[doc="<p>Contains the output of SetLoadBalancerListenerSSLCertificate.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetLoadBalancerListenerSSLCertificateOutput;
 
 struct SetLoadBalancerListenerSSLCertificateOutputDeserializer;
@@ -4909,13 +5162,16 @@ impl SetLoadBalancerListenerSSLCertificateOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for SetLoadBalancerPoliciesForBackendServer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetLoadBalancerPoliciesForBackendServerInput {
     #[doc="<p>The port number associated with the EC2 instance.</p>"]
+    #[serde(rename="InstancePort")]
     pub instance_port: i64,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The names of the policies. If the list is empty, then all current polices are removed from the EC2 instance.</p>"]
+    #[serde(rename="PolicyNames")]
     pub policy_names: Vec<String>,
 }
 
@@ -4943,7 +5199,7 @@ impl SetLoadBalancerPoliciesForBackendServerInputSerializer {
 }
 
 #[doc="<p>Contains the output of SetLoadBalancerPoliciesForBackendServer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetLoadBalancerPoliciesForBackendServerOutput;
 
 struct SetLoadBalancerPoliciesForBackendServerOutputDeserializer;
@@ -4964,13 +5220,16 @@ impl SetLoadBalancerPoliciesForBackendServerOutputDeserializer {
     }
 }
 #[doc="<p>Contains the parameters for SetLoadBalancePoliciesOfListener.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetLoadBalancerPoliciesOfListenerInput {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
     pub load_balancer_name: String,
     #[doc="<p>The external port of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerPort")]
     pub load_balancer_port: i64,
     #[doc="<p>The names of the policies. This list must include all policies to be enabled. If you omit a policy that is currently enabled, it is disabled. If the list is empty, all current policies are disabled.</p>"]
+    #[serde(rename="PolicyNames")]
     pub policy_names: Vec<String>,
 }
 
@@ -4996,7 +5255,7 @@ impl SetLoadBalancerPoliciesOfListenerInputSerializer {
 }
 
 #[doc="<p>Contains the output of SetLoadBalancePoliciesOfListener.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetLoadBalancerPoliciesOfListenerOutput;
 
 struct SetLoadBalancerPoliciesOfListenerOutputDeserializer;
@@ -5017,11 +5276,15 @@ impl SetLoadBalancerPoliciesOfListenerOutputDeserializer {
     }
 }
 #[doc="<p>Information about a source security group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SourceSecurityGroup {
     #[doc="<p>The name of the security group.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>The owner of the security group.</p>"]
+    #[serde(rename="OwnerAlias")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_alias: Option<String>,
 }
 
@@ -5155,11 +5418,14 @@ impl SubnetsSerializer {
 }
 
 #[doc="<p>Information about a tag.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>The key of the tag.</p>"]
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="<p>The value of the tag.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -5229,11 +5495,15 @@ impl TagSerializer {
 }
 
 #[doc="<p>The tags associated with a load balancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagDescription {
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_name: Option<String>,
     #[doc="<p>The tags.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -5351,9 +5621,11 @@ impl TagKeyListSerializer {
 }
 
 #[doc="<p>The key of a tag.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagKeyOnly {
     #[doc="<p>The name of the key.</p>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
 }
 

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -40,11 +40,13 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>Information about an action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Action {
     #[doc="<p>The Amazon Resource Name (ARN) of the target group.</p>"]
+    #[serde(rename="TargetGroupArn")]
     pub target_group_arn: String,
     #[doc="<p>The type of action.</p>"]
+    #[serde(rename="Type")]
     pub type_: String,
 }
 
@@ -180,11 +182,13 @@ impl ActionsSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource.</p>"]
+    #[serde(rename="ResourceArns")]
     pub resource_arns: Vec<String>,
     #[doc="<p>The tags. Each resource can have a maximum of 10 tags.</p>"]
+    #[serde(rename="Tags")]
     pub tags: Vec<Tag>,
 }
 
@@ -206,7 +210,7 @@ impl AddTagsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsOutput;
 
 struct AddTagsOutputDeserializer;
@@ -226,11 +230,15 @@ impl AddTagsOutputDeserializer {
     }
 }
 #[doc="<p>Information about an Availability Zone.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AvailabilityZone {
     #[doc="<p>The ID of the subnet.</p>"]
+    #[serde(rename="SubnetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_id: Option<String>,
     #[doc="<p>The name of the Availability Zone.</p>"]
+    #[serde(rename="ZoneName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub zone_name: Option<String>,
 }
 
@@ -336,9 +344,11 @@ impl CanonicalHostedZoneIdDeserializer {
     }
 }
 #[doc="<p>Information about an SSL server certificate deployed on a load balancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Certificate {
     #[doc="<p>The Amazon Resource Name (ARN) of the certificate.</p>"]
+    #[serde(rename="CertificateArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificate_arn: Option<String>,
 }
 
@@ -471,11 +481,15 @@ impl CertificateListSerializer {
 }
 
 #[doc="<p>Information about a cipher used in a policy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Cipher {
     #[doc="<p>The name of the cipher.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The priority of the cipher.</p>"]
+    #[serde(rename="Priority")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub priority: Option<i64>,
 }
 
@@ -609,19 +623,27 @@ impl ConditionFieldNameDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateListenerInput {
     #[doc="<p>The SSL server certificate. You must provide exactly one certificate if the protocol is HTTPS.</p>"]
+    #[serde(rename="Certificates")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificates: Option<Vec<Certificate>>,
     #[doc="<p>The default action for the listener.</p>"]
+    #[serde(rename="DefaultActions")]
     pub default_actions: Vec<Action>,
     #[doc="<p>The Amazon Resource Name (ARN) of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerArn")]
     pub load_balancer_arn: String,
     #[doc="<p>The port on which the load balancer is listening.</p>"]
+    #[serde(rename="Port")]
     pub port: i64,
     #[doc="<p>The protocol for connections from clients to the load balancer.</p>"]
+    #[serde(rename="Protocol")]
     pub protocol: String,
     #[doc="<p>The security policy that defines which ciphers and protocols are supported. The default is the current predefined security policy.</p>"]
+    #[serde(rename="SslPolicy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssl_policy: Option<String>,
 }
 
@@ -657,9 +679,11 @@ impl CreateListenerInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateListenerOutput {
     #[doc="<p>Information about the listener.</p>"]
+    #[serde(rename="Listeners")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub listeners: Option<Vec<Listener>>,
 }
 
@@ -705,19 +729,29 @@ impl CreateListenerOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoadBalancerInput {
     #[doc="<p>The type of IP addresses used by the subnets for your load balancer. The possible values are <code>ipv4</code> (for IPv4 addresses) and <code>dualstack</code> (for IPv4 and IPv6 addresses). Internal load balancers must use <code>ipv4</code>.</p>"]
+    #[serde(rename="IpAddressType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_address_type: Option<String>,
     #[doc="<p>The name of the load balancer.</p> <p>This name must be unique per region per account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The nodes of an Internet-facing load balancer have public IP addresses. The DNS name of an Internet-facing load balancer is publicly resolvable to the public IP addresses of the nodes. Therefore, Internet-facing load balancers can route requests from clients over the Internet.</p> <p>The nodes of an internal load balancer have only private IP addresses. The DNS name of an internal load balancer is publicly resolvable to the private IP addresses of the nodes. Therefore, internal load balancers can only route requests from clients with access to the VPC for the load balancer.</p> <p>The default is an Internet-facing load balancer.</p>"]
+    #[serde(rename="Scheme")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheme: Option<String>,
     #[doc="<p>The IDs of the security groups to assign to the load balancer.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<String>>,
     #[doc="<p>The IDs of the subnets to attach to the load balancer. You can specify only one subnet per Availability Zone. You must specify subnets from at least two Availability Zones.</p>"]
+    #[serde(rename="Subnets")]
     pub subnets: Vec<String>,
     #[doc="<p>One or more tags to assign to the load balancer.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -754,9 +788,11 @@ impl CreateLoadBalancerInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoadBalancerOutput {
     #[doc="<p>Information about the load balancer.</p>"]
+    #[serde(rename="LoadBalancers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancers: Option<Vec<LoadBalancer>>,
 }
 
@@ -803,15 +839,19 @@ impl CreateLoadBalancerOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRuleInput {
     #[doc="<p>An action. Each action has the type <code>forward</code> and specifies a target group.</p>"]
+    #[serde(rename="Actions")]
     pub actions: Vec<Action>,
     #[doc="<p>A condition. Each condition specifies a field name and a single value.</p> <p>If the field name is <code>host-header</code>, you can specify a single host name (for example, my.example.com). A host name is case insensitive, can be up to 128 characters in length, and can contain any of the following characters. Note that you can include up to three wildcard characters.</p> <ul> <li> <p>A-Z, a-z, 0-9</p> </li> <li> <p>- .</p> </li> <li> <p>* (matches 0 or more characters)</p> </li> <li> <p>? (matches exactly 1 character)</p> </li> </ul> <p>If the field name is <code>path-pattern</code>, you can specify a single path pattern. A path pattern is case sensitive, can be up to 128 characters in length, and can contain any of the following characters. Note that you can include up to three wildcard characters.</p> <ul> <li> <p>A-Z, a-z, 0-9</p> </li> <li> <p>_ - . $ / ~ \" ' @ : +</p> </li> <li> <p>&amp; (using &amp;amp;)</p> </li> <li> <p>* (matches 0 or more characters)</p> </li> <li> <p>? (matches exactly 1 character)</p> </li> </ul>"]
+    #[serde(rename="Conditions")]
     pub conditions: Vec<RuleCondition>,
     #[doc="<p>The Amazon Resource Name (ARN) of the listener.</p>"]
+    #[serde(rename="ListenerArn")]
     pub listener_arn: String,
     #[doc="<p>The priority for the rule. A listener can't have multiple rules with the same priority.</p>"]
+    #[serde(rename="Priority")]
     pub priority: i64,
 }
 
@@ -837,9 +877,11 @@ impl CreateRuleInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRuleOutput {
     #[doc="<p>Information about the rule.</p>"]
+    #[serde(rename="Rules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rules: Option<Vec<Rule>>,
 }
 
@@ -884,31 +926,51 @@ impl CreateRuleOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTargetGroupInput {
     #[doc="<p>The approximate amount of time, in seconds, between health checks of an individual target. The default is 30 seconds.</p>"]
+    #[serde(rename="HealthCheckIntervalSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_interval_seconds: Option<i64>,
     #[doc="<p>The ping path that is the destination on the targets for health checks. The default is /.</p>"]
+    #[serde(rename="HealthCheckPath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_path: Option<String>,
     #[doc="<p>The port the load balancer uses when performing health checks on targets. The default is <code>traffic-port</code>, which indicates the port on which each target receives traffic from the load balancer.</p>"]
+    #[serde(rename="HealthCheckPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_port: Option<String>,
     #[doc="<p>The protocol the load balancer uses when performing health checks on targets. The default is the HTTP protocol.</p>"]
+    #[serde(rename="HealthCheckProtocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_protocol: Option<String>,
     #[doc="<p>The amount of time, in seconds, during which no response from a target means a failed health check. The default is 5 seconds.</p>"]
+    #[serde(rename="HealthCheckTimeoutSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_timeout_seconds: Option<i64>,
     #[doc="<p>The number of consecutive health checks successes required before considering an unhealthy target healthy. The default is 5.</p>"]
+    #[serde(rename="HealthyThresholdCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub healthy_threshold_count: Option<i64>,
     #[doc="<p>The HTTP codes to use when checking for a successful response from a target. The default is 200.</p>"]
+    #[serde(rename="Matcher")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub matcher: Option<Matcher>,
     #[doc="<p>The name of the target group.</p> <p>This name must be unique per region per account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The port on which the targets receive traffic. This port is used unless you specify a port override when registering the target.</p>"]
+    #[serde(rename="Port")]
     pub port: i64,
     #[doc="<p>The protocol to use for routing traffic to the targets.</p>"]
+    #[serde(rename="Protocol")]
     pub protocol: String,
     #[doc="<p>The number of consecutive health check failures required before considering a target unhealthy. The default is 2.</p>"]
+    #[serde(rename="UnhealthyThresholdCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unhealthy_threshold_count: Option<i64>,
     #[doc="<p>The identifier of the virtual private cloud (VPC).</p>"]
+    #[serde(rename="VpcId")]
     pub vpc_id: String,
 }
 
@@ -965,9 +1027,11 @@ impl CreateTargetGroupInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTargetGroupOutput {
     #[doc="<p>Information about the target group.</p>"]
+    #[serde(rename="TargetGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_groups: Option<Vec<TargetGroup>>,
 }
 
@@ -1042,9 +1106,10 @@ impl DNSNameDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteListenerInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the listener.</p>"]
+    #[serde(rename="ListenerArn")]
     pub listener_arn: String,
 }
 
@@ -1064,7 +1129,7 @@ impl DeleteListenerInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteListenerOutput;
 
 struct DeleteListenerOutputDeserializer;
@@ -1083,9 +1148,10 @@ impl DeleteListenerOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLoadBalancerInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerArn")]
     pub load_balancer_arn: String,
 }
 
@@ -1105,7 +1171,7 @@ impl DeleteLoadBalancerInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLoadBalancerOutput;
 
 struct DeleteLoadBalancerOutputDeserializer;
@@ -1124,9 +1190,10 @@ impl DeleteLoadBalancerOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRuleInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the rule.</p>"]
+    #[serde(rename="RuleArn")]
     pub rule_arn: String,
 }
 
@@ -1146,7 +1213,7 @@ impl DeleteRuleInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRuleOutput;
 
 struct DeleteRuleOutputDeserializer;
@@ -1165,9 +1232,10 @@ impl DeleteRuleOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTargetGroupInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the target group.</p>"]
+    #[serde(rename="TargetGroupArn")]
     pub target_group_arn: String,
 }
 
@@ -1187,7 +1255,7 @@ impl DeleteTargetGroupInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTargetGroupOutput;
 
 struct DeleteTargetGroupOutputDeserializer;
@@ -1206,11 +1274,13 @@ impl DeleteTargetGroupOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterTargetsInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the target group.</p>"]
+    #[serde(rename="TargetGroupArn")]
     pub target_group_arn: String,
     #[doc="<p>The targets. If you specified a port override when you registered a target, you must specify both the target ID and the port when you deregister it.</p>"]
+    #[serde(rename="Targets")]
     pub targets: Vec<TargetDescription>,
 }
 
@@ -1233,7 +1303,7 @@ impl DeregisterTargetsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterTargetsOutput;
 
 struct DeregisterTargetsOutputDeserializer;
@@ -1252,11 +1322,15 @@ impl DeregisterTargetsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountLimitsInput {
     #[doc="<p>The marker for the next set of results. (You received this marker from a previous call.)</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of results to return with this call.</p>"]
+    #[serde(rename="PageSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub page_size: Option<i64>,
 }
 
@@ -1282,11 +1356,15 @@ impl DescribeAccountLimitsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountLimitsOutput {
     #[doc="<p>Information about the limits.</p>"]
+    #[serde(rename="Limits")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub limits: Option<Vec<Limit>>,
     #[doc="<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
 }
 
@@ -1336,15 +1414,23 @@ impl DescribeAccountLimitsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeListenersInput {
     #[doc="<p>The Amazon Resource Names (ARN) of the listeners.</p>"]
+    #[serde(rename="ListenerArns")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub listener_arns: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_arn: Option<String>,
     #[doc="<p>The marker for the next set of results. (You received this marker from a previous call.)</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of results to return with this call.</p>"]
+    #[serde(rename="PageSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub page_size: Option<i64>,
 }
 
@@ -1379,11 +1465,15 @@ impl DescribeListenersInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeListenersOutput {
     #[doc="<p>Information about the listeners.</p>"]
+    #[serde(rename="Listeners")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub listeners: Option<Vec<Listener>>,
     #[doc="<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
 }
 
@@ -1433,9 +1523,10 @@ impl DescribeListenersOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancerAttributesInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerArn")]
     pub load_balancer_arn: String,
 }
 
@@ -1455,9 +1546,11 @@ impl DescribeLoadBalancerAttributesInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancerAttributesOutput {
     #[doc="<p>Information about the load balancer attributes.</p>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<Vec<LoadBalancerAttribute>>,
 }
 
@@ -1505,15 +1598,23 @@ impl DescribeLoadBalancerAttributesOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancersInput {
     #[doc="<p>The Amazon Resource Names (ARN) of the load balancers. You can specify up to 20 load balancers in a single call.</p>"]
+    #[serde(rename="LoadBalancerArns")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_arns: Option<Vec<String>>,
     #[doc="<p>The marker for the next set of results. (You received this marker from a previous call.)</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The names of the load balancers.</p>"]
+    #[serde(rename="Names")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub names: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return with this call.</p>"]
+    #[serde(rename="PageSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub page_size: Option<i64>,
 }
 
@@ -1549,11 +1650,15 @@ impl DescribeLoadBalancersInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBalancersOutput {
     #[doc="<p>Information about the load balancers.</p>"]
+    #[serde(rename="LoadBalancers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancers: Option<Vec<LoadBalancer>>,
     #[doc="<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
 }
 
@@ -1604,15 +1709,23 @@ impl DescribeLoadBalancersOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRulesInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the listener.</p>"]
+    #[serde(rename="ListenerArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub listener_arn: Option<String>,
     #[doc="<p>The marker for the next set of results. (You received this marker from a previous call.)</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of results to return with this call.</p>"]
+    #[serde(rename="PageSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub page_size: Option<i64>,
     #[doc="<p>The Amazon Resource Names (ARN) of the rules.</p>"]
+    #[serde(rename="RuleArns")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rule_arns: Option<Vec<String>>,
 }
 
@@ -1647,11 +1760,15 @@ impl DescribeRulesInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRulesOutput {
     #[doc="<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
     #[doc="<p>Information about the rules.</p>"]
+    #[serde(rename="Rules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rules: Option<Vec<Rule>>,
 }
 
@@ -1700,13 +1817,19 @@ impl DescribeRulesOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSSLPoliciesInput {
     #[doc="<p>The marker for the next set of results. (You received this marker from a previous call.)</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The names of the policies.</p>"]
+    #[serde(rename="Names")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub names: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return with this call.</p>"]
+    #[serde(rename="PageSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub page_size: Option<i64>,
 }
 
@@ -1737,11 +1860,15 @@ impl DescribeSSLPoliciesInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSSLPoliciesOutput {
     #[doc="<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
     #[doc="<p>Information about the policies.</p>"]
+    #[serde(rename="SslPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssl_policies: Option<Vec<SslPolicy>>,
 }
 
@@ -1792,9 +1919,10 @@ impl DescribeSSLPoliciesOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsInput {
     #[doc="<p>The Amazon Resource Names (ARN) of the resources.</p>"]
+    #[serde(rename="ResourceArns")]
     pub resource_arns: Vec<String>,
 }
 
@@ -1815,9 +1943,11 @@ impl DescribeTagsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsOutput {
     #[doc="<p>Information about the tags.</p>"]
+    #[serde(rename="TagDescriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_descriptions: Option<Vec<TagDescription>>,
 }
 
@@ -1864,9 +1994,10 @@ impl DescribeTagsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTargetGroupAttributesInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the target group.</p>"]
+    #[serde(rename="TargetGroupArn")]
     pub target_group_arn: String,
 }
 
@@ -1886,9 +2017,11 @@ impl DescribeTargetGroupAttributesInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTargetGroupAttributesOutput {
     #[doc="<p>Information about the target group attributes</p>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<Vec<TargetGroupAttribute>>,
 }
 
@@ -1936,17 +2069,27 @@ impl DescribeTargetGroupAttributesOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTargetGroupsInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_arn: Option<String>,
     #[doc="<p>The marker for the next set of results. (You received this marker from a previous call.)</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The names of the target groups.</p>"]
+    #[serde(rename="Names")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub names: Option<Vec<String>>,
     #[doc="<p>The maximum number of results to return with this call.</p>"]
+    #[serde(rename="PageSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub page_size: Option<i64>,
     #[doc="<p>The Amazon Resource Names (ARN) of the target groups.</p>"]
+    #[serde(rename="TargetGroupArns")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_group_arns: Option<Vec<String>>,
 }
 
@@ -1986,11 +2129,15 @@ impl DescribeTargetGroupsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTargetGroupsOutput {
     #[doc="<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
     #[doc="<p>Information about the target groups.</p>"]
+    #[serde(rename="TargetGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_groups: Option<Vec<TargetGroup>>,
 }
 
@@ -2041,11 +2188,14 @@ impl DescribeTargetGroupsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTargetHealthInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the target group.</p>"]
+    #[serde(rename="TargetGroupArn")]
     pub target_group_arn: String,
     #[doc="<p>The targets.</p>"]
+    #[serde(rename="Targets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub targets: Option<Vec<TargetDescription>>,
 }
 
@@ -2070,9 +2220,11 @@ impl DescribeTargetHealthInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTargetHealthOutput {
     #[doc="<p>Information about the health of the targets.</p>"]
+    #[serde(rename="TargetHealthDescriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_health_descriptions: Option<Vec<TargetHealthDescription>>,
 }
 
@@ -2230,11 +2382,15 @@ impl IsDefaultDeserializer {
     }
 }
 #[doc="<p>Information about an Elastic Load Balancing resource limit for your AWS account.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Limit {
     #[doc="<p>The maximum value of the limit.</p>"]
+    #[serde(rename="Max")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max: Option<String>,
     #[doc="<p>The name of the limit. The possible values are:</p> <ul> <li> <p>application-load-balancers</p> </li> <li> <p>listeners-per-application-load-balancer</p> </li> <li> <p>rules-per-application-load-balancer</p> </li> <li> <p>target-groups</p> </li> <li> <p>targets-per-application-load-balancer</p> </li> </ul>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -2377,21 +2533,35 @@ impl ListOfStringSerializer {
 }
 
 #[doc="<p>Information about a listener.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Listener {
     #[doc="<p>The SSL server certificate. You must provide a certificate if the protocol is HTTPS.</p>"]
+    #[serde(rename="Certificates")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificates: Option<Vec<Certificate>>,
     #[doc="<p>The default actions for the listener.</p>"]
+    #[serde(rename="DefaultActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_actions: Option<Vec<Action>>,
     #[doc="<p>The Amazon Resource Name (ARN) of the listener.</p>"]
+    #[serde(rename="ListenerArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub listener_arn: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_arn: Option<String>,
     #[doc="<p>The port on which the load balancer is listening.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The protocol for connections from clients to the load balancer.</p>"]
+    #[serde(rename="Protocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub protocol: Option<String>,
     #[doc="<p>The security policy that defines which ciphers and protocols are supported. The default is the current predefined security policy.</p>"]
+    #[serde(rename="SslPolicy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssl_policy: Option<String>,
 }
 
@@ -2533,31 +2703,55 @@ impl ListenersDeserializer {
     }
 }
 #[doc="<p>Information about a load balancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBalancer {
     #[doc="<p>The Availability Zones for the load balancer.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<AvailabilityZone>>,
     #[doc="<p>The ID of the Amazon Route 53 hosted zone associated with the load balancer.</p>"]
+    #[serde(rename="CanonicalHostedZoneId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub canonical_hosted_zone_id: Option<String>,
     #[doc="<p>The date and time the load balancer was created.</p>"]
+    #[serde(rename="CreatedTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub created_time: Option<String>,
     #[doc="<p>The public DNS name of the load balancer.</p>"]
+    #[serde(rename="DNSName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dns_name: Option<String>,
     #[doc="<p>The type of IP addresses used by the subnets for your load balancer. The possible values are <code>ipv4</code> (for IPv4 addresses) and <code>dualstack</code> (for IPv4 and IPv6 addresses).</p>"]
+    #[serde(rename="IpAddressType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_address_type: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_arn: Option<String>,
     #[doc="<p>The name of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_name: Option<String>,
     #[doc="<p>The nodes of an Internet-facing load balancer have public IP addresses. The DNS name of an Internet-facing load balancer is publicly resolvable to the public IP addresses of the nodes. Therefore, Internet-facing load balancers can route requests from clients over the Internet.</p> <p>The nodes of an internal load balancer have only private IP addresses. The DNS name of an internal load balancer is publicly resolvable to the private IP addresses of the nodes. Therefore, internal load balancers can only route requests from clients with access to the VPC for the load balancer.</p>"]
+    #[serde(rename="Scheme")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scheme: Option<String>,
     #[doc="<p>The IDs of the security groups for the load balancer.</p>"]
+    #[serde(rename="SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_groups: Option<Vec<String>>,
     #[doc="<p>The state of the load balancer.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<LoadBalancerState>,
     #[doc="<p>The type of load balancer.</p>"]
+    #[serde(rename="Type")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub type_: Option<String>,
     #[doc="<p>The ID of the VPC for the load balancer.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -2724,11 +2918,15 @@ impl LoadBalancerArnsSerializer {
 }
 
 #[doc="<p>Information about a load balancer attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBalancerAttribute {
     #[doc="<p>The name of the attribute.</p> <ul> <li> <p> <code>access_logs.s3.enabled</code> - Indicates whether access logs stored in Amazon S3 are enabled. The value is <code>true</code> or <code>false</code>.</p> </li> <li> <p> <code>access_logs.s3.bucket</code> - The name of the S3 bucket for the access logs. This attribute is required if access logs in Amazon S3 are enabled. The bucket must exist in the same region as the load balancer and have a bucket policy that grants Elastic Load Balancing permission to write to the bucket.</p> </li> <li> <p> <code>access_logs.s3.prefix</code> - The prefix for the location in the S3 bucket. If you don't specify a prefix, the access logs are stored in the root of the bucket.</p> </li> <li> <p> <code>deletion_protection.enabled</code> - Indicates whether deletion protection is enabled. The value is <code>true</code> or <code>false</code>.</p> </li> <li> <p> <code>idle_timeout.timeout_seconds</code> - The idle timeout value, in seconds. The valid range is 1-3600. The default is 60 seconds.</p> </li> </ul>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>The value of the attribute.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -2921,11 +3119,15 @@ impl LoadBalancerSchemeEnumDeserializer {
     }
 }
 #[doc="<p>Information about the state of the load balancer.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBalancerState {
     #[doc="<p>The state code. The initial state of the load balancer is <code>provisioning</code>. After the load balancer is fully set up and ready to route traffic, its state is <code>active</code>. If the load balancer could not be set up, its state is <code>failed</code>.</p>"]
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<String>,
     #[doc="<p>A description of the state.</p>"]
+    #[serde(rename="Reason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reason: Option<String>,
 }
 
@@ -3060,9 +3262,10 @@ impl MarkerDeserializer {
     }
 }
 #[doc="<p>Information to use when checking for a successful response from a target.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Matcher {
     #[doc="<p>The HTTP codes. You can specify values between 200 and 499. The default value is 200. You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\").</p>"]
+    #[serde(rename="HttpCode")]
     pub http_code: String,
 }
 
@@ -3138,19 +3341,30 @@ impl MaxDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyListenerInput {
     #[doc="<p>The SSL server certificate.</p>"]
+    #[serde(rename="Certificates")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificates: Option<Vec<Certificate>>,
     #[doc="<p>The default actions.</p>"]
+    #[serde(rename="DefaultActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_actions: Option<Vec<Action>>,
     #[doc="<p>The Amazon Resource Name (ARN) of the listener.</p>"]
+    #[serde(rename="ListenerArn")]
     pub listener_arn: String,
     #[doc="<p>The port for connections from clients to the load balancer.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The protocol for connections from clients to the load balancer.</p>"]
+    #[serde(rename="Protocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub protocol: Option<String>,
     #[doc="<p>The security policy that defines which protocols and ciphers are supported. For more information, see <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies\">Security Policies</a> in the <i>Application Load Balancers Guide</i>.</p>"]
+    #[serde(rename="SslPolicy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssl_policy: Option<String>,
 }
 
@@ -3192,9 +3406,11 @@ impl ModifyListenerInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyListenerOutput {
     #[doc="<p>Information about the modified listeners.</p>"]
+    #[serde(rename="Listeners")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub listeners: Option<Vec<Listener>>,
 }
 
@@ -3240,11 +3456,13 @@ impl ModifyListenerOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyLoadBalancerAttributesInput {
     #[doc="<p>The load balancer attributes.</p>"]
+    #[serde(rename="Attributes")]
     pub attributes: Vec<LoadBalancerAttribute>,
     #[doc="<p>The Amazon Resource Name (ARN) of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerArn")]
     pub load_balancer_arn: String,
 }
 
@@ -3267,9 +3485,11 @@ impl ModifyLoadBalancerAttributesInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyLoadBalancerAttributesOutput {
     #[doc="<p>Information about the load balancer attributes.</p>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<Vec<LoadBalancerAttribute>>,
 }
 
@@ -3317,13 +3537,18 @@ impl ModifyLoadBalancerAttributesOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyRuleInput {
     #[doc="<p>The actions.</p>"]
+    #[serde(rename="Actions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub actions: Option<Vec<Action>>,
     #[doc="<p>The conditions.</p>"]
+    #[serde(rename="Conditions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub conditions: Option<Vec<RuleCondition>>,
     #[doc="<p>The Amazon Resource Name (ARN) of the rule.</p>"]
+    #[serde(rename="RuleArn")]
     pub rule_arn: String,
 }
 
@@ -3351,9 +3576,11 @@ impl ModifyRuleInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyRuleOutput {
     #[doc="<p>Information about the rule.</p>"]
+    #[serde(rename="Rules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rules: Option<Vec<Rule>>,
 }
 
@@ -3398,11 +3625,13 @@ impl ModifyRuleOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyTargetGroupAttributesInput {
     #[doc="<p>The attributes.</p>"]
+    #[serde(rename="Attributes")]
     pub attributes: Vec<TargetGroupAttribute>,
     #[doc="<p>The Amazon Resource Name (ARN) of the target group.</p>"]
+    #[serde(rename="TargetGroupArn")]
     pub target_group_arn: String,
 }
 
@@ -3425,9 +3654,11 @@ impl ModifyTargetGroupAttributesInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyTargetGroupAttributesOutput {
     #[doc="<p>Information about the attributes.</p>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<Vec<TargetGroupAttribute>>,
 }
 
@@ -3475,25 +3706,42 @@ impl ModifyTargetGroupAttributesOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyTargetGroupInput {
     #[doc="<p>The approximate amount of time, in seconds, between health checks of an individual target.</p>"]
+    #[serde(rename="HealthCheckIntervalSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_interval_seconds: Option<i64>,
     #[doc="<p>The ping path that is the destination for the health check request.</p>"]
+    #[serde(rename="HealthCheckPath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_path: Option<String>,
     #[doc="<p>The port to use to connect with the target.</p>"]
+    #[serde(rename="HealthCheckPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_port: Option<String>,
     #[doc="<p>The protocol to use to connect with the target.</p>"]
+    #[serde(rename="HealthCheckProtocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_protocol: Option<String>,
     #[doc="<p>The amount of time, in seconds, during which no response means a failed health check.</p>"]
+    #[serde(rename="HealthCheckTimeoutSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_timeout_seconds: Option<i64>,
     #[doc="<p>The number of consecutive health checks successes required before considering an unhealthy target healthy.</p>"]
+    #[serde(rename="HealthyThresholdCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub healthy_threshold_count: Option<i64>,
     #[doc="<p>The HTTP codes to use when checking for a successful response from a target.</p>"]
+    #[serde(rename="Matcher")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub matcher: Option<Matcher>,
     #[doc="<p>The Amazon Resource Name (ARN) of the target group.</p>"]
+    #[serde(rename="TargetGroupArn")]
     pub target_group_arn: String,
     #[doc="<p>The number of consecutive health check failures required before considering the target unhealthy.</p>"]
+    #[serde(rename="UnhealthyThresholdCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unhealthy_threshold_count: Option<i64>,
 }
 
@@ -3544,9 +3792,11 @@ impl ModifyTargetGroupInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyTargetGroupOutput {
     #[doc="<p>Information about the target group.</p>"]
+    #[serde(rename="TargetGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_groups: Option<Vec<TargetGroup>>,
 }
 
@@ -3649,11 +3899,13 @@ impl ProtocolEnumDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterTargetsInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the target group.</p>"]
+    #[serde(rename="TargetGroupArn")]
     pub target_group_arn: String,
     #[doc="<p>The targets. The default port for a target is the port for the target group. You can specify a port override. If a target is already registered, you can register it again using a different port.</p>"]
+    #[serde(rename="Targets")]
     pub targets: Vec<TargetDescription>,
 }
 
@@ -3676,7 +3928,7 @@ impl RegisterTargetsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterTargetsOutput;
 
 struct RegisterTargetsOutputDeserializer;
@@ -3695,11 +3947,13 @@ impl RegisterTargetsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource.</p>"]
+    #[serde(rename="ResourceArns")]
     pub resource_arns: Vec<String>,
     #[doc="<p>The tag keys for the tags to remove.</p>"]
+    #[serde(rename="TagKeys")]
     pub tag_keys: Vec<String>,
 }
 
@@ -3721,7 +3975,7 @@ impl RemoveTagsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsOutput;
 
 struct RemoveTagsOutputDeserializer;
@@ -3767,17 +4021,27 @@ impl ResourceArnsSerializer {
 }
 
 #[doc="<p>Information about a rule.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Rule {
     #[doc="<p>The actions.</p>"]
+    #[serde(rename="Actions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub actions: Option<Vec<Action>>,
     #[doc="<p>The conditions.</p>"]
+    #[serde(rename="Conditions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub conditions: Option<Vec<RuleCondition>>,
     #[doc="<p>Indicates whether this is the default rule.</p>"]
+    #[serde(rename="IsDefault")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_default: Option<bool>,
     #[doc="<p>The priority.</p>"]
+    #[serde(rename="Priority")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub priority: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the rule.</p>"]
+    #[serde(rename="RuleArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rule_arn: Option<String>,
 }
 
@@ -3867,11 +4131,15 @@ impl RuleArnsSerializer {
 }
 
 #[doc="<p>Information about a condition for a rule.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RuleCondition {
     #[doc="<p>The name of the field. The possible values are <code>host-header</code> and <code>path-pattern</code>.</p>"]
+    #[serde(rename="Field")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub field: Option<String>,
     #[doc="<p>The condition value.</p> <p>If the field name is <code>host-header</code>, you can specify a single host name (for example, my.example.com). A host name is case insensitive, can be up to 128 characters in length, and can contain any of the following characters. Note that you can include up to three wildcard characters.</p> <ul> <li> <p>A-Z, a-z, 0-9</p> </li> <li> <p>- .</p> </li> <li> <p>* (matches 0 or more characters)</p> </li> <li> <p>? (matches exactly 1 character)</p> </li> </ul> <p>If the field name is <code>path-pattern</code>, you can specify a single path pattern (for example, /img/*). A path pattern is case sensitive, can be up to 128 characters in length, and can contain any of the following characters. Note that you can include up to three wildcard characters.</p> <ul> <li> <p>A-Z, a-z, 0-9</p> </li> <li> <p>_ - . $ / ~ \" ' @ : +</p> </li> <li> <p>&amp; (using &amp;amp;)</p> </li> <li> <p>* (matches 0 or more characters)</p> </li> <li> <p>? (matches exactly 1 character)</p> </li> </ul>"]
+    #[serde(rename="Values")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub values: Option<Vec<String>>,
 }
 
@@ -4011,11 +4279,15 @@ impl RulePriorityListSerializer {
 }
 
 #[doc="<p>Information about the priorities for the rules for a listener.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RulePriorityPair {
     #[doc="<p>The rule priority.</p>"]
+    #[serde(rename="Priority")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub priority: Option<i64>,
     #[doc="<p>The Amazon Resource Name (ARN) of the rule.</p>"]
+    #[serde(rename="RuleArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rule_arn: Option<String>,
 }
 
@@ -4149,11 +4421,13 @@ impl SecurityGroupsSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIpAddressTypeInput {
     #[doc="<p>The IP address type. The possible values are <code>ipv4</code> (for IPv4 addresses) and <code>dualstack</code> (for IPv4 and IPv6 addresses). Internal load balancers must use <code>ipv4</code>.</p>"]
+    #[serde(rename="IpAddressType")]
     pub ip_address_type: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerArn")]
     pub load_balancer_arn: String,
 }
 
@@ -4175,9 +4449,11 @@ impl SetIpAddressTypeInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIpAddressTypeOutput {
     #[doc="<p>The IP address type.</p>"]
+    #[serde(rename="IpAddressType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_address_type: Option<String>,
 }
 
@@ -4224,9 +4500,10 @@ impl SetIpAddressTypeOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetRulePrioritiesInput {
     #[doc="<p>The rule priorities.</p>"]
+    #[serde(rename="RulePriorities")]
     pub rule_priorities: Vec<RulePriorityPair>,
 }
 
@@ -4247,9 +4524,11 @@ impl SetRulePrioritiesInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetRulePrioritiesOutput {
     #[doc="<p>Information about the rules.</p>"]
+    #[serde(rename="Rules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rules: Option<Vec<Rule>>,
 }
 
@@ -4294,11 +4573,13 @@ impl SetRulePrioritiesOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetSecurityGroupsInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerArn")]
     pub load_balancer_arn: String,
     #[doc="<p>The IDs of the security groups.</p>"]
+    #[serde(rename="SecurityGroups")]
     pub security_groups: Vec<String>,
 }
 
@@ -4321,9 +4602,11 @@ impl SetSecurityGroupsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetSecurityGroupsOutput {
     #[doc="<p>The IDs of the security groups associated with the load balancer.</p>"]
+    #[serde(rename="SecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub security_group_ids: Option<Vec<String>>,
 }
 
@@ -4370,11 +4653,13 @@ impl SetSecurityGroupsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetSubnetsInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the load balancer.</p>"]
+    #[serde(rename="LoadBalancerArn")]
     pub load_balancer_arn: String,
     #[doc="<p>The IDs of the subnets. You must specify at least two subnets. You can add only one subnet per Availability Zone.</p>"]
+    #[serde(rename="Subnets")]
     pub subnets: Vec<String>,
 }
 
@@ -4395,9 +4680,11 @@ impl SetSubnetsInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetSubnetsOutput {
     #[doc="<p>Information about the subnet and Availability Zone.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<AvailabilityZone>>,
 }
 
@@ -4486,13 +4773,19 @@ impl SslPoliciesDeserializer {
     }
 }
 #[doc="<p>Information about a policy used for SSL negotiation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SslPolicy {
     #[doc="<p>The ciphers.</p>"]
+    #[serde(rename="Ciphers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ciphers: Option<Vec<Cipher>>,
     #[doc="<p>The name of the policy.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The protocols.</p>"]
+    #[serde(rename="SslProtocols")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssl_protocols: Option<Vec<String>>,
 }
 
@@ -4697,11 +4990,14 @@ impl SubnetsSerializer {
 }
 
 #[doc="<p>Information about a tag.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>The key of the tag.</p>"]
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="<p>The value of the tag.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -4771,11 +5067,15 @@ impl TagSerializer {
 }
 
 #[doc="<p>The tags associated with a resource.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagDescription {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource.</p>"]
+    #[serde(rename="ResourceArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_arn: Option<String>,
     #[doc="<p>Information about the tags.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -4960,11 +5260,14 @@ impl TagValueDeserializer {
     }
 }
 #[doc="<p>Information about a target.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TargetDescription {
     #[doc="<p>The ID of the target.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The port on which the target is listening.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
 }
 
@@ -5044,35 +5347,63 @@ impl TargetDescriptionsSerializer {
 }
 
 #[doc="<p>Information about a target group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TargetGroup {
     #[doc="<p>The approximate amount of time, in seconds, between health checks of an individual target.</p>"]
+    #[serde(rename="HealthCheckIntervalSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_interval_seconds: Option<i64>,
     #[doc="<p>The destination for the health check request.</p>"]
+    #[serde(rename="HealthCheckPath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_path: Option<String>,
     #[doc="<p>The port to use to connect with the target.</p>"]
+    #[serde(rename="HealthCheckPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_port: Option<String>,
     #[doc="<p>The protocol to use to connect with the target.</p>"]
+    #[serde(rename="HealthCheckProtocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_protocol: Option<String>,
     #[doc="<p>The amount of time, in seconds, during which no response means a failed health check.</p>"]
+    #[serde(rename="HealthCheckTimeoutSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_timeout_seconds: Option<i64>,
     #[doc="<p>The number of consecutive health checks successes required before considering an unhealthy target healthy.</p>"]
+    #[serde(rename="HealthyThresholdCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub healthy_threshold_count: Option<i64>,
     #[doc="<p>The Amazon Resource Names (ARN) of the load balancers that route traffic to this target group.</p>"]
+    #[serde(rename="LoadBalancerArns")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancer_arns: Option<Vec<String>>,
     #[doc="<p>The HTTP codes to use when checking for a successful response from a target.</p>"]
+    #[serde(rename="Matcher")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub matcher: Option<Matcher>,
     #[doc="<p>The port on which the targets are listening.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The protocol to use for routing traffic to the targets.</p>"]
+    #[serde(rename="Protocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub protocol: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the target group.</p>"]
+    #[serde(rename="TargetGroupArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_group_arn: Option<String>,
     #[doc="<p>The name of the target group.</p>"]
+    #[serde(rename="TargetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_group_name: Option<String>,
     #[doc="<p>The number of consecutive health check failures required before considering the target unhealthy.</p>"]
+    #[serde(rename="UnhealthyThresholdCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub unhealthy_threshold_count: Option<i64>,
     #[doc="<p>The ID of the VPC for the targets.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -5196,11 +5527,15 @@ impl TargetGroupArnsSerializer {
 }
 
 #[doc="<p>Information about a target group attribute.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TargetGroupAttribute {
     #[doc="<p>The name of the attribute.</p> <ul> <li> <p> <code>deregistration_delay.timeout_seconds</code> - The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from <code>draining</code> to <code>unused</code>. The range is 0-3600 seconds. The default value is 300 seconds.</p> </li> <li> <p> <code>stickiness.enabled</code> - Indicates whether sticky sessions are enabled. The value is <code>true</code> or <code>false</code>.</p> </li> <li> <p> <code>stickiness.type</code> - The type of sticky sessions. The possible value is <code>lb_cookie</code>.</p> </li> <li> <p> <code>stickiness.lb_cookie.duration_seconds</code> - The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).</p> </li> </ul>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>The value of the attribute.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -5422,13 +5757,19 @@ impl TargetGroupsDeserializer {
     }
 }
 #[doc="<p>Information about the current health of a target.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TargetHealth {
     #[doc="<p>A description of the target health that provides additional details. If the state is <code>healthy</code>, a description is not provided.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The reason code. If the target state is <code>healthy</code>, a reason code is not provided.</p> <p>If the target state is <code>initial</code>, the reason code can be one of the following values:</p> <ul> <li> <p> <code>Elb.RegistrationInProgress</code> - The target is in the process of being registered with the load balancer.</p> </li> <li> <p> <code>Elb.InitialHealthChecking</code> - The load balancer is still sending the target the minimum number of health checks required to determine its health status.</p> </li> </ul> <p>If the target state is <code>unhealthy</code>, the reason code can be one of the following values:</p> <ul> <li> <p> <code>Target.ResponseCodeMismatch</code> - The health checks did not return an expected HTTP code.</p> </li> <li> <p> <code>Target.Timeout</code> - The health check requests timed out.</p> </li> <li> <p> <code>Target.FailedHealthChecks</code> - The health checks failed because the connection to the target timed out, the target response was malformed, or the target failed the health check for an unknown reason.</p> </li> <li> <p> <code>Elb.InternalError</code> - The health checks failed due to an internal error.</p> </li> </ul> <p>If the target state is <code>unused</code>, the reason code can be one of the following values:</p> <ul> <li> <p> <code>Target.NotRegistered</code> - The target is not registered with the target group.</p> </li> <li> <p> <code>Target.NotInUse</code> - The target group is not used by any load balancer or the target is in an Availability Zone that is not enabled for its load balancer.</p> </li> <li> <p> <code>Target.InvalidState</code> - The target is in the stopped or terminated state.</p> </li> </ul> <p>If the target state is <code>draining</code>, the reason code can be the following value:</p> <ul> <li> <p> <code>Target.DeregistrationInProgress</code> - The target is in the process of being deregistered and the deregistration delay period has not expired.</p> </li> </ul>"]
+    #[serde(rename="Reason")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reason: Option<String>,
     #[doc="<p>The state of the target.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -5486,13 +5827,19 @@ impl TargetHealthDeserializer {
     }
 }
 #[doc="<p>Information about the health of a target.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TargetHealthDescription {
     #[doc="<p>The port to use to connect with the target.</p>"]
+    #[serde(rename="HealthCheckPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_port: Option<String>,
     #[doc="<p>The description of the target.</p>"]
+    #[serde(rename="Target")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target: Option<TargetDescription>,
     #[doc="<p>The health information for the target.</p>"]
+    #[serde(rename="TargetHealth")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_health: Option<TargetHealth>,
 }
 

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddInstanceFleetInput {
     #[doc="<p>The unique identifier of the cluster.</p>"]
     #[serde(rename="ClusterId")]
@@ -38,7 +38,7 @@ pub struct AddInstanceFleetInput {
     pub instance_fleet: InstanceFleetConfig,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddInstanceFleetOutput {
     #[doc="<p>The unique identifier of the cluster.</p>"]
     #[serde(rename="ClusterId")]
@@ -51,7 +51,7 @@ pub struct AddInstanceFleetOutput {
 }
 
 #[doc="<p>Input to an AddInstanceGroups call.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddInstanceGroupsInput {
     #[doc="<p>Instance groups to add.</p>"]
     #[serde(rename="InstanceGroups")]
@@ -62,7 +62,7 @@ pub struct AddInstanceGroupsInput {
 }
 
 #[doc="<p>Output from an AddInstanceGroups call.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddInstanceGroupsOutput {
     #[doc="<p>Instance group IDs of the newly created instance groups.</p>"]
     #[serde(rename="InstanceGroupIds")]
@@ -75,7 +75,7 @@ pub struct AddInstanceGroupsOutput {
 }
 
 #[doc="<p> The input argument to the <a>AddJobFlowSteps</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddJobFlowStepsInput {
     #[doc="<p>A string that uniquely identifies the job flow. This identifier is returned by <a>RunJobFlow</a> and can also be obtained from <a>ListClusters</a>. </p>"]
     #[serde(rename="JobFlowId")]
@@ -86,7 +86,7 @@ pub struct AddJobFlowStepsInput {
 }
 
 #[doc="<p> The output for the <a>AddJobFlowSteps</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddJobFlowStepsOutput {
     #[doc="<p>The identifiers of the list of steps added to the job flow.</p>"]
     #[serde(rename="StepIds")]
@@ -95,7 +95,7 @@ pub struct AddJobFlowStepsOutput {
 }
 
 #[doc="<p>This input identifies a cluster and a list of tags to attach.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsInput {
     #[doc="<p>The Amazon EMR resource identifier to which tags will be added. This value must be a cluster identifier.</p>"]
     #[serde(rename="ResourceId")]
@@ -106,7 +106,7 @@ pub struct AddTagsInput {
 }
 
 #[doc="<p>This output indicates the result of adding tags to a resource.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsOutput;
 
 #[doc="<p>An application is any Amazon or third-party software that you can add to the cluster. This structure contains a list of strings that indicates the software to use with the cluster and accepts a user argument list. Amazon EMR accepts and forwards the argument list to the corresponding installation script as bootstrap action argument. For more information, see <a href=\"http://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-mapr.html\">Using the MapR Distribution for Hadoop</a>. Currently supported values are:</p> <ul> <li> <p>\"mapr-m3\" - launch the cluster using MapR M3 Edition.</p> </li> <li> <p>\"mapr-m5\" - launch the cluster using MapR M5 Edition.</p> </li> <li> <p>\"mapr\" with the user arguments specifying \"--edition,m3\" or \"--edition,m5\" - launch the cluster using MapR M3 or M5 Edition, respectively.</p> </li> </ul> <note> <p>In Amazon EMR releases 4.x and later, the only accepted parameter is the application name. To pass arguments to applications, you supply a configuration for each application.</p> </note>"]
@@ -131,7 +131,7 @@ pub struct Application {
 }
 
 #[doc="<p>An automatic scaling policy for a core instance group or task instance group in an Amazon EMR cluster. An automatic scaling policy defines how an instance group dynamically adds and terminates EC2 instances in response to the value of a CloudWatch metric. See <a>PutAutoScalingPolicy</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoScalingPolicy {
     #[doc="<p>The upper and lower EC2 instance limits for an automatic scaling policy. Automatic scaling activity will not cause an instance group to grow above or below these limits.</p>"]
     #[serde(rename="Constraints")]
@@ -142,7 +142,7 @@ pub struct AutoScalingPolicy {
 }
 
 #[doc="<p>An automatic scaling policy for a core instance group or task instance group in an Amazon EMR cluster. The automatic scaling policy defines how an instance group dynamically adds and terminates EC2 instances in response to the value of a CloudWatch metric. See <a>PutAutoScalingPolicy</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoScalingPolicyDescription {
     #[doc="<p>The upper and lower EC2 instance limits for an automatic scaling policy. Automatic scaling activity will not cause an instance group to grow above or below these limits.</p>"]
     #[serde(rename="Constraints")]
@@ -159,7 +159,7 @@ pub struct AutoScalingPolicyDescription {
 }
 
 #[doc="<p>The reason for an <a>AutoScalingPolicyStatus</a> change.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoScalingPolicyStateChangeReason {
     #[doc="<p>The code indicating the reason for the change in status.<code>USER_REQUEST</code> indicates that the scaling policy status was changed by a user. <code>PROVISION_FAILURE</code> indicates that the status change was because the policy failed to provision. <code>CLEANUP_FAILURE</code> indicates an error.</p>"]
     #[serde(rename="Code")]
@@ -172,7 +172,7 @@ pub struct AutoScalingPolicyStateChangeReason {
 }
 
 #[doc="<p>The status of an automatic scaling policy. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutoScalingPolicyStatus {
     #[doc="<p>Indicates the status of the automatic scaling policy.</p>"]
     #[serde(rename="State")]
@@ -196,7 +196,7 @@ pub struct BootstrapActionConfig {
 }
 
 #[doc="<p>Reports the configuration of a bootstrap action in a cluster (job flow).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BootstrapActionDetail {
     #[doc="<p>A description of the bootstrap action.</p>"]
     #[serde(rename="BootstrapActionConfig")]
@@ -205,7 +205,7 @@ pub struct BootstrapActionDetail {
 }
 
 #[doc="<p>Specification of the status of a CancelSteps request. Available only in Amazon EMR version 4.8.0 and later, excluding version 5.0.0.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelStepsInfo {
     #[doc="<p>The reason for the failure if the CancelSteps request fails.</p>"]
     #[serde(rename="Reason")]
@@ -222,7 +222,7 @@ pub struct CancelStepsInfo {
 }
 
 #[doc="<p>The input argument to the <a>CancelSteps</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelStepsInput {
     #[doc="<p>The <code>ClusterID</code> for which specified steps will be canceled. Use <a>RunJobFlow</a> and <a>ListClusters</a> to get ClusterIDs. </p>"]
     #[serde(rename="ClusterId")]
@@ -235,7 +235,7 @@ pub struct CancelStepsInput {
 }
 
 #[doc="<p> The output for the <a>CancelSteps</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelStepsOutput {
     #[doc="<p>A list of <a>CancelStepsInfo</a>, which shows the status of specified cancel requests for each <code>StepID</code> specified.</p>"]
     #[serde(rename="CancelStepsInfoList")]
@@ -281,7 +281,7 @@ pub struct CloudWatchAlarmDefinition {
 }
 
 #[doc="<p>The detailed description of the cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Cluster {
     #[doc="<p>The applications installed on this cluster.</p>"]
     #[serde(rename="Applications")]
@@ -382,7 +382,7 @@ pub struct Cluster {
 }
 
 #[doc="<p>The reason that the cluster changed to its current state.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterStateChangeReason {
     #[doc="<p>The programmatic code for the state change reason.</p>"]
     #[serde(rename="Code")]
@@ -395,7 +395,7 @@ pub struct ClusterStateChangeReason {
 }
 
 #[doc="<p>The detailed status of the cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterStatus {
     #[doc="<p>The current state of the cluster.</p>"]
     #[serde(rename="State")]
@@ -412,7 +412,7 @@ pub struct ClusterStatus {
 }
 
 #[doc="<p>The summary description of the cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterSummary {
     #[doc="<p>The unique identifier for the cluster.</p>"]
     #[serde(rename="Id")]
@@ -433,7 +433,7 @@ pub struct ClusterSummary {
 }
 
 #[doc="<p>Represents the timeline of the cluster's lifecycle.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterTimeline {
     #[doc="<p>The creation date and time of the cluster.</p>"]
     #[serde(rename="CreationDateTime")]
@@ -450,7 +450,7 @@ pub struct ClusterTimeline {
 }
 
 #[doc="<p>An entity describing an executable that runs on a cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Command {
     #[doc="<p>Arguments for Amazon EMR to pass to the command for execution.</p>"]
     #[serde(rename="Args")]
@@ -483,7 +483,7 @@ pub struct Configuration {
     pub properties: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSecurityConfigurationInput {
     #[doc="<p>The name of the security configuration.</p>"]
     #[serde(rename="Name")]
@@ -493,7 +493,7 @@ pub struct CreateSecurityConfigurationInput {
     pub security_configuration: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSecurityConfigurationOutput {
     #[doc="<p>The date and time the security configuration was created.</p>"]
     #[serde(rename="CreationDateTime")]
@@ -503,18 +503,18 @@ pub struct CreateSecurityConfigurationOutput {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSecurityConfigurationInput {
     #[doc="<p>The name of the security configuration.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSecurityConfigurationOutput;
 
 #[doc="<p>This input determines which cluster to describe.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClusterInput {
     #[doc="<p>The identifier of the cluster to describe.</p>"]
     #[serde(rename="ClusterId")]
@@ -522,7 +522,7 @@ pub struct DescribeClusterInput {
 }
 
 #[doc="<p>This output contains the description of the cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClusterOutput {
     #[doc="<p>This output contains the details for the requested cluster.</p>"]
     #[serde(rename="Cluster")]
@@ -531,7 +531,7 @@ pub struct DescribeClusterOutput {
 }
 
 #[doc="<p> The input for the <a>DescribeJobFlows</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeJobFlowsInput {
     #[doc="<p>Return only job flows created after this date and time.</p>"]
     #[serde(rename="CreatedAfter")]
@@ -552,7 +552,7 @@ pub struct DescribeJobFlowsInput {
 }
 
 #[doc="<p> The output for the <a>DescribeJobFlows</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeJobFlowsOutput {
     #[doc="<p>A list of job flows matching the parameters supplied.</p>"]
     #[serde(rename="JobFlows")]
@@ -560,14 +560,14 @@ pub struct DescribeJobFlowsOutput {
     pub job_flows: Option<Vec<JobFlowDetail>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSecurityConfigurationInput {
     #[doc="<p>The name of the security configuration.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSecurityConfigurationOutput {
     #[doc="<p>The date and time the security configuration was created</p>"]
     #[serde(rename="CreationDateTime")]
@@ -584,7 +584,7 @@ pub struct DescribeSecurityConfigurationOutput {
 }
 
 #[doc="<p>This input determines which step to describe.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStepInput {
     #[doc="<p>The identifier of the cluster with steps to describe.</p>"]
     #[serde(rename="ClusterId")]
@@ -595,7 +595,7 @@ pub struct DescribeStepInput {
 }
 
 #[doc="<p>This output contains the description of the cluster step.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStepOutput {
     #[doc="<p>The step details for the requested step identifier.</p>"]
     #[serde(rename="Step")]
@@ -604,7 +604,7 @@ pub struct DescribeStepOutput {
 }
 
 #[doc="<p>Configuration of requested EBS block device associated with the instance group.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EbsBlockDevice {
     #[doc="<p>The device name that is exposed to the instance, such as /dev/sdh.</p>"]
     #[serde(rename="Device")]
@@ -617,7 +617,7 @@ pub struct EbsBlockDevice {
 }
 
 #[doc="<p>Configuration of requested EBS block device associated with the instance group with count of volumes that will be associated to every instance.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EbsBlockDeviceConfig {
     #[doc="<p>EBS volume specifications such as volume type, IOPS, and size (GiB) that will be requested for the EBS volume attached to an EC2 instance in the cluster.</p>"]
     #[serde(rename="VolumeSpecification")]
@@ -629,7 +629,7 @@ pub struct EbsBlockDeviceConfig {
 }
 
 #[doc="<p>The Amazon EBS configuration of a cluster instance.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EbsConfiguration {
     #[doc="<p>An array of Amazon EBS volume specifications attached to a cluster instance.</p>"]
     #[serde(rename="EbsBlockDeviceConfigs")]
@@ -642,7 +642,7 @@ pub struct EbsConfiguration {
 }
 
 #[doc="<p>EBS block device that's attached to an EC2 instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EbsVolume {
     #[doc="<p>The device name that is exposed to the instance, such as /dev/sdh.</p>"]
     #[serde(rename="Device")]
@@ -655,7 +655,7 @@ pub struct EbsVolume {
 }
 
 #[doc="<p>Provides information about the EC2 instances in a cluster grouped by category. For example, key name, subnet ID, IAM instance profile, and so on.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Ec2InstanceAttributes {
     #[doc="<p>A list of additional Amazon EC2 security group IDs for the master node.</p>"]
     #[serde(rename="AdditionalMasterSecurityGroups")]
@@ -704,7 +704,7 @@ pub struct Ec2InstanceAttributes {
 }
 
 #[doc="<p>The details of the step failure. The service attempts to detect the root cause for many common failures.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailureDetails {
     #[doc="<p>The path to the log file where the step failure root cause was originally recorded.</p>"]
     #[serde(rename="LogFile")]
@@ -741,7 +741,7 @@ pub struct HadoopJarStepConfig {
 }
 
 #[doc="<p>A cluster step consisting of a JAR file whose main function will be executed. The main function submits a job for Hadoop to execute and waits for the job to finish or fail.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HadoopStepConfig {
     #[doc="<p>The list of command line arguments to pass to the JAR file's main function for execution.</p>"]
     #[serde(rename="Args")]
@@ -762,7 +762,7 @@ pub struct HadoopStepConfig {
 }
 
 #[doc="<p>Represents an EC2 instance provisioned as part of cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Instance {
     #[doc="<p>The list of EBS volumes that are attached to this instance.</p>"]
     #[serde(rename="EbsVolumes")]
@@ -815,7 +815,7 @@ pub struct Instance {
 }
 
 #[doc="<p>Describes an instance fleet, which is a group of EC2 instances that host a particular node type (master, core, or task) in an Amazon EMR cluster. Instance fleets can consist of a mix of instance types and On-Demand and Spot instances, which are provisioned to meet a defined target capacity. </p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceFleet {
     #[doc="<p>The unique identifier of the instance fleet.</p>"]
     #[serde(rename="Id")]
@@ -860,7 +860,7 @@ pub struct InstanceFleet {
 }
 
 #[doc="<p>The configuration that defines an instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceFleetConfig {
     #[doc="<p>The node type that the instance fleet hosts. Valid values are MASTER,CORE,and TASK.</p>"]
     #[serde(rename="InstanceFleetType")]
@@ -888,7 +888,7 @@ pub struct InstanceFleetConfig {
 }
 
 #[doc="<p>Configuration parameters for an instance fleet modification request.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceFleetModifyConfig {
     #[doc="<p>A unique identifier for the instance fleet.</p>"]
     #[serde(rename="InstanceFleetId")]
@@ -912,7 +912,7 @@ pub struct InstanceFleetProvisioningSpecifications {
 }
 
 #[doc="<p>Provides status change reason details for the instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceFleetStateChangeReason {
     #[doc="<p>A code corresponding to the reason the state change occurred.</p>"]
     #[serde(rename="Code")]
@@ -925,7 +925,7 @@ pub struct InstanceFleetStateChangeReason {
 }
 
 #[doc="<p>The status of the instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceFleetStatus {
     #[doc="<p>A code representing the instance fleet status.</p>"]
     #[serde(rename="State")]
@@ -942,7 +942,7 @@ pub struct InstanceFleetStatus {
 }
 
 #[doc="<p>Provides historical timestamps for the instance fleet, including the time of creation, the time it became ready to run jobs, and the time of termination.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceFleetTimeline {
     #[doc="<p>The time and date the instance fleet was created.</p>"]
     #[serde(rename="CreationDateTime")]
@@ -959,7 +959,7 @@ pub struct InstanceFleetTimeline {
 }
 
 #[doc="<p>This entity represents an instance group, which is a group of instances that have common purpose. For example, CORE instance group is used for HDFS.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceGroup {
     #[doc="<p>An automatic scaling policy for a core instance group or task instance group in an Amazon EMR cluster. The automatic scaling policy defines how an instance group dynamically adds and terminates EC2 instances in response to the value of a CloudWatch metric. See PutAutoScalingPolicy.</p>"]
     #[serde(rename="AutoScalingPolicy")]
@@ -1020,7 +1020,7 @@ pub struct InstanceGroup {
 }
 
 #[doc="<p>Configuration defining a new instance group.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceGroupConfig {
     #[doc="<p>An automatic scaling policy for a core instance group or task instance group in an Amazon EMR cluster. The automatic scaling policy defines how an instance group dynamically adds and terminates EC2 instances in response to the value of a CloudWatch metric. See <a>PutAutoScalingPolicy</a>.</p>"]
     #[serde(rename="AutoScalingPolicy")]
@@ -1058,7 +1058,7 @@ pub struct InstanceGroupConfig {
 }
 
 #[doc="<p>Detailed information about an instance group.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceGroupDetail {
     #[doc="<p>Bid price for EC2 Instances when launching nodes as Spot Instances, expressed in USD.</p>"]
     #[serde(rename="BidPrice")]
@@ -1112,7 +1112,7 @@ pub struct InstanceGroupDetail {
 }
 
 #[doc="<p>Modify an instance group size.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceGroupModifyConfig {
     #[doc="<p>The EC2 InstanceIds to terminate. After you terminate the instances, the instance group will not return to its original requested size.</p>"]
     #[serde(rename="EC2InstanceIdsToTerminate")]
@@ -1132,7 +1132,7 @@ pub struct InstanceGroupModifyConfig {
 }
 
 #[doc="<p>The status change reason details for the instance group.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceGroupStateChangeReason {
     #[doc="<p>The programmable code for the state change reason.</p>"]
     #[serde(rename="Code")]
@@ -1145,7 +1145,7 @@ pub struct InstanceGroupStateChangeReason {
 }
 
 #[doc="<p>The details of the instance group status.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceGroupStatus {
     #[doc="<p>The current state of the instance group.</p>"]
     #[serde(rename="State")]
@@ -1162,7 +1162,7 @@ pub struct InstanceGroupStatus {
 }
 
 #[doc="<p>The timeline of the instance group lifecycle.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceGroupTimeline {
     #[doc="<p>The creation date and time of the instance group.</p>"]
     #[serde(rename="CreationDateTime")]
@@ -1196,7 +1196,7 @@ pub struct InstanceResizePolicy {
 }
 
 #[doc="<p>The details of the status change reason for the instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceStateChangeReason {
     #[doc="<p>The programmable code for the state change reason.</p>"]
     #[serde(rename="Code")]
@@ -1209,7 +1209,7 @@ pub struct InstanceStateChangeReason {
 }
 
 #[doc="<p>The instance status details.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceStatus {
     #[doc="<p>The current state of the instance.</p>"]
     #[serde(rename="State")]
@@ -1226,7 +1226,7 @@ pub struct InstanceStatus {
 }
 
 #[doc="<p>The timeline of the instance lifecycle.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceTimeline {
     #[doc="<p>The creation date and time of the instance.</p>"]
     #[serde(rename="CreationDateTime")]
@@ -1243,7 +1243,7 @@ pub struct InstanceTimeline {
 }
 
 #[doc="<p>An instance type configuration for each instance type in an instance fleet, which determines the EC2 instances Amazon EMR attempts to provision to fulfill On-Demand and Spot target capacities. There can be a maximum of 5 instance type configurations in a fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceTypeConfig {
     #[doc="<p>The bid price for each EC2 Spot instance type as defined by <code>InstanceType</code>. Expressed in USD. If neither <code>BidPrice</code> nor <code>BidPriceAsPercentageOfOnDemandPrice</code> is provided, <code>BidPriceAsPercentageOfOnDemandPrice</code> defaults to 100%. </p>"]
     #[serde(rename="BidPrice")]
@@ -1271,7 +1271,7 @@ pub struct InstanceTypeConfig {
 }
 
 #[doc="<p>The configuration specification for each instance type in an instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceTypeSpecification {
     #[doc="<p>The bid price for each EC2 Spot instance type as defined by <code>InstanceType</code>. Expressed in USD.</p>"]
     #[serde(rename="BidPrice")]
@@ -1304,7 +1304,7 @@ pub struct InstanceTypeSpecification {
 }
 
 #[doc="<p>A description of a cluster (job flow).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobFlowDetail {
     #[doc="<p>Used only for version 2.x and 3.x of Amazon EMR. The version of the AMI used to initialize Amazon EC2 instances in the job flow. For a list of AMI versions supported by Amazon EMR, see <a href=\"http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/EnvironmentConfig_AMIVersion.html#ami-versions-supported\">AMI Versions Supported in EMR</a> in the <i>Amazon EMR Developer Guide.</i> </p>"]
     #[serde(rename="AmiVersion")]
@@ -1361,7 +1361,7 @@ pub struct JobFlowDetail {
 }
 
 #[doc="<p>Describes the status of the cluster (job flow).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobFlowExecutionStatusDetail {
     #[doc="<p>The creation date and time of the job flow.</p>"]
     #[serde(rename="CreationDateTime")]
@@ -1388,7 +1388,7 @@ pub struct JobFlowExecutionStatusDetail {
 }
 
 #[doc="<p>A description of the Amazon EC2 instance on which the cluster (job flow) runs. A valid JobFlowInstancesConfig must contain either InstanceGroups or InstanceFleets, which is the recommended configuration. They cannot be used together. You may also have MasterInstanceType, SlaveInstanceType, and InstanceCount (all three must be present), but we don't recommend this configuration.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobFlowInstancesConfig {
     #[doc="<p>A list of additional Amazon EC2 security group IDs for the master node.</p>"]
     #[serde(rename="AdditionalMasterSecurityGroups")]
@@ -1461,7 +1461,7 @@ pub struct JobFlowInstancesConfig {
 }
 
 #[doc="<p>Specify the type of Amazon EC2 instances that the cluster (job flow) runs on.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobFlowInstancesDetail {
     #[doc="<p>The name of an Amazon EC2 key pair that can be used to ssh to the master node.</p>"]
     #[serde(rename="Ec2KeyName")]
@@ -1528,7 +1528,7 @@ pub struct KeyValue {
 }
 
 #[doc="<p>This input determines which bootstrap actions to retrieve.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBootstrapActionsInput {
     #[doc="<p>The cluster identifier for the bootstrap actions to list.</p>"]
     #[serde(rename="ClusterId")]
@@ -1540,7 +1540,7 @@ pub struct ListBootstrapActionsInput {
 }
 
 #[doc="<p>This output contains the bootstrap actions detail.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBootstrapActionsOutput {
     #[doc="<p>The bootstrap actions associated with the cluster.</p>"]
     #[serde(rename="BootstrapActions")]
@@ -1553,7 +1553,7 @@ pub struct ListBootstrapActionsOutput {
 }
 
 #[doc="<p>This input determines how the ListClusters action filters the list of clusters that it returns.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListClustersInput {
     #[doc="<p>The cluster state filters to apply when listing clusters.</p>"]
     #[serde(rename="ClusterStates")]
@@ -1574,7 +1574,7 @@ pub struct ListClustersInput {
 }
 
 #[doc="<p>This contains a ClusterSummaryList with the cluster details; for example, the cluster IDs, names, and status.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListClustersOutput {
     #[doc="<p>The list of clusters for the account based on the given filters.</p>"]
     #[serde(rename="Clusters")]
@@ -1586,7 +1586,7 @@ pub struct ListClustersOutput {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInstanceFleetsInput {
     #[doc="<p>The unique identifier of the cluster.</p>"]
     #[serde(rename="ClusterId")]
@@ -1597,7 +1597,7 @@ pub struct ListInstanceFleetsInput {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInstanceFleetsOutput {
     #[doc="<p>The list of instance fleets for the cluster and given filters.</p>"]
     #[serde(rename="InstanceFleets")]
@@ -1610,7 +1610,7 @@ pub struct ListInstanceFleetsOutput {
 }
 
 #[doc="<p>This input determines which instance groups to retrieve.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInstanceGroupsInput {
     #[doc="<p>The identifier of the cluster for which to list the instance groups.</p>"]
     #[serde(rename="ClusterId")]
@@ -1622,7 +1622,7 @@ pub struct ListInstanceGroupsInput {
 }
 
 #[doc="<p>This input determines which instance groups to retrieve.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInstanceGroupsOutput {
     #[doc="<p>The list of instance groups for the cluster and given filters.</p>"]
     #[serde(rename="InstanceGroups")]
@@ -1635,7 +1635,7 @@ pub struct ListInstanceGroupsOutput {
 }
 
 #[doc="<p>This input determines which instances to list.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInstancesInput {
     #[doc="<p>The identifier of the cluster for which to list the instances.</p>"]
     #[serde(rename="ClusterId")]
@@ -1667,7 +1667,7 @@ pub struct ListInstancesInput {
 }
 
 #[doc="<p>This output contains the list of instances.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInstancesOutput {
     #[doc="<p>The list of instances for the cluster and given filters.</p>"]
     #[serde(rename="Instances")]
@@ -1679,7 +1679,7 @@ pub struct ListInstancesOutput {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSecurityConfigurationsInput {
     #[doc="<p>The pagination token that indicates the set of results to retrieve.</p>"]
     #[serde(rename="Marker")]
@@ -1687,7 +1687,7 @@ pub struct ListSecurityConfigurationsInput {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSecurityConfigurationsOutput {
     #[doc="<p>A pagination token that indicates the next set of results to retrieve. Include the marker in the next ListSecurityConfiguration call to retrieve the next page of results, if required.</p>"]
     #[serde(rename="Marker")]
@@ -1700,7 +1700,7 @@ pub struct ListSecurityConfigurationsOutput {
 }
 
 #[doc="<p>This input determines which steps to list.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStepsInput {
     #[doc="<p>The identifier of the cluster for which to list the steps.</p>"]
     #[serde(rename="ClusterId")]
@@ -1720,7 +1720,7 @@ pub struct ListStepsInput {
 }
 
 #[doc="<p>This output contains the list of steps returned in reverse order. This means that the last step is the first element in the list.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStepsOutput {
     #[doc="<p>The pagination token that indicates the next set of results to retrieve.</p>"]
     #[serde(rename="Marker")]
@@ -1745,7 +1745,7 @@ pub struct MetricDimension {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyInstanceFleetInput {
     #[doc="<p>The unique identifier of the cluster.</p>"]
     #[serde(rename="ClusterId")]
@@ -1756,7 +1756,7 @@ pub struct ModifyInstanceFleetInput {
 }
 
 #[doc="<p>Change the size of some instance groups.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyInstanceGroupsInput {
     #[doc="<p>The ID of the cluster to which the instance group belongs.</p>"]
     #[serde(rename="ClusterId")]
@@ -1781,7 +1781,7 @@ pub struct PlacementType {
     pub availability_zones: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutAutoScalingPolicyInput {
     #[doc="<p>Specifies the definition of the automatic scaling policy.</p>"]
     #[serde(rename="AutoScalingPolicy")]
@@ -1794,7 +1794,7 @@ pub struct PutAutoScalingPolicyInput {
     pub instance_group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutAutoScalingPolicyOutput {
     #[doc="<p>The automatic scaling policy definition.</p>"]
     #[serde(rename="AutoScalingPolicy")]
@@ -1810,7 +1810,7 @@ pub struct PutAutoScalingPolicyOutput {
     pub instance_group_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveAutoScalingPolicyInput {
     #[doc="<p>Specifies the ID of a cluster. The instance group to which the automatic scaling policy is applied is within this cluster.</p>"]
     #[serde(rename="ClusterId")]
@@ -1820,11 +1820,11 @@ pub struct RemoveAutoScalingPolicyInput {
     pub instance_group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveAutoScalingPolicyOutput;
 
 #[doc="<p>This input identifies a cluster and a list of tags to remove.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsInput {
     #[doc="<p>The Amazon EMR resource identifier from which tags will be removed. This value must be a cluster identifier.</p>"]
     #[serde(rename="ResourceId")]
@@ -1835,11 +1835,11 @@ pub struct RemoveTagsInput {
 }
 
 #[doc="<p>This output indicates the result of removing tags from a resource.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsOutput;
 
 #[doc="<p> Input to the <a>RunJobFlow</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RunJobFlowInput {
     #[doc="<p>A JSON string for selecting additional features.</p>"]
     #[serde(rename="AdditionalInfo")]
@@ -1930,7 +1930,7 @@ pub struct RunJobFlowInput {
 }
 
 #[doc="<p> The result of the <a>RunJobFlow</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RunJobFlowOutput {
     #[doc="<p>An unique identifier for the job flow.</p>"]
     #[serde(rename="JobFlowId")]
@@ -2000,7 +2000,7 @@ pub struct ScriptBootstrapActionConfig {
 }
 
 #[doc="<p>The creation date and time, and name, of a security configuration.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SecurityConfigurationSummary {
     #[doc="<p>The date and time the security configuration was created.</p>"]
     #[serde(rename="CreationDateTime")]
@@ -2013,7 +2013,7 @@ pub struct SecurityConfigurationSummary {
 }
 
 #[doc="<p> The input argument to the <a>TerminationProtection</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetTerminationProtectionInput {
     #[doc="<p> A list of strings that uniquely identify the clusters to protect. This identifier is returned by <a>RunJobFlow</a> and can also be obtained from <a>DescribeJobFlows</a> . </p>"]
     #[serde(rename="JobFlowIds")]
@@ -2024,7 +2024,7 @@ pub struct SetTerminationProtectionInput {
 }
 
 #[doc="<p>The input to the SetVisibleToAllUsers action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetVisibleToAllUsersInput {
     #[doc="<p>Identifiers of the job flows to receive the new visibility setting.</p>"]
     #[serde(rename="JobFlowIds")]
@@ -2079,7 +2079,7 @@ pub struct SpotProvisioningSpecification {
 }
 
 #[doc="<p>This represents a step in a cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Step {
     #[doc="<p>This specifies what action to take when the cluster step fails. Possible values are TERMINATE_CLUSTER, CANCEL_AND_WAIT, and CONTINUE.</p>"]
     #[serde(rename="ActionOnFailure")]
@@ -2119,7 +2119,7 @@ pub struct StepConfig {
 }
 
 #[doc="<p>Combines the execution state and configuration of a step.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StepDetail {
     #[doc="<p>The description of the step status.</p>"]
     #[serde(rename="ExecutionStatusDetail")]
@@ -2130,7 +2130,7 @@ pub struct StepDetail {
 }
 
 #[doc="<p>The execution state of a step.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StepExecutionStatusDetail {
     #[doc="<p>The creation date and time of the step.</p>"]
     #[serde(rename="CreationDateTime")]
@@ -2153,7 +2153,7 @@ pub struct StepExecutionStatusDetail {
 }
 
 #[doc="<p>The details of the step state change reason.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StepStateChangeReason {
     #[doc="<p>The programmable code for the state change reason. Note: Currently, the service provides no code for the state change.</p>"]
     #[serde(rename="Code")]
@@ -2166,7 +2166,7 @@ pub struct StepStateChangeReason {
 }
 
 #[doc="<p>The execution status details of the cluster step.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StepStatus {
     #[doc="<p>The details for the step failure including reason, message, and log file path where the root cause was identified.</p>"]
     #[serde(rename="FailureDetails")]
@@ -2187,7 +2187,7 @@ pub struct StepStatus {
 }
 
 #[doc="<p>The summary of the cluster step.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StepSummary {
     #[doc="<p>This specifies what action to take when the cluster step fails. Possible values are TERMINATE_CLUSTER, CANCEL_AND_WAIT, and CONTINUE.</p>"]
     #[serde(rename="ActionOnFailure")]
@@ -2212,7 +2212,7 @@ pub struct StepSummary {
 }
 
 #[doc="<p>The timeline of the cluster step lifecycle.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StepTimeline {
     #[doc="<p>The date and time when the cluster step was created.</p>"]
     #[serde(rename="CreationDateTime")]
@@ -2229,7 +2229,7 @@ pub struct StepTimeline {
 }
 
 #[doc="<p>The list of supported product configurations which allow user-supplied arguments. EMR accepts these arguments and forwards them to the corresponding installation script as bootstrap action arguments.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SupportedProductConfig {
     #[doc="<p>The list of user-supplied arguments.</p>"]
     #[serde(rename="Args")]
@@ -2255,7 +2255,7 @@ pub struct Tag {
 }
 
 #[doc="<p> Input to the <a>TerminateJobFlows</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateJobFlowsInput {
     #[doc="<p>A list of job flows to be shutdown.</p>"]
     #[serde(rename="JobFlowIds")]

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -28,17 +28,17 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRuleRequest {
     #[doc="<p>The name of the rule.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventBusRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventBusResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the account permitted to write events to the current account.</p>"]
     #[serde(rename="Arn")]
@@ -54,14 +54,14 @@ pub struct DescribeEventBusResponse {
     pub policy: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRuleRequest {
     #[doc="<p>The name of the rule.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRuleResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the rule.</p>"]
     #[serde(rename="Arn")]
@@ -93,7 +93,7 @@ pub struct DescribeRuleResponse {
     pub state: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableRuleRequest {
     #[doc="<p>The name of the rule.</p>"]
     #[serde(rename="Name")]
@@ -112,7 +112,7 @@ pub struct EcsParameters {
     pub task_definition_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableRuleRequest {
     #[doc="<p>The name of the rule.</p>"]
     #[serde(rename="Name")]
@@ -139,7 +139,7 @@ pub struct KinesisParameters {
     pub partition_key_path: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRuleNamesByTargetRequest {
     #[doc="<p>The maximum number of results to return.</p>"]
     #[serde(rename="Limit")]
@@ -154,7 +154,7 @@ pub struct ListRuleNamesByTargetRequest {
     pub target_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRuleNamesByTargetResponse {
     #[doc="<p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>"]
     #[serde(rename="NextToken")]
@@ -166,7 +166,7 @@ pub struct ListRuleNamesByTargetResponse {
     pub rule_names: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRulesRequest {
     #[doc="<p>The maximum number of results to return.</p>"]
     #[serde(rename="Limit")]
@@ -182,7 +182,7 @@ pub struct ListRulesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRulesResponse {
     #[doc="<p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>"]
     #[serde(rename="NextToken")]
@@ -194,7 +194,7 @@ pub struct ListRulesResponse {
     pub rules: Option<Vec<Rule>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTargetsByRuleRequest {
     #[doc="<p>The maximum number of results to return.</p>"]
     #[serde(rename="Limit")]
@@ -209,7 +209,7 @@ pub struct ListTargetsByRuleRequest {
     pub rule: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTargetsByRuleResponse {
     #[doc="<p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>"]
     #[serde(rename="NextToken")]
@@ -221,7 +221,7 @@ pub struct ListTargetsByRuleResponse {
     pub targets: Option<Vec<Target>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutEventsRequest {
     #[doc="<p>The entry that defines an event in your system. You can specify several parameters for the entry such as the source and type of the event, resources associated with the event, and so on.</p>"]
     #[serde(rename="Entries")]
@@ -229,7 +229,7 @@ pub struct PutEventsRequest {
 }
 
 #[doc="<p>Represents an event to be submitted.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutEventsRequestEntry {
     #[doc="<p>In the JSON sense, an object containing fields, which may also contain nested subobjects. No constraints are imposed on its contents.</p>"]
     #[serde(rename="Detail")]
@@ -253,7 +253,7 @@ pub struct PutEventsRequestEntry {
     pub time: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutEventsResponse {
     #[doc="<p>The successfully and unsuccessfully ingested events results. If the ingestion was successful, the entry has the event ID in it. Otherwise, you can use the error code and error message to identify the problem with the entry.</p>"]
     #[serde(rename="Entries")]
@@ -266,7 +266,7 @@ pub struct PutEventsResponse {
 }
 
 #[doc="<p>Represents an event that failed to be submitted.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutEventsResultEntry {
     #[doc="<p>The error code that indicates why the event submission failed.</p>"]
     #[serde(rename="ErrorCode")]
@@ -282,7 +282,7 @@ pub struct PutEventsResultEntry {
     pub event_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutPermissionRequest {
     #[doc="<p>The action that you are enabling the other account to perform. Currently, this must be <code>events:PutEvents</code>.</p>"]
     #[serde(rename="Action")]
@@ -295,7 +295,7 @@ pub struct PutPermissionRequest {
     pub statement_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRuleRequest {
     #[doc="<p>A description of the rule.</p>"]
     #[serde(rename="Description")]
@@ -322,7 +322,7 @@ pub struct PutRuleRequest {
     pub state: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRuleResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the rule.</p>"]
     #[serde(rename="RuleArn")]
@@ -330,7 +330,7 @@ pub struct PutRuleResponse {
     pub rule_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutTargetsRequest {
     #[doc="<p>The name of the rule.</p>"]
     #[serde(rename="Rule")]
@@ -340,7 +340,7 @@ pub struct PutTargetsRequest {
     pub targets: Vec<Target>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutTargetsResponse {
     #[doc="<p>The failed target entries.</p>"]
     #[serde(rename="FailedEntries")]
@@ -353,7 +353,7 @@ pub struct PutTargetsResponse {
 }
 
 #[doc="<p>Represents a target that failed to be added to a rule.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutTargetsResultEntry {
     #[doc="<p>The error code that indicates why the target addition failed. If the value is <code>ConcurrentModificationException</code>, too many requests were made at the same time.</p>"]
     #[serde(rename="ErrorCode")]
@@ -369,14 +369,14 @@ pub struct PutTargetsResultEntry {
     pub target_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemovePermissionRequest {
     #[doc="<p>The statement ID corresponding to the account that is no longer allowed to put events to the default event bus.</p>"]
     #[serde(rename="StatementId")]
     pub statement_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTargetsRequest {
     #[doc="<p>The IDs of the targets to remove from the rule.</p>"]
     #[serde(rename="Ids")]
@@ -386,7 +386,7 @@ pub struct RemoveTargetsRequest {
     pub rule: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTargetsResponse {
     #[doc="<p>The failed target entries.</p>"]
     #[serde(rename="FailedEntries")]
@@ -399,7 +399,7 @@ pub struct RemoveTargetsResponse {
 }
 
 #[doc="<p>Represents a target that failed to be removed from a rule.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTargetsResultEntry {
     #[doc="<p>The error code that indicates why the target removal failed. If the value is <code>ConcurrentModificationException</code>, too many requests were made at the same time.</p>"]
     #[serde(rename="ErrorCode")]
@@ -416,7 +416,7 @@ pub struct RemoveTargetsResultEntry {
 }
 
 #[doc="<p>Contains information about a rule in Amazon CloudWatch Events.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Rule {
     #[doc="<p>The Amazon Resource Name (ARN) of the rule.</p>"]
     #[serde(rename="Arn")]
@@ -506,7 +506,7 @@ pub struct Target {
     pub run_command_parameters: Option<RunCommandParameters>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestEventPatternRequest {
     #[doc="<p>The event, in JSON format, to test against the event pattern.</p>"]
     #[serde(rename="Event")]
@@ -516,7 +516,7 @@ pub struct TestEventPatternRequest {
     pub event_pattern: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestEventPatternResponse {
     #[doc="<p>Indicates whether the event matches the event pattern.</p>"]
     #[serde(rename="Result")]

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -74,7 +74,7 @@ pub struct CopyCommand {
     pub data_table_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeliveryStreamInput {
     #[doc="<p>The name of the delivery stream. This name must be unique per AWS account in the same region. If the delivery streams are in different accounts or different regions, you can have multiple delivery streams with the same name.</p>"]
     #[serde(rename="DeliveryStreamName")]
@@ -101,7 +101,7 @@ pub struct CreateDeliveryStreamInput {
     pub redshift_destination_configuration: Option<RedshiftDestinationConfiguration>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeliveryStreamOutput {
     #[doc="<p>The ARN of the delivery stream.</p>"]
     #[serde(rename="DeliveryStreamARN")]
@@ -109,18 +109,18 @@ pub struct CreateDeliveryStreamOutput {
     pub delivery_stream_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDeliveryStreamInput {
     #[doc="<p>The name of the delivery stream.</p>"]
     #[serde(rename="DeliveryStreamName")]
     pub delivery_stream_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDeliveryStreamOutput;
 
 #[doc="<p>Contains information about a delivery stream.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeliveryStreamDescription {
     #[doc="<p>The date and time that the delivery stream was created.</p>"]
     #[serde(rename="CreateTimestamp")]
@@ -157,7 +157,7 @@ pub struct DeliveryStreamDescription {
     pub version_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDeliveryStreamInput {
     #[doc="<p>The name of the delivery stream.</p>"]
     #[serde(rename="DeliveryStreamName")]
@@ -172,7 +172,7 @@ pub struct DescribeDeliveryStreamInput {
     pub limit: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDeliveryStreamOutput {
     #[doc="<p>Information about the delivery stream.</p>"]
     #[serde(rename="DeliveryStreamDescription")]
@@ -180,7 +180,7 @@ pub struct DescribeDeliveryStreamOutput {
 }
 
 #[doc="<p>Describes the destination for a delivery stream.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DestinationDescription {
     #[doc="<p>The ID of the destination.</p>"]
     #[serde(rename="DestinationId")]
@@ -217,7 +217,7 @@ pub struct ElasticsearchBufferingHints {
 }
 
 #[doc="<p>Describes the configuration of a destination in Amazon ES.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticsearchDestinationConfiguration {
     #[doc="<p>The buffering options. If no value is specified, the default values for <b>ElasticsearchBufferingHints</b> are used.</p>"]
     #[serde(rename="BufferingHints")]
@@ -261,7 +261,7 @@ pub struct ElasticsearchDestinationConfiguration {
 }
 
 #[doc="<p>The destination description in Amazon ES.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticsearchDestinationDescription {
     #[doc="<p>The buffering options.</p>"]
     #[serde(rename="BufferingHints")]
@@ -310,7 +310,7 @@ pub struct ElasticsearchDestinationDescription {
 }
 
 #[doc="<p>Describes an update for a destination in Amazon ES.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticsearchDestinationUpdate {
     #[doc="<p>The buffering options. If no value is specified, <b>ElasticsearchBufferingHints</b> object default values are used. </p>"]
     #[serde(rename="BufferingHints")]
@@ -377,7 +377,7 @@ pub struct EncryptionConfiguration {
 }
 
 #[doc="<p>Describes the configuration of a destination in Amazon S3.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExtendedS3DestinationConfiguration {
     #[doc="<p>The ARN of the S3 bucket.</p>"]
     #[serde(rename="BucketARN")]
@@ -420,7 +420,7 @@ pub struct ExtendedS3DestinationConfiguration {
 }
 
 #[doc="<p>Describes a destination in Amazon S3.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExtendedS3DestinationDescription {
     #[doc="<p>The ARN of the S3 bucket.</p>"]
     #[serde(rename="BucketARN")]
@@ -460,7 +460,7 @@ pub struct ExtendedS3DestinationDescription {
 }
 
 #[doc="<p>Describes an update for a destination in Amazon S3.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExtendedS3DestinationUpdate {
     #[doc="<p>The ARN of the S3 bucket.</p>"]
     #[serde(rename="BucketARN")]
@@ -504,13 +504,13 @@ pub struct ExtendedS3DestinationUpdate {
     pub s3_backup_update: Option<S3DestinationUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetKinesisStreamInput {
     #[serde(rename="DeliveryStreamARN")]
     pub delivery_stream_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetKinesisStreamOutput {
     #[serde(rename="CredentialsForReadingKinesisStream")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -529,7 +529,7 @@ pub struct KMSEncryptionConfig {
 }
 
 #[doc="<p>The stream and role ARNs for a Kinesis stream used as the source for a delivery stream.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisStreamSourceConfiguration {
     #[doc="<p>The ARN of the source Kinesis stream.</p>"]
     #[serde(rename="KinesisStreamARN")]
@@ -540,7 +540,7 @@ pub struct KinesisStreamSourceConfiguration {
 }
 
 #[doc="<p>Details about a Kinesis stream used as the source for a Kinesis Firehose delivery stream.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisStreamSourceDescription {
     #[doc="<p>Kinesis Firehose starts retrieving records from the Kinesis stream starting with this time stamp.</p>"]
     #[serde(rename="DeliveryStartTimestamp")]
@@ -556,7 +556,7 @@ pub struct KinesisStreamSourceDescription {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeliveryStreamsInput {
     #[doc="<p>The delivery stream type. This can be one of the following values:</p> <ul> <li> <p> <code>DirectPut</code>: Provider applications access the delivery stream directly.</p> </li> <li> <p> <code>KinesisStreamAsSource</code>: The delivery stream uses a Kinesis stream as a source.</p> </li> </ul> <p>This parameter is optional. If this parameter is omitted, delivery streams of all types are returned.</p>"]
     #[serde(rename="DeliveryStreamType")]
@@ -572,7 +572,7 @@ pub struct ListDeliveryStreamsInput {
     pub limit: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeliveryStreamsOutput {
     #[doc="<p>The names of the delivery streams.</p>"]
     #[serde(rename="DeliveryStreamNames")]
@@ -618,7 +618,7 @@ pub struct ProcessorParameter {
     pub parameter_value: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRecordBatchInput {
     #[doc="<p>The name of the delivery stream.</p>"]
     #[serde(rename="DeliveryStreamName")]
@@ -628,7 +628,7 @@ pub struct PutRecordBatchInput {
     pub records: Vec<Record>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRecordBatchOutput {
     #[doc="<p>The number of records that might have failed processing.</p>"]
     #[serde(rename="FailedPutCount")]
@@ -639,7 +639,7 @@ pub struct PutRecordBatchOutput {
 }
 
 #[doc="<p>Contains the result for an individual record from a <a>PutRecordBatch</a> request. If the record is successfully added to your delivery stream, it receives a record ID. If the record fails to be added to your delivery stream, the result includes an error code and an error message.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRecordBatchResponseEntry {
     #[doc="<p>The error code for an individual record result.</p>"]
     #[serde(rename="ErrorCode")]
@@ -655,7 +655,7 @@ pub struct PutRecordBatchResponseEntry {
     pub record_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRecordInput {
     #[doc="<p>The name of the delivery stream.</p>"]
     #[serde(rename="DeliveryStreamName")]
@@ -665,7 +665,7 @@ pub struct PutRecordInput {
     pub record: Record,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRecordOutput {
     #[doc="<p>The ID of the record.</p>"]
     #[serde(rename="RecordId")]
@@ -673,7 +673,7 @@ pub struct PutRecordOutput {
 }
 
 #[doc="<p>The unit of data in a delivery stream.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Record {
     #[doc="<p>The data blob, which is base64-encoded when the blob is serialized. The maximum size of the data blob, before base64-encoding, is 1,000 KB.</p>"]
     #[serde(rename="Data")]
@@ -686,7 +686,7 @@ pub struct Record {
 }
 
 #[doc="<p>Describes the configuration of a destination in Amazon Redshift.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RedshiftDestinationConfiguration {
     #[doc="<p>The CloudWatch logging options for your delivery stream.</p>"]
     #[serde(rename="CloudWatchLoggingOptions")]
@@ -729,7 +729,7 @@ pub struct RedshiftDestinationConfiguration {
 }
 
 #[doc="<p>Describes a destination in Amazon Redshift.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RedshiftDestinationDescription {
     #[doc="<p>The CloudWatch logging options for your delivery stream.</p>"]
     #[serde(rename="CloudWatchLoggingOptions")]
@@ -769,7 +769,7 @@ pub struct RedshiftDestinationDescription {
 }
 
 #[doc="<p>Describes an update for a destination in Amazon Redshift.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RedshiftDestinationUpdate {
     #[doc="<p>The CloudWatch logging options for your delivery stream.</p>"]
     #[serde(rename="CloudWatchLoggingOptions")]
@@ -827,7 +827,7 @@ pub struct RedshiftRetryOptions {
 }
 
 #[doc="<p>Describes the configuration of a destination in Amazon S3.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3DestinationConfiguration {
     #[doc="<p>The ARN of the S3 bucket.</p>"]
     #[serde(rename="BucketARN")]
@@ -858,7 +858,7 @@ pub struct S3DestinationConfiguration {
 }
 
 #[doc="<p>Describes a destination in Amazon S3.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3DestinationDescription {
     #[doc="<p>The ARN of the S3 bucket.</p>"]
     #[serde(rename="BucketARN")]
@@ -886,7 +886,7 @@ pub struct S3DestinationDescription {
 }
 
 #[doc="<p>Describes an update for a destination in Amazon S3.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3DestinationUpdate {
     #[doc="<p>The ARN of the S3 bucket.</p>"]
     #[serde(rename="BucketARN")]
@@ -918,7 +918,7 @@ pub struct S3DestinationUpdate {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SessionCredentials {
     #[serde(rename="AccessKeyId")]
     pub access_key_id: String,
@@ -931,7 +931,7 @@ pub struct SessionCredentials {
 }
 
 #[doc="<p>Details about a Kinesis stream used as the source for a Kinesis Firehose delivery stream.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SourceDescription {
     #[doc="<p>The <a>KinesisStreamSourceDescription</a> value for the source Kinesis stream.</p>"]
     #[serde(rename="KinesisStreamSourceDescription")]
@@ -939,7 +939,7 @@ pub struct SourceDescription {
     pub kinesis_stream_source_description: Option<KinesisStreamSourceDescription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDestinationInput {
     #[doc="<p>Obtain this value from the <b>VersionId</b> result of <a>DeliveryStreamDescription</a>. This value is required, and helps the service to perform conditional operations. For example, if there is an interleaving update and this value is null, then the update destination fails. After the update is successful, the <b>VersionId</b> value is updated. The service then performs a merge of the old configuration with the new configuration.</p>"]
     #[serde(rename="CurrentDeliveryStreamVersionId")]
@@ -964,7 +964,7 @@ pub struct UpdateDestinationInput {
     pub redshift_destination_update: Option<RedshiftDestinationUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDestinationOutput;
 
 /// Errors returned by CreateDeliveryStream

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptMatchInput {
     #[doc="<p>Player response to the proposed match.</p>"]
     #[serde(rename="AcceptanceType")]
@@ -42,11 +42,11 @@ pub struct AcceptMatchInput {
     pub ticket_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptMatchOutput;
 
 #[doc="<p>Properties describing a fleet alias.</p> <p>Alias-related operations include:</p> <ul> <li> <p> <a>CreateAlias</a> </p> </li> <li> <p> <a>ListAliases</a> </p> </li> <li> <p> <a>DescribeAlias</a> </p> </li> <li> <p> <a>UpdateAlias</a> </p> </li> <li> <p> <a>DeleteAlias</a> </p> </li> <li> <p> <a>ResolveAlias</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Alias {
     #[doc="<p>Unique identifier for an alias; alias ARNs are unique across all regions.</p>"]
     #[serde(rename="AliasArn")]
@@ -100,7 +100,7 @@ pub struct AttributeValue {
 }
 
 #[doc="<p>Temporary access credentials used for uploading game build files to Amazon GameLift. They are valid for a limited time. If they expire before you upload your game build, get a new set by calling <a>RequestUploadCredentials</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AwsCredentials {
     #[doc="<p>Temporary key allowing access to the Amazon GameLift S3 account.</p>"]
     #[serde(rename="AccessKeyId")]
@@ -117,7 +117,7 @@ pub struct AwsCredentials {
 }
 
 #[doc="<p>Properties describing a game build.</p> <p>Build-related operations include:</p> <ul> <li> <p> <a>CreateBuild</a> </p> </li> <li> <p> <a>ListBuilds</a> </p> </li> <li> <p> <a>DescribeBuild</a> </p> </li> <li> <p> <a>UpdateBuild</a> </p> </li> <li> <p> <a>DeleteBuild</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Build {
     #[doc="<p>Unique identifier for a build.</p>"]
     #[serde(rename="BuildId")]
@@ -150,7 +150,7 @@ pub struct Build {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAliasInput {
     #[doc="<p>Human-readable description of an alias.</p>"]
     #[serde(rename="Description")]
@@ -165,7 +165,7 @@ pub struct CreateAliasInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAliasOutput {
     #[doc="<p>Object that describes the newly created alias record.</p>"]
     #[serde(rename="Alias")]
@@ -174,7 +174,7 @@ pub struct CreateAliasOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBuildInput {
     #[doc="<p>Descriptive label that is associated with a build. Build names do not need to be unique. You can use <a>UpdateBuild</a> to change this value later. </p>"]
     #[serde(rename="Name")]
@@ -195,7 +195,7 @@ pub struct CreateBuildInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBuildOutput {
     #[doc="<p>The newly created build record, including a unique build ID and status. </p>"]
     #[serde(rename="Build")]
@@ -212,7 +212,7 @@ pub struct CreateBuildOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFleetInput {
     #[doc="<p>Unique identifier for a build to be deployed on the new fleet. The build must have been successfully uploaded to Amazon GameLift and be in a <code>READY</code> status. This fleet setting cannot be changed once the fleet is created.</p>"]
     #[serde(rename="BuildId")]
@@ -262,7 +262,7 @@ pub struct CreateFleetInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFleetOutput {
     #[doc="<p>Properties for the newly created fleet.</p>"]
     #[serde(rename="FleetAttributes")]
@@ -271,7 +271,7 @@ pub struct CreateFleetOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGameSessionInput {
     #[doc="<p>Unique identifier for an alias associated with the fleet to create a game session in. Each request must reference either a fleet ID or alias ID, but not both.</p>"]
     #[serde(rename="AliasId")]
@@ -311,7 +311,7 @@ pub struct CreateGameSessionInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGameSessionOutput {
     #[doc="<p>Object that describes the newly created game session record.</p>"]
     #[serde(rename="GameSession")]
@@ -320,7 +320,7 @@ pub struct CreateGameSessionOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGameSessionQueueInput {
     #[doc="<p>List of fleets that can be used to fulfill game session placement requests in the queue. Fleets are identified by either a fleet ARN or a fleet alias ARN. Destinations are listed in default preference order.</p>"]
     #[serde(rename="Destinations")]
@@ -340,7 +340,7 @@ pub struct CreateGameSessionQueueInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGameSessionQueueOutput {
     #[doc="<p>Object that describes the newly created game session queue.</p>"]
     #[serde(rename="GameSessionQueue")]
@@ -349,7 +349,7 @@ pub struct CreateGameSessionQueueOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateMatchmakingConfigurationInput {
     #[doc="<p>Flag that determines whether or not a match that was created with this configuration must be accepted by the matched players. To require acceptance, set to TRUE.</p>"]
     #[serde(rename="AcceptanceRequired")]
@@ -397,7 +397,7 @@ pub struct CreateMatchmakingConfigurationInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateMatchmakingConfigurationOutput {
     #[doc="<p>Object that describes the newly created matchmaking configuration.</p>"]
     #[serde(rename="Configuration")]
@@ -406,7 +406,7 @@ pub struct CreateMatchmakingConfigurationOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateMatchmakingRuleSetInput {
     #[doc="<p>Unique identifier for a matchmaking rule set. This name is used to identify the rule set associated with a matchmaking configuration.</p>"]
     #[serde(rename="Name")]
@@ -417,7 +417,7 @@ pub struct CreateMatchmakingRuleSetInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateMatchmakingRuleSetOutput {
     #[doc="<p>Object that describes the newly created matchmaking rule set.</p>"]
     #[serde(rename="RuleSet")]
@@ -425,7 +425,7 @@ pub struct CreateMatchmakingRuleSetOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePlayerSessionInput {
     #[doc="<p>Unique identifier for the game session to add a player to.</p>"]
     #[serde(rename="GameSessionId")]
@@ -440,7 +440,7 @@ pub struct CreatePlayerSessionInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePlayerSessionOutput {
     #[doc="<p>Object that describes the newly created player session record.</p>"]
     #[serde(rename="PlayerSession")]
@@ -449,7 +449,7 @@ pub struct CreatePlayerSessionOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePlayerSessionsInput {
     #[doc="<p>Unique identifier for the game session to add players to.</p>"]
     #[serde(rename="GameSessionId")]
@@ -464,7 +464,7 @@ pub struct CreatePlayerSessionsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePlayerSessionsOutput {
     #[doc="<p>Collection of player session objects created for the added players.</p>"]
     #[serde(rename="PlayerSessions")]
@@ -473,7 +473,7 @@ pub struct CreatePlayerSessionsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAliasInput {
     #[doc="<p>Unique identifier for a fleet alias. Specify the alias you want to delete.</p>"]
     #[serde(rename="AliasId")]
@@ -481,7 +481,7 @@ pub struct DeleteAliasInput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBuildInput {
     #[doc="<p>Unique identifier for a build to delete.</p>"]
     #[serde(rename="BuildId")]
@@ -489,7 +489,7 @@ pub struct DeleteBuildInput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFleetInput {
     #[doc="<p>Unique identifier for a fleet to be deleted.</p>"]
     #[serde(rename="FleetId")]
@@ -497,29 +497,29 @@ pub struct DeleteFleetInput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteGameSessionQueueInput {
     #[doc="<p>Descriptive label that is associated with game session queue. Queue names must be unique within each region.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteGameSessionQueueOutput;
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMatchmakingConfigurationInput {
     #[doc="<p>Unique identifier for a matchmaking configuration</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMatchmakingConfigurationOutput;
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteScalingPolicyInput {
     #[doc="<p>Unique identifier for a fleet to be deleted.</p>"]
     #[serde(rename="FleetId")]
@@ -530,7 +530,7 @@ pub struct DeleteScalingPolicyInput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAliasInput {
     #[doc="<p>Unique identifier for a fleet alias. Specify the alias you want to retrieve.</p>"]
     #[serde(rename="AliasId")]
@@ -538,7 +538,7 @@ pub struct DescribeAliasInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAliasOutput {
     #[doc="<p>Object that contains the requested alias.</p>"]
     #[serde(rename="Alias")]
@@ -547,7 +547,7 @@ pub struct DescribeAliasOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBuildInput {
     #[doc="<p>Unique identifier for a build to retrieve properties for.</p>"]
     #[serde(rename="BuildId")]
@@ -555,7 +555,7 @@ pub struct DescribeBuildInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBuildOutput {
     #[doc="<p>Set of properties describing the requested build.</p>"]
     #[serde(rename="Build")]
@@ -564,7 +564,7 @@ pub struct DescribeBuildOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEC2InstanceLimitsInput {
     #[doc="<p>Name of an EC2 instance type that is supported in Amazon GameLift. A fleet instance type determines the computing resources of each instance in the fleet, including CPU, memory, storage, and networking capacity. Amazon GameLift supports the following EC2 instance types. See <a href=\"http://aws.amazon.com/ec2/instance-types/\">Amazon EC2 Instance Types</a> for detailed descriptions. Leave this parameter blank to retrieve limits for all types.</p>"]
     #[serde(rename="EC2InstanceType")]
@@ -573,7 +573,7 @@ pub struct DescribeEC2InstanceLimitsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEC2InstanceLimitsOutput {
     #[doc="<p>Object that contains the maximum number of instances for the specified instance type.</p>"]
     #[serde(rename="EC2InstanceLimits")]
@@ -582,7 +582,7 @@ pub struct DescribeEC2InstanceLimitsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetAttributesInput {
     #[doc="<p>Unique identifier for a fleet(s) to retrieve attributes for. To request attributes for all fleets, leave this parameter empty.</p>"]
     #[serde(rename="FleetIds")]
@@ -599,7 +599,7 @@ pub struct DescribeFleetAttributesInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetAttributesOutput {
     #[doc="<p>Collection of objects containing attribute metadata for each requested fleet ID.</p>"]
     #[serde(rename="FleetAttributes")]
@@ -612,7 +612,7 @@ pub struct DescribeFleetAttributesOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetCapacityInput {
     #[doc="<p>Unique identifier for a fleet(s) to retrieve capacity information for. To request capacity information for all fleets, leave this parameter empty.</p>"]
     #[serde(rename="FleetIds")]
@@ -629,7 +629,7 @@ pub struct DescribeFleetCapacityInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetCapacityOutput {
     #[doc="<p>Collection of objects containing capacity information for each requested fleet ID. Leave this parameter empty to retrieve capacity information for all fleets.</p>"]
     #[serde(rename="FleetCapacity")]
@@ -642,7 +642,7 @@ pub struct DescribeFleetCapacityOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetEventsInput {
     #[doc="<p>Most recent date to retrieve event logs for. If no end time is specified, this call returns entries from the specified start time up to the present. Format is a number expressed in Unix time as milliseconds (ex: \"1469498468.057\").</p>"]
     #[serde(rename="EndTime")]
@@ -666,7 +666,7 @@ pub struct DescribeFleetEventsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetEventsOutput {
     #[doc="<p>Collection of objects containing event log entries for the specified fleet.</p>"]
     #[serde(rename="Events")]
@@ -679,7 +679,7 @@ pub struct DescribeFleetEventsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetPortSettingsInput {
     #[doc="<p>Unique identifier for a fleet to retrieve port settings for.</p>"]
     #[serde(rename="FleetId")]
@@ -687,7 +687,7 @@ pub struct DescribeFleetPortSettingsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetPortSettingsOutput {
     #[doc="<p>Object that contains port settings for the requested fleet ID.</p>"]
     #[serde(rename="InboundPermissions")]
@@ -696,7 +696,7 @@ pub struct DescribeFleetPortSettingsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetUtilizationInput {
     #[doc="<p>Unique identifier for a fleet(s) to retrieve utilization data for. To request utilization data for all fleets, leave this parameter empty.</p>"]
     #[serde(rename="FleetIds")]
@@ -713,7 +713,7 @@ pub struct DescribeFleetUtilizationInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFleetUtilizationOutput {
     #[doc="<p>Collection of objects containing utilization information for each requested fleet ID.</p>"]
     #[serde(rename="FleetUtilization")]
@@ -726,7 +726,7 @@ pub struct DescribeFleetUtilizationOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeGameSessionDetailsInput {
     #[doc="<p>Unique identifier for an alias associated with the fleet to retrieve all game sessions for.</p>"]
     #[serde(rename="AliasId")]
@@ -755,7 +755,7 @@ pub struct DescribeGameSessionDetailsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeGameSessionDetailsOutput {
     #[doc="<p>Collection of objects containing game session properties and the protection policy currently in force for each session matching the request.</p>"]
     #[serde(rename="GameSessionDetails")]
@@ -768,7 +768,7 @@ pub struct DescribeGameSessionDetailsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeGameSessionPlacementInput {
     #[doc="<p>Unique identifier for a game session placement to retrieve.</p>"]
     #[serde(rename="PlacementId")]
@@ -776,7 +776,7 @@ pub struct DescribeGameSessionPlacementInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeGameSessionPlacementOutput {
     #[doc="<p>Object that describes the requested game session placement.</p>"]
     #[serde(rename="GameSessionPlacement")]
@@ -785,7 +785,7 @@ pub struct DescribeGameSessionPlacementOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeGameSessionQueuesInput {
     #[doc="<p>Maximum number of results to return. Use this parameter with <code>NextToken</code> to get results as a set of sequential pages.</p>"]
     #[serde(rename="Limit")]
@@ -802,7 +802,7 @@ pub struct DescribeGameSessionQueuesInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeGameSessionQueuesOutput {
     #[doc="<p>Collection of objects that describes the requested game session queues.</p>"]
     #[serde(rename="GameSessionQueues")]
@@ -815,7 +815,7 @@ pub struct DescribeGameSessionQueuesOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeGameSessionsInput {
     #[doc="<p>Unique identifier for an alias associated with the fleet to retrieve all game sessions for. </p>"]
     #[serde(rename="AliasId")]
@@ -844,7 +844,7 @@ pub struct DescribeGameSessionsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeGameSessionsOutput {
     #[doc="<p>Collection of objects containing game session properties for each session matching the request.</p>"]
     #[serde(rename="GameSessions")]
@@ -857,7 +857,7 @@ pub struct DescribeGameSessionsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancesInput {
     #[doc="<p>Unique identifier for a fleet to retrieve instance information for.</p>"]
     #[serde(rename="FleetId")]
@@ -877,7 +877,7 @@ pub struct DescribeInstancesInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancesOutput {
     #[doc="<p>Collection of objects containing properties for each instance returned.</p>"]
     #[serde(rename="Instances")]
@@ -890,7 +890,7 @@ pub struct DescribeInstancesOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMatchmakingConfigurationsInput {
     #[doc="<p>Maximum number of results to return. Use this parameter with <code>NextToken</code> to get results as a set of sequential pages. This parameter is limited to 10.</p>"]
     #[serde(rename="Limit")]
@@ -911,7 +911,7 @@ pub struct DescribeMatchmakingConfigurationsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMatchmakingConfigurationsOutput {
     #[doc="<p>Collection of requested matchmaking configuration objects.</p>"]
     #[serde(rename="Configurations")]
@@ -924,7 +924,7 @@ pub struct DescribeMatchmakingConfigurationsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMatchmakingInput {
     #[doc="<p>Unique identifier for a matchmaking ticket. To request all existing tickets, leave this parameter empty.</p>"]
     #[serde(rename="TicketIds")]
@@ -932,7 +932,7 @@ pub struct DescribeMatchmakingInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMatchmakingOutput {
     #[doc="<p>Collection of existing matchmaking ticket objects matching the request.</p>"]
     #[serde(rename="TicketList")]
@@ -941,7 +941,7 @@ pub struct DescribeMatchmakingOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMatchmakingRuleSetsInput {
     #[doc="<p>Maximum number of results to return. Use this parameter with <code>NextToken</code> to get results as a set of sequential pages.</p>"]
     #[serde(rename="Limit")]
@@ -958,7 +958,7 @@ pub struct DescribeMatchmakingRuleSetsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMatchmakingRuleSetsOutput {
     #[doc="<p>Token that indicates where to resume retrieving results on the next call to this action. If no token is returned, these results represent the end of the list.</p>"]
     #[serde(rename="NextToken")]
@@ -970,7 +970,7 @@ pub struct DescribeMatchmakingRuleSetsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePlayerSessionsInput {
     #[doc="<p>Unique identifier for the game session to retrieve player sessions for.</p>"]
     #[serde(rename="GameSessionId")]
@@ -999,7 +999,7 @@ pub struct DescribePlayerSessionsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePlayerSessionsOutput {
     #[doc="<p>Token that indicates where to resume retrieving results on the next call to this action. If no token is returned, these results represent the end of the list.</p>"]
     #[serde(rename="NextToken")]
@@ -1012,7 +1012,7 @@ pub struct DescribePlayerSessionsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRuntimeConfigurationInput {
     #[doc="<p>Unique identifier for a fleet to get the run-time configuration for.</p>"]
     #[serde(rename="FleetId")]
@@ -1020,7 +1020,7 @@ pub struct DescribeRuntimeConfigurationInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRuntimeConfigurationOutput {
     #[doc="<p>Instructions describing how server processes should be launched and maintained on each instance in the fleet.</p>"]
     #[serde(rename="RuntimeConfiguration")]
@@ -1029,7 +1029,7 @@ pub struct DescribeRuntimeConfigurationOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScalingPoliciesInput {
     #[doc="<p>Unique identifier for a fleet to retrieve scaling policies for.</p>"]
     #[serde(rename="FleetId")]
@@ -1049,7 +1049,7 @@ pub struct DescribeScalingPoliciesInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeScalingPoliciesOutput {
     #[doc="<p>Token that indicates where to resume retrieving results on the next call to this action. If no token is returned, these results represent the end of the list.</p>"]
     #[serde(rename="NextToken")]
@@ -1062,7 +1062,7 @@ pub struct DescribeScalingPoliciesOutput {
 }
 
 #[doc="<p>Player information for use when creating player sessions using a game session placement request with <a>StartGameSessionPlacement</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DesiredPlayerSession {
     #[doc="<p>Developer-defined information related to a player. Amazon GameLift does not use this data, so it can be formatted as needed for use in the game.</p>"]
     #[serde(rename="PlayerData")]
@@ -1075,7 +1075,7 @@ pub struct DesiredPlayerSession {
 }
 
 #[doc="<p>Current status of fleet capacity. The number of active instances should match or be in the process of matching the number of desired instances. Pending and terminating counts are non-zero only if fleet capacity is adjusting to an <a>UpdateFleetCapacity</a> request, or if access to resources is temporarily affected.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EC2InstanceCounts {
     #[doc="<p>Actual number of active instances in the fleet.</p>"]
     #[serde(rename="ACTIVE")]
@@ -1108,7 +1108,7 @@ pub struct EC2InstanceCounts {
 }
 
 #[doc="<p>Maximum number of instances allowed based on the Amazon Elastic Compute Cloud (Amazon EC2) instance type. Instance limits can be retrieved by calling <a>DescribeEC2InstanceLimits</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EC2InstanceLimit {
     #[doc="<p>Number of instances of the specified type that are currently in use by this AWS account.</p>"]
     #[serde(rename="CurrentInstances")]
@@ -1125,7 +1125,7 @@ pub struct EC2InstanceLimit {
 }
 
 #[doc="<p>Log entry describing an event that involves Amazon GameLift resources (such as a fleet). In addition to tracking activity, event codes and messages can provide additional information for troubleshooting and debugging problems.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Event {
     #[doc="<p>Type of event being logged. The following events are currently in use:</p> <ul> <li> <p>General events:</p> <ul> <li> <p> <b>GENERIC_EVENT</b> – An unspecified event has occurred.</p> </li> </ul> </li> <li> <p>Fleet creation events:</p> <ul> <li> <p> <b>FLEET_CREATED</b> – A fleet record was successfully created with a status of <code>NEW</code>. Event messaging includes the fleet ID.</p> </li> <li> <p> <b>FLEET_STATE_DOWNLOADING</b> – Fleet status changed from <code>NEW</code> to <code>DOWNLOADING</code>. The compressed build has started downloading to a fleet instance for installation.</p> </li> <li> <p> <b>FLEET_BINARY_DOWNLOAD_FAILED</b> – The build failed to download to the fleet instance.</p> </li> <li> <p> <b>FLEET_CREATION_EXTRACTING_BUILD</b> – The game server build was successfully downloaded to an instance, and the build files are now being extracted from the uploaded build and saved to an instance. Failure at this stage prevents a fleet from moving to <code>ACTIVE</code> status. Logs for this stage display a list of the files that are extracted and saved on the instance. Access the logs by using the URL in <i>PreSignedLogUrl</i>.</p> </li> <li> <p> <b>FLEET_CREATION_RUNNING_INSTALLER</b> – The game server build files were successfully extracted, and the Amazon GameLift is now running the build's install script (if one is included). Failure in this stage prevents a fleet from moving to <code>ACTIVE</code> status. Logs for this stage list the installation steps and whether or not the install completed successfully. Access the logs by using the URL in <i>PreSignedLogUrl</i>. </p> </li> <li> <p> <b>FLEET_CREATION_VALIDATING_RUNTIME_CONFIG</b> – The build process was successful, and the Amazon GameLift is now verifying that the game server launch paths, which are specified in the fleet's run-time configuration, exist. If any listed launch path exists, Amazon GameLift tries to launch a game server process and waits for the process to report ready. Failures in this stage prevent a fleet from moving to <code>ACTIVE</code> status. Logs for this stage list the launch paths in the run-time configuration and indicate whether each is found. Access the logs by using the URL in <i>PreSignedLogUrl</i>. </p> </li> <li> <p> <b>FLEET_STATE_VALIDATING</b> – Fleet status changed from <code>DOWNLOADING</code> to <code>VALIDATING</code>.</p> </li> <li> <p> <b>FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND</b> – Validation of the run-time configuration failed because the executable specified in a launch path does not exist on the instance.</p> </li> <li> <p> <b>FLEET_STATE_BUILDING</b> – Fleet status changed from <code>VALIDATING</code> to <code>BUILDING</code>.</p> </li> <li> <p> <b>FLEET_VALIDATION_EXECUTABLE_RUNTIME_FAILURE</b> – Validation of the run-time configuration failed because the executable specified in a launch path failed to run on the fleet instance.</p> </li> <li> <p> <b>FLEET_STATE_ACTIVATING</b> – Fleet status changed from <code>BUILDING</code> to <code>ACTIVATING</code>. </p> </li> <li> <p> <b>FLEET_ACTIVATION_FAILED</b> - The fleet failed to successfully complete one of the steps in the fleet activation process. This event code indicates that the game build was successfully downloaded to a fleet instance, built, and validated, but was not able to start a server process. A possible reason for failure is that the game server is not reporting \"process ready\" to the Amazon GameLift service.</p> </li> <li> <p> <b>FLEET_STATE_ACTIVE</b> – The fleet's status changed from <code>ACTIVATING</code> to <code>ACTIVE</code>. The fleet is now ready to host game sessions.</p> </li> </ul> </li> <li> <p>Other fleet events:</p> <ul> <li> <p> <b>FLEET_SCALING_EVENT</b> – A change was made to the fleet's capacity settings (desired instances, minimum/maximum scaling limits). Event messaging includes the new capacity settings.</p> </li> <li> <p> <b>FLEET_NEW_GAME_SESSION_PROTECTION_POLICY_UPDATED</b> – A change was made to the fleet's game session protection policy setting. Event messaging includes both the old and new policy setting. </p> </li> <li> <p> <b>FLEET_DELETED</b> – A request to delete a fleet was initiated.</p> </li> </ul> </li> </ul>"]
     #[serde(rename="EventCode")]
@@ -1154,7 +1154,7 @@ pub struct Event {
 }
 
 #[doc="<p>General properties describing a fleet.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FleetAttributes {
     #[doc="<p>Unique identifier for a build.</p>"]
     #[serde(rename="BuildId")]
@@ -1219,7 +1219,7 @@ pub struct FleetAttributes {
 }
 
 #[doc="<p>Information about the fleet's capacity. Fleet capacity is measured in EC2 instances. By default, new fleets have a capacity of one instance, but can be updated as needed. The maximum number of instances for a fleet is determined by the fleet's instance type.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FleetCapacity {
     #[doc="<p>Unique identifier for a fleet.</p>"]
     #[serde(rename="FleetId")]
@@ -1236,7 +1236,7 @@ pub struct FleetCapacity {
 }
 
 #[doc="<p>Current status of fleet utilization, including the number of game and player sessions being hosted.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FleetUtilization {
     #[doc="<p>Number of active game sessions currently being hosted on all instances in the fleet.</p>"]
     #[serde(rename="ActiveGameSessionCount")]
@@ -1272,7 +1272,7 @@ pub struct GameProperty {
 }
 
 #[doc="<p>Properties describing a game session.</p> <p>A game session in ACTIVE status can host players. When a game session ends, its status is set to <code>TERMINATED</code>. </p> <p>Once the session ends, the game session object is retained for 30 days. This means you can reuse idempotency token values after this time. Game session logs are retained for 14 days.</p> <p>Game-session-related operations include:</p> <ul> <li> <p> <a>CreateGameSession</a> </p> </li> <li> <p> <a>DescribeGameSessions</a> </p> </li> <li> <p> <a>DescribeGameSessionDetails</a> </p> </li> <li> <p> <a>SearchGameSessions</a> </p> </li> <li> <p> <a>UpdateGameSession</a> </p> </li> <li> <p> <a>GetGameSessionLogUrl</a> </p> </li> <li> <p>Game session placements</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GameSession {
     #[doc="<p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").</p>"]
     #[serde(rename="CreationTime")]
@@ -1333,7 +1333,7 @@ pub struct GameSession {
 }
 
 #[doc="<p>Connection information for the new game session that is created with matchmaking. (with <a>StartMatchmaking</a>). Once a match is set, the FlexMatch engine places the match and creates a new game session for it. This information, including the game session endpoint and player sessions for each player in the original matchmaking request, is added to the <a>MatchmakingTicket</a>, which can be retrieved by calling <a>DescribeMatchmaking</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GameSessionConnectionInfo {
     #[doc="<p>Amazon Resource Name (<a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-arn-format.html\">ARN</a>) that is assigned to a game session and uniquely identifies it.</p>"]
     #[serde(rename="GameSessionArn")]
@@ -1354,7 +1354,7 @@ pub struct GameSessionConnectionInfo {
 }
 
 #[doc="<p>A game session's properties plus the protection policy currently in force.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GameSessionDetail {
     #[doc="<p>Object that describes a game session.</p>"]
     #[serde(rename="GameSession")]
@@ -1367,7 +1367,7 @@ pub struct GameSessionDetail {
 }
 
 #[doc="<p>Object that describes a <a>StartGameSessionPlacement</a> request. This object includes the full details of the original request plus the current status and start/end time stamps.</p> <p>Game session placement-related operations include:</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GameSessionPlacement {
     #[doc="<p>Time stamp indicating when this request was completed, canceled, or timed out.</p>"]
     #[serde(rename="EndTime")]
@@ -1436,7 +1436,7 @@ pub struct GameSessionPlacement {
 }
 
 #[doc="<p>Configuration of a queue that is used to process game session placement requests. The queue configuration identifies several game features:</p> <ul> <li> <p>The destinations where a new game session can potentially be hosted. Amazon GameLift tries these destinations in an order based on either the queue's default order or player latency information, if provided in a placement request. With latency information, Amazon GameLift can place game sessions where the majority of players are reporting the lowest possible latency. </p> </li> <li> <p>The length of time that placement requests can wait in the queue before timing out. </p> </li> <li> <p>A set of optional latency policies that protect individual players from high latencies, preventing game sessions from being placed where any individual player is reporting latency higher than a policy's maximum.</p> </li> </ul> <p>Queue-related operations include:</p> <ul> <li> <p> <a>CreateGameSessionQueue</a> </p> </li> <li> <p> <a>DescribeGameSessionQueues</a> </p> </li> <li> <p> <a>UpdateGameSessionQueue</a> </p> </li> <li> <p> <a>DeleteGameSessionQueue</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GameSessionQueue {
     #[doc="<p>List of fleets that can be used to fulfill game session placement requests in the queue. Fleets are identified by either a fleet ARN or a fleet alias ARN. Destinations are listed in default preference order.</p>"]
     #[serde(rename="Destinations")]
@@ -1470,7 +1470,7 @@ pub struct GameSessionQueueDestination {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGameSessionLogUrlInput {
     #[doc="<p>Unique identifier for the game session to get logs for.</p>"]
     #[serde(rename="GameSessionId")]
@@ -1478,7 +1478,7 @@ pub struct GetGameSessionLogUrlInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGameSessionLogUrlOutput {
     #[doc="<p>Location of the requested game session logs, available for download.</p>"]
     #[serde(rename="PreSignedUrl")]
@@ -1487,7 +1487,7 @@ pub struct GetGameSessionLogUrlOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceAccessInput {
     #[doc="<p>Unique identifier for a fleet that contains the instance you want access to. The fleet can be in any of the following statuses: <code>ACTIVATING</code>, <code>ACTIVE</code>, or <code>ERROR</code>. Fleets with an <code>ERROR</code> status may be accessible for a short time before they are deleted.</p>"]
     #[serde(rename="FleetId")]
@@ -1498,7 +1498,7 @@ pub struct GetInstanceAccessInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceAccessOutput {
     #[doc="<p>Object that contains connection information for a fleet instance, including IP address and access credentials.</p>"]
     #[serde(rename="InstanceAccess")]
@@ -1507,7 +1507,7 @@ pub struct GetInstanceAccessOutput {
 }
 
 #[doc="<p>Properties that describe an instance of a virtual computing resource that hosts one or more game servers. A fleet may contain zero or more instances.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Instance {
     #[doc="<p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").</p>"]
     #[serde(rename="CreationTime")]
@@ -1540,7 +1540,7 @@ pub struct Instance {
 }
 
 #[doc="<p>Information required to remotely connect to a fleet instance. Access is requested by calling <a>GetInstanceAccess</a>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceAccess {
     #[doc="<p>Credentials required to access the instance.</p>"]
     #[serde(rename="Credentials")]
@@ -1565,7 +1565,7 @@ pub struct InstanceAccess {
 }
 
 #[doc="<p>Set of credentials required to remotely access a fleet instance. Access credentials are requested by calling <a>GetInstanceAccess</a> and returned in an <a>InstanceAccess</a> object.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceCredentials {
     #[doc="<p>Secret string. For Windows instances, the secret is a password for use with Windows Remote Desktop. For Linux instances, it is a private key (which must be saved as a <code>.pem</code> file) for use with SSH.</p>"]
     #[serde(rename="Secret")]
@@ -1595,7 +1595,7 @@ pub struct IpPermission {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAliasesInput {
     #[doc="<p>Maximum number of results to return. Use this parameter with <code>NextToken</code> to get results as a set of sequential pages.</p>"]
     #[serde(rename="Limit")]
@@ -1616,7 +1616,7 @@ pub struct ListAliasesInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAliasesOutput {
     #[doc="<p>Collection of alias records that match the list request.</p>"]
     #[serde(rename="Aliases")]
@@ -1629,7 +1629,7 @@ pub struct ListAliasesOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBuildsInput {
     #[doc="<p>Maximum number of results to return. Use this parameter with <code>NextToken</code> to get results as a set of sequential pages.</p>"]
     #[serde(rename="Limit")]
@@ -1646,7 +1646,7 @@ pub struct ListBuildsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBuildsOutput {
     #[doc="<p>Collection of build records that match the request.</p>"]
     #[serde(rename="Builds")]
@@ -1659,7 +1659,7 @@ pub struct ListBuildsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFleetsInput {
     #[doc="<p>Unique identifier for a build to return fleets for. Use this parameter to return only fleets using the specified build. To retrieve all fleets, leave this parameter empty.</p>"]
     #[serde(rename="BuildId")]
@@ -1676,7 +1676,7 @@ pub struct ListFleetsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFleetsOutput {
     #[doc="<p>Set of fleet IDs matching the list request. You can retrieve additional information about all returned fleets by passing this result set to a call to <a>DescribeFleetAttributes</a>, <a>DescribeFleetCapacity</a>, or <a>DescribeFleetUtilization</a>.</p>"]
     #[serde(rename="FleetIds")]
@@ -1689,7 +1689,7 @@ pub struct ListFleetsOutput {
 }
 
 #[doc="<p>New player session created as a result of a successful FlexMatch match. A successful match automatically creates new player sessions for every player ID in the original matchmaking request. </p> <p>When players connect to the match's game session, they must include both player ID and player session ID in order to claim their assigned player slot.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MatchedPlayerSession {
     #[doc="<p>Unique identifier for a player </p>"]
     #[serde(rename="PlayerId")]
@@ -1702,7 +1702,7 @@ pub struct MatchedPlayerSession {
 }
 
 #[doc="<p>Guidelines for use with FlexMatch to match players into games. All matchmaking requests must specify a matchmaking configuration.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MatchmakingConfiguration {
     #[doc="<p>Flag that determines whether or not a match that was created with this configuration must be accepted by the matched players. To require acceptance, set to TRUE.</p>"]
     #[serde(rename="AcceptanceRequired")]
@@ -1759,7 +1759,7 @@ pub struct MatchmakingConfiguration {
 }
 
 #[doc="<p>Set of rule statements, used with FlexMatch, that determine how to build a certain kind of player match. Each rule set describes a type of group to be created and defines the parameters for acceptable player matches. Rule sets are used in <a>MatchmakingConfiguration</a> objects.</p> <p>A rule set may define the following elements for a match. For detailed information and examples showing how to construct a rule set, see <a href=\"http://docs.aws.amazon.com/gamelift/latest/developerguide/match-rules.html\">Create Matchmaking Rules for Your Game</a>. </p> <ul> <li> <p>Teams -- Required. A rule set must define one or multiple teams for the match and set minimum and maximum team sizes. For example, a rule set might describe a 4x4 match that requires all eight slots to be filled. </p> </li> <li> <p>Player attributes -- Optional. These attributes specify a set of player characteristics to evaluate when looking for a match. Matchmaking requests that use a rule set with player attributes must provide the corresponding attribute values. For example, an attribute might specify a player's skill or level.</p> </li> <li> <p>Rules -- Optional. Rules define how to evaluate potential players for a match based on player attributes. A rule might specify minimum requirements for individual players--such as each player must meet a certain skill level, or may describe an entire group--such as all teams must be evenly matched or have at least one player in a certain role. </p> </li> <li> <p>Expansions -- Optional. Expansions allow you to relax the rules after a period of time if no acceptable matches are found. This feature lets you balance getting players into games in a reasonable amount of time instead of making them wait indefinitely for the best possible match. For example, you might use an expansion to increase the maximum skill variance between players after 30 seconds.</p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MatchmakingRuleSet {
     #[doc="<p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").</p>"]
     #[serde(rename="CreationTime")]
@@ -1775,7 +1775,7 @@ pub struct MatchmakingRuleSet {
 }
 
 #[doc="<p>Ticket generated to track the progress of a matchmaking request. Each ticket is uniquely identified by a ticket ID, supplied by the requester, when creating a matchmaking request with <a>StartMatchmaking</a>. Tickets can be retrieved by calling <a>DescribeMatchmaking</a> with the ticket ID.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MatchmakingTicket {
     #[doc="<p>Name of the <a>MatchmakingConfiguration</a> that is used with this ticket. Matchmaking configurations determine how players are grouped into a match and how a new game session is created for the match.</p>"]
     #[serde(rename="ConfigurationName")]
@@ -1812,7 +1812,7 @@ pub struct MatchmakingTicket {
 }
 
 #[doc="<p>Information about a player session that was created as part of a <a>StartGameSessionPlacement</a> request. This object contains only the player ID and player session ID. To retrieve full details on a player session, call <a>DescribePlayerSessions</a> with the player session ID.</p> <p>Player-session-related operations include:</p> <ul> <li> <p> <a>CreatePlayerSession</a> </p> </li> <li> <p> <a>CreatePlayerSessions</a> </p> </li> <li> <p> <a>DescribePlayerSessions</a> </p> </li> <li> <p>Game session placements</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlacedPlayerSession {
     #[doc="<p>Unique identifier for a player that is associated with this player session.</p>"]
     #[serde(rename="PlayerId")]
@@ -1876,7 +1876,7 @@ pub struct PlayerLatencyPolicy {
 }
 
 #[doc="<p>Properties describing a player session. Player session objects are created either by creating a player session for a specific game session, or as part of a game session placement. A player session represents either a player reservation for a game session (status <code>RESERVED</code>) or actual player activity in a game session (status <code>ACTIVE</code>). A player session object (including player data) is automatically passed to a game session when the player connects to the game session and is validated.</p> <p>When a player disconnects, the player session status changes to <code>COMPLETED</code>. Once the session ends, the player session object is retained for 30 days and then removed.</p> <p>Player-session-related operations include:</p> <ul> <li> <p> <a>CreatePlayerSession</a> </p> </li> <li> <p> <a>CreatePlayerSessions</a> </p> </li> <li> <p> <a>DescribePlayerSessions</a> </p> </li> <li> <p>Game session placements</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlayerSession {
     #[doc="<p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").</p>"]
     #[serde(rename="CreationTime")]
@@ -1921,7 +1921,7 @@ pub struct PlayerSession {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutScalingPolicyInput {
     #[doc="<p>Comparison operator to use when measuring the metric against the threshold value.</p>"]
     #[serde(rename="ComparisonOperator")]
@@ -1950,7 +1950,7 @@ pub struct PutScalingPolicyInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutScalingPolicyOutput {
     #[doc="<p>Descriptive label that is associated with a scaling policy. Policy names do not need to be unique.</p>"]
     #[serde(rename="Name")]
@@ -1959,7 +1959,7 @@ pub struct PutScalingPolicyOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestUploadCredentialsInput {
     #[doc="<p>Unique identifier for a build to get credentials for.</p>"]
     #[serde(rename="BuildId")]
@@ -1967,7 +1967,7 @@ pub struct RequestUploadCredentialsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestUploadCredentialsOutput {
     #[doc="<p>Amazon S3 path and key, identifying where the game build files are stored.</p>"]
     #[serde(rename="StorageLocation")]
@@ -1980,7 +1980,7 @@ pub struct RequestUploadCredentialsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResolveAliasInput {
     #[doc="<p>Unique identifier for the alias you want to resolve.</p>"]
     #[serde(rename="AliasId")]
@@ -1988,7 +1988,7 @@ pub struct ResolveAliasInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResolveAliasOutput {
     #[doc="<p>Fleet identifier that is associated with the requested alias.</p>"]
     #[serde(rename="FleetId")]
@@ -2061,7 +2061,7 @@ pub struct S3Location {
 }
 
 #[doc="<p>Rule that controls how a fleet is scaled. Scaling policies are uniquely identified by the combination of name and fleet ID.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScalingPolicy {
     #[doc="<p>Comparison operator to use when measuring a metric against the threshold value.</p>"]
     #[serde(rename="ComparisonOperator")]
@@ -2102,7 +2102,7 @@ pub struct ScalingPolicy {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchGameSessionsInput {
     #[doc="<p>Unique identifier for an alias associated with the fleet to search for active game sessions. Each request must reference either a fleet ID or alias ID, but not both.</p>"]
     #[serde(rename="AliasId")]
@@ -2131,7 +2131,7 @@ pub struct SearchGameSessionsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchGameSessionsOutput {
     #[doc="<p>Collection of objects containing game session properties for each session matching the request.</p>"]
     #[serde(rename="GameSessions")]
@@ -2159,7 +2159,7 @@ pub struct ServerProcess {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartGameSessionPlacementInput {
     #[doc="<p>Set of information on each player to create a player session for.</p>"]
     #[serde(rename="DesiredPlayerSessions")]
@@ -2193,7 +2193,7 @@ pub struct StartGameSessionPlacementInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartGameSessionPlacementOutput {
     #[doc="<p>Object that describes the newly created game session placement. This object includes all the information provided in the request, as well as start/end time stamps and placement status. </p>"]
     #[serde(rename="GameSessionPlacement")]
@@ -2202,7 +2202,7 @@ pub struct StartGameSessionPlacementOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartMatchmakingInput {
     #[doc="<p>Name of the matchmaking configuration to use for this request. Matchmaking configurations must exist in the same region as this request.</p>"]
     #[serde(rename="ConfigurationName")]
@@ -2217,7 +2217,7 @@ pub struct StartMatchmakingInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartMatchmakingOutput {
     #[doc="<p>Ticket representing the matchmaking request. This object include the information included in the request, ticket status, and match results as generated during the matchmaking process.</p>"]
     #[serde(rename="MatchmakingTicket")]
@@ -2226,7 +2226,7 @@ pub struct StartMatchmakingOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopGameSessionPlacementInput {
     #[doc="<p>Unique identifier for a game session placement to cancel.</p>"]
     #[serde(rename="PlacementId")]
@@ -2234,7 +2234,7 @@ pub struct StopGameSessionPlacementInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopGameSessionPlacementOutput {
     #[doc="<p>Object that describes the canceled game session placement, with <code>CANCELLED</code> status and an end time stamp. </p>"]
     #[serde(rename="GameSessionPlacement")]
@@ -2243,18 +2243,18 @@ pub struct StopGameSessionPlacementOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopMatchmakingInput {
     #[doc="<p>Unique identifier for a matchmaking ticket.</p>"]
     #[serde(rename="TicketId")]
     pub ticket_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopMatchmakingOutput;
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAliasInput {
     #[doc="<p>Unique identifier for a fleet alias. Specify the alias you want to update.</p>"]
     #[serde(rename="AliasId")]
@@ -2274,7 +2274,7 @@ pub struct UpdateAliasInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAliasOutput {
     #[doc="<p>Object that contains the updated alias configuration.</p>"]
     #[serde(rename="Alias")]
@@ -2283,7 +2283,7 @@ pub struct UpdateAliasOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateBuildInput {
     #[doc="<p>Unique identifier for a build to update.</p>"]
     #[serde(rename="BuildId")]
@@ -2299,7 +2299,7 @@ pub struct UpdateBuildInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateBuildOutput {
     #[doc="<p>Object that contains the updated build record.</p>"]
     #[serde(rename="Build")]
@@ -2308,7 +2308,7 @@ pub struct UpdateBuildOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFleetAttributesInput {
     #[doc="<p>Human-readable description of a fleet.</p>"]
     #[serde(rename="Description")]
@@ -2336,7 +2336,7 @@ pub struct UpdateFleetAttributesInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFleetAttributesOutput {
     #[doc="<p>Unique identifier for a fleet that was updated.</p>"]
     #[serde(rename="FleetId")]
@@ -2345,7 +2345,7 @@ pub struct UpdateFleetAttributesOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFleetCapacityInput {
     #[doc="<p>Number of EC2 instances you want this fleet to host.</p>"]
     #[serde(rename="DesiredInstances")]
@@ -2365,7 +2365,7 @@ pub struct UpdateFleetCapacityInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFleetCapacityOutput {
     #[doc="<p>Unique identifier for a fleet that was updated.</p>"]
     #[serde(rename="FleetId")]
@@ -2374,7 +2374,7 @@ pub struct UpdateFleetCapacityOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFleetPortSettingsInput {
     #[doc="<p>Unique identifier for a fleet to update port settings for.</p>"]
     #[serde(rename="FleetId")]
@@ -2390,7 +2390,7 @@ pub struct UpdateFleetPortSettingsInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFleetPortSettingsOutput {
     #[doc="<p>Unique identifier for a fleet that was updated.</p>"]
     #[serde(rename="FleetId")]
@@ -2399,7 +2399,7 @@ pub struct UpdateFleetPortSettingsOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGameSessionInput {
     #[doc="<p>Unique identifier for the game session to update.</p>"]
     #[serde(rename="GameSessionId")]
@@ -2423,7 +2423,7 @@ pub struct UpdateGameSessionInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGameSessionOutput {
     #[doc="<p>Object that contains the updated game session metadata.</p>"]
     #[serde(rename="GameSession")]
@@ -2432,7 +2432,7 @@ pub struct UpdateGameSessionOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGameSessionQueueInput {
     #[doc="<p>List of fleets that can be used to fulfill game session placement requests in the queue. Fleets are identified by either a fleet ARN or a fleet alias ARN. Destinations are listed in default preference order. When updating this list, provide a complete list of destinations.</p>"]
     #[serde(rename="Destinations")]
@@ -2452,7 +2452,7 @@ pub struct UpdateGameSessionQueueInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGameSessionQueueOutput {
     #[doc="<p>Object that describes the newly updated game session queue.</p>"]
     #[serde(rename="GameSessionQueue")]
@@ -2461,7 +2461,7 @@ pub struct UpdateGameSessionQueueOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMatchmakingConfigurationInput {
     #[doc="<p>Flag that determines whether or not a match that was created with this configuration must be accepted by the matched players. To require acceptance, set to TRUE.</p>"]
     #[serde(rename="AcceptanceRequired")]
@@ -2513,7 +2513,7 @@ pub struct UpdateMatchmakingConfigurationInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMatchmakingConfigurationOutput {
     #[doc="<p>Object that describes the updated matchmaking configuration.</p>"]
     #[serde(rename="Configuration")]
@@ -2522,7 +2522,7 @@ pub struct UpdateMatchmakingConfigurationOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRuntimeConfigurationInput {
     #[doc="<p>Unique identifier for a fleet to update run-time configuration for.</p>"]
     #[serde(rename="FleetId")]
@@ -2533,7 +2533,7 @@ pub struct UpdateRuntimeConfigurationInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRuntimeConfigurationOutput {
     #[doc="<p>The run-time configuration currently in force. If the update was successful, this object matches the one in the request.</p>"]
     #[serde(rename="RuntimeConfiguration")]
@@ -2542,7 +2542,7 @@ pub struct UpdateRuntimeConfigurationOutput {
 }
 
 #[doc="<p>Represents the input for a request action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ValidateMatchmakingRuleSetInput {
     #[doc="<p>Collection of matchmaking rules to validate, formatted as a JSON string.</p>"]
     #[serde(rename="RuleSetBody")]
@@ -2550,7 +2550,7 @@ pub struct ValidateMatchmakingRuleSetInput {
 }
 
 #[doc="<p>Represents the returned data in response to a request action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ValidateMatchmakingRuleSetOutput {
     #[doc="<p>Response indicating whether or not the rule set is valid.</p>"]
     #[serde(rename="Valid")]

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 #[doc="<p>Provides options to abort a multipart upload identified by the upload ID.</p> <p>For information about the underlying REST API, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html\">Abort Multipart Upload</a>. For conceptual information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AbortMultipartUploadInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -44,7 +44,7 @@ pub struct AbortMultipartUploadInput {
 }
 
 #[doc="<p>The input values for <code>AbortVaultLock</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AbortVaultLockInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -55,7 +55,7 @@ pub struct AbortVaultLockInput {
 }
 
 #[doc="<p>The input values for <code>AddTagsToVault</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToVaultInput {
     #[doc="<p>The tags to add to the vault. Each tag is composed of a key and a value. The value can be an empty string.</p>"]
     #[serde(rename="Tags")]
@@ -70,7 +70,7 @@ pub struct AddTagsToVaultInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p> <p>For information about the underlying REST API, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html\">Upload Archive</a>. For conceptual information, see <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ArchiveCreationOutput {
     #[doc="<p>The ID of the archive. This value is also included as part of the location.</p>"]
     #[serde(rename="archiveId")]
@@ -87,7 +87,7 @@ pub struct ArchiveCreationOutput {
 }
 
 #[doc="<p>Provides options to complete a multipart upload operation. This informs Amazon Glacier that all the archive parts have been uploaded and Amazon Glacier can now assemble the archive from the uploaded parts. After assembling and saving the archive to the vault, Amazon Glacier returns the URI path of the newly created archive resource.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompleteMultipartUploadInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -109,7 +109,7 @@ pub struct CompleteMultipartUploadInput {
 }
 
 #[doc="<p>The input values for <code>CompleteVaultLock</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompleteVaultLockInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -123,7 +123,7 @@ pub struct CompleteVaultLockInput {
 }
 
 #[doc="<p>Provides options to create a vault.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVaultInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -134,7 +134,7 @@ pub struct CreateVaultInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVaultOutput {
     #[doc="<p>The URI of the vault that was created.</p>"]
     #[serde(rename="location")]
@@ -165,7 +165,7 @@ pub struct DataRetrievalRule {
 }
 
 #[doc="<p>Provides options for deleting an archive from an Amazon Glacier vault.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteArchiveInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -179,7 +179,7 @@ pub struct DeleteArchiveInput {
 }
 
 #[doc="<p>DeleteVaultAccessPolicy input.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVaultAccessPolicyInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
@@ -190,7 +190,7 @@ pub struct DeleteVaultAccessPolicyInput {
 }
 
 #[doc="<p>Provides options for deleting a vault from Amazon Glacier.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVaultInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -201,7 +201,7 @@ pub struct DeleteVaultInput {
 }
 
 #[doc="<p>Provides options for deleting a vault notification configuration from an Amazon Glacier vault.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVaultNotificationsInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
@@ -212,7 +212,7 @@ pub struct DeleteVaultNotificationsInput {
 }
 
 #[doc="<p>Provides options for retrieving a job description.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeJobInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
@@ -226,7 +226,7 @@ pub struct DescribeJobInput {
 }
 
 #[doc="<p>Provides options for retrieving metadata for a specific vault in Amazon Glacier.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVaultInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
@@ -237,7 +237,7 @@ pub struct DescribeVaultInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVaultOutput {
     #[doc="<p>The Universal Coordinated Time (UTC) date when the vault was created. This value should be a string in the ISO 8601 date format, for example <code>2012-03-20T17:03:43.221Z</code>.</p>"]
     #[serde(rename="CreationDate")]
@@ -266,7 +266,7 @@ pub struct DescribeVaultOutput {
 }
 
 #[doc="<p>Input for GetDataRetrievalPolicy.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDataRetrievalPolicyInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
@@ -274,7 +274,7 @@ pub struct GetDataRetrievalPolicyInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to the <code>GetDataRetrievalPolicy</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDataRetrievalPolicyOutput {
     #[doc="<p>Contains the returned data retrieval policy in JSON format.</p>"]
     #[serde(rename="Policy")]
@@ -283,7 +283,7 @@ pub struct GetDataRetrievalPolicyOutput {
 }
 
 #[doc="<p>Provides options for downloading output of an Amazon Glacier job.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobOutputInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -301,26 +301,44 @@ pub struct GetJobOutputInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobOutputOutput {
     #[doc="<p>Indicates the range units accepted. For more information, see <a href=\"http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html\">RFC2616</a>. </p>"]
+    #[serde(rename="acceptRanges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub accept_ranges: Option<String>,
     #[doc="<p>The description of an archive.</p>"]
+    #[serde(rename="archiveDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub archive_description: Option<String>,
     #[doc="<p>The job data, either archive data or inventory data.</p>"]
+    #[serde(rename="body")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub body: Option<Vec<u8>>,
     #[doc="<p>The checksum of the data in the response. This header is returned only when retrieving the output for an archive retrieval job. Furthermore, this header appears only under the following conditions:</p> <ul> <li> <p>You get the entire range of the archive.</p> </li> <li> <p>You request a range to return of the archive that starts and ends on a multiple of 1 MB. For example, if you have an 3.1 MB archive and you specify a range to return that starts at 1 MB and ends at 2 MB, then the x-amz-sha256-tree-hash is returned as a response header.</p> </li> <li> <p>You request a range of the archive to return that starts on a multiple of 1 MB and goes to the end of the archive. For example, if you have a 3.1 MB archive and you specify a range that starts at 2 MB and ends at 3.1 MB (the end of the archive), then the x-amz-sha256-tree-hash is returned as a response header.</p> </li> </ul>"]
+    #[serde(rename="checksum")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub checksum: Option<String>,
     #[doc="<p>The range of bytes returned by Amazon Glacier. If only partial output is downloaded, the response provides the range of bytes Amazon Glacier returned. For example, bytes 0-1048575/8388608 returns the first 1 MB from 8 MB.</p>"]
+    #[serde(rename="contentRange")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_range: Option<String>,
     #[doc="<p>The Content-Type depends on whether the job output is an archive or a vault inventory. For archive data, the Content-Type is application/octet-stream. For vault inventory, if you requested CSV format when you initiated the job, the Content-Type is text/csv. Otherwise, by default, vault inventory is returned as JSON, and the Content-Type is application/json.</p>"]
+    #[serde(rename="contentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_type: Option<String>,
     #[doc="<p>The HTTP response code for a job output request. The value depends on whether a range was specified in the request.</p>"]
+    #[serde(rename="status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<i64>,
 }
 
 #[doc="<p>Input for GetVaultAccessPolicy.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetVaultAccessPolicyInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -331,7 +349,7 @@ pub struct GetVaultAccessPolicyInput {
 }
 
 #[doc="<p>Output for GetVaultAccessPolicy.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetVaultAccessPolicyOutput {
     #[doc="<p>Contains the returned vault access policy as a JSON string.</p>"]
     #[serde(rename="policy")]
@@ -340,7 +358,7 @@ pub struct GetVaultAccessPolicyOutput {
 }
 
 #[doc="<p>The input values for <code>GetVaultLock</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetVaultLockInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -351,7 +369,7 @@ pub struct GetVaultLockInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetVaultLockOutput {
     #[doc="<p>The UTC date and time at which the vault lock was put into the <code>InProgress</code> state.</p>"]
     #[serde(rename="CreationDate")]
@@ -372,7 +390,7 @@ pub struct GetVaultLockOutput {
 }
 
 #[doc="<p>Provides options for retrieving the notification configuration set on an Amazon Glacier vault.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetVaultNotificationsInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -383,7 +401,7 @@ pub struct GetVaultNotificationsInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetVaultNotificationsOutput {
     #[doc="<p>Returns the notification configuration set on the vault.</p>"]
     #[serde(rename="vaultNotificationConfig")]
@@ -392,7 +410,7 @@ pub struct GetVaultNotificationsOutput {
 }
 
 #[doc="<p>Describes an Amazon Glacier job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GlacierJobDescription {
     #[doc="<p>The job type. It is either ArchiveRetrieval or InventoryRetrieval.</p>"]
     #[serde(rename="Action")]
@@ -469,7 +487,7 @@ pub struct GlacierJobDescription {
 }
 
 #[doc="<p>Provides options for initiating an Amazon Glacier job.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateJobInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -484,7 +502,7 @@ pub struct InitiateJobInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateJobOutput {
     #[doc="<p>The ID of the job.</p>"]
     #[serde(rename="jobId")]
@@ -497,7 +515,7 @@ pub struct InitiateJobOutput {
 }
 
 #[doc="<p>Provides options for initiating a multipart upload to an Amazon Glacier vault.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateMultipartUploadInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
@@ -516,7 +534,7 @@ pub struct InitiateMultipartUploadInput {
 }
 
 #[doc="<p>The Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateMultipartUploadOutput {
     #[doc="<p>The relative URI path of the multipart upload ID Amazon Glacier created.</p>"]
     #[serde(rename="location")]
@@ -529,7 +547,7 @@ pub struct InitiateMultipartUploadOutput {
 }
 
 #[doc="<p>The input values for <code>InitiateVaultLock</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateVaultLockInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -544,7 +562,7 @@ pub struct InitiateVaultLockInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateVaultLockOutput {
     #[doc="<p>The lock ID, which is used to complete the vault locking process.</p>"]
     #[serde(rename="lockId")]
@@ -553,7 +571,7 @@ pub struct InitiateVaultLockOutput {
 }
 
 #[doc="<p>Describes the options for a range inventory retrieval job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InventoryRetrievalJobDescription {
     #[doc="<p>The end of the date range in UTC for vault inventory retrieval that includes archives created before this date. This value should be a string in the ISO 8601 date format, for example <code>2013-03-20T17:03:43Z</code>.</p>"]
     #[serde(rename="EndDate")]
@@ -578,7 +596,7 @@ pub struct InventoryRetrievalJobDescription {
 }
 
 #[doc="<p>Provides options for specifying a range inventory retrieval job.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InventoryRetrievalJobInput {
     #[doc="<p>The end of the date range in UTC for vault inventory retrieval that includes archives created before this date. This value should be a string in the ISO 8601 date format, for example <code>2013-03-20T17:03:43Z</code>.</p>"]
     #[serde(rename="EndDate")]
@@ -599,7 +617,7 @@ pub struct InventoryRetrievalJobInput {
 }
 
 #[doc="<p>Provides options for defining a job.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobParameters {
     #[doc="<p>The ID of the archive that you want to retrieve. This field is required only if <code>Type</code> is set to archive-retrieval. An error occurs if you specify this request parameter for an inventory retrieval job request. </p>"]
     #[serde(rename="ArchiveId")]
@@ -636,7 +654,7 @@ pub struct JobParameters {
 }
 
 #[doc="<p>Provides options for retrieving a job list for an Amazon Glacier vault.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
@@ -663,7 +681,7 @@ pub struct ListJobsInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsOutput {
     #[doc="<p>A list of job objects. Each job object contains metadata describing the job.</p>"]
     #[serde(rename="JobList")]
@@ -676,7 +694,7 @@ pub struct ListJobsOutput {
 }
 
 #[doc="<p>Provides options for retrieving list of in-progress multipart uploads for an Amazon Glacier vault.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListMultipartUploadsInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
@@ -695,7 +713,7 @@ pub struct ListMultipartUploadsInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListMultipartUploadsOutput {
     #[doc="<p>An opaque string that represents where to continue pagination of the results. You use the marker in a new List Multipart Uploads request to obtain more uploads in the list. If there are no more uploads, this value is <code>null</code>.</p>"]
     #[serde(rename="Marker")]
@@ -708,7 +726,7 @@ pub struct ListMultipartUploadsOutput {
 }
 
 #[doc="<p>Provides options for retrieving a list of parts of an archive that have been uploaded in a specific multipart upload.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPartsInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
@@ -730,7 +748,7 @@ pub struct ListPartsInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPartsOutput {
     #[doc="<p>The description of the archive that was specified in the Initiate Multipart Upload request.</p>"]
     #[serde(rename="ArchiveDescription")]
@@ -762,14 +780,14 @@ pub struct ListPartsOutput {
     pub vault_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProvisionedCapacityInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '-' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, don't include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
     pub account_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProvisionedCapacityOutput {
     #[doc="<p>The response body contains the following JSON fields.</p>"]
     #[serde(rename="ProvisionedCapacityList")]
@@ -778,7 +796,7 @@ pub struct ListProvisionedCapacityOutput {
 }
 
 #[doc="<p>The input value for <code>ListTagsForVaultInput</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForVaultInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -789,7 +807,7 @@ pub struct ListTagsForVaultInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForVaultOutput {
     #[doc="<p>The tags attached to the vault. Each tag is composed of a key and a value.</p>"]
     #[serde(rename="Tags")]
@@ -798,7 +816,7 @@ pub struct ListTagsForVaultOutput {
 }
 
 #[doc="<p>Provides options to retrieve the vault list owned by the calling user's account. The list provides metadata information for each vault.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVaultsInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -814,7 +832,7 @@ pub struct ListVaultsInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVaultsOutput {
     #[doc="<p>The vault ARN at which to continue pagination of the results. You use the marker in another List Vaults request to obtain more vaults in the list.</p>"]
     #[serde(rename="Marker")]
@@ -827,7 +845,7 @@ pub struct ListVaultsOutput {
 }
 
 #[doc="<p>A list of the part sizes of the multipart upload.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PartListElement {
     #[doc="<p>The byte range of a part, inclusive of the upper value of the range.</p>"]
     #[serde(rename="RangeInBytes")]
@@ -840,7 +858,7 @@ pub struct PartListElement {
 }
 
 #[doc="<p>The definition for a provisioned capacity unit.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisionedCapacityDescription {
     #[doc="<p>The ID that identifies the provisioned capacity unit.</p>"]
     #[serde(rename="CapacityId")]
@@ -856,14 +874,14 @@ pub struct ProvisionedCapacityDescription {
     pub start_date: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseProvisionedCapacityInput {
     #[doc="<p>The AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '-' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, don't include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
     pub account_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseProvisionedCapacityOutput {
     #[doc="<p>The ID that identifies the provisioned capacity unit.</p>"]
     #[serde(rename="capacityId")]
@@ -872,7 +890,7 @@ pub struct PurchaseProvisionedCapacityOutput {
 }
 
 #[doc="<p>The input value for <code>RemoveTagsFromVaultInput</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromVaultInput {
     #[doc="<p>A list of tag keys. Each corresponding tag is removed from the vault.</p>"]
     #[serde(rename="TagKeys")]
@@ -887,7 +905,7 @@ pub struct RemoveTagsFromVaultInput {
 }
 
 #[doc="<p>SetDataRetrievalPolicy input.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetDataRetrievalPolicyInput {
     #[doc="<p>The data retrieval policy in JSON format.</p>"]
     #[serde(rename="Policy")]
@@ -899,7 +917,7 @@ pub struct SetDataRetrievalPolicyInput {
 }
 
 #[doc="<p>SetVaultAccessPolicy input.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetVaultAccessPolicyInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -914,7 +932,7 @@ pub struct SetVaultAccessPolicyInput {
 }
 
 #[doc="<p>Provides options to configure notifications that will be sent when specific events happen to a vault.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetVaultNotificationsInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>"]
     #[serde(rename="accountId")]
@@ -929,7 +947,7 @@ pub struct SetVaultNotificationsInput {
 }
 
 #[doc="<p>Provides options to add an archive to a vault.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadArchiveInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
@@ -956,7 +974,7 @@ pub struct UploadArchiveInput {
 }
 
 #[doc="<p>A list of in-progress multipart uploads for a vault.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadListElement {
     #[doc="<p>The description of the archive that was specified in the Initiate Multipart Upload request.</p>"]
     #[serde(rename="ArchiveDescription")]
@@ -981,7 +999,7 @@ pub struct UploadListElement {
 }
 
 #[doc="<p>Provides options to upload a part of an archive in a multipart upload operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadMultipartPartInput {
     #[doc="<p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>"]
     #[serde(rename="accountId")]
@@ -1011,7 +1029,7 @@ pub struct UploadMultipartPartInput {
 }
 
 #[doc="<p>Contains the Amazon Glacier response to your request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadMultipartPartOutput {
     #[doc="<p>The SHA256 tree hash that Amazon Glacier computed for the uploaded part.</p>"]
     #[serde(rename="checksum")]
@@ -1029,7 +1047,7 @@ pub struct VaultAccessPolicy {
 }
 
 #[doc="<p>Contains the vault lock policy.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VaultLockPolicy {
     #[doc="<p>The vault lock policy.</p>"]
     #[serde(rename="Policy")]

--- a/rusoto/services/glue/src/generated.rs
+++ b/rusoto/services/glue/src/generated.rs
@@ -38,7 +38,7 @@ pub struct Action {
     pub job_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchCreatePartitionRequest {
     #[doc="<p>The ID of the catalog in which the partion is to be created. Currently, this should be the AWS account ID.</p>"]
     #[serde(rename="CatalogId")]
@@ -55,7 +55,7 @@ pub struct BatchCreatePartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchCreatePartitionResponse {
     #[doc="<p>Errors encountered when trying to create the requested partitions.</p>"]
     #[serde(rename="Errors")]
@@ -63,7 +63,7 @@ pub struct BatchCreatePartitionResponse {
     pub errors: Option<Vec<PartitionError>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDeleteConnectionRequest {
     #[doc="<p>The ID of the Data Catalog in which the connections reside. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -74,7 +74,7 @@ pub struct BatchDeleteConnectionRequest {
     pub connection_name_list: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDeleteConnectionResponse {
     #[doc="<p>A map of the names of connections that were not successfully deleted to error details.</p>"]
     #[serde(rename="Errors")]
@@ -86,7 +86,7 @@ pub struct BatchDeleteConnectionResponse {
     pub succeeded: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDeletePartitionRequest {
     #[doc="<p>The ID of the Data Catalog where the partition to be deleted resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -103,7 +103,7 @@ pub struct BatchDeletePartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDeletePartitionResponse {
     #[doc="<p>Errors encountered when trying to delete the requested partitions.</p>"]
     #[serde(rename="Errors")]
@@ -111,7 +111,7 @@ pub struct BatchDeletePartitionResponse {
     pub errors: Option<Vec<PartitionError>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDeleteTableRequest {
     #[doc="<p>The ID of the Data Catalog where the table resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -125,7 +125,7 @@ pub struct BatchDeleteTableRequest {
     pub tables_to_delete: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDeleteTableResponse {
     #[doc="<p>A list of errors encountered in attempting to delete the specified tables.</p>"]
     #[serde(rename="Errors")]
@@ -133,7 +133,7 @@ pub struct BatchDeleteTableResponse {
     pub errors: Option<Vec<TableError>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetPartitionRequest {
     #[doc="<p>The ID of the Data Catalog where the partitions in question reside. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -150,7 +150,7 @@ pub struct BatchGetPartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetPartitionResponse {
     #[doc="<p>A list of the requested partitions.</p>"]
     #[serde(rename="Partitions")]
@@ -163,7 +163,7 @@ pub struct BatchGetPartitionResponse {
 }
 
 #[doc="<p>Specifies a table definition in the Data Catalog.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CatalogEntry {
     #[doc="<p>The database in which the table metadata resides.</p>"]
     #[serde(rename="DatabaseName")]
@@ -174,7 +174,7 @@ pub struct CatalogEntry {
 }
 
 #[doc="<p>A structure containing migration status information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CatalogImportStatus {
     #[doc="<p>True if the migration has completed, or False otherwise.</p>"]
     #[serde(rename="ImportCompleted")]
@@ -191,7 +191,7 @@ pub struct CatalogImportStatus {
 }
 
 #[doc="<p>Classifiers are written in Python and triggered during a Crawl Task. You can write your own Classifiers to best categorize your data sources and specify the appropriate schemas to use for them. A Classifier first checks whether a given file is in a format it can handle, and then, if so, creates a schema in the form of a <code>StructType</code> object that matches that data format.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Classifier {
     #[doc="<p>A GrokClassifier object.</p>"]
     #[serde(rename="GrokClassifier")]
@@ -277,7 +277,7 @@ pub struct Condition {
 }
 
 #[doc="<p>Defines a connection to a data source.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Connection {
     #[doc="<p>A list of key-value pairs used as parameters for this connection.</p>"]
     #[serde(rename="ConnectionProperties")]
@@ -318,7 +318,7 @@ pub struct Connection {
 }
 
 #[doc="<p>A structure used to specify a connection to create or update.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConnectionInput {
     #[doc="<p>A list of key-value pairs used as parameters for this connection.</p>"]
     #[serde(rename="ConnectionProperties")]
@@ -356,7 +356,7 @@ pub struct ConnectionsList {
 }
 
 #[doc="<p>Specifies a crawler program that examines a data source and uses classifiers to try to its schema. If successful, the crawler records metatdata concerning the data source in the Data Catalog.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Crawler {
     #[doc="<p>A list of custom <code>Classifier</code>s associated with this Crawler.</p>"]
     #[serde(rename="Classifiers")]
@@ -421,7 +421,7 @@ pub struct Crawler {
 }
 
 #[doc="<p>Metrics for a specified crawler.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CrawlerMetrics {
     #[doc="<p>The name of the crawler.</p>"]
     #[serde(rename="CrawlerName")]
@@ -470,7 +470,7 @@ pub struct CrawlerTargets {
     pub s3_targets: Option<Vec<S3Target>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClassifierRequest {
     #[doc="<p>A grok classifier to create.</p>"]
     #[serde(rename="GrokClassifier")]
@@ -478,10 +478,10 @@ pub struct CreateClassifierRequest {
     pub grok_classifier: Option<CreateGrokClassifierRequest>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClassifierResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConnectionRequest {
     #[doc="<p>The ID of the Data Catalog in which to create the connection. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -492,10 +492,10 @@ pub struct CreateConnectionRequest {
     pub connection_input: ConnectionInput,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConnectionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCrawlerRequest {
     #[doc="<p>A list of custom <code>Classifier</code> names that the user has registered. By default, all AWS classifiers are included in a crawl, but these custom classifiers always override the default classifiers for a given classification.</p>"]
     #[serde(rename="Classifiers")]
@@ -531,10 +531,10 @@ pub struct CreateCrawlerRequest {
     pub targets: CrawlerTargets,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCrawlerResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDatabaseRequest {
     #[doc="<p>The ID of the Data Catalog in which to create the database. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -545,10 +545,10 @@ pub struct CreateDatabaseRequest {
     pub database_input: DatabaseInput,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDatabaseResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDevEndpointRequest {
     #[doc="<p>The name to be assigned to the new DevEndpoint.</p>"]
     #[serde(rename="EndpointName")]
@@ -580,7 +580,7 @@ pub struct CreateDevEndpointRequest {
     pub subnet_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDevEndpointResponse {
     #[doc="<p>The AWS availability zone where this DevEndpoint is located.</p>"]
     #[serde(rename="AvailabilityZone")]
@@ -637,7 +637,7 @@ pub struct CreateDevEndpointResponse {
 }
 
 #[doc="<p>Specifies a Grok classifier for CreateClassifier to create.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGrokClassifierRequest {
     #[doc="<p>The type of result that the classifier matches, such as Twitter Json, Omniture logs, Cloudwatch logs, and so forth.</p>"]
     #[serde(rename="Classification")]
@@ -654,7 +654,7 @@ pub struct CreateGrokClassifierRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobRequest {
     #[doc="<p>The number of capacity units allocated to this job.</p>"]
     #[serde(rename="AllocatedCapacity")]
@@ -695,7 +695,7 @@ pub struct CreateJobRequest {
     pub role: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobResponse {
     #[doc="<p>The unique name of the new job that has been created.</p>"]
     #[serde(rename="Name")]
@@ -703,7 +703,7 @@ pub struct CreateJobResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePartitionRequest {
     #[doc="<p>The ID of the catalog in which the partion is to be created. Currently, this should be the AWS account ID.</p>"]
     #[serde(rename="CatalogId")]
@@ -720,10 +720,10 @@ pub struct CreatePartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePartitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateScriptRequest {
     #[doc="<p>A list of the edges in the DAG.</p>"]
     #[serde(rename="DagEdges")]
@@ -735,7 +735,7 @@ pub struct CreateScriptRequest {
     pub dag_nodes: Option<Vec<CodeGenNode>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateScriptResponse {
     #[doc="<p>The Python script generated from the DAG.</p>"]
     #[serde(rename="PythonScript")]
@@ -743,7 +743,7 @@ pub struct CreateScriptResponse {
     pub python_script: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTableRequest {
     #[doc="<p>The ID of the Data Catalog in which to create the <code>Table</code>. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -757,10 +757,10 @@ pub struct CreateTableRequest {
     pub table_input: TableInput,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTableResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTriggerRequest {
     #[doc="<p>The actions initiated by this trigger when it fires.</p>"]
     #[serde(rename="Actions")]
@@ -785,7 +785,7 @@ pub struct CreateTriggerRequest {
     pub type_: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTriggerResponse {
     #[doc="<p>The name assigned to the new trigger.</p>"]
     #[serde(rename="Name")]
@@ -793,7 +793,7 @@ pub struct CreateTriggerResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserDefinedFunctionRequest {
     #[doc="<p>The ID of the Data Catalog in which to create the function. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -807,11 +807,11 @@ pub struct CreateUserDefinedFunctionRequest {
     pub function_input: UserDefinedFunctionInput,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserDefinedFunctionResponse;
 
 #[doc="<p>The <code>Database</code> object represents a logical grouping of tables that may reside in a Hive metastore or an RDBMS.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Database {
     #[doc="<p>The time at which the metadata database was created in the catalog.</p>"]
     #[serde(rename="CreateTime")]
@@ -835,7 +835,7 @@ pub struct Database {
 }
 
 #[doc="<p>The structure used to create or updata a database.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DatabaseInput {
     #[doc="<p>Description of the database</p>"]
     #[serde(rename="Description")]
@@ -854,17 +854,17 @@ pub struct DatabaseInput {
     pub parameters: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClassifierRequest {
     #[doc="<p>Name of the <code>Classifier</code> to remove.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClassifierResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConnectionRequest {
     #[doc="<p>The ID of the Data Catalog in which the connection resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -875,20 +875,20 @@ pub struct DeleteConnectionRequest {
     pub connection_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConnectionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCrawlerRequest {
     #[doc="<p>Name of the <code>Crawler</code> to remove.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCrawlerResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDatabaseRequest {
     #[doc="<p>The ID of the Data Catalog in which the database resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -899,27 +899,27 @@ pub struct DeleteDatabaseRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDatabaseResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDevEndpointRequest {
     #[doc="<p>The name of the DevEndpoint.</p>"]
     #[serde(rename="EndpointName")]
     pub endpoint_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDevEndpointResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteJobRequest {
     #[doc="<p>The name of the job to delete.</p>"]
     #[serde(rename="JobName")]
     pub job_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteJobResponse {
     #[doc="<p>The name of the job that was deleted.</p>"]
     #[serde(rename="JobName")]
@@ -927,7 +927,7 @@ pub struct DeleteJobResponse {
     pub job_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePartitionRequest {
     #[doc="<p>The ID of the Data Catalog where the partition to be deleted resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -944,10 +944,10 @@ pub struct DeletePartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePartitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTableRequest {
     #[doc="<p>The ID of the Data Catalog where the table resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -961,17 +961,17 @@ pub struct DeleteTableRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTableResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTriggerRequest {
     #[doc="<p>The name of the trigger to delete.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTriggerResponse {
     #[doc="<p>The name of the trigger that was deleted.</p>"]
     #[serde(rename="Name")]
@@ -979,7 +979,7 @@ pub struct DeleteTriggerResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserDefinedFunctionRequest {
     #[doc="<p>The ID of the Data Catalog where the function to be deleted is located. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -993,11 +993,11 @@ pub struct DeleteUserDefinedFunctionRequest {
     pub function_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserDefinedFunctionResponse;
 
 #[doc="<p>A development endpoint where a developer can remotely debug ETL scripts.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DevEndpoint {
     #[doc="<p>The AWS availability zone where this DevEndpoint is located.</p>"]
     #[serde(rename="AvailabilityZone")]
@@ -1070,7 +1070,7 @@ pub struct DevEndpoint {
 }
 
 #[doc="<p>Custom libraries to be loaded into a DevEndpoint.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DevEndpointCustomLibraries {
     #[doc="<p>Path to one or more Java Jars in an S3 bucket that should be loaded in your DevEndpoint.</p>"]
     #[serde(rename="ExtraJarsS3Path")]
@@ -1083,7 +1083,7 @@ pub struct DevEndpointCustomLibraries {
 }
 
 #[doc="<p>Contains details about an error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ErrorDetail {
     #[doc="<p>The code associated with this error.</p>"]
     #[serde(rename="ErrorCode")]
@@ -1104,7 +1104,7 @@ pub struct ExecutionProperty {
     pub max_concurrent_runs: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCatalogImportStatusRequest {
     #[doc="<p>The ID of the catalog to migrate. Currently, this should be the AWS account ID.</p>"]
     #[serde(rename="CatalogId")]
@@ -1112,7 +1112,7 @@ pub struct GetCatalogImportStatusRequest {
     pub catalog_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCatalogImportStatusResponse {
     #[doc="<p>The status of the specified catalog migration.</p>"]
     #[serde(rename="ImportStatus")]
@@ -1120,14 +1120,14 @@ pub struct GetCatalogImportStatusResponse {
     pub import_status: Option<CatalogImportStatus>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetClassifierRequest {
     #[doc="<p>Name of the <code>Classifier</code> to retrieve.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetClassifierResponse {
     #[doc="<p>The requested <code>Classifier</code>.</p>"]
     #[serde(rename="Classifier")]
@@ -1135,7 +1135,7 @@ pub struct GetClassifierResponse {
     pub classifier: Option<Classifier>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetClassifiersRequest {
     #[doc="<p>Size of the list to return (optional).</p>"]
     #[serde(rename="MaxResults")]
@@ -1147,7 +1147,7 @@ pub struct GetClassifiersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetClassifiersResponse {
     #[doc="<p>The requested list of <code>Classifier</code> objects.</p>"]
     #[serde(rename="Classifiers")]
@@ -1159,7 +1159,7 @@ pub struct GetClassifiersResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConnectionRequest {
     #[doc="<p>The ID of the Data Catalog in which the connection resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -1170,7 +1170,7 @@ pub struct GetConnectionRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConnectionResponse {
     #[doc="<p>The requested connection definition.</p>"]
     #[serde(rename="Connection")]
@@ -1179,7 +1179,7 @@ pub struct GetConnectionResponse {
 }
 
 #[doc="<p>Filters the connection definitions returned by the <code>GetConnections</code> API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConnectionsFilter {
     #[doc="<p>The type of connections to return.</p>"]
     #[serde(rename="ConnectionType")]
@@ -1191,7 +1191,7 @@ pub struct GetConnectionsFilter {
     pub match_criteria: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConnectionsRequest {
     #[doc="<p>The ID of the Data Catalog in which the connections reside. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -1211,7 +1211,7 @@ pub struct GetConnectionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConnectionsResponse {
     #[doc="<p>A list of requested connection definitions.</p>"]
     #[serde(rename="ConnectionList")]
@@ -1223,7 +1223,7 @@ pub struct GetConnectionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCrawlerMetricsRequest {
     #[doc="<p>A list of the names of crawlers about which to retrieve metrics.</p>"]
     #[serde(rename="CrawlerNameList")]
@@ -1239,7 +1239,7 @@ pub struct GetCrawlerMetricsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCrawlerMetricsResponse {
     #[doc="<p>A list of metrics for the specified crawler.</p>"]
     #[serde(rename="CrawlerMetricsList")]
@@ -1251,14 +1251,14 @@ pub struct GetCrawlerMetricsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCrawlerRequest {
     #[doc="<p>Name of the <code>Crawler</code> to retrieve metadata for.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCrawlerResponse {
     #[doc="<p>The metadata for the specified <code>Crawler</code>.</p>"]
     #[serde(rename="Crawler")]
@@ -1266,7 +1266,7 @@ pub struct GetCrawlerResponse {
     pub crawler: Option<Crawler>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCrawlersRequest {
     #[doc="<p>The number of Crawlers to return on each call.</p>"]
     #[serde(rename="MaxResults")]
@@ -1278,7 +1278,7 @@ pub struct GetCrawlersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCrawlersResponse {
     #[doc="<p>A list of <code>Crawler</code> metadata.</p>"]
     #[serde(rename="Crawlers")]
@@ -1290,7 +1290,7 @@ pub struct GetCrawlersResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDatabaseRequest {
     #[doc="<p>The ID of the Data Catalog in which the database resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -1301,7 +1301,7 @@ pub struct GetDatabaseRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDatabaseResponse {
     #[doc="<p>The definition of the specified database in the catalog.</p>"]
     #[serde(rename="Database")]
@@ -1309,7 +1309,7 @@ pub struct GetDatabaseResponse {
     pub database: Option<Database>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDatabasesRequest {
     #[doc="<p>The ID of the Data Catalog from which to retrieve <code>Databases</code>. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -1325,7 +1325,7 @@ pub struct GetDatabasesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDatabasesResponse {
     #[doc="<p>A list of <code>Database</code> objects from the specified catalog.</p>"]
     #[serde(rename="DatabaseList")]
@@ -1336,7 +1336,7 @@ pub struct GetDatabasesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDataflowGraphRequest {
     #[doc="<p>The Python script to transform.</p>"]
     #[serde(rename="PythonScript")]
@@ -1344,7 +1344,7 @@ pub struct GetDataflowGraphRequest {
     pub python_script: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDataflowGraphResponse {
     #[doc="<p>A list of the edges in the resulting DAG.</p>"]
     #[serde(rename="DagEdges")]
@@ -1356,14 +1356,14 @@ pub struct GetDataflowGraphResponse {
     pub dag_nodes: Option<Vec<CodeGenNode>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDevEndpointRequest {
     #[doc="<p>Name of the DevEndpoint for which to retrieve information.</p>"]
     #[serde(rename="EndpointName")]
     pub endpoint_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDevEndpointResponse {
     #[doc="<p>A DevEndpoint definition.</p>"]
     #[serde(rename="DevEndpoint")]
@@ -1371,7 +1371,7 @@ pub struct GetDevEndpointResponse {
     pub dev_endpoint: Option<DevEndpoint>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDevEndpointsRequest {
     #[doc="<p>The maximum size of information to return.</p>"]
     #[serde(rename="MaxResults")]
@@ -1383,7 +1383,7 @@ pub struct GetDevEndpointsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDevEndpointsResponse {
     #[doc="<p>A list of DevEndpoint definitions.</p>"]
     #[serde(rename="DevEndpoints")]
@@ -1395,14 +1395,14 @@ pub struct GetDevEndpointsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobRequest {
     #[doc="<p>The name of the job to retrieve.</p>"]
     #[serde(rename="JobName")]
     pub job_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobResponse {
     #[doc="<p>The requested job definition.</p>"]
     #[serde(rename="Job")]
@@ -1410,7 +1410,7 @@ pub struct GetJobResponse {
     pub job: Option<Job>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobRunRequest {
     #[doc="<p>Name of the job being run.</p>"]
     #[serde(rename="JobName")]
@@ -1424,7 +1424,7 @@ pub struct GetJobRunRequest {
     pub run_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobRunResponse {
     #[doc="<p>The requested job-run metadata.</p>"]
     #[serde(rename="JobRun")]
@@ -1432,7 +1432,7 @@ pub struct GetJobRunResponse {
     pub job_run: Option<JobRun>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobRunsRequest {
     #[doc="<p>The name of the job for which to retrieve all job runs.</p>"]
     #[serde(rename="JobName")]
@@ -1447,7 +1447,7 @@ pub struct GetJobRunsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobRunsResponse {
     #[doc="<p>A list of job-run metatdata objects.</p>"]
     #[serde(rename="JobRuns")]
@@ -1459,7 +1459,7 @@ pub struct GetJobRunsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobsRequest {
     #[doc="<p>The maximum size of the response.</p>"]
     #[serde(rename="MaxResults")]
@@ -1471,7 +1471,7 @@ pub struct GetJobsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobsResponse {
     #[doc="<p>A list of jobs.</p>"]
     #[serde(rename="Jobs")]
@@ -1483,7 +1483,7 @@ pub struct GetJobsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMappingRequest {
     #[doc="<p>Parameters for the mapping.</p>"]
     #[serde(rename="Location")]
@@ -1498,14 +1498,14 @@ pub struct GetMappingRequest {
     pub source: CatalogEntry,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMappingResponse {
     #[doc="<p>A list of mappings to the specified targets.</p>"]
     #[serde(rename="Mapping")]
     pub mapping: Vec<MappingEntry>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPartitionRequest {
     #[doc="<p>The ID of the Data Catalog where the partition in question resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -1522,7 +1522,7 @@ pub struct GetPartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPartitionResponse {
     #[doc="<p>The requested information, in the form of a <code>Partition</code> object.</p>"]
     #[serde(rename="Partition")]
@@ -1530,7 +1530,7 @@ pub struct GetPartitionResponse {
     pub partition: Option<Partition>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPartitionsRequest {
     #[doc="<p>The ID of the Data Catalog where the partitions in question reside. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -1560,7 +1560,7 @@ pub struct GetPartitionsRequest {
     pub table_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPartitionsResponse {
     #[doc="<p>A continuation token, if the returned list of partitions does not does not include the last one.</p>"]
     #[serde(rename="NextToken")]
@@ -1572,7 +1572,7 @@ pub struct GetPartitionsResponse {
     pub partitions: Option<Vec<Partition>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPlanRequest {
     #[doc="<p>Parameters for the mapping.</p>"]
     #[serde(rename="Location")]
@@ -1590,7 +1590,7 @@ pub struct GetPlanRequest {
     pub source: CatalogEntry,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPlanResponse {
     #[doc="<p>A python script to perform the mapping.</p>"]
     #[serde(rename="PythonScript")]
@@ -1598,7 +1598,7 @@ pub struct GetPlanResponse {
     pub python_script: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTableRequest {
     #[doc="<p>The ID of the Data Catalog where the table resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -1612,7 +1612,7 @@ pub struct GetTableRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTableResponse {
     #[doc="<p>The <code>Table</code> object that defines the specified table.</p>"]
     #[serde(rename="Table")]
@@ -1620,7 +1620,7 @@ pub struct GetTableResponse {
     pub table: Option<Table>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTableVersionsRequest {
     #[doc="<p>The ID of the Data Catalog where the tables reside. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -1642,7 +1642,7 @@ pub struct GetTableVersionsRequest {
     pub table_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTableVersionsResponse {
     #[doc="<p>A continuation token, if the list of available versions does not include the last one.</p>"]
     #[serde(rename="NextToken")]
@@ -1654,7 +1654,7 @@ pub struct GetTableVersionsResponse {
     pub table_versions: Option<Vec<TableVersion>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTablesRequest {
     #[doc="<p>The ID of the Data Catalog where the tables reside. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -1677,7 +1677,7 @@ pub struct GetTablesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTablesResponse {
     #[doc="<p>A continuation token, present if the current list segment is not the last.</p>"]
     #[serde(rename="NextToken")]
@@ -1689,14 +1689,14 @@ pub struct GetTablesResponse {
     pub table_list: Option<Vec<Table>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTriggerRequest {
     #[doc="<p>The name of the trigger to retrieve.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTriggerResponse {
     #[doc="<p>The requested trigger definition.</p>"]
     #[serde(rename="Trigger")]
@@ -1704,7 +1704,7 @@ pub struct GetTriggerResponse {
     pub trigger: Option<Trigger>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTriggersRequest {
     #[doc="<p>The name of the job for which to retrieve triggers.</p>"]
     #[serde(rename="DependentJobName")]
@@ -1720,7 +1720,7 @@ pub struct GetTriggersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTriggersResponse {
     #[doc="<p>A continuation token, if not all the requested triggers have yet been returned.</p>"]
     #[serde(rename="NextToken")]
@@ -1732,7 +1732,7 @@ pub struct GetTriggersResponse {
     pub triggers: Option<Vec<Trigger>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserDefinedFunctionRequest {
     #[doc="<p>The ID of the Data Catalog where the function to be retrieved is located. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -1746,7 +1746,7 @@ pub struct GetUserDefinedFunctionRequest {
     pub function_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserDefinedFunctionResponse {
     #[doc="<p>The requested function definition.</p>"]
     #[serde(rename="UserDefinedFunction")]
@@ -1754,7 +1754,7 @@ pub struct GetUserDefinedFunctionResponse {
     pub user_defined_function: Option<UserDefinedFunction>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserDefinedFunctionsRequest {
     #[doc="<p>The ID of the Data Catalog where the functions to be retrieved are located. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -1776,7 +1776,7 @@ pub struct GetUserDefinedFunctionsRequest {
     pub pattern: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserDefinedFunctionsResponse {
     #[doc="<p>A continuation token, if the list of functions returned does not include the last requested function.</p>"]
     #[serde(rename="NextToken")]
@@ -1789,7 +1789,7 @@ pub struct GetUserDefinedFunctionsResponse {
 }
 
 #[doc="<p>A classifier that uses <code>grok</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GrokClassifier {
     #[doc="<p>The data form that the classifier matches, such as Twitter, JSON, Omniture Logs, and so forth.</p>"]
     #[serde(rename="Classification")]
@@ -1818,7 +1818,7 @@ pub struct GrokClassifier {
     pub version: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportCatalogToGlueRequest {
     #[doc="<p>The ID of the catalog to import. Currently, this should be the AWS account ID.</p>"]
     #[serde(rename="CatalogId")]
@@ -1826,7 +1826,7 @@ pub struct ImportCatalogToGlueRequest {
     pub catalog_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportCatalogToGlueResponse;
 
 #[doc="<p>Specifies a JDBC target for a crawl.</p>"]
@@ -1847,7 +1847,7 @@ pub struct JdbcTarget {
 }
 
 #[doc="<p>Specifies a job in the Data Catalog.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Job {
     #[doc="<p>The number of capacity units allocated to this job.</p>"]
     #[serde(rename="AllocatedCapacity")]
@@ -1900,7 +1900,7 @@ pub struct Job {
 }
 
 #[doc="<p>Defines a point which a job can resume processing.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobBookmarkEntry {
     #[doc="<p>The attempt ID number.</p>"]
     #[serde(rename="Attempt")]
@@ -1938,7 +1938,7 @@ pub struct JobCommand {
 }
 
 #[doc="<p>Contains information about a job run.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobRun {
     #[doc="<p>The amount of infrastructure capacity allocated to this job run.</p>"]
     #[serde(rename="AllocatedCapacity")]
@@ -1995,7 +1995,7 @@ pub struct JobRun {
 }
 
 #[doc="<p>Specifies information used to update an existing job.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobUpdate {
     #[doc="<p>The number of capacity units allocated to this job.</p>"]
     #[serde(rename="AllocatedCapacity")]
@@ -2036,7 +2036,7 @@ pub struct JobUpdate {
 }
 
 #[doc="<p>Status and error information about the most recent crawl.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LastCrawlInfo {
     #[doc="<p>Error information about the last crawl, if an error occurred.</p>"]
     #[serde(rename="ErrorMessage")]
@@ -2065,7 +2065,7 @@ pub struct LastCrawlInfo {
 }
 
 #[doc="<p>The location of resources.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Location {
     #[doc="<p>A JDBC location.</p>"]
     #[serde(rename="Jdbc")]
@@ -2118,7 +2118,7 @@ pub struct Order {
 }
 
 #[doc="<p>Represents a slice of table data.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Partition {
     #[doc="<p>The time at which the partition was created.</p>"]
     #[serde(rename="CreationTime")]
@@ -2155,7 +2155,7 @@ pub struct Partition {
 }
 
 #[doc="<p>Contains information about a partition error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PartitionError {
     #[doc="<p>Details about the partition error.</p>"]
     #[serde(rename="ErrorDetail")]
@@ -2168,7 +2168,7 @@ pub struct PartitionError {
 }
 
 #[doc="<p>The structure used to create and update a partion.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PartitionInput {
     #[doc="<p>The last time at which the partition was accessed.</p>"]
     #[serde(rename="LastAccessTime")]
@@ -2216,7 +2216,7 @@ pub struct PhysicalConnectionRequirements {
 }
 
 #[doc="<p>A job run that preceded this one.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Predecessor {
     #[doc="<p>The name of the predecessor job.</p>"]
     #[serde(rename="JobName")]
@@ -2241,14 +2241,14 @@ pub struct Predicate {
     pub logical: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetJobBookmarkRequest {
     #[doc="<p>The name of the job in question.</p>"]
     #[serde(rename="JobName")]
     pub job_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetJobBookmarkResponse {
     #[doc="<p>The reset bookmark entry.</p>"]
     #[serde(rename="JobBookmarkEntry")]
@@ -2283,7 +2283,7 @@ pub struct S3Target {
 }
 
 #[doc="<p>A scheduling object using a <code>cron</code> statement to schedule an event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Schedule {
     #[doc="<p>A <code>cron</code> expression that can be used as a Cloudwatch event to schedule something (see <a href=\"http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html\">CloudWatch Schedule Expression Syntax</a>. For example, to run something every day at 12:15 UTC, you would specify: <code>cron(15 12 * * ? *)</code>.</p>"]
     #[serde(rename="ScheduleExpression")]
@@ -2309,7 +2309,7 @@ pub struct SchemaChangePolicy {
 }
 
 #[doc="<p>Defines a non-overlapping region of a table's partitions, allowing multiple requests to be executed in parallel.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Segment {
     #[doc="<p>The zero-based index number of the this segment. For example, if the total number of segments is 4, SegmentNumber values will range from zero through three.</p>"]
     #[serde(rename="SegmentNumber")]
@@ -2353,27 +2353,27 @@ pub struct SkewedInfo {
     pub skewed_column_values: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartCrawlerRequest {
     #[doc="<p>Name of the <code>Crawler</code> to start.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartCrawlerResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartCrawlerScheduleRequest {
     #[doc="<p>Name of the crawler to schedule.</p>"]
     #[serde(rename="CrawlerName")]
     pub crawler_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartCrawlerScheduleResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartJobRunRequest {
     #[doc="<p>The infrastructure capacity to allocate to this job.</p>"]
     #[serde(rename="AllocatedCapacity")]
@@ -2392,7 +2392,7 @@ pub struct StartJobRunRequest {
     pub job_run_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartJobRunResponse {
     #[doc="<p>The ID assigned to this job run.</p>"]
     #[serde(rename="JobRunId")]
@@ -2400,14 +2400,14 @@ pub struct StartJobRunResponse {
     pub job_run_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartTriggerRequest {
     #[doc="<p>The name of the trigger to start.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartTriggerResponse {
     #[doc="<p>The name of the trigger that was started.</p>"]
     #[serde(rename="Name")]
@@ -2415,34 +2415,34 @@ pub struct StartTriggerResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopCrawlerRequest {
     #[doc="<p>Name of the <code>Crawler</code> to stop.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopCrawlerResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopCrawlerScheduleRequest {
     #[doc="<p>Name of the crawler whose schedule state to set.</p>"]
     #[serde(rename="CrawlerName")]
     pub crawler_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopCrawlerScheduleResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopTriggerRequest {
     #[doc="<p>The name of the trigger to stop.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopTriggerResponse {
     #[doc="<p>The name of the trigger that was stopped.</p>"]
     #[serde(rename="Name")]
@@ -2504,7 +2504,7 @@ pub struct StorageDescriptor {
 }
 
 #[doc="<p>Represents a collection of related data organized in columns and rows.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Table {
     #[doc="<p>Time when the table definition was created in the Data Catalog.</p>"]
     #[serde(rename="CreateTime")]
@@ -2572,7 +2572,7 @@ pub struct Table {
 }
 
 #[doc="<p>An error record for table operations.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TableError {
     #[doc="<p>Detail about the error.</p>"]
     #[serde(rename="ErrorDetail")]
@@ -2585,7 +2585,7 @@ pub struct TableError {
 }
 
 #[doc="<p>Structure used to create or update the table.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TableInput {
     #[doc="<p>Description of the table.</p>"]
     #[serde(rename="Description")]
@@ -2636,7 +2636,7 @@ pub struct TableInput {
     pub view_original_text: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TableVersion {
     #[serde(rename="Table")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -2647,7 +2647,7 @@ pub struct TableVersion {
 }
 
 #[doc="<p>Information about a specific trigger.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Trigger {
     #[doc="<p>The actions initiated by this trigger.</p>"]
     #[serde(rename="Actions")]
@@ -2684,7 +2684,7 @@ pub struct Trigger {
 }
 
 #[doc="<p>A structure used to provide information used to updata a trigger.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TriggerUpdate {
     #[doc="<p>The actions initiated by this trigger.</p>"]
     #[serde(rename="Actions")]
@@ -2708,7 +2708,7 @@ pub struct TriggerUpdate {
     pub schedule: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateClassifierRequest {
     #[doc="<p>A <code>GrokClassifier</code> object with updated fields.</p>"]
     #[serde(rename="GrokClassifier")]
@@ -2716,10 +2716,10 @@ pub struct UpdateClassifierRequest {
     pub grok_classifier: Option<UpdateGrokClassifierRequest>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateClassifierResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateConnectionRequest {
     #[doc="<p>The ID of the Data Catalog in which the connection resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -2733,10 +2733,10 @@ pub struct UpdateConnectionRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateConnectionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateCrawlerRequest {
     #[doc="<p>A list of custom <code>Classifier</code> names that the user has registered. By default, all AWS classifiers are included in a crawl, but these custom classifiers always override the default classifiers for a given classification.</p>"]
     #[serde(rename="Classifiers")]
@@ -2775,10 +2775,10 @@ pub struct UpdateCrawlerRequest {
     pub targets: Option<CrawlerTargets>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateCrawlerResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateCrawlerScheduleRequest {
     #[doc="<p>Name of the crawler whose schedule to update.</p>"]
     #[serde(rename="CrawlerName")]
@@ -2789,10 +2789,10 @@ pub struct UpdateCrawlerScheduleRequest {
     pub schedule: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateCrawlerScheduleResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDatabaseRequest {
     #[doc="<p>The ID of the Data Catalog in which the metadata database resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -2806,10 +2806,10 @@ pub struct UpdateDatabaseRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDatabaseResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDevEndpointRequest {
     #[doc="<p>Custom Python or Java custom libraries to be loaded in the DevEndpoint.</p>"]
     #[serde(rename="CustomLibraries")]
@@ -2824,11 +2824,11 @@ pub struct UpdateDevEndpointRequest {
     pub public_key: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDevEndpointResponse;
 
 #[doc="<p>Specifies a Grok classifier to update when passed to UpdateClassifier.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGrokClassifierRequest {
     #[doc="<p>The type of result that the classifier matches, such as Twitter Json, Omniture logs, Cloudwatch logs, and so forth.</p>"]
     #[serde(rename="Classification")]
@@ -2847,7 +2847,7 @@ pub struct UpdateGrokClassifierRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateJobRequest {
     #[doc="<p>Name of the job definition to update.</p>"]
     #[serde(rename="JobName")]
@@ -2857,7 +2857,7 @@ pub struct UpdateJobRequest {
     pub job_update: JobUpdate,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateJobResponse {
     #[doc="<p>Returns the name of the updated job.</p>"]
     #[serde(rename="JobName")]
@@ -2865,7 +2865,7 @@ pub struct UpdateJobResponse {
     pub job_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePartitionRequest {
     #[doc="<p>The ID of the Data Catalog where the partition to be updated resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -2885,10 +2885,10 @@ pub struct UpdatePartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePartitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTableRequest {
     #[doc="<p>The ID of the Data Catalog where the table resides. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -2902,10 +2902,10 @@ pub struct UpdateTableRequest {
     pub table_input: TableInput,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTableResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTriggerRequest {
     #[doc="<p>The name of the trigger to update.</p>"]
     #[serde(rename="Name")]
@@ -2915,7 +2915,7 @@ pub struct UpdateTriggerRequest {
     pub trigger_update: TriggerUpdate,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTriggerResponse {
     #[doc="<p>The resulting trigger definition.</p>"]
     #[serde(rename="Trigger")]
@@ -2923,7 +2923,7 @@ pub struct UpdateTriggerResponse {
     pub trigger: Option<Trigger>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserDefinedFunctionRequest {
     #[doc="<p>The ID of the Data Catalog where the function to be updated is located. If none is supplied, the AWS account ID is used by default.</p>"]
     #[serde(rename="CatalogId")]
@@ -2940,11 +2940,11 @@ pub struct UpdateUserDefinedFunctionRequest {
     pub function_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserDefinedFunctionResponse;
 
 #[doc="<p>Represents the equivalent of a Hive user-defined function (<code>UDF</code>) definition.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserDefinedFunction {
     #[doc="<p>The Java class that contains the function code.</p>"]
     #[serde(rename="ClassName")]
@@ -2973,7 +2973,7 @@ pub struct UserDefinedFunction {
 }
 
 #[doc="<p>A structure used to create or updata a user-defined function.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserDefinedFunctionInput {
     #[doc="<p>The Java class that contains the function code.</p>"]
     #[serde(rename="ClassName")]

--- a/rusoto/services/greengrass/src/generated.rs
+++ b/rusoto/services/greengrass/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateRoleToGroupRequest {
     #[doc="The unique Id of the AWS Greengrass Group"]
     #[serde(rename="GroupId")]
@@ -40,7 +40,7 @@ pub struct AssociateRoleToGroupRequest {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateRoleToGroupResponse {
     #[doc="Time the role arn was associated to your group."]
     #[serde(rename="AssociatedAt")]
@@ -48,7 +48,7 @@ pub struct AssociateRoleToGroupResponse {
     pub associated_at: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateServiceRoleToAccountRequest {
     #[doc="Role arn you wish to associate with this account."]
     #[serde(rename="RoleArn")]
@@ -56,7 +56,7 @@ pub struct AssociateServiceRoleToAccountRequest {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateServiceRoleToAccountResponse {
     #[doc="Time when the service role was associated to the account."]
     #[serde(rename="AssociatedAt")]
@@ -116,7 +116,7 @@ pub struct CoreDefinitionVersion {
 }
 
 #[doc="Information on the core definition request"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCoreDefinitionRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -132,7 +132,7 @@ pub struct CreateCoreDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCoreDefinitionResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -164,7 +164,7 @@ pub struct CreateCoreDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCoreDefinitionVersionRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -179,7 +179,7 @@ pub struct CreateCoreDefinitionVersionRequest {
     pub cores: Option<Vec<Core>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCoreDefinitionVersionResponse {
     #[doc="Arn of the version."]
     #[serde(rename="Arn")]
@@ -199,7 +199,7 @@ pub struct CreateCoreDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeploymentRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -222,7 +222,7 @@ pub struct CreateDeploymentRequest {
     pub group_version_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeploymentResponse {
     #[doc="Arn of the deployment."]
     #[serde(rename="DeploymentArn")]
@@ -234,7 +234,7 @@ pub struct CreateDeploymentResponse {
     pub deployment_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeviceDefinitionRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -250,7 +250,7 @@ pub struct CreateDeviceDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeviceDefinitionResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -282,7 +282,7 @@ pub struct CreateDeviceDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeviceDefinitionVersionRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -297,7 +297,7 @@ pub struct CreateDeviceDefinitionVersionRequest {
     pub devices: Option<Vec<Device>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeviceDefinitionVersionResponse {
     #[doc="Arn of the version."]
     #[serde(rename="Arn")]
@@ -317,7 +317,7 @@ pub struct CreateDeviceDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFunctionDefinitionRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -333,7 +333,7 @@ pub struct CreateFunctionDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFunctionDefinitionResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -366,7 +366,7 @@ pub struct CreateFunctionDefinitionResponse {
 }
 
 #[doc="Function definition version"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFunctionDefinitionVersionRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -381,7 +381,7 @@ pub struct CreateFunctionDefinitionVersionRequest {
     pub functions: Option<Vec<Function>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFunctionDefinitionVersionResponse {
     #[doc="Arn of the version."]
     #[serde(rename="Arn")]
@@ -401,7 +401,7 @@ pub struct CreateFunctionDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGroupCertificateAuthorityRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -412,7 +412,7 @@ pub struct CreateGroupCertificateAuthorityRequest {
     pub group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGroupCertificateAuthorityResponse {
     #[doc="Arn of the group certificate authority."]
     #[serde(rename="GroupCertificateAuthorityArn")]
@@ -420,7 +420,7 @@ pub struct CreateGroupCertificateAuthorityResponse {
     pub group_certificate_authority_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGroupRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -436,7 +436,7 @@ pub struct CreateGroupRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGroupResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -468,7 +468,7 @@ pub struct CreateGroupResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGroupVersionRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -499,7 +499,7 @@ pub struct CreateGroupVersionRequest {
     pub subscription_definition_version_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGroupVersionResponse {
     #[doc="Arn of the version."]
     #[serde(rename="Arn")]
@@ -519,7 +519,7 @@ pub struct CreateGroupVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoggerDefinitionRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -535,7 +535,7 @@ pub struct CreateLoggerDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoggerDefinitionResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -567,7 +567,7 @@ pub struct CreateLoggerDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoggerDefinitionVersionRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -582,7 +582,7 @@ pub struct CreateLoggerDefinitionVersionRequest {
     pub loggers: Option<Vec<Logger>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoggerDefinitionVersionResponse {
     #[doc="Arn of the version."]
     #[serde(rename="Arn")]
@@ -602,7 +602,7 @@ pub struct CreateLoggerDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubscriptionDefinitionRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -618,7 +618,7 @@ pub struct CreateSubscriptionDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubscriptionDefinitionResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -650,7 +650,7 @@ pub struct CreateSubscriptionDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubscriptionDefinitionVersionRequest {
     #[doc="The client token used to request idempotent operations."]
     #[serde(rename="AmznClientToken")]
@@ -665,7 +665,7 @@ pub struct CreateSubscriptionDefinitionVersionRequest {
     pub subscriptions: Option<Vec<Subscription>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubscriptionDefinitionVersionResponse {
     #[doc="Arn of the version."]
     #[serde(rename="Arn")]
@@ -686,7 +686,7 @@ pub struct CreateSubscriptionDefinitionVersionResponse {
 }
 
 #[doc="Information on the Definition"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DefinitionInformation {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -718,68 +718,68 @@ pub struct DefinitionInformation {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCoreDefinitionRequest {
     #[doc="core definition Id"]
     #[serde(rename="CoreDefinitionId")]
     pub core_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCoreDefinitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDeviceDefinitionRequest {
     #[doc="device definition Id"]
     #[serde(rename="DeviceDefinitionId")]
     pub device_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDeviceDefinitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFunctionDefinitionRequest {
     #[doc="the unique Id of the lambda definition"]
     #[serde(rename="FunctionDefinitionId")]
     pub function_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFunctionDefinitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteGroupRequest {
     #[doc="The unique Id of the AWS Greengrass Group"]
     #[serde(rename="GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteGroupResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLoggerDefinitionRequest {
     #[doc="logger definition Id"]
     #[serde(rename="LoggerDefinitionId")]
     pub logger_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLoggerDefinitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSubscriptionDefinitionRequest {
     #[doc="subscription definition Id"]
     #[serde(rename="SubscriptionDefinitionId")]
     pub subscription_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSubscriptionDefinitionResponse;
 
 #[doc="Information on the deployment"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Deployment {
     #[doc="Timestamp when the deployment was created."]
     #[serde(rename="CreatedAt")]
@@ -829,14 +829,14 @@ pub struct DeviceDefinitionVersion {
     pub devices: Option<Vec<Device>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateRoleFromGroupRequest {
     #[doc="The unique Id of the AWS Greengrass Group"]
     #[serde(rename="GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateRoleFromGroupResponse {
     #[doc="Time when the role was disassociated from the group."]
     #[serde(rename="DisassociatedAt")]
@@ -844,10 +844,10 @@ pub struct DisassociateRoleFromGroupResponse {
     pub disassociated_at: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateServiceRoleFromAccountRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateServiceRoleFromAccountResponse {
     #[doc="Time when the service role was disassociated from the account."]
     #[serde(rename="DisassociatedAt")]
@@ -856,15 +856,19 @@ pub struct DisassociateServiceRoleFromAccountResponse {
 }
 
 #[doc="Empty"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Empty;
 
 #[doc="ErrorDetail"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ErrorDetail {
     #[doc="Detailed Error Code"]
+    #[serde(rename="DetailedErrorCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub detailed_error_code: Option<String>,
     #[doc="Detailed Error Message"]
+    #[serde(rename="DetailedErrorMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub detailed_error_message: Option<String>,
 }
 
@@ -933,22 +937,26 @@ pub struct FunctionDefinitionVersion {
 }
 
 #[doc="General Error"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GeneralError {
     #[doc="Error Details"]
+    #[serde(rename="ErrorDetails")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub error_details: Option<Vec<ErrorDetail>>,
     #[doc="Message"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAssociatedRoleRequest {
     #[doc="The unique Id of the AWS Greengrass Group"]
     #[serde(rename="GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAssociatedRoleResponse {
     #[doc="Time when the role was associated for the group."]
     #[serde(rename="AssociatedAt")]
@@ -960,14 +968,14 @@ pub struct GetAssociatedRoleResponse {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConnectivityInfoRequest {
     #[doc="Thing Name"]
     #[serde(rename="ThingName")]
     pub thing_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConnectivityInfoResponse {
     #[doc="Connectivity info array"]
     #[serde(rename="ConnectivityInfo")]
@@ -979,14 +987,14 @@ pub struct GetConnectivityInfoResponse {
     pub message: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCoreDefinitionRequest {
     #[doc="core definition Id"]
     #[serde(rename="CoreDefinitionId")]
     pub core_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCoreDefinitionResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -1018,7 +1026,7 @@ pub struct GetCoreDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCoreDefinitionVersionRequest {
     #[doc="core definition Id"]
     #[serde(rename="CoreDefinitionId")]
@@ -1028,7 +1036,7 @@ pub struct GetCoreDefinitionVersionRequest {
     pub core_definition_version_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCoreDefinitionVersionResponse {
     #[doc="Arn of the core definition version."]
     #[serde(rename="Arn")]
@@ -1052,7 +1060,7 @@ pub struct GetCoreDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentStatusRequest {
     #[doc="the deployment Id"]
     #[serde(rename="DeploymentId")]
@@ -1062,7 +1070,7 @@ pub struct GetDeploymentStatusRequest {
     pub group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeploymentStatusResponse {
     #[doc="Status of the deployment."]
     #[serde(rename="DeploymentStatus")]
@@ -1078,14 +1086,14 @@ pub struct GetDeploymentStatusResponse {
     pub updated_at: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeviceDefinitionRequest {
     #[doc="device definition Id"]
     #[serde(rename="DeviceDefinitionId")]
     pub device_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeviceDefinitionResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -1117,7 +1125,7 @@ pub struct GetDeviceDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeviceDefinitionVersionRequest {
     #[doc="device definition Id"]
     #[serde(rename="DeviceDefinitionId")]
@@ -1127,7 +1135,7 @@ pub struct GetDeviceDefinitionVersionRequest {
     pub device_definition_version_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeviceDefinitionVersionResponse {
     #[doc="Arn of the device definition version."]
     #[serde(rename="Arn")]
@@ -1151,14 +1159,14 @@ pub struct GetDeviceDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFunctionDefinitionRequest {
     #[doc="the unique Id of the lambda definition"]
     #[serde(rename="FunctionDefinitionId")]
     pub function_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFunctionDefinitionResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -1190,7 +1198,7 @@ pub struct GetFunctionDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFunctionDefinitionVersionRequest {
     #[doc="the unique Id of the lambda definition"]
     #[serde(rename="FunctionDefinitionId")]
@@ -1200,7 +1208,7 @@ pub struct GetFunctionDefinitionVersionRequest {
     pub function_definition_version_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFunctionDefinitionVersionResponse {
     #[doc="Arn of the function definition version."]
     #[serde(rename="Arn")]
@@ -1223,7 +1231,7 @@ pub struct GetFunctionDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupCertificateAuthorityRequest {
     #[doc="certificate authority Id"]
     #[serde(rename="CertificateAuthorityId")]
@@ -1233,7 +1241,7 @@ pub struct GetGroupCertificateAuthorityRequest {
     pub group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupCertificateAuthorityResponse {
     #[doc="Arn of the certificate authority for the group."]
     #[serde(rename="GroupCertificateAuthorityArn")]
@@ -1249,14 +1257,14 @@ pub struct GetGroupCertificateAuthorityResponse {
     pub pem_encoded_certificate: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupCertificateConfigurationRequest {
     #[doc="The unique Id of the AWS Greengrass Group"]
     #[serde(rename="GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupCertificateConfigurationResponse {
     #[doc="Amount of time when the certificate authority expires in milliseconds."]
     #[serde(rename="CertificateAuthorityExpiryInMilliseconds")]
@@ -1272,14 +1280,14 @@ pub struct GetGroupCertificateConfigurationResponse {
     pub group_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupRequest {
     #[doc="The unique Id of the AWS Greengrass Group"]
     #[serde(rename="GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -1311,7 +1319,7 @@ pub struct GetGroupResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupVersionRequest {
     #[doc="The unique Id of the AWS Greengrass Group"]
     #[serde(rename="GroupId")]
@@ -1321,7 +1329,7 @@ pub struct GetGroupVersionRequest {
     pub group_version_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupVersionResponse {
     #[doc="Arn of the group version."]
     #[serde(rename="Arn")]
@@ -1345,14 +1353,14 @@ pub struct GetGroupVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLoggerDefinitionRequest {
     #[doc="logger definition Id"]
     #[serde(rename="LoggerDefinitionId")]
     pub logger_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLoggerDefinitionResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -1384,7 +1392,7 @@ pub struct GetLoggerDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLoggerDefinitionVersionRequest {
     #[doc="logger definition Id"]
     #[serde(rename="LoggerDefinitionId")]
@@ -1394,7 +1402,7 @@ pub struct GetLoggerDefinitionVersionRequest {
     pub logger_definition_version_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLoggerDefinitionVersionResponse {
     #[doc="Arn of the logger definition version."]
     #[serde(rename="Arn")]
@@ -1418,10 +1426,10 @@ pub struct GetLoggerDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetServiceRoleForAccountRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetServiceRoleForAccountResponse {
     #[doc="Time when the service role was associated to the account."]
     #[serde(rename="AssociatedAt")]
@@ -1433,14 +1441,14 @@ pub struct GetServiceRoleForAccountResponse {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSubscriptionDefinitionRequest {
     #[doc="subscription definition Id"]
     #[serde(rename="SubscriptionDefinitionId")]
     pub subscription_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSubscriptionDefinitionResponse {
     #[doc="Arn of the definition."]
     #[serde(rename="Arn")]
@@ -1472,7 +1480,7 @@ pub struct GetSubscriptionDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSubscriptionDefinitionVersionRequest {
     #[doc="subscription definition Id"]
     #[serde(rename="SubscriptionDefinitionId")]
@@ -1482,7 +1490,7 @@ pub struct GetSubscriptionDefinitionVersionRequest {
     pub subscription_definition_version_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSubscriptionDefinitionVersionResponse {
     #[doc="Arn of the subscription definition version."]
     #[serde(rename="Arn")]
@@ -1507,7 +1515,7 @@ pub struct GetSubscriptionDefinitionVersionResponse {
 }
 
 #[doc="Information on group certificate authority properties"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GroupCertificateAuthorityProperties {
     #[doc="Arn of the certificate authority for the group."]
     #[serde(rename="GroupCertificateAuthorityArn")]
@@ -1520,18 +1528,24 @@ pub struct GroupCertificateAuthorityProperties {
 }
 
 #[doc="Information on the group certificate configuration"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GroupCertificateConfiguration {
     #[doc="Amount of time when the certificate authority expires in milliseconds."]
+    #[serde(rename="CertificateAuthorityExpiryInMilliseconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificate_authority_expiry_in_milliseconds: Option<String>,
     #[doc="Amount of time when the certificate expires in milliseconds."]
+    #[serde(rename="CertificateExpiryInMilliseconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificate_expiry_in_milliseconds: Option<String>,
     #[doc="Id of the group the certificate configuration belongs to."]
+    #[serde(rename="GroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_id: Option<String>,
 }
 
 #[doc="Information of a group"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GroupInformation {
     #[doc="Arn of a group."]
     #[serde(rename="Arn")]
@@ -1588,7 +1602,7 @@ pub struct GroupVersion {
     pub subscription_definition_version_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCoreDefinitionVersionsRequest {
     #[doc="core definition Id"]
     #[serde(rename="CoreDefinitionId")]
@@ -1603,7 +1617,7 @@ pub struct ListCoreDefinitionVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCoreDefinitionVersionsResponse {
     #[doc="The token for the next set of results, or ''null'' if there are no additional results."]
     #[serde(rename="NextToken")]
@@ -1615,7 +1629,7 @@ pub struct ListCoreDefinitionVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCoreDefinitionsRequest {
     #[doc="Specifies the maximum number of list results to be returned in this page"]
     #[serde(rename="MaxResults")]
@@ -1627,7 +1641,7 @@ pub struct ListCoreDefinitionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCoreDefinitionsResponse {
     #[doc="Definitions"]
     #[serde(rename="Definitions")]
@@ -1640,15 +1654,19 @@ pub struct ListCoreDefinitionsResponse {
 }
 
 #[doc="List of definition response"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDefinitionsResponse {
     #[doc="Definitions"]
+    #[serde(rename="Definitions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub definitions: Option<Vec<DefinitionInformation>>,
     #[doc="The token for the next set of results, or ''null'' if there are no additional results."]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeploymentsRequest {
     #[doc="The unique Id of the AWS Greengrass Group"]
     #[serde(rename="GroupId")]
@@ -1663,7 +1681,7 @@ pub struct ListDeploymentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeploymentsResponse {
     #[doc="Information on deployments"]
     #[serde(rename="Deployments")]
@@ -1675,7 +1693,7 @@ pub struct ListDeploymentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeviceDefinitionVersionsRequest {
     #[doc="device definition Id"]
     #[serde(rename="DeviceDefinitionId")]
@@ -1690,7 +1708,7 @@ pub struct ListDeviceDefinitionVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeviceDefinitionVersionsResponse {
     #[doc="The token for the next set of results, or ''null'' if there are no additional results."]
     #[serde(rename="NextToken")]
@@ -1702,7 +1720,7 @@ pub struct ListDeviceDefinitionVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeviceDefinitionsRequest {
     #[doc="Specifies the maximum number of list results to be returned in this page"]
     #[serde(rename="MaxResults")]
@@ -1714,7 +1732,7 @@ pub struct ListDeviceDefinitionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeviceDefinitionsResponse {
     #[doc="Definitions"]
     #[serde(rename="Definitions")]
@@ -1726,7 +1744,7 @@ pub struct ListDeviceDefinitionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFunctionDefinitionVersionsRequest {
     #[doc="the unique Id of the lambda definition"]
     #[serde(rename="FunctionDefinitionId")]
@@ -1741,7 +1759,7 @@ pub struct ListFunctionDefinitionVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFunctionDefinitionVersionsResponse {
     #[doc="The token for the next set of results, or ''null'' if there are no additional results."]
     #[serde(rename="NextToken")]
@@ -1753,7 +1771,7 @@ pub struct ListFunctionDefinitionVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFunctionDefinitionsRequest {
     #[doc="Specifies the maximum number of list results to be returned in this page"]
     #[serde(rename="MaxResults")]
@@ -1765,7 +1783,7 @@ pub struct ListFunctionDefinitionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFunctionDefinitionsResponse {
     #[doc="Definitions"]
     #[serde(rename="Definitions")]
@@ -1777,14 +1795,14 @@ pub struct ListFunctionDefinitionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupCertificateAuthoritiesRequest {
     #[doc="The unique Id of the AWS Greengrass Group"]
     #[serde(rename="GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupCertificateAuthoritiesResponse {
     #[doc="List of certificate authorities associated with the group."]
     #[serde(rename="GroupCertificateAuthorities")]
@@ -1792,7 +1810,7 @@ pub struct ListGroupCertificateAuthoritiesResponse {
     pub group_certificate_authorities: Option<Vec<GroupCertificateAuthorityProperties>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupVersionsRequest {
     #[doc="The unique Id of the AWS Greengrass Group"]
     #[serde(rename="GroupId")]
@@ -1807,7 +1825,7 @@ pub struct ListGroupVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupVersionsResponse {
     #[doc="The token for the next set of results, or ''null'' if there are no additional results."]
     #[serde(rename="NextToken")]
@@ -1819,7 +1837,7 @@ pub struct ListGroupVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupsRequest {
     #[doc="Specifies the maximum number of list results to be returned in this page"]
     #[serde(rename="MaxResults")]
@@ -1831,7 +1849,7 @@ pub struct ListGroupsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupsResponse {
     #[doc="Groups"]
     #[serde(rename="Groups")]
@@ -1843,7 +1861,7 @@ pub struct ListGroupsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLoggerDefinitionVersionsRequest {
     #[doc="logger definition Id"]
     #[serde(rename="LoggerDefinitionId")]
@@ -1858,7 +1876,7 @@ pub struct ListLoggerDefinitionVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLoggerDefinitionVersionsResponse {
     #[doc="The token for the next set of results, or ''null'' if there are no additional results."]
     #[serde(rename="NextToken")]
@@ -1870,7 +1888,7 @@ pub struct ListLoggerDefinitionVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLoggerDefinitionsRequest {
     #[doc="Specifies the maximum number of list results to be returned in this page"]
     #[serde(rename="MaxResults")]
@@ -1882,7 +1900,7 @@ pub struct ListLoggerDefinitionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLoggerDefinitionsResponse {
     #[doc="Definitions"]
     #[serde(rename="Definitions")]
@@ -1894,7 +1912,7 @@ pub struct ListLoggerDefinitionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSubscriptionDefinitionVersionsRequest {
     #[doc="Specifies the maximum number of list results to be returned in this page"]
     #[serde(rename="MaxResults")]
@@ -1909,7 +1927,7 @@ pub struct ListSubscriptionDefinitionVersionsRequest {
     pub subscription_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSubscriptionDefinitionVersionsResponse {
     #[doc="The token for the next set of results, or ''null'' if there are no additional results."]
     #[serde(rename="NextToken")]
@@ -1921,7 +1939,7 @@ pub struct ListSubscriptionDefinitionVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSubscriptionDefinitionsRequest {
     #[doc="Specifies the maximum number of list results to be returned in this page"]
     #[serde(rename="MaxResults")]
@@ -1933,7 +1951,7 @@ pub struct ListSubscriptionDefinitionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSubscriptionDefinitionsResponse {
     #[doc="Definitions"]
     #[serde(rename="Definitions")]
@@ -1946,11 +1964,15 @@ pub struct ListSubscriptionDefinitionsResponse {
 }
 
 #[doc="List of versions response"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVersionsResponse {
     #[doc="The token for the next set of results, or ''null'' if there are no additional results."]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="Versions"]
+    #[serde(rename="Versions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub versions: Option<Vec<VersionInformation>>,
 }
 
@@ -2019,7 +2041,7 @@ pub struct SubscriptionDefinitionVersion {
 }
 
 #[doc="connectivity info request"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateConnectivityInfoRequest {
     #[doc="Connectivity info array"]
     #[serde(rename="ConnectivityInfo")]
@@ -2030,7 +2052,7 @@ pub struct UpdateConnectivityInfoRequest {
     pub thing_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateConnectivityInfoResponse {
     #[doc="Response Text"]
     #[serde(rename="Message")]
@@ -2042,7 +2064,7 @@ pub struct UpdateConnectivityInfoResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateCoreDefinitionRequest {
     #[doc="core definition Id"]
     #[serde(rename="CoreDefinitionId")]
@@ -2053,10 +2075,10 @@ pub struct UpdateCoreDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateCoreDefinitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDeviceDefinitionRequest {
     #[doc="device definition Id"]
     #[serde(rename="DeviceDefinitionId")]
@@ -2067,10 +2089,10 @@ pub struct UpdateDeviceDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDeviceDefinitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFunctionDefinitionRequest {
     #[doc="the unique Id of the lambda definition"]
     #[serde(rename="FunctionDefinitionId")]
@@ -2081,10 +2103,10 @@ pub struct UpdateFunctionDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFunctionDefinitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGroupCertificateConfigurationRequest {
     #[doc="Amount of time when the certificate expires in milliseconds."]
     #[serde(rename="CertificateExpiryInMilliseconds")]
@@ -2095,7 +2117,7 @@ pub struct UpdateGroupCertificateConfigurationRequest {
     pub group_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGroupCertificateConfigurationResponse {
     #[doc="Amount of time when the certificate authority expires in milliseconds."]
     #[serde(rename="CertificateAuthorityExpiryInMilliseconds")]
@@ -2111,7 +2133,7 @@ pub struct UpdateGroupCertificateConfigurationResponse {
     pub group_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGroupRequest {
     #[doc="The unique Id of the AWS Greengrass Group"]
     #[serde(rename="GroupId")]
@@ -2122,10 +2144,10 @@ pub struct UpdateGroupRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGroupResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateLoggerDefinitionRequest {
     #[doc="logger definition Id"]
     #[serde(rename="LoggerDefinitionId")]
@@ -2136,10 +2158,10 @@ pub struct UpdateLoggerDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateLoggerDefinitionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSubscriptionDefinitionRequest {
     #[doc="name of the definition"]
     #[serde(rename="Name")]
@@ -2150,11 +2172,11 @@ pub struct UpdateSubscriptionDefinitionRequest {
     pub subscription_definition_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSubscriptionDefinitionResponse;
 
 #[doc="Information on the version"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VersionInformation {
     #[doc="Arn of the version."]
     #[serde(rename="Arn")]

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Information about an entity that is affected by a Health event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AffectedEntity {
     #[doc="<p>The 12-digit AWS account number that contains the affected entity.</p>"]
     #[serde(rename="awsAccountId")]
@@ -62,7 +62,7 @@ pub struct AffectedEntity {
 }
 
 #[doc="<p>A range of dates and times that is used by the <a>EventFilter</a> and <a>EntityFilter</a> objects. If <code>from</code> is set and <code>to</code> is set: match items where the timestamp (<code>startTime</code>, <code>endTime</code>, or <code>lastUpdatedTime</code>) is between <code>from</code> and <code>to</code> inclusive. If <code>from</code> is set and <code>to</code> is not set: match items where the timestamp value is equal to or after <code>from</code>. If <code>from</code> is not set and <code>to</code> is set: match items where the timestamp value is equal to or before <code>to</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DateTimeRange {
     #[doc="<p>The starting date and time of a time range.</p>"]
     #[serde(rename="from")]
@@ -74,7 +74,7 @@ pub struct DateTimeRange {
     pub to: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAffectedEntitiesRequest {
     #[doc="<p>Values to narrow the results returned. At least one event ARN is required. </p>"]
     #[serde(rename="filter")]
@@ -93,7 +93,7 @@ pub struct DescribeAffectedEntitiesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAffectedEntitiesResponse {
     #[doc="<p>The entities that match the filter criteria.</p>"]
     #[serde(rename="entities")]
@@ -105,7 +105,7 @@ pub struct DescribeAffectedEntitiesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEntityAggregatesRequest {
     #[doc="<p>A list of event ARNs (unique identifiers). For example: <code>\"arn:aws:health:us-east-1::event/AWS_EC2_MAINTENANCE_5331\", \"arn:aws:health:us-west-1::event/AWS_EBS_LOST_VOLUME_xyz\"</code> </p>"]
     #[serde(rename="eventArns")]
@@ -113,7 +113,7 @@ pub struct DescribeEntityAggregatesRequest {
     pub event_arns: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEntityAggregatesResponse {
     #[doc="<p>The number of entities that are affected by each of the specified events.</p>"]
     #[serde(rename="entityAggregates")]
@@ -121,7 +121,7 @@ pub struct DescribeEntityAggregatesResponse {
     pub entity_aggregates: Option<Vec<EntityAggregate>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventAggregatesRequest {
     #[doc="<p>The only currently supported value is <code>eventTypeCategory</code>.</p>"]
     #[serde(rename="aggregateField")]
@@ -140,7 +140,7 @@ pub struct DescribeEventAggregatesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventAggregatesResponse {
     #[doc="<p>The number of events in each category that meet the optional filter criteria.</p>"]
     #[serde(rename="eventAggregates")]
@@ -152,7 +152,7 @@ pub struct DescribeEventAggregatesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventDetailsRequest {
     #[doc="<p>A list of event ARNs (unique identifiers). For example: <code>\"arn:aws:health:us-east-1::event/AWS_EC2_MAINTENANCE_5331\", \"arn:aws:health:us-west-1::event/AWS_EBS_LOST_VOLUME_xyz\"</code> </p>"]
     #[serde(rename="eventArns")]
@@ -163,7 +163,7 @@ pub struct DescribeEventDetailsRequest {
     pub locale: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventDetailsResponse {
     #[doc="<p>Error messages for any events that could not be retrieved.</p>"]
     #[serde(rename="failedSet")]
@@ -175,7 +175,7 @@ pub struct DescribeEventDetailsResponse {
     pub successful_set: Option<Vec<EventDetails>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventTypesRequest {
     #[doc="<p>Values to narrow the results returned.</p>"]
     #[serde(rename="filter")]
@@ -195,7 +195,7 @@ pub struct DescribeEventTypesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventTypesResponse {
     #[doc="<p>A list of event types that match the filter criteria. Event types have a category (<code>issue</code>, <code>accountNotification</code>, or <code>scheduledChange</code>), a service (for example, <code>EC2</code>, <code>RDS</code>, <code>DATAPIPELINE</code>, <code>BILLING</code>), and a code (in the format <code>AWS_<i>SERVICE</i>_<i>DESCRIPTION</i> </code>; for example, <code>AWS_EC2_SYSTEM_MAINTENANCE_EVENT</code>).</p>"]
     #[serde(rename="eventTypes")]
@@ -207,7 +207,7 @@ pub struct DescribeEventTypesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsRequest {
     #[doc="<p>Values to narrow the results returned.</p>"]
     #[serde(rename="filter")]
@@ -227,7 +227,7 @@ pub struct DescribeEventsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsResponse {
     #[doc="<p>The events that match the specified filter criteria.</p>"]
     #[serde(rename="events")]
@@ -240,7 +240,7 @@ pub struct DescribeEventsResponse {
 }
 
 #[doc="<p>The number of entities that are affected by one or more events. Returned by the <a>DescribeEntityAggregates</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EntityAggregate {
     #[doc="<p>The number entities that match the criteria for the specified events.</p>"]
     #[serde(rename="count")]
@@ -253,7 +253,7 @@ pub struct EntityAggregate {
 }
 
 #[doc="<p>The values to use to filter results from the <a>DescribeAffectedEntities</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EntityFilter {
     #[doc="<p>A list of entity ARNs (unique identifiers).</p>"]
     #[serde(rename="entityArns")]
@@ -281,7 +281,7 @@ pub struct EntityFilter {
 }
 
 #[doc="<p>Summary information about an event, returned by the <a>DescribeEvents</a> operation. The <a>DescribeEventDetails</a> operation also returns this information, as well as the <a>EventDescription</a> and additional event metadata.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Event {
     #[doc="<p>The unique identifier for the event. Format: <code>arn:aws:health:<i>event-region</i>::event/<i>EVENT_TYPE_PLUS_ID</i> </code>. Example: <code>arn:aws:health:us-east-1::event/AWS_EC2_MAINTENANCE_5331</code> </p>"]
     #[serde(rename="arn")]
@@ -326,7 +326,7 @@ pub struct Event {
 }
 
 #[doc="<p>The number of events of each issue type. Returned by the <a>DescribeEventAggregates</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventAggregate {
     #[doc="<p>The issue type for the associated count.</p>"]
     #[serde(rename="aggregateValue")]
@@ -339,7 +339,7 @@ pub struct EventAggregate {
 }
 
 #[doc="<p>Detailed information about an event. A combination of an <a>Event</a> object, an <a>EventDescription</a> object, and additional metadata about the event. Returned by the <a>DescribeEventDetails</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventDetails {
     #[doc="<p>Summary information about the event.</p>"]
     #[serde(rename="event")]
@@ -356,7 +356,7 @@ pub struct EventDetails {
 }
 
 #[doc="<p>Error information returned when a <a>DescribeEventDetails</a> operation cannot find a specified event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventDetailsErrorItem {
     #[doc="<p>A message that describes the error.</p>"]
     #[serde(rename="errorMessage")]
@@ -373,7 +373,7 @@ pub struct EventDetailsErrorItem {
 }
 
 #[doc="<p>The values to use to filter results from the <a>DescribeEvents</a> and <a>DescribeEventAggregates</a> operations.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventFilter {
     #[doc="<p>A list of AWS availability zones.</p>"]
     #[serde(rename="availabilityZones")]
@@ -430,7 +430,7 @@ pub struct EventFilter {
 }
 
 #[doc="<p>The values to use to filter results from the <a>DescribeEventTypes</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventTypeFilter {
     #[doc="<p>A list of event type category codes (<code>issue</code>, <code>scheduledChange</code>, or <code>accountNotification</code>).</p>"]
     #[serde(rename="eventTypeCategories")]

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -40,17 +40,23 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>Contains information about an AWS access key.</p> <p> This data type is used as a response element in the <a>CreateAccessKey</a> and <a>ListAccessKeys</a> actions. </p> <note> <p>The <code>SecretAccessKey</code> value is returned only in response to <a>CreateAccessKey</a>. You can get a secret access key only when you first create an access key; you cannot recover the secret access key later. If you lose a secret access key, you must create a new access key.</p> </note>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccessKey {
     #[doc="<p>The ID for this access key.</p>"]
+    #[serde(rename="AccessKeyId")]
     pub access_key_id: String,
     #[doc="<p>The date when the access key was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>The secret key used to sign requests.</p>"]
+    #[serde(rename="SecretAccessKey")]
     pub secret_access_key: String,
     #[doc="<p>The status of the access key. <code>Active</code> means the key is valid for API calls, while <code>Inactive</code> means it is not. </p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The name of the IAM user that the access key is associated with.</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -128,13 +134,16 @@ impl AccessKeyIdTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about the last time an AWS access key was used.</p> <p>This data type is used as a response element in the <a>GetAccessKeyLastUsed</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccessKeyLastUsed {
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the access key was most recently used. This field is null when:</p> <ul> <li> <p>The user does not have an access key.</p> </li> <li> <p>An access key exists but has never been used, at least not since IAM started tracking this information on April 22nd, 2015.</p> </li> <li> <p>There is no sign-in data associated with the user</p> </li> </ul>"]
+    #[serde(rename="LastUsedDate")]
     pub last_used_date: String,
     #[doc="<p>The AWS region where this access key was most recently used. This field is displays \"N/A\" when:</p> <ul> <li> <p>The user does not have an access key.</p> </li> <li> <p>An access key exists but has never been used, at least not since IAM started tracking this information on April 22nd, 2015.</p> </li> <li> <p>There is no sign-in data associated with the user</p> </li> </ul> <p>For more information about AWS regions, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html\">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>"]
+    #[serde(rename="Region")]
     pub region: String,
     #[doc="<p>The name of the AWS service with which this access key was most recently used. This field displays \"N/A\" when:</p> <ul> <li> <p>The user does not have an access key.</p> </li> <li> <p>An access key exists but has never been used, at least not since IAM started tracking this information on April 22nd, 2015.</p> </li> <li> <p>There is no sign-in data associated with the user</p> </li> </ul>"]
+    #[serde(rename="ServiceName")]
     pub service_name: String,
 }
 
@@ -188,15 +197,23 @@ impl AccessKeyLastUsedDeserializer {
     }
 }
 #[doc="<p>Contains information about an AWS access key, without its secret key.</p> <p>This data type is used as a response element in the <a>ListAccessKeys</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccessKeyMetadata {
     #[doc="<p>The ID for this access key.</p>"]
+    #[serde(rename="AccessKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub access_key_id: Option<String>,
     #[doc="<p>The date when the access key was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>The status of the access key. <code>Active</code> means the key is valid for API calls; <code>Inactive</code> means it is not.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The name of the IAM user that the key is associated with.</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -392,11 +409,13 @@ impl ActionNameTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddClientIDToOpenIDConnectProviderRequest {
     #[doc="<p>The client ID (also known as audience) to add to the IAM OpenID Connect provider resource.</p>"]
+    #[serde(rename="ClientID")]
     pub client_id: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM OpenID Connect (OIDC) provider resource to add the client ID to. You can get a list of OIDC provider ARNs by using the <a>ListOpenIDConnectProviders</a> action.</p>"]
+    #[serde(rename="OpenIDConnectProviderArn")]
     pub open_id_connect_provider_arn: String,
 }
 
@@ -420,11 +439,13 @@ impl AddClientIDToOpenIDConnectProviderRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddRoleToInstanceProfileRequest {
     #[doc="<p>The name of the instance profile to update.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="InstanceProfileName")]
     pub instance_profile_name: String,
     #[doc="<p>The name of the role to add.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -446,11 +467,13 @@ impl AddRoleToInstanceProfileRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddUserToGroupRequest {
     #[doc="<p>The name of the group to update.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>The name of the user to add.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -486,11 +509,13 @@ impl ArnTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachGroupPolicyRequest {
     #[doc="<p>The name (friendly name, not ARN) of the group to attach the policy to.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy you want to attach.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
 }
 
@@ -512,11 +537,13 @@ impl AttachGroupPolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachRolePolicyRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy you want to attach.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
     #[doc="<p>The name (friendly name, not ARN) of the role to attach the policy to.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -538,11 +565,13 @@ impl AttachRolePolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachUserPolicyRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy you want to attach.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
     #[doc="<p>The name (friendly name, not ARN) of the IAM user to attach the policy to.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -606,10 +635,14 @@ impl AttachedPoliciesListTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about an attached policy.</p> <p>An attached policy is a managed policy that has been attached to a user, group, or role. This data type is used as a response element in the <a>ListAttachedGroupPolicies</a>, <a>ListAttachedRolePolicies</a>, <a>ListAttachedUserPolicies</a>, and <a>GetAccountAuthorizationDetails</a> actions. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachedPolicy {
+    #[serde(rename="PolicyArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_arn: Option<String>,
     #[doc="<p>The friendly name of the attached policy.</p>"]
+    #[serde(rename="PolicyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_name: Option<String>,
 }
 
@@ -800,11 +833,13 @@ impl CertificateListTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChangePasswordRequest {
     #[doc="<p>The new password. The new password must conform to the AWS account's password policy, if one exists.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of almost any printable ASCII character from the space (\\u0020) through the end of the ASCII character range (\\u00FF). You can also include the tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D) characters. Although any of these characters are valid in a password, note that many tools, such as the AWS Management Console, might restrict the ability to enter certain characters because they have special meaning within that tool.</p>"]
+    #[serde(rename="NewPassword")]
     pub new_password: String,
     #[doc="<p>The IAM user's current password.</p>"]
+    #[serde(rename="OldPassword")]
     pub old_password: String,
 }
 
@@ -908,13 +943,19 @@ impl ColumnNumberDeserializer {
     }
 }
 #[doc="<p>Contains information about a condition context key. It includes the name of the key and specifies the value (or values, if the context key supports multiple values) to use in the simulation. This information is used when evaluating the <code>Condition</code> elements of the input policies.</p> <p>This data type is used as an input parameter to <code> <a>SimulateCustomPolicy</a> </code> and <code> <a>SimulateCustomPolicy</a> </code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ContextEntry {
     #[doc="<p>The full name of a condition context key, including the service prefix. For example, <code>aws:SourceIp</code> or <code>s3:VersionId</code>.</p>"]
+    #[serde(rename="ContextKeyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub context_key_name: Option<String>,
     #[doc="<p>The data type of the value (or values) specified in the <code>ContextKeyValues</code> parameter.</p>"]
+    #[serde(rename="ContextKeyType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub context_key_type: Option<String>,
     #[doc="<p>The value (or values, if the condition context key supports multiple values) to provide to the simulation for use when the key is referenced by a <code>Condition</code> element in an input policy.</p>"]
+    #[serde(rename="ContextKeyValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub context_key_values: Option<Vec<String>>,
 }
 
@@ -1027,9 +1068,11 @@ impl ContextKeyValueListTypeSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAccessKeyRequest {
     #[doc="<p>The name of the IAM user that the new key will belong to.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -1052,9 +1095,10 @@ impl CreateAccessKeyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>CreateAccessKey</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAccessKeyResponse {
     #[doc="<p>A structure with details about the access key.</p>"]
+    #[serde(rename="AccessKey")]
     pub access_key: AccessKey,
 }
 
@@ -1100,9 +1144,10 @@ impl CreateAccessKeyResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAccountAliasRequest {
     #[doc="<p>The account alias to create.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of lowercase letters, digits, and dashes. You cannot start or finish with a dash, nor can you have two dashes in a row.</p>"]
+    #[serde(rename="AccountAlias")]
     pub account_alias: String,
 }
 
@@ -1122,11 +1167,14 @@ impl CreateAccountAliasRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGroupRequest {
     #[doc="<p>The name of the group to create. Do not include the path in this value.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-. The group name must be unique within the account. Group names are not distinguished by case. For example, you cannot create groups named both \"ADMINS\" and \"admins\".</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p> The path to the group. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
 }
 
@@ -1151,9 +1199,10 @@ impl CreateGroupRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>CreateGroup</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGroupResponse {
     #[doc="<p>A structure containing details about the new group.</p>"]
+    #[serde(rename="Group")]
     pub group: Group,
 }
 
@@ -1198,11 +1247,14 @@ impl CreateGroupResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstanceProfileRequest {
     #[doc="<p>The name of the instance profile to create.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="InstanceProfileName")]
     pub instance_profile_name: String,
     #[doc="<p> The path to the instance profile. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
 }
 
@@ -1227,9 +1279,10 @@ impl CreateInstanceProfileRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>CreateInstanceProfile</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstanceProfileResponse {
     #[doc="<p>A structure containing details about the new instance profile.</p>"]
+    #[serde(rename="InstanceProfile")]
     pub instance_profile: InstanceProfile,
 }
 
@@ -1276,13 +1329,17 @@ impl CreateInstanceProfileResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoginProfileRequest {
     #[doc="<p>The new password for the user.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of almost any printable ASCII character from the space (\\u0020) through the end of the ASCII character range (\\u00FF). You can also include the tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D) characters. Although any of these characters are valid in a password, note that many tools, such as the AWS Management Console, might restrict the ability to enter certain characters because they have special meaning within that tool.</p>"]
+    #[serde(rename="Password")]
     pub password: String,
     #[doc="<p>Specifies whether the user is required to set a new password on next sign-in.</p>"]
+    #[serde(rename="PasswordResetRequired")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password_reset_required: Option<bool>,
     #[doc="<p>The name of the IAM user to create a password for. The user must already exist.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -1309,9 +1366,10 @@ impl CreateLoginProfileRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>CreateLoginProfile</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLoginProfileResponse {
     #[doc="<p>A structure containing the user name and password create date.</p>"]
+    #[serde(rename="LoginProfile")]
     pub login_profile: LoginProfile,
 }
 
@@ -1357,13 +1415,17 @@ impl CreateLoginProfileResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateOpenIDConnectProviderRequest {
     #[doc="<p>A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the <code>client_id</code> parameter on OAuth requests.)</p> <p>You can register multiple client IDs with the same provider. For example, you might have multiple applications that use the same OIDC provider. You cannot register more than 100 client IDs with a single IAM OIDC provider.</p> <p>There is no defined format for a client ID. The <code>CreateOpenIDConnectProviderRequest</code> action accepts client IDs up to 255 characters long.</p>"]
+    #[serde(rename="ClientIDList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_id_list: Option<Vec<String>>,
     #[doc="<p>A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s). Typically this list includes only one entry. However, IAM lets you have up to five thumbprints for an OIDC provider. This lets you maintain multiple thumbprints if the identity provider is rotating certificates.</p> <p>The server certificate thumbprint is the hex-encoded SHA-1 hash value of the X.509 certificate used by the domain where the OpenID Connect provider makes its keys available. It is always a 40-character string.</p> <p>You must provide at least one thumbprint when creating an IAM OIDC provider. For example, if the OIDC provider is <code>server.example.com</code> and the provider stores its keys at \"https://keys.server.example.com/openid-connect\", the thumbprint string would be the hex-encoded SHA-1 hash value of the certificate used by https://keys.server.example.com.</p> <p>For more information about obtaining the OIDC provider's thumbprint, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/identity-providers-oidc-obtain-thumbprint.html\">Obtaining the Thumbprint for an OpenID Connect Provider</a> in the <i>IAM User Guide</i>.</p>"]
+    #[serde(rename="ThumbprintList")]
     pub thumbprint_list: Vec<String>,
     #[doc="<p>The URL of the identity provider. The URL must begin with \"https://\" and should correspond to the <code>iss</code> claim in the provider's OpenID Connect ID tokens. Per the OIDC standard, path components are allowed but query parameters are not. Typically the URL consists of only a host name, like \"https://server.example.org\" or \"https://example.com\".</p> <p>You cannot register the same provider multiple times in a single AWS account. If you try to submit a URL that has already been used for an OpenID Connect provider in the AWS account, you will get an error.</p>"]
+    #[serde(rename="Url")]
     pub url: String,
 }
 
@@ -1392,9 +1454,11 @@ impl CreateOpenIDConnectProviderRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>CreateOpenIDConnectProvider</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateOpenIDConnectProviderResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the new IAM OpenID Connect provider that is created. For more information, see <a>OpenIDConnectProviderListEntry</a>. </p>"]
+    #[serde(rename="OpenIDConnectProviderArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub open_id_connect_provider_arn: Option<String>,
 }
 
@@ -1442,15 +1506,21 @@ impl CreateOpenIDConnectProviderResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePolicyRequest {
     #[doc="<p>A friendly description of the policy.</p> <p>Typically used to store information about the permissions defined in the policy. For example, \"Grants access to production DynamoDB tables.\"</p> <p>The policy description is immutable. After a value is assigned, it cannot be changed.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The path for the policy.</p> <p>For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
     #[doc="<p>The JSON policy document that you want to use as the content for the new policy.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="PolicyDocument")]
     pub policy_document: String,
     #[doc="<p>The friendly name of the policy.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -1481,9 +1551,11 @@ impl CreatePolicyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>CreatePolicy</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePolicyResponse {
     #[doc="<p>A structure containing details about the new policy.</p>"]
+    #[serde(rename="Policy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy: Option<Policy>,
 }
 
@@ -1529,13 +1601,17 @@ impl CreatePolicyResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePolicyVersionRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy to which you want to add a new version.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
     #[doc="<p>The JSON policy document that you want to use as the content for this new version of the policy.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="PolicyDocument")]
     pub policy_document: String,
     #[doc="<p>Specifies whether to set this version as the policy's default version.</p> <p>When this parameter is <code>true</code>, the new policy version becomes the operative version; that is, the version that is in effect for the IAM users, groups, and roles that the policy is attached to.</p> <p>For more information about managed policy versions, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for Managed Policies</a> in the <i>IAM User Guide</i>.</p>"]
+    #[serde(rename="SetAsDefault")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub set_as_default: Option<bool>,
 }
 
@@ -1562,9 +1638,11 @@ impl CreatePolicyVersionRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>CreatePolicyVersion</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePolicyVersionResponse {
     #[doc="<p>A structure containing details about the new policy version.</p>"]
+    #[serde(rename="PolicyVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_version: Option<PolicyVersion>,
 }
 
@@ -1611,15 +1689,21 @@ impl CreatePolicyVersionResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRoleRequest {
     #[doc="<p>The trust relationship policy document that grants an entity permission to assume the role.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="AssumeRolePolicyDocument")]
     pub assume_role_policy_document: String,
     #[doc="<p>A customer-provided description of the role.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p> The path to the role. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
     #[doc="<p>The name of the role to create.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p> <p>Role names are not distinguished by case. For example, you cannot create roles named both \"PRODROLE\" and \"prodrole\".</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -1650,9 +1734,10 @@ impl CreateRoleRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>CreateRole</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRoleResponse {
     #[doc="<p>A structure containing details about the new role.</p>"]
+    #[serde(rename="Role")]
     pub role: Role,
 }
 
@@ -1697,11 +1782,13 @@ impl CreateRoleResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSAMLProviderRequest {
     #[doc="<p>The name of the provider to create.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>An XML document generated by an identity provider (IdP) that supports SAML 2.0. The document includes the issuer's name, expiration information, and keys that can be used to validate the SAML authentication response (assertions) that are received from the IdP. You must generate the metadata document using the identity management software that is used as your organization's IdP.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html\">About SAML 2.0-based Federation</a> in the <i>IAM User Guide</i> </p>"]
+    #[serde(rename="SAMLMetadataDocument")]
     pub saml_metadata_document: String,
 }
 
@@ -1724,9 +1811,11 @@ impl CreateSAMLProviderRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>CreateSAMLProvider</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSAMLProviderResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the new SAML provider resource in IAM.</p>"]
+    #[serde(rename="SAMLProviderArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub saml_provider_arn: Option<String>,
 }
 
@@ -1773,13 +1862,18 @@ impl CreateSAMLProviderResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateServiceLinkedRoleRequest {
     #[doc="<p>The AWS service to which this role is attached. You use a string similar to a URL but without the http:// in front. For example: <code>elasticbeanstalk.amazonaws.com</code> </p>"]
+    #[serde(rename="AWSServiceName")]
     pub aws_service_name: String,
     #[doc="<p>A string that you provide, which is combined with the service name to form the complete role name. If you make multiple requests for the same service, then you must supply a different <code>CustomSuffix</code> for each request. Otherwise the request fails with a duplicate role name error. For example, you could add <code>-1</code> or <code>-debug</code> to the suffix.</p>"]
+    #[serde(rename="CustomSuffix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub custom_suffix: Option<String>,
     #[doc="<p>The description of the role.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
 }
 
@@ -1807,9 +1901,11 @@ impl CreateServiceLinkedRoleRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateServiceLinkedRoleResponse {
     #[doc="<p>A <a>Role</a> object that contains details about the newly created role.</p>"]
+    #[serde(rename="Role")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role: Option<Role>,
 }
 
@@ -1855,11 +1951,13 @@ impl CreateServiceLinkedRoleResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateServiceSpecificCredentialRequest {
     #[doc="<p>The name of the AWS service that is to be associated with the credentials. The service you specify here is the only service that can be accessed using these credentials.</p>"]
+    #[serde(rename="ServiceName")]
     pub service_name: String,
     #[doc="<p>The name of the IAM user that is to be associated with the credentials. The new service-specific credentials have the same permissions as the associated user except that they can be used only to access the specified service.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -1881,9 +1979,11 @@ impl CreateServiceSpecificCredentialRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateServiceSpecificCredentialResponse {
     #[doc="<p>A structure that contains information about the newly created service-specific credential.</p> <important> <p>This is the only time that the password for this credential set is available. It cannot be recovered later. Instead, you will have to reset the password with <a>ResetServiceSpecificCredential</a>.</p> </important>"]
+    #[serde(rename="ServiceSpecificCredential")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub service_specific_credential: Option<ServiceSpecificCredential>,
 }
 
@@ -1929,11 +2029,14 @@ impl CreateServiceSpecificCredentialResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserRequest {
     #[doc="<p> The path for the user name. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
     #[doc="<p>The name of the user to create.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-. User names are not distinguished by case. For example, you cannot create users named both \"TESTUSER\" and \"testuser\".</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -1958,9 +2061,11 @@ impl CreateUserRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>CreateUser</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserResponse {
     #[doc="<p>A structure with details about the new IAM user.</p>"]
+    #[serde(rename="User")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user: Option<User>,
 }
 
@@ -2005,11 +2110,14 @@ impl CreateUserResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVirtualMFADeviceRequest {
     #[doc="<p> The path for the virtual MFA device. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
     #[doc="<p>The name of the virtual MFA device. Use with path to uniquely identify a virtual MFA device.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="VirtualMFADeviceName")]
     pub virtual_mfa_device_name: String,
 }
 
@@ -2034,9 +2142,10 @@ impl CreateVirtualMFADeviceRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>CreateVirtualMFADevice</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateVirtualMFADeviceResponse {
     #[doc="<p>A structure containing details about the new virtual MFA device.</p>"]
+    #[serde(rename="VirtualMFADevice")]
     pub virtual_mfa_device: VirtualMFADevice,
 }
 
@@ -2097,11 +2206,13 @@ impl DateTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeactivateMFADeviceRequest {
     #[doc="<p>The serial number that uniquely identifies the MFA device. For virtual MFA devices, the serial number is the device ARN.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@:/-</p>"]
+    #[serde(rename="SerialNumber")]
     pub serial_number: String,
     #[doc="<p>The name of the user whose MFA device you want to deactivate.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -2123,11 +2234,14 @@ impl DeactivateMFADeviceRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAccessKeyRequest {
     #[doc="<p>The access key ID for the access key ID and secret access key you want to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>"]
+    #[serde(rename="AccessKeyId")]
     pub access_key_id: String,
     #[doc="<p>The name of the user whose access key pair you want to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -2151,9 +2265,10 @@ impl DeleteAccessKeyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAccountAliasRequest {
     #[doc="<p>The name of the account alias to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of lowercase letters, digits, and dashes. You cannot start or finish with a dash, nor can you have two dashes in a row.</p>"]
+    #[serde(rename="AccountAlias")]
     pub account_alias: String,
 }
 
@@ -2173,11 +2288,13 @@ impl DeleteAccountAliasRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteGroupPolicyRequest {
     #[doc="<p>The name (friendly name, not ARN) identifying the group that the policy is embedded in.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>The name identifying the policy document to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -2199,9 +2316,10 @@ impl DeleteGroupPolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteGroupRequest {
     #[doc="<p>The name of the IAM group to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
 }
 
@@ -2221,9 +2339,10 @@ impl DeleteGroupRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteInstanceProfileRequest {
     #[doc="<p>The name of the instance profile to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="InstanceProfileName")]
     pub instance_profile_name: String,
 }
 
@@ -2243,9 +2362,10 @@ impl DeleteInstanceProfileRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLoginProfileRequest {
     #[doc="<p>The name of the user whose password you want to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -2265,9 +2385,10 @@ impl DeleteLoginProfileRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteOpenIDConnectProviderRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM OpenID Connect provider resource object to delete. You can get a list of OpenID Connect provider resource ARNs by using the <a>ListOpenIDConnectProviders</a> action.</p>"]
+    #[serde(rename="OpenIDConnectProviderArn")]
     pub open_id_connect_provider_arn: String,
 }
 
@@ -2287,9 +2408,10 @@ impl DeleteOpenIDConnectProviderRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePolicyRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy you want to delete.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
 }
 
@@ -2309,11 +2431,13 @@ impl DeletePolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePolicyVersionRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy from which you want to delete a version.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
     #[doc="<p>The policy version to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that consists of the lowercase letter 'v' followed by one or two digits, and optionally followed by a period '.' and a string of letters and digits.</p> <p>For more information about managed policy versions, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for Managed Policies</a> in the <i>IAM User Guide</i>.</p>"]
+    #[serde(rename="VersionId")]
     pub version_id: String,
 }
 
@@ -2335,11 +2459,13 @@ impl DeletePolicyVersionRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRolePolicyRequest {
     #[doc="<p>The name of the inline policy to delete from the specified IAM role.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
     #[doc="<p>The name (friendly name, not ARN) identifying the role that the policy is embedded in.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -2361,9 +2487,10 @@ impl DeleteRolePolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRoleRequest {
     #[doc="<p>The name of the role to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -2383,9 +2510,10 @@ impl DeleteRoleRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSAMLProviderRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the SAML provider to delete.</p>"]
+    #[serde(rename="SAMLProviderArn")]
     pub saml_provider_arn: String,
 }
 
@@ -2405,11 +2533,13 @@ impl DeleteSAMLProviderRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSSHPublicKeyRequest {
     #[doc="<p>The unique identifier for the SSH public key.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>"]
+    #[serde(rename="SSHPublicKeyId")]
     pub ssh_public_key_id: String,
     #[doc="<p>The name of the IAM user associated with the SSH public key.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -2431,9 +2561,10 @@ impl DeleteSSHPublicKeyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteServerCertificateRequest {
     #[doc="<p>The name of the server certificate you want to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="ServerCertificateName")]
     pub server_certificate_name: String,
 }
 
@@ -2453,11 +2584,14 @@ impl DeleteServerCertificateRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteServiceSpecificCredentialRequest {
     #[doc="<p>The unique identifier of the service-specific credential. You can get this value by calling <a>ListServiceSpecificCredentials</a>.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>"]
+    #[serde(rename="ServiceSpecificCredentialId")]
     pub service_specific_credential_id: String,
     #[doc="<p>The name of the IAM user associated with the service-specific credential. If this value is not specified, then the operation assumes the user whose credentials are used to call the operation.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -2481,11 +2615,14 @@ impl DeleteServiceSpecificCredentialRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSigningCertificateRequest {
     #[doc="<p>The ID of the signing certificate to delete.</p> <p>The format of this parameter, as described by its <a href=\"http://wikipedia.org/wiki/regex\">regex</a> pattern, is a string of characters that can be upper- or lower-cased letters or digits.</p>"]
+    #[serde(rename="CertificateId")]
     pub certificate_id: String,
     #[doc="<p>The name of the user the signing certificate belongs to.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -2509,11 +2646,13 @@ impl DeleteSigningCertificateRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserPolicyRequest {
     #[doc="<p>The name identifying the policy document to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
     #[doc="<p>The name (friendly name, not ARN) identifying the user that the policy is embedded in.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -2535,9 +2674,10 @@ impl DeleteUserPolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserRequest {
     #[doc="<p>The name of the user to delete.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -2557,9 +2697,10 @@ impl DeleteUserRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVirtualMFADeviceRequest {
     #[doc="<p>The serial number that uniquely identifies the MFA device. For virtual MFA devices, the serial number is the same as the ARN.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@:/-</p>"]
+    #[serde(rename="SerialNumber")]
     pub serial_number: String,
 }
 
@@ -2579,11 +2720,13 @@ impl DeleteVirtualMFADeviceRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachGroupPolicyRequest {
     #[doc="<p>The name (friendly name, not ARN) of the IAM group to detach the policy from.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy you want to detach.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
 }
 
@@ -2605,11 +2748,13 @@ impl DetachGroupPolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachRolePolicyRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy you want to detach.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
     #[doc="<p>The name (friendly name, not ARN) of the IAM role to detach the policy from.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -2631,11 +2776,13 @@ impl DetachRolePolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachUserPolicyRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy you want to detach.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
     #[doc="<p>The name (friendly name, not ARN) of the IAM user to detach the policy from.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -2657,15 +2804,19 @@ impl DetachUserPolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableMFADeviceRequest {
     #[doc="<p>An authentication code emitted by the device. </p> <p>The format for this parameter is a string of 6 digits.</p> <important> <p>Submit your request immediately after generating the authentication codes. If you generate the codes and then wait too long to submit the request, the MFA device successfully associates with the user but the MFA device becomes out of sync. This happens because time-based one-time passwords (TOTP) expire after a short period of time. If this happens, you can <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_sync.html\">resync the device</a>.</p> </important>"]
+    #[serde(rename="AuthenticationCode1")]
     pub authentication_code_1: String,
     #[doc="<p>A subsequent authentication code emitted by the device.</p> <p>The format for this parameter is a string of 6 digits.</p> <important> <p>Submit your request immediately after generating the authentication codes. If you generate the codes and then wait too long to submit the request, the MFA device successfully associates with the user but the MFA device becomes out of sync. This happens because time-based one-time passwords (TOTP) expire after a short period of time. If this happens, you can <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_sync.html\">resync the device</a>.</p> </important>"]
+    #[serde(rename="AuthenticationCode2")]
     pub authentication_code_2: String,
     #[doc="<p>The serial number that uniquely identifies the MFA device. For virtual MFA devices, the serial number is the device ARN.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@:/-</p>"]
+    #[serde(rename="SerialNumber")]
     pub serial_number: String,
     #[doc="<p>The name of the IAM user for whom you want to enable the MFA device.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -2742,23 +2893,37 @@ impl EvalDecisionSourceTypeDeserializer {
     }
 }
 #[doc="<p>Contains the results of a simulation.</p> <p>This data type is used by the return parameter of <code> <a>SimulateCustomPolicy</a> </code> and <code> <a>SimulatePrincipalPolicy</a> </code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EvaluationResult {
     #[doc="<p>The name of the API action tested on the indicated resource.</p>"]
+    #[serde(rename="EvalActionName")]
     pub eval_action_name: String,
     #[doc="<p>The result of the simulation.</p>"]
+    #[serde(rename="EvalDecision")]
     pub eval_decision: String,
     #[doc="<p>Additional details about the results of the evaluation decision. When there are both IAM policies and resource policies, this parameter explains how each set of policies contributes to the final evaluation decision. When simulating cross-account access to a resource, both the resource-based policy and the caller's IAM policy must grant access. See <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_compare-resource-policies.html\">How IAM Roles Differ from Resource-based Policies</a> </p>"]
+    #[serde(rename="EvalDecisionDetails")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub eval_decision_details: Option<::std::collections::HashMap<String, String>>,
     #[doc="<p>The ARN of the resource that the indicated API action was tested on.</p>"]
+    #[serde(rename="EvalResourceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub eval_resource_name: Option<String>,
     #[doc="<p>A list of the statements in the input policies that determine the result for this scenario. Remember that even if multiple statements allow the action on the resource, if only one statement denies that action, then the explicit deny overrides any allow, and the deny statement is the only entry included in the result.</p>"]
+    #[serde(rename="MatchedStatements")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub matched_statements: Option<Vec<Statement>>,
     #[doc="<p>A list of context keys that are required by the included input policies but that were not provided by one of the input parameters. This list is used when the resource in a simulation is \"*\", either explicitly, or when the <code>ResourceArns</code> parameter blank. If you include a list of resources, then any missing context values are instead included under the <code>ResourceSpecificResults</code> section. To discover the context keys used by a set of policies, you can call <a>GetContextKeysForCustomPolicy</a> or <a>GetContextKeysForPrincipalPolicy</a>.</p>"]
+    #[serde(rename="MissingContextValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub missing_context_values: Option<Vec<String>>,
     #[doc="<p>A structure that details how AWS Organizations and its service control policies affect the results of the simulation. Only applies if the simulated user's account is part of an organization.</p>"]
+    #[serde(rename="OrganizationsDecisionDetail")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub organizations_decision_detail: Option<OrganizationsDecisionDetail>,
     #[doc="<p>The individual results of the simulation of the API action specified in EvalActionName on each resource.</p>"]
+    #[serde(rename="ResourceSpecificResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_specific_results: Option<Vec<ResourceSpecificResult>>,
 }
 
@@ -2890,11 +3055,15 @@ impl ExistingUserNameTypeDeserializer {
     }
 }
 #[doc="<p>Contains the response to a successful <a>GenerateCredentialReport</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenerateCredentialReportResponse {
     #[doc="<p>Information about the credential report.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Information about the state of the credential report.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -2944,9 +3113,10 @@ impl GenerateCredentialReportResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccessKeyLastUsedRequest {
     #[doc="<p>The identifier of an access key.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>"]
+    #[serde(rename="AccessKeyId")]
     pub access_key_id: String,
 }
 
@@ -2967,11 +3137,15 @@ impl GetAccessKeyLastUsedRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetAccessKeyLastUsed</a> request. It is also returned as a member of the <a>AccessKeyMetaData</a> structure returned by the <a>ListAccessKeys</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccessKeyLastUsedResponse {
     #[doc="<p>Contains information about the last time the access key was used.</p>"]
+    #[serde(rename="AccessKeyLastUsed")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub access_key_last_used: Option<AccessKeyLastUsed>,
     #[doc="<p>The name of the AWS IAM user that owns this access key.</p> <p/>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -3023,13 +3197,19 @@ impl GetAccessKeyLastUsedResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccountAuthorizationDetailsRequest {
     #[doc="<p>A list of entity types used to filter the results. Only the entities that match the types you specify are included in the output. Use the value <code>LocalManagedPolicy</code> to include customer managed policies.</p> <p>The format for this parameter is a comma-separated (if more than one) list of strings. Each string value in the list must be one of the valid values listed below.</p>"]
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<Vec<String>>,
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
 }
 
@@ -3061,19 +3241,31 @@ impl GetAccountAuthorizationDetailsRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetAccountAuthorizationDetails</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccountAuthorizationDetailsResponse {
     #[doc="<p>A list containing information about IAM groups.</p>"]
+    #[serde(rename="GroupDetailList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_detail_list: Option<Vec<GroupDetail>>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list containing information about managed policies.</p>"]
+    #[serde(rename="Policies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policies: Option<Vec<ManagedPolicyDetail>>,
     #[doc="<p>A list containing information about IAM roles.</p>"]
+    #[serde(rename="RoleDetailList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_detail_list: Option<Vec<RoleDetail>>,
     #[doc="<p>A list containing information about IAM users.</p>"]
+    #[serde(rename="UserDetailList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_detail_list: Option<Vec<UserDetail>>,
 }
 
@@ -3144,9 +3336,10 @@ impl GetAccountAuthorizationDetailsResponseDeserializer {
     }
 }
 #[doc="<p>Contains the response to a successful <a>GetAccountPasswordPolicy</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccountPasswordPolicyResponse {
     #[doc="<p>A structure that contains details about the account's password policy.</p>"]
+    #[serde(rename="PasswordPolicy")]
     pub password_policy: PasswordPolicy,
 }
 
@@ -3195,9 +3388,11 @@ impl GetAccountPasswordPolicyResponseDeserializer {
     }
 }
 #[doc="<p>Contains the response to a successful <a>GetAccountSummary</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccountSummaryResponse {
     #[doc="<p>A set of key value pairs containing information about IAM entity usage and IAM quotas.</p>"]
+    #[serde(rename="SummaryMap")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub summary_map: Option<::std::collections::HashMap<String, i64>>,
 }
 
@@ -3244,9 +3439,10 @@ impl GetAccountSummaryResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetContextKeysForCustomPolicyRequest {
     #[doc="<p>A list of policies for which you want the list of context keys referenced in those policies. Each document is specified as a string containing the complete, valid JSON text of an IAM policy.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="PolicyInputList")]
     pub policy_input_list: Vec<String>,
 }
 
@@ -3268,9 +3464,11 @@ impl GetContextKeysForCustomPolicyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetContextKeysForPrincipalPolicy</a> or <a>GetContextKeysForCustomPolicy</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetContextKeysForPolicyResponse {
     #[doc="<p>The list of context keys that are referenced in the input policies.</p>"]
+    #[serde(rename="ContextKeyNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub context_key_names: Option<Vec<String>>,
 }
 
@@ -3316,11 +3514,14 @@ impl GetContextKeysForPolicyResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetContextKeysForPrincipalPolicyRequest {
     #[doc="<p>An optional list of additional policies for which you want the list of context keys that are referenced.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="PolicyInputList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_input_list: Option<Vec<String>>,
     #[doc="<p>The ARN of a user, group, or role whose policies contain the context keys that you want listed. If you specify a user, the list includes context keys that are found in all policies attached to the user as well as to all groups that the user is a member of. If you pick a group or a role, then it includes only those context keys that are found in policies attached to that entity. Note that all parameters are shown in unencoded form here for clarity, but must be URL encoded to be included as a part of a real HTML request.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicySourceArn")]
     pub policy_source_arn: String,
 }
 
@@ -3348,13 +3549,23 @@ impl GetContextKeysForPrincipalPolicyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetCredentialReport</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCredentialReportResponse {
     #[doc="<p>Contains the credential report. The report is Base64-encoded.</p>"]
+    #[serde(rename="Content")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub content: Option<Vec<u8>>,
     #[doc="<p> The date and time when the credential report was created, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>.</p>"]
+    #[serde(rename="GeneratedTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub generated_time: Option<String>,
     #[doc="<p>The format (MIME type) of the credential report.</p>"]
+    #[serde(rename="ReportFormat")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub report_format: Option<String>,
 }
 
@@ -3411,11 +3622,13 @@ impl GetCredentialReportResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupPolicyRequest {
     #[doc="<p>The name of the group the policy is associated with.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>The name of the policy document to get.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -3438,13 +3651,16 @@ impl GetGroupPolicyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetGroupPolicy</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupPolicyResponse {
     #[doc="<p>The group the policy is associated with.</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>The policy document.</p>"]
+    #[serde(rename="PolicyDocument")]
     pub policy_document: String,
     #[doc="<p>The name of the policy.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -3499,13 +3715,18 @@ impl GetGroupPolicyResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupRequest {
     #[doc="<p>The name of the group.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
 }
 
@@ -3534,15 +3755,21 @@ impl GetGroupRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetGroup</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetGroupResponse {
     #[doc="<p>A structure that contains details about the group.</p>"]
+    #[serde(rename="Group")]
     pub group: Group,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of users in the group.</p>"]
+    #[serde(rename="Users")]
     pub users: Vec<User>,
 }
 
@@ -3599,9 +3826,10 @@ impl GetGroupResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceProfileRequest {
     #[doc="<p>The name of the instance profile to get information about.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="InstanceProfileName")]
     pub instance_profile_name: String,
 }
 
@@ -3622,9 +3850,10 @@ impl GetInstanceProfileRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetInstanceProfile</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceProfileResponse {
     #[doc="<p>A structure containing details about the instance profile.</p>"]
+    #[serde(rename="InstanceProfile")]
     pub instance_profile: InstanceProfile,
 }
 
@@ -3671,9 +3900,10 @@ impl GetInstanceProfileResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLoginProfileRequest {
     #[doc="<p>The name of the user whose login profile you want to retrieve.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -3694,9 +3924,10 @@ impl GetLoginProfileRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetLoginProfile</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLoginProfileResponse {
     #[doc="<p>A structure containing the user name and password create date for the user.</p>"]
+    #[serde(rename="LoginProfile")]
     pub login_profile: LoginProfile,
 }
 
@@ -3742,9 +3973,10 @@ impl GetLoginProfileResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOpenIDConnectProviderRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the OIDC provider resource object in IAM to get information for. You can get a list of OIDC provider resource ARNs by using the <a>ListOpenIDConnectProviders</a> action.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="OpenIDConnectProviderArn")]
     pub open_id_connect_provider_arn: String,
 }
 
@@ -3765,15 +3997,23 @@ impl GetOpenIDConnectProviderRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetOpenIDConnectProvider</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOpenIDConnectProviderResponse {
     #[doc="<p>A list of client IDs (also known as audiences) that are associated with the specified IAM OIDC provider resource object. For more information, see <a>CreateOpenIDConnectProvider</a>.</p>"]
+    #[serde(rename="ClientIDList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub client_id_list: Option<Vec<String>>,
     #[doc="<p>The date and time when the IAM OIDC provider resource object was created in the AWS account.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>A list of certificate thumbprints that are associated with the specified IAM OIDC provider resource object. For more information, see <a>CreateOpenIDConnectProvider</a>. </p>"]
+    #[serde(rename="ThumbprintList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub thumbprint_list: Option<Vec<String>>,
     #[doc="<p>The URL that the IAM OIDC provider resource object is associated with. For more information, see <a>CreateOpenIDConnectProvider</a>.</p>"]
+    #[serde(rename="Url")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
 }
 
@@ -3833,9 +4073,10 @@ impl GetOpenIDConnectProviderResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPolicyRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the managed policy that you want information about.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
 }
 
@@ -3856,9 +4097,11 @@ impl GetPolicyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetPolicy</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPolicyResponse {
     #[doc="<p>A structure containing details about the policy.</p>"]
+    #[serde(rename="Policy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy: Option<Policy>,
 }
 
@@ -3904,11 +4147,13 @@ impl GetPolicyResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPolicyVersionRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the managed policy that you want information about.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
     #[doc="<p>Identifies the policy version to retrieve.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that consists of the lowercase letter 'v' followed by one or two digits, and optionally followed by a period '.' and a string of letters and digits.</p>"]
+    #[serde(rename="VersionId")]
     pub version_id: String,
 }
 
@@ -3931,9 +4176,11 @@ impl GetPolicyVersionRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetPolicyVersion</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPolicyVersionResponse {
     #[doc="<p>A structure containing details about the policy version.</p>"]
+    #[serde(rename="PolicyVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_version: Option<PolicyVersion>,
 }
 
@@ -3980,11 +4227,13 @@ impl GetPolicyVersionResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRolePolicyRequest {
     #[doc="<p>The name of the policy document to get.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
     #[doc="<p>The name of the role associated with the policy.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -4007,13 +4256,16 @@ impl GetRolePolicyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetRolePolicy</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRolePolicyResponse {
     #[doc="<p>The policy document.</p>"]
+    #[serde(rename="PolicyDocument")]
     pub policy_document: String,
     #[doc="<p>The name of the policy.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
     #[doc="<p>The role the policy is associated with.</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -4068,9 +4320,10 @@ impl GetRolePolicyResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRoleRequest {
     #[doc="<p>The name of the IAM role to get information about.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -4091,9 +4344,10 @@ impl GetRoleRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetRole</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRoleResponse {
     #[doc="<p>A structure containing details about the IAM role.</p>"]
+    #[serde(rename="Role")]
     pub role: Role,
 }
 
@@ -4138,9 +4392,10 @@ impl GetRoleResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSAMLProviderRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the SAML provider resource object in IAM to get information about.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="SAMLProviderArn")]
     pub saml_provider_arn: String,
 }
 
@@ -4161,13 +4416,19 @@ impl GetSAMLProviderRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetSAMLProvider</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSAMLProviderResponse {
     #[doc="<p>The date and time when the SAML provider was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>The XML metadata document that includes information about an identity provider.</p>"]
+    #[serde(rename="SAMLMetadataDocument")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub saml_metadata_document: Option<String>,
     #[doc="<p>The expiration date and time for the SAML provider.</p>"]
+    #[serde(rename="ValidUntil")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub valid_until: Option<String>,
 }
 
@@ -4220,13 +4481,16 @@ impl GetSAMLProviderResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSSHPublicKeyRequest {
     #[doc="<p>Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use <code>SSH</code>. To retrieve the public key in PEM format, use <code>PEM</code>.</p>"]
+    #[serde(rename="Encoding")]
     pub encoding: String,
     #[doc="<p>The unique identifier for the SSH public key.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>"]
+    #[serde(rename="SSHPublicKeyId")]
     pub ssh_public_key_id: String,
     #[doc="<p>The name of the IAM user associated with the SSH public key.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -4251,9 +4515,11 @@ impl GetSSHPublicKeyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetSSHPublicKey</a> request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSSHPublicKeyResponse {
     #[doc="<p>A structure containing details about the SSH public key.</p>"]
+    #[serde(rename="SSHPublicKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssh_public_key: Option<SSHPublicKey>,
 }
 
@@ -4300,9 +4566,10 @@ impl GetSSHPublicKeyResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetServerCertificateRequest {
     #[doc="<p>The name of the server certificate you want to retrieve information about.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="ServerCertificateName")]
     pub server_certificate_name: String,
 }
 
@@ -4323,9 +4590,10 @@ impl GetServerCertificateRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetServerCertificate</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetServerCertificateResponse {
     #[doc="<p>A structure containing details about the server certificate.</p>"]
+    #[serde(rename="ServerCertificate")]
     pub server_certificate: ServerCertificate,
 }
 
@@ -4372,11 +4640,13 @@ impl GetServerCertificateResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserPolicyRequest {
     #[doc="<p>The name of the policy document to get.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
     #[doc="<p>The name of the user who the policy is associated with.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -4399,13 +4669,16 @@ impl GetUserPolicyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetUserPolicy</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserPolicyResponse {
     #[doc="<p>The policy document.</p>"]
+    #[serde(rename="PolicyDocument")]
     pub policy_document: String,
     #[doc="<p>The name of the policy.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
     #[doc="<p>The user the policy is associated with.</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -4461,9 +4734,11 @@ impl GetUserPolicyResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserRequest {
     #[doc="<p>The name of the user to get information about.</p> <p>This parameter is optional. If it is not included, it defaults to the user making the request. This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -4486,9 +4761,10 @@ impl GetUserRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetUser</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUserResponse {
     #[doc="<p>A structure containing details about the IAM user.</p>"]
+    #[serde(rename="User")]
     pub user: User,
 }
 
@@ -4534,17 +4810,22 @@ impl GetUserResponseDeserializer {
     }
 }
 #[doc="<p>Contains information about an IAM group entity.</p> <p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateGroup</a> </p> </li> <li> <p> <a>GetGroup</a> </p> </li> <li> <p> <a>ListGroups</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Group {
     #[doc="<p> The Amazon Resource Name (ARN) specifying the group. For more information about ARNs and how to use them in policies, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="Arn")]
     pub arn: String,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the group was created.</p>"]
+    #[serde(rename="CreateDate")]
     pub create_date: String,
     #[doc="<p> The stable and unique string identifying the group. For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="GroupId")]
     pub group_id: String,
     #[doc="<p>The friendly name that identifies the group.</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>The path to the group. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="Path")]
     pub path: String,
 }
 
@@ -4604,20 +4885,34 @@ impl GroupDeserializer {
     }
 }
 #[doc="<p>Contains information about an IAM group, including all of the group's policies.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GroupDetail {
+    #[serde(rename="Arn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
     #[doc="<p>A list of the managed policies attached to the group.</p>"]
+    #[serde(rename="AttachedManagedPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attached_managed_policies: Option<Vec<AttachedPolicy>>,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the group was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>The stable and unique string identifying the group. For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="GroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_id: Option<String>,
     #[doc="<p>The friendly name that identifies the group.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
     #[doc="<p>A list of the inline policies embedded in the group.</p>"]
+    #[serde(rename="GroupPolicyList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_policy_list: Option<Vec<PolicyDetail>>,
     #[doc="<p>The path to the group. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
 }
 
@@ -4838,19 +5133,25 @@ impl IdTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about an instance profile.</p> <p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateInstanceProfile</a> </p> </li> <li> <p> <a>GetInstanceProfile</a> </p> </li> <li> <p> <a>ListInstanceProfiles</a> </p> </li> <li> <p> <a>ListInstanceProfilesForRole</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceProfile {
     #[doc="<p> The Amazon Resource Name (ARN) specifying the instance profile. For more information about ARNs and how to use them in policies, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="Arn")]
     pub arn: String,
     #[doc="<p>The date when the instance profile was created.</p>"]
+    #[serde(rename="CreateDate")]
     pub create_date: String,
     #[doc="<p> The stable and unique string identifying the instance profile. For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="InstanceProfileId")]
     pub instance_profile_id: String,
     #[doc="<p>The name identifying the instance profile.</p>"]
+    #[serde(rename="InstanceProfileName")]
     pub instance_profile_name: String,
     #[doc="<p> The path to the instance profile. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="Path")]
     pub path: String,
     #[doc="<p>The role associated with the instance profile.</p>"]
+    #[serde(rename="Roles")]
     pub roles: Vec<Role>,
 }
 
@@ -4983,13 +5284,19 @@ impl LineNumberDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAccessKeysRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The name of the user.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -5020,13 +5327,18 @@ impl ListAccessKeysRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListAccessKeys</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAccessKeysResponse {
     #[doc="<p>A list of objects containing metadata about the access keys.</p>"]
+    #[serde(rename="AccessKeyMetadata")]
     pub access_key_metadata: Vec<AccessKeyMetadata>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5082,11 +5394,15 @@ impl ListAccessKeysResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAccountAliasesRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
 }
 
@@ -5113,13 +5429,18 @@ impl ListAccountAliasesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListAccountAliases</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAccountAliasesResponse {
     #[doc="<p>A list of aliases associated with the account. AWS supports only one alias per account.</p>"]
+    #[serde(rename="AccountAliases")]
     pub account_aliases: Vec<String>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5175,15 +5496,22 @@ impl ListAccountAliasesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttachedGroupPoliciesRequest {
     #[doc="<p>The name (friendly name, not ARN) of the group to list attached policies for.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The path prefix for filtering the results. This parameter is optional. If it is not included, it defaults to a slash (/), listing all policies.</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="PathPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path_prefix: Option<String>,
 }
 
@@ -5216,13 +5544,19 @@ impl ListAttachedGroupPoliciesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListAttachedGroupPolicies</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttachedGroupPoliciesResponse {
     #[doc="<p>A list of the attached policies.</p>"]
+    #[serde(rename="AttachedPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attached_policies: Option<Vec<AttachedPolicy>>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5277,15 +5611,22 @@ impl ListAttachedGroupPoliciesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttachedRolePoliciesRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The path prefix for filtering the results. This parameter is optional. If it is not included, it defaults to a slash (/), listing all policies.</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="PathPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path_prefix: Option<String>,
     #[doc="<p>The name (friendly name, not ARN) of the role to list attached policies for.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -5318,13 +5659,19 @@ impl ListAttachedRolePoliciesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListAttachedRolePolicies</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttachedRolePoliciesResponse {
     #[doc="<p>A list of the attached policies.</p>"]
+    #[serde(rename="AttachedPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attached_policies: Option<Vec<AttachedPolicy>>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5379,15 +5726,22 @@ impl ListAttachedRolePoliciesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttachedUserPoliciesRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The path prefix for filtering the results. This parameter is optional. If it is not included, it defaults to a slash (/), listing all policies.</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="PathPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path_prefix: Option<String>,
     #[doc="<p>The name (friendly name, not ARN) of the user to list attached policies for.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -5420,13 +5774,19 @@ impl ListAttachedUserPoliciesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListAttachedUserPolicies</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttachedUserPoliciesResponse {
     #[doc="<p>A list of the attached policies.</p>"]
+    #[serde(rename="AttachedPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attached_policies: Option<Vec<AttachedPolicy>>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5481,17 +5841,26 @@ impl ListAttachedUserPoliciesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListEntitiesForPolicyRequest {
     #[doc="<p>The entity type to use for filtering the results.</p> <p>For example, when <code>EntityFilter</code> is <code>Role</code>, only the roles that are attached to the specified policy are returned. This parameter is optional. If it is not included, all attached entities (users, groups, and roles) are returned. The argument for this parameter must be one of the valid values listed below.</p>"]
+    #[serde(rename="EntityFilter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub entity_filter: Option<String>,
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The path prefix for filtering the results. This parameter is optional. If it is not included, it defaults to a slash (/), listing all entities.</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="PathPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path_prefix: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy for which you want the versions.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
 }
 
@@ -5528,17 +5897,27 @@ impl ListEntitiesForPolicyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListEntitiesForPolicy</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListEntitiesForPolicyResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of IAM groups that the policy is attached to.</p>"]
+    #[serde(rename="PolicyGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_groups: Option<Vec<PolicyGroup>>,
     #[doc="<p>A list of IAM roles that the policy is attached to.</p>"]
+    #[serde(rename="PolicyRoles")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_roles: Option<Vec<PolicyRole>>,
     #[doc="<p>A list of IAM users that the policy is attached to.</p>"]
+    #[serde(rename="PolicyUsers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_users: Option<Vec<PolicyUser>>,
 }
 
@@ -5604,13 +5983,18 @@ impl ListEntitiesForPolicyResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupPoliciesRequest {
     #[doc="<p>The name of the group to list policies for.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
 }
 
@@ -5639,13 +6023,18 @@ impl ListGroupPoliciesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListGroupPolicies</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupPoliciesResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of policy names.</p>"]
+    #[serde(rename="PolicyNames")]
     pub policy_names: Vec<String>,
 }
 
@@ -5701,13 +6090,18 @@ impl ListGroupPoliciesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupsForUserRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The name of the user to list groups for.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -5736,13 +6130,18 @@ impl ListGroupsForUserRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListGroupsForUser</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupsForUserResponse {
     #[doc="<p>A list of groups.</p>"]
+    #[serde(rename="Groups")]
     pub groups: Vec<Group>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5797,13 +6196,19 @@ impl ListGroupsForUserResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupsRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p> The path prefix for filtering the results. For example, the prefix <code>/division_abc/subdivision_xyz/</code> gets all groups whose path starts with <code>/division_abc/subdivision_xyz/</code>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing all groups. This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="PathPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path_prefix: Option<String>,
 }
 
@@ -5834,13 +6239,18 @@ impl ListGroupsRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListGroups</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGroupsResponse {
     #[doc="<p>A list of groups.</p>"]
+    #[serde(rename="Groups")]
     pub groups: Vec<Group>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5895,13 +6305,18 @@ impl ListGroupsResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInstanceProfilesForRoleRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The name of the role to list instance profiles for.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -5930,13 +6345,18 @@ impl ListInstanceProfilesForRoleRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListInstanceProfilesForRole</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInstanceProfilesForRoleResponse {
     #[doc="<p>A list of instance profiles.</p>"]
+    #[serde(rename="InstanceProfiles")]
     pub instance_profiles: Vec<InstanceProfile>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5993,13 +6413,19 @@ impl ListInstanceProfilesForRoleResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInstanceProfilesRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p> The path prefix for filtering the results. For example, the prefix <code>/application_abc/component_xyz/</code> gets all instance profiles whose path starts with <code>/application_abc/component_xyz/</code>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing all instance profiles. This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="PathPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path_prefix: Option<String>,
 }
 
@@ -6030,13 +6456,18 @@ impl ListInstanceProfilesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListInstanceProfiles</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInstanceProfilesResponse {
     #[doc="<p>A list of instance profiles.</p>"]
+    #[serde(rename="InstanceProfiles")]
     pub instance_profiles: Vec<InstanceProfile>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -6092,13 +6523,19 @@ impl ListInstanceProfilesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListMFADevicesRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The name of the user whose MFA devices you want to list.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -6129,13 +6566,18 @@ impl ListMFADevicesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListMFADevices</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListMFADevicesResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>A list of MFA devices.</p>"]
+    #[serde(rename="MFADevices")]
     pub mfa_devices: Vec<MFADevice>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -6191,7 +6633,7 @@ impl ListMFADevicesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOpenIDConnectProvidersRequest;
 
 
@@ -6210,9 +6652,11 @@ impl ListOpenIDConnectProvidersRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListOpenIDConnectProviders</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOpenIDConnectProvidersResponse {
     #[doc="<p>The list of IAM OIDC provider resource objects defined in the AWS account.</p>"]
+    #[serde(rename="OpenIDConnectProviderList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub open_id_connect_provider_list: Option<Vec<OpenIDConnectProviderListEntry>>,
 }
 
@@ -6258,17 +6702,27 @@ impl ListOpenIDConnectProvidersResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPoliciesRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>A flag to filter the results to only the attached policies.</p> <p>When <code>OnlyAttached</code> is <code>true</code>, the returned list contains only the policies that are attached to an IAM user, group, or role. When <code>OnlyAttached</code> is <code>false</code>, or when the parameter is not included, all policies are returned.</p>"]
+    #[serde(rename="OnlyAttached")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub only_attached: Option<bool>,
     #[doc="<p>The path prefix for filtering the results. This parameter is optional. If it is not included, it defaults to a slash (/), listing all policies. This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="PathPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path_prefix: Option<String>,
     #[doc="<p>The scope to use for filtering the results.</p> <p>To list only AWS managed policies, set <code>Scope</code> to <code>AWS</code>. To list only the customer managed policies in your AWS account, set <code>Scope</code> to <code>Local</code>.</p> <p>This parameter is optional. If it is not included, or if it is set to <code>All</code>, all policies are returned.</p>"]
+    #[serde(rename="Scope")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scope: Option<String>,
 }
 
@@ -6307,13 +6761,19 @@ impl ListPoliciesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListPolicies</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPoliciesResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of policies.</p>"]
+    #[serde(rename="Policies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policies: Option<Vec<Policy>>,
 }
 
@@ -6369,13 +6829,18 @@ impl ListPoliciesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPolicyVersionsRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy for which you want the versions.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
 }
 
@@ -6404,13 +6869,19 @@ impl ListPolicyVersionsRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListPolicyVersions</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPolicyVersionsResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of policy versions.</p> <p>For more information about managed policy versions, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for Managed Policies</a> in the <i>IAM User Guide</i>.</p>"]
+    #[serde(rename="Versions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub versions: Option<Vec<PolicyVersion>>,
 }
 
@@ -6464,13 +6935,18 @@ impl ListPolicyVersionsResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRolePoliciesRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The name of the role to list policies for.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -6499,13 +6975,18 @@ impl ListRolePoliciesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListRolePolicies</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRolePoliciesResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of policy names.</p>"]
+    #[serde(rename="PolicyNames")]
     pub policy_names: Vec<String>,
 }
 
@@ -6561,13 +7042,19 @@ impl ListRolePoliciesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRolesRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p> The path prefix for filtering the results. For example, the prefix <code>/application_abc/component_xyz/</code> gets all roles whose path starts with <code>/application_abc/component_xyz/</code>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing all roles. This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="PathPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path_prefix: Option<String>,
 }
 
@@ -6598,13 +7085,18 @@ impl ListRolesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListRoles</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRolesResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of roles.</p>"]
+    #[serde(rename="Roles")]
     pub roles: Vec<Role>,
 }
 
@@ -6658,7 +7150,7 @@ impl ListRolesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSAMLProvidersRequest;
 
 
@@ -6677,9 +7169,11 @@ impl ListSAMLProvidersRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListSAMLProviders</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSAMLProvidersResponse {
     #[doc="<p>The list of SAML provider resource objects defined in IAM for this AWS account.</p>"]
+    #[serde(rename="SAMLProviderList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub saml_provider_list: Option<Vec<SAMLProviderListEntry>>,
 }
 
@@ -6726,13 +7220,19 @@ impl ListSAMLProvidersResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSSHPublicKeysRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The name of the IAM user to list SSH public keys for. If none is specified, the UserName field is determined implicitly based on the AWS access key used to sign the request.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -6763,13 +7263,19 @@ impl ListSSHPublicKeysRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListSSHPublicKeys</a> request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSSHPublicKeysResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of the SSH public keys assigned to IAM user.</p>"]
+    #[serde(rename="SSHPublicKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssh_public_keys: Option<Vec<SSHPublicKeyMetadata>>,
 }
 
@@ -6825,13 +7331,19 @@ impl ListSSHPublicKeysResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListServerCertificatesRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p> The path prefix for filtering the results. For example: <code>/company/servercerts</code> would get all server certificates for which the path starts with <code>/company/servercerts</code>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing all server certificates. This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="PathPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path_prefix: Option<String>,
 }
 
@@ -6862,13 +7374,18 @@ impl ListServerCertificatesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListServerCertificates</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListServerCertificatesResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of server certificates.</p>"]
+    #[serde(rename="ServerCertificateMetadataList")]
     pub server_certificate_metadata_list: Vec<ServerCertificateMetadata>,
 }
 
@@ -6922,11 +7439,15 @@ impl ListServerCertificatesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListServiceSpecificCredentialsRequest {
     #[doc="<p>Filters the returned results to only those for the specified AWS service. If not specified, then AWS returns service-specific credentials for all services.</p>"]
+    #[serde(rename="ServiceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub service_name: Option<String>,
     #[doc="<p>The name of the user whose service-specific credentials you want information about. If this value is not specified then the operation assumes the user whose credentials are used to call the operation.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -6952,9 +7473,11 @@ impl ListServiceSpecificCredentialsRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListServiceSpecificCredentialsResponse {
     #[doc="<p>A list of structures that each contain details about a service-specific credential.</p>"]
+    #[serde(rename="ServiceSpecificCredentials")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub service_specific_credentials: Option<Vec<ServiceSpecificCredentialMetadata>>,
 }
 
@@ -7000,13 +7523,19 @@ impl ListServiceSpecificCredentialsResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSigningCertificatesRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The name of the IAM user whose signing certificates you want to examine.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -7037,13 +7566,18 @@ impl ListSigningCertificatesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListSigningCertificates</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSigningCertificatesResponse {
     #[doc="<p>A list of the user's signing certificate information.</p>"]
+    #[serde(rename="Certificates")]
     pub certificates: Vec<SigningCertificate>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -7100,13 +7634,18 @@ impl ListSigningCertificatesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUserPoliciesRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The name of the user to list policies for.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -7135,13 +7674,18 @@ impl ListUserPoliciesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListUserPolicies</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUserPoliciesResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of policy names.</p>"]
+    #[serde(rename="PolicyNames")]
     pub policy_names: Vec<String>,
 }
 
@@ -7197,13 +7741,19 @@ impl ListUserPoliciesResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUsersRequest {
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p> The path prefix for filtering the results. For example: <code>/division_abc/subdivision_xyz/</code>, which would get all user names whose path starts with <code>/division_abc/subdivision_xyz/</code>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing all user names. This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="PathPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path_prefix: Option<String>,
 }
 
@@ -7234,13 +7784,18 @@ impl ListUsersRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListUsers</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListUsersResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of users.</p>"]
+    #[serde(rename="Users")]
     pub users: Vec<User>,
 }
 
@@ -7294,13 +7849,19 @@ impl ListUsersResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVirtualMFADevicesRequest {
     #[doc="<p> The status (<code>Unassigned</code> or <code>Assigned</code>) of the devices to list. If you do not specify an <code>AssignmentStatus</code>, the action defaults to <code>Any</code> which lists both assigned and unassigned virtual MFA devices.</p>"]
+    #[serde(rename="AssignmentStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub assignment_status: Option<String>,
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
 }
 
@@ -7331,13 +7892,18 @@ impl ListVirtualMFADevicesRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>ListVirtualMFADevices</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVirtualMFADevicesResponse {
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The list of virtual MFA devices in the current account that match the <code>AssignmentStatus</code> value that was passed in the request.</p>"]
+    #[serde(rename="VirtualMFADevices")]
     pub virtual_mfa_devices: Vec<VirtualMFADevice>,
 }
 
@@ -7394,13 +7960,17 @@ impl ListVirtualMFADevicesResponseDeserializer {
     }
 }
 #[doc="<p>Contains the user name and password create date for a user.</p> <p> This data type is used as a response element in the <a>CreateLoginProfile</a> and <a>GetLoginProfile</a> actions. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoginProfile {
     #[doc="<p>The date when the password for the user was created.</p>"]
+    #[serde(rename="CreateDate")]
     pub create_date: String,
     #[doc="<p>Specifies whether the user is required to set a new password on next sign-in.</p>"]
+    #[serde(rename="PasswordResetRequired")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password_reset_required: Option<bool>,
     #[doc="<p>The name of the user, which can be used for signing in to the AWS Management Console.</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -7456,13 +8026,16 @@ impl LoginProfileDeserializer {
     }
 }
 #[doc="<p>Contains information about an MFA device.</p> <p>This data type is used as a response element in the <a>ListMFADevices</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MFADevice {
     #[doc="<p>The date when the MFA device was enabled for the user.</p>"]
+    #[serde(rename="EnableDate")]
     pub enable_date: String,
     #[doc="<p>The serial number that uniquely identifies the MFA device. For virtual MFA devices, the serial number is the device ARN.</p>"]
+    #[serde(rename="SerialNumber")]
     pub serial_number: String,
     #[doc="<p>The user with whom the MFA device is associated.</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -7518,28 +8091,50 @@ impl MFADeviceDeserializer {
     }
 }
 #[doc="<p>Contains information about a managed policy, including the policy's ARN, versions, and the number of principal entities (users, groups, and roles) that the policy is attached to.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> action.</p> <p>For more information about managed policies, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ManagedPolicyDetail {
+    #[serde(rename="Arn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
     #[doc="<p>The number of principal entities (users, groups, and roles) that the policy is attached to.</p>"]
+    #[serde(rename="AttachmentCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachment_count: Option<i64>,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the policy was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>The identifier for the version of the policy that is set as the default (operative) version.</p> <p>For more information about policy versions, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for Managed Policies</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="DefaultVersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_version_id: Option<String>,
     #[doc="<p>A friendly description of the policy.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Specifies whether the policy can be attached to an IAM user, group, or role.</p>"]
+    #[serde(rename="IsAttachable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_attachable: Option<bool>,
     #[doc="<p>The path to the policy.</p> <p>For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
     #[doc="<p>The stable and unique string identifying the policy.</p> <p>For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="PolicyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_id: Option<String>,
     #[doc="<p>The friendly name (not ARN) identifying the policy.</p>"]
+    #[serde(rename="PolicyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_name: Option<String>,
     #[doc="<p>A list containing information about the versions of the policy.</p>"]
+    #[serde(rename="PolicyVersionList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_version_list: Option<Vec<PolicyVersion>>,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the policy was last updated.</p> <p>When a policy has only one version, this field contains the date and time when the policy was created. When a policy has more than one version, this field contains the date and time when the most recent policy version was created.</p>"]
+    #[serde(rename="UpdateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub update_date: Option<String>,
 }
 
@@ -7754,8 +8349,10 @@ impl MinimumPasswordLengthTypeDeserializer {
     }
 }
 #[doc="<p>Contains the Amazon Resource Name (ARN) for an IAM OpenID Connect provider.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OpenIDConnectProviderListEntry {
+    #[serde(rename="Arn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
 }
 
@@ -7857,9 +8454,11 @@ impl OpenIDConnectProviderUrlTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about AWS Organizations's affect on a policy simulation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OrganizationsDecisionDetail {
     #[doc="<p>Specifies whether the simulated action is allowed by the AWS Organizations service control policies that impact the simulated user's account.</p>"]
+    #[serde(rename="AllowedByOrganizations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allowed_by_organizations: Option<bool>,
 }
 
@@ -7907,27 +8506,47 @@ impl OrganizationsDecisionDetailDeserializer {
     }
 }
 #[doc="<p>Contains information about the account password policy.</p> <p> This data type is used as a response element in the <a>GetAccountPasswordPolicy</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PasswordPolicy {
     #[doc="<p>Specifies whether IAM users are allowed to change their own password.</p>"]
+    #[serde(rename="AllowUsersToChangePassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_users_to_change_password: Option<bool>,
     #[doc="<p>Indicates whether passwords in the account expire. Returns true if MaxPasswordAge is contains a value greater than 0. Returns false if MaxPasswordAge is 0 or not present.</p>"]
+    #[serde(rename="ExpirePasswords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expire_passwords: Option<bool>,
     #[doc="<p>Specifies whether IAM users are prevented from setting a new password after their password has expired.</p>"]
+    #[serde(rename="HardExpiry")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hard_expiry: Option<bool>,
     #[doc="<p>The number of days that an IAM user password is valid.</p>"]
+    #[serde(rename="MaxPasswordAge")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_password_age: Option<i64>,
     #[doc="<p>Minimum length to require for IAM user passwords.</p>"]
+    #[serde(rename="MinimumPasswordLength")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub minimum_password_length: Option<i64>,
     #[doc="<p>Specifies the number of previous passwords that IAM users are prevented from reusing.</p>"]
+    #[serde(rename="PasswordReusePrevention")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password_reuse_prevention: Option<i64>,
     #[doc="<p>Specifies whether to require lowercase characters for IAM user passwords.</p>"]
+    #[serde(rename="RequireLowercaseCharacters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub require_lowercase_characters: Option<bool>,
     #[doc="<p>Specifies whether to require numbers for IAM user passwords.</p>"]
+    #[serde(rename="RequireNumbers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub require_numbers: Option<bool>,
     #[doc="<p>Specifies whether to require symbols for IAM user passwords.</p>"]
+    #[serde(rename="RequireSymbols")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub require_symbols: Option<bool>,
     #[doc="<p>Specifies whether to require uppercase characters for IAM user passwords.</p>"]
+    #[serde(rename="RequireUppercaseCharacters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub require_uppercase_characters: Option<bool>,
 }
 
@@ -8044,26 +8663,46 @@ impl PathTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about a managed policy.</p> <p>This data type is used as a response element in the <a>CreatePolicy</a>, <a>GetPolicy</a>, and <a>ListPolicies</a> actions. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Policy {
+    #[serde(rename="Arn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
     #[doc="<p>The number of entities (users, groups, and roles) that the policy is attached to.</p>"]
+    #[serde(rename="AttachmentCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attachment_count: Option<i64>,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the policy was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>The identifier for the version of the policy that is set as the default version.</p>"]
+    #[serde(rename="DefaultVersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_version_id: Option<String>,
     #[doc="<p>A friendly description of the policy.</p> <p>This element is included in the response to the <a>GetPolicy</a> operation. It is not included in the response to the <a>ListPolicies</a> operation. </p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Specifies whether the policy can be attached to an IAM user, group, or role.</p>"]
+    #[serde(rename="IsAttachable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_attachable: Option<bool>,
     #[doc="<p>The path to the policy.</p> <p>For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
     #[doc="<p>The stable and unique string identifying the policy.</p> <p>For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="PolicyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_id: Option<String>,
     #[doc="<p>The friendly name (not ARN) identifying the policy.</p>"]
+    #[serde(rename="PolicyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_name: Option<String>,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the policy was last updated.</p> <p>When a policy has only one version, this field contains the date and time when the policy was created. When a policy has more than one version, this field contains the date and time when the most recent policy version was created.</p>"]
+    #[serde(rename="UpdateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub update_date: Option<String>,
 }
 
@@ -8164,11 +8803,15 @@ impl PolicyDescriptionTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about an IAM policy, including the policy document.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyDetail {
     #[doc="<p>The policy document.</p>"]
+    #[serde(rename="PolicyDocument")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_document: Option<String>,
     #[doc="<p>The name of the policy.</p>"]
+    #[serde(rename="PolicyName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_name: Option<String>,
 }
 
@@ -8331,11 +8974,15 @@ impl PolicyEvaluationDecisionTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about a group that a managed policy is attached to.</p> <p>This data type is used as a response element in the <a>ListEntitiesForPolicy</a> action. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyGroup {
     #[doc="<p>The stable and unique string identifying the group. For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html\">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p>"]
+    #[serde(rename="GroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_id: Option<String>,
     #[doc="<p>The name (friendly name, not ARN) identifying the group.</p>"]
+    #[serde(rename="GroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_name: Option<String>,
 }
 
@@ -8552,11 +9199,15 @@ impl PolicyPathTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about a role that a managed policy is attached to.</p> <p>This data type is used as a response element in the <a>ListEntitiesForPolicy</a> action. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyRole {
     #[doc="<p>The stable and unique string identifying the role. For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html\">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p>"]
+    #[serde(rename="RoleId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_id: Option<String>,
     #[doc="<p>The name (friendly name, not ARN) identifying the role.</p>"]
+    #[serde(rename="RoleName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_name: Option<String>,
 }
 
@@ -8663,11 +9314,15 @@ impl PolicySourceTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about a user that a managed policy is attached to.</p> <p>This data type is used as a response element in the <a>ListEntitiesForPolicy</a> action. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyUser {
     #[doc="<p>The stable and unique string identifying the user. For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html\">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p>"]
+    #[serde(rename="UserId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_id: Option<String>,
     #[doc="<p>The name (friendly name, not ARN) identifying the user.</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -8760,15 +9415,23 @@ impl PolicyUserListTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about a version of a managed policy.</p> <p>This data type is used as a response element in the <a>CreatePolicyVersion</a>, <a>GetPolicyVersion</a>, <a>ListPolicyVersions</a>, and <a>GetAccountAuthorizationDetails</a> actions. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyVersion {
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the policy version was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>The policy document.</p> <p>The policy document is returned in the response to the <a>GetPolicyVersion</a> and <a>GetAccountAuthorizationDetails</a> operations. It is not returned in the response to the <a>CreatePolicyVersion</a> or <a>ListPolicyVersions</a> operations. </p>"]
+    #[serde(rename="Document")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub document: Option<String>,
     #[doc="<p>Specifies whether the policy version is set as the policy's default version.</p>"]
+    #[serde(rename="IsDefaultVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_default_version: Option<bool>,
     #[doc="<p>The identifier for the policy version.</p> <p>Policy version identifiers always begin with <code>v</code> (always lowercase). When a policy is created, the first policy version is <code>v1</code>. </p>"]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -8844,11 +9507,15 @@ impl PolicyVersionIdTypeDeserializer {
     }
 }
 #[doc="<p>Contains the row and column of a location of a <code>Statement</code> element in a policy document.</p> <p>This data type is used as a member of the <code> <a>Statement</a> </code> type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Position {
     #[doc="<p>The column in the line containing the specified position in the document.</p>"]
+    #[serde(rename="Column")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub column: Option<i64>,
     #[doc="<p>The line containing the specified position in the document.</p>"]
+    #[serde(rename="Line")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub line: Option<i64>,
 }
 
@@ -8940,13 +9607,16 @@ impl PublicKeyMaterialTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutGroupPolicyRequest {
     #[doc="<p>The name of the group to associate the policy with.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>The policy document.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="PolicyDocument")]
     pub policy_document: String,
     #[doc="<p>The name of the policy document.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -8970,13 +9640,16 @@ impl PutGroupPolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRolePolicyRequest {
     #[doc="<p>The policy document.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="PolicyDocument")]
     pub policy_document: String,
     #[doc="<p>The name of the policy document.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
     #[doc="<p>The name of the role to associate the policy with.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -9000,13 +9673,16 @@ impl PutRolePolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutUserPolicyRequest {
     #[doc="<p>The policy document.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="PolicyDocument")]
     pub policy_document: String,
     #[doc="<p>The name of the policy document.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
     #[doc="<p>The name of the user to associate the policy with.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -9030,11 +9706,13 @@ impl PutUserPolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveClientIDFromOpenIDConnectProviderRequest {
     #[doc="<p>The client ID (also known as audience) to remove from the IAM OIDC provider resource. For more information about client IDs, see <a>CreateOpenIDConnectProvider</a>.</p>"]
+    #[serde(rename="ClientID")]
     pub client_id: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM OIDC provider resource to remove the client ID from. You can get a list of OIDC provider ARNs by using the <a>ListOpenIDConnectProviders</a> action.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="OpenIDConnectProviderArn")]
     pub open_id_connect_provider_arn: String,
 }
 
@@ -9058,11 +9736,13 @@ impl RemoveClientIDFromOpenIDConnectProviderRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveRoleFromInstanceProfileRequest {
     #[doc="<p>The name of the instance profile to update.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="InstanceProfileName")]
     pub instance_profile_name: String,
     #[doc="<p>The name of the role to remove.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -9084,11 +9764,13 @@ impl RemoveRoleFromInstanceProfileRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveUserFromGroupRequest {
     #[doc="<p>The name of the group to update.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>The name of the user to remove.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -9166,11 +9848,14 @@ impl ReportStateTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetServiceSpecificCredentialRequest {
     #[doc="<p>The unique identifier of the service-specific credential.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>"]
+    #[serde(rename="ServiceSpecificCredentialId")]
     pub service_specific_credential_id: String,
     #[doc="<p>The name of the IAM user associated with the service-specific credential. If this value is not specified, then the operation assumes the user whose credentials are used to call the operation.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -9194,9 +9879,11 @@ impl ResetServiceSpecificCredentialRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetServiceSpecificCredentialResponse {
     #[doc="<p>A structure with details about the updated service-specific credential, including the new password.</p> <important> <p>This is the <b>only</b> time that you can access the password. You cannot recover the password later, but you can reset it again.</p> </important>"]
+    #[serde(rename="ServiceSpecificCredential")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub service_specific_credential: Option<ServiceSpecificCredential>,
 }
 
@@ -9269,17 +9956,25 @@ impl ResourceNameTypeDeserializer {
     }
 }
 #[doc="<p>Contains the result of the simulation of a single API action call on a single resource.</p> <p>This data type is used by a member of the <a>EvaluationResult</a> data type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceSpecificResult {
     #[doc="<p>Additional details about the results of the evaluation decision. When there are both IAM policies and resource policies, this parameter explains how each set of policies contributes to the final evaluation decision. When simulating cross-account access to a resource, both the resource-based policy and the caller's IAM policy must grant access.</p>"]
+    #[serde(rename="EvalDecisionDetails")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub eval_decision_details: Option<::std::collections::HashMap<String, String>>,
     #[doc="<p>The result of the simulation of the simulated API action on the resource specified in <code>EvalResourceName</code>.</p>"]
+    #[serde(rename="EvalResourceDecision")]
     pub eval_resource_decision: String,
     #[doc="<p>The name of the simulated resource, in Amazon Resource Name (ARN) format.</p>"]
+    #[serde(rename="EvalResourceName")]
     pub eval_resource_name: String,
     #[doc="<p>A list of the statements in the input policies that determine the result for this part of the simulation. Remember that even if multiple statements allow the action on the resource, if <i>any</i> statement denies that action, then the explicit deny overrides any allow, and the deny statement is the only entry included in the result.</p>"]
+    #[serde(rename="MatchedStatements")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub matched_statements: Option<Vec<Statement>>,
     #[doc="<p>A list of context keys that are required by the included input policies but that were not provided by one of the input parameters. This list is used when a list of ARNs is included in the <code>ResourceArns</code> parameter instead of \"*\". If you do not specify individual resources, by setting <code>ResourceArns</code> to \"*\" or by not including the <code>ResourceArns</code> parameter, then any missing context values are instead included under the <code>EvaluationResults</code> section. To discover the context keys used by a set of policies, you can call <a>GetContextKeysForCustomPolicy</a> or <a>GetContextKeysForPrincipalPolicy</a>.</p>"]
+    #[serde(rename="MissingContextValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub missing_context_values: Option<Vec<String>>,
 }
 
@@ -9386,15 +10081,19 @@ impl ResourceSpecificResultListTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResyncMFADeviceRequest {
     #[doc="<p>An authentication code emitted by the device.</p> <p>The format for this parameter is a sequence of six digits.</p>"]
+    #[serde(rename="AuthenticationCode1")]
     pub authentication_code_1: String,
     #[doc="<p>A subsequent authentication code emitted by the device.</p> <p>The format for this parameter is a sequence of six digits.</p>"]
+    #[serde(rename="AuthenticationCode2")]
     pub authentication_code_2: String,
     #[doc="<p>Serial number that uniquely identifies the MFA device.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="SerialNumber")]
     pub serial_number: String,
     #[doc="<p>The name of the user whose MFA device you want to resynchronize.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -9421,21 +10120,30 @@ impl ResyncMFADeviceRequestSerializer {
 }
 
 #[doc="<p>Contains information about an IAM role. This structure is returned as a response element in several APIs that interact with roles.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Role {
     #[doc="<p> The Amazon Resource Name (ARN) specifying the role. For more information about ARNs and how to use them in policies, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>IAM User Guide</i> guide. </p>"]
+    #[serde(rename="Arn")]
     pub arn: String,
     #[doc="<p>The policy that grants an entity permission to assume the role.</p>"]
+    #[serde(rename="AssumeRolePolicyDocument")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub assume_role_policy_document: Option<String>,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the role was created.</p>"]
+    #[serde(rename="CreateDate")]
     pub create_date: String,
     #[doc="<p>A description of the role that you provide.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p> The path to the role. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="Path")]
     pub path: String,
     #[doc="<p> The stable and unique string identifying the role. For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="RoleId")]
     pub role_id: String,
     #[doc="<p>The friendly name that identifies the role.</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -9519,24 +10227,42 @@ impl RoleDescriptionTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about an IAM role, including all of the role's policies.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RoleDetail {
+    #[serde(rename="Arn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
     #[doc="<p>The trust policy that grants permission to assume the role.</p>"]
+    #[serde(rename="AssumeRolePolicyDocument")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub assume_role_policy_document: Option<String>,
     #[doc="<p>A list of managed policies attached to the role. These policies are the role's access (permissions) policies.</p>"]
+    #[serde(rename="AttachedManagedPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attached_managed_policies: Option<Vec<AttachedPolicy>>,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the role was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>A list of instance profiles that contain this role.</p>"]
+    #[serde(rename="InstanceProfileList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_profile_list: Option<Vec<InstanceProfile>>,
     #[doc="<p>The path to the role. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
     #[doc="<p>The stable and unique string identifying the role. For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="RoleId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_id: Option<String>,
     #[doc="<p>The friendly name that identifies the role.</p>"]
+    #[serde(rename="RoleName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_name: Option<String>,
     #[doc="<p>A list of inline policies embedded in the role. These policies are the role's access (permissions) policies.</p>"]
+    #[serde(rename="RolePolicyList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_policy_list: Option<Vec<PolicyDetail>>,
 }
 
@@ -9726,13 +10452,19 @@ impl SAMLMetadataDocumentTypeDeserializer {
     }
 }
 #[doc="<p>Contains the list of SAML providers for this account.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SAMLProviderListEntry {
     #[doc="<p>The Amazon Resource Name (ARN) of the SAML provider.</p>"]
+    #[serde(rename="Arn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
     #[doc="<p>The date and time when the SAML provider was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>The expiration date and time for the SAML provider.</p>"]
+    #[serde(rename="ValidUntil")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub valid_until: Option<String>,
 }
 
@@ -9828,19 +10560,26 @@ impl SAMLProviderListTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about an SSH public key.</p> <p>This data type is used as a response element in the <a>GetSSHPublicKey</a> and <a>UploadSSHPublicKey</a> actions. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SSHPublicKey {
     #[doc="<p>The MD5 message digest of the SSH public key.</p>"]
+    #[serde(rename="Fingerprint")]
     pub fingerprint: String,
     #[doc="<p>The SSH public key.</p>"]
+    #[serde(rename="SSHPublicKeyBody")]
     pub ssh_public_key_body: String,
     #[doc="<p>The unique identifier for the SSH public key.</p>"]
+    #[serde(rename="SSHPublicKeyId")]
     pub ssh_public_key_id: String,
     #[doc="<p>The status of the SSH public key. <code>Active</code> means the key can be used for authentication with an AWS CodeCommit repository. <code>Inactive</code> means the key cannot be used.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the SSH public key was uploaded.</p>"]
+    #[serde(rename="UploadDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_date: Option<String>,
     #[doc="<p>The name of the IAM user associated with the SSH public key.</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -9951,15 +10690,19 @@ impl SSHPublicKeyListTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about an SSH public key, without the key's body or fingerprint.</p> <p>This data type is used as a response element in the <a>ListSSHPublicKeys</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SSHPublicKeyMetadata {
     #[doc="<p>The unique identifier for the SSH public key.</p>"]
+    #[serde(rename="SSHPublicKeyId")]
     pub ssh_public_key_id: String,
     #[doc="<p>The status of the SSH public key. <code>Active</code> means the key can be used for authentication with an AWS CodeCommit repository. <code>Inactive</code> means the key cannot be used.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the SSH public key was uploaded.</p>"]
+    #[serde(rename="UploadDate")]
     pub upload_date: String,
     #[doc="<p>The name of the IAM user associated with the SSH public key.</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -10032,13 +10775,17 @@ impl SerialNumberTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about a server certificate.</p> <p> This data type is used as a response element in the <a>GetServerCertificate</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ServerCertificate {
     #[doc="<p>The contents of the public key certificate.</p>"]
+    #[serde(rename="CertificateBody")]
     pub certificate_body: String,
     #[doc="<p>The contents of the public key certificate chain.</p>"]
+    #[serde(rename="CertificateChain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificate_chain: Option<String>,
     #[doc="<p>The meta information of the server certificate, such as its name, path, ID, and ARN.</p>"]
+    #[serde(rename="ServerCertificateMetadata")]
     pub server_certificate_metadata: ServerCertificateMetadata,
 }
 
@@ -10096,19 +10843,27 @@ impl ServerCertificateDeserializer {
     }
 }
 #[doc="<p>Contains information about a server certificate without its certificate body, certificate chain, and private key.</p> <p> This data type is used as a response element in the <a>UploadServerCertificate</a> and <a>ListServerCertificates</a> actions. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ServerCertificateMetadata {
     #[doc="<p> The Amazon Resource Name (ARN) specifying the server certificate. For more information about ARNs and how to use them in policies, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="Arn")]
     pub arn: String,
     #[doc="<p>The date on which the certificate is set to expire.</p>"]
+    #[serde(rename="Expiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expiration: Option<String>,
     #[doc="<p> The path to the server certificate. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="Path")]
     pub path: String,
     #[doc="<p> The stable and unique string identifying the server certificate. For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="ServerCertificateId")]
     pub server_certificate_id: String,
     #[doc="<p>The name that identifies the server certificate.</p>"]
+    #[serde(rename="ServerCertificateName")]
     pub server_certificate_name: String,
     #[doc="<p>The date when the server certificate was uploaded.</p>"]
+    #[serde(rename="UploadDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_date: Option<String>,
 }
 
@@ -10258,21 +11013,28 @@ impl ServicePasswordDeserializer {
     }
 }
 #[doc="<p>Contains the details of a service specific credential.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ServiceSpecificCredential {
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the service-specific credential were created.</p>"]
+    #[serde(rename="CreateDate")]
     pub create_date: String,
     #[doc="<p>The name of the service associated with the service-specific credential.</p>"]
+    #[serde(rename="ServiceName")]
     pub service_name: String,
     #[doc="<p>The generated password for the service-specific credential.</p>"]
+    #[serde(rename="ServicePassword")]
     pub service_password: String,
     #[doc="<p>The unique identifier for the service-specific credential.</p>"]
+    #[serde(rename="ServiceSpecificCredentialId")]
     pub service_specific_credential_id: String,
     #[doc="<p>The generated user name for the service-specific credential. This value is generated by combining the IAM user's name combined with the ID number of the AWS account, as in <code>jane-at-123456789012</code>, for example. This value cannot be configured by the user.</p>"]
+    #[serde(rename="ServiceUserName")]
     pub service_user_name: String,
     #[doc="<p>The status of the service-specific credential. <code>Active</code> means the key is valid for API calls, while <code>Inactive</code> means it is not.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The name of the IAM user associated with the service-specific credential.</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -10359,19 +11121,25 @@ impl ServiceSpecificCredentialIdDeserializer {
     }
 }
 #[doc="<p>Contains additional details about a service-specific credential.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ServiceSpecificCredentialMetadata {
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the service-specific credential were created.</p>"]
+    #[serde(rename="CreateDate")]
     pub create_date: String,
     #[doc="<p>The name of the service associated with the service-specific credential.</p>"]
+    #[serde(rename="ServiceName")]
     pub service_name: String,
     #[doc="<p>The unique identifier for the service-specific credential.</p>"]
+    #[serde(rename="ServiceSpecificCredentialId")]
     pub service_specific_credential_id: String,
     #[doc="<p>The generated user name for the service-specific credential.</p>"]
+    #[serde(rename="ServiceUserName")]
     pub service_user_name: String,
     #[doc="<p>The status of the service-specific credential. <code>Active</code> means the key is valid for API calls, while <code>Inactive</code> means it is not.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The name of the IAM user associated with the service-specific credential.</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -10495,11 +11263,13 @@ impl ServiceUserNameDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetDefaultPolicyVersionRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM policy whose default version you want to set.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicyArn")]
     pub policy_arn: String,
     #[doc="<p>The version of the policy to set as the default (operative) version.</p> <p>For more information about managed policy versions, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for Managed Policies</a> in the <i>IAM User Guide</i>.</p>"]
+    #[serde(rename="VersionId")]
     pub version_id: String,
 }
 
@@ -10522,17 +11292,23 @@ impl SetDefaultPolicyVersionRequestSerializer {
 }
 
 #[doc="<p>Contains information about an X.509 signing certificate.</p> <p>This data type is used as a response element in the <a>UploadSigningCertificate</a> and <a>ListSigningCertificates</a> actions. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SigningCertificate {
     #[doc="<p>The contents of the signing certificate.</p>"]
+    #[serde(rename="CertificateBody")]
     pub certificate_body: String,
     #[doc="<p>The ID for the signing certificate.</p>"]
+    #[serde(rename="CertificateId")]
     pub certificate_id: String,
     #[doc="<p>The status of the signing certificate. <code>Active</code> means the key is valid for API calls, while <code>Inactive</code> means it is not.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The date when the signing certificate was uploaded.</p>"]
+    #[serde(rename="UploadDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_date: Option<String>,
     #[doc="<p>The name of the user the signing certificate is associated with.</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -10595,27 +11371,45 @@ impl SigningCertificateDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SimulateCustomPolicyRequest {
     #[doc="<p>A list of names of API actions to evaluate in the simulation. Each action is evaluated against each resource. Each action must include the service identifier, such as <code>iam:CreateUser</code>.</p>"]
+    #[serde(rename="ActionNames")]
     pub action_names: Vec<String>,
     #[doc="<p>The ARN of the IAM user that you want to use as the simulated caller of the APIs. <code>CallerArn</code> is required if you include a <code>ResourcePolicy</code> so that the policy's <code>Principal</code> element has a value to use in evaluating the policy.</p> <p>You can specify only the ARN of an IAM user. You cannot specify the ARN of an assumed role, federated user, or a service principal.</p>"]
+    #[serde(rename="CallerArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub caller_arn: Option<String>,
     #[doc="<p>A list of context keys and corresponding values for the simulation to use. Whenever a context key is evaluated in one of the simulated IAM permission policies, the corresponding value is supplied.</p>"]
+    #[serde(rename="ContextEntries")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub context_entries: Option<Vec<ContextEntry>>,
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>A list of policy documents to include in the simulation. Each document is specified as a string containing the complete, valid JSON text of an IAM policy. Do not include any resource-based policies in this parameter. Any resource-based policy must be submitted with the <code>ResourcePolicy</code> parameter. The policies cannot be \"scope-down\" policies, such as you could include in a call to <a href=\"http://docs.aws.amazon.com/IAM/latest/APIReference/API_GetFederationToken.html\">GetFederationToken</a> or one of the <a href=\"http://docs.aws.amazon.com/IAM/latest/APIReference/API_AssumeRole.html\">AssumeRole</a> APIs to restrict what a user can do while using the temporary credentials.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="PolicyInputList")]
     pub policy_input_list: Vec<String>,
     #[doc="<p>A list of ARNs of AWS resources to include in the simulation. If this parameter is not provided then the value defaults to <code>*</code> (all resources). Each API in the <code>ActionNames</code> parameter is evaluated for each resource in this list. The simulation determines the access result (allowed or denied) of each combination and reports it in the response.</p> <p>The simulation does not automatically retrieve policies for the specified resources. If you want to include a resource policy in the simulation, then you must include the policy as a string in the <code>ResourcePolicy</code> parameter.</p> <p>If you include a <code>ResourcePolicy</code>, then it must be applicable to all of the resources included in the simulation or you receive an invalid input error.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="ResourceArns")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_arns: Option<Vec<String>>,
     #[doc="<p>Specifies the type of simulation to run. Different APIs that support resource-based policies require different combinations of resources. By specifying the type of simulation to run, you enable the policy simulator to enforce the presence of the required resources to ensure reliable simulation results. If your simulation does not match one of the following scenarios, then you can omit this parameter. The following list shows each of the supported scenario values and the resources that you must define to run the simulation.</p> <p>Each of the EC2 scenarios requires that you specify instance, image, and security-group resources. If your scenario includes an EBS volume, then you must specify that volume as a resource. If the EC2 scenario includes VPC, then you must supply the network-interface resource. If it includes an IP subnet, then you must specify the subnet resource. For more information on the EC2 scenario options, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html\">Supported Platforms</a> in the <i>AWS EC2 User Guide</i>.</p> <ul> <li> <p> <b>EC2-Classic-InstanceStore</b> </p> <p>instance, image, security-group</p> </li> <li> <p> <b>EC2-Classic-EBS</b> </p> <p>instance, image, security-group, volume</p> </li> <li> <p> <b>EC2-VPC-InstanceStore</b> </p> <p>instance, image, security-group, network-interface</p> </li> <li> <p> <b>EC2-VPC-InstanceStore-Subnet</b> </p> <p>instance, image, security-group, network-interface, subnet</p> </li> <li> <p> <b>EC2-VPC-EBS</b> </p> <p>instance, image, security-group, network-interface, volume</p> </li> <li> <p> <b>EC2-VPC-EBS-Subnet</b> </p> <p>instance, image, security-group, network-interface, subnet, volume</p> </li> </ul>"]
+    #[serde(rename="ResourceHandlingOption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_handling_option: Option<String>,
     #[doc="<p>An AWS account ID that specifies the owner of any simulated resource that does not identify its owner in the resource ARN, such as an S3 bucket or object. If <code>ResourceOwner</code> is specified, it is also used as the account owner of any <code>ResourcePolicy</code> included in the simulation. If the <code>ResourceOwner</code> parameter is not specified, then the owner of the resources and the resource policy defaults to the account of the identity provided in <code>CallerArn</code>. This parameter is required only if you specify a resource-based policy and account that owns the resource is different from the account that owns the simulated calling user <code>CallerArn</code>.</p>"]
+    #[serde(rename="ResourceOwner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_owner: Option<String>,
     #[doc="<p>A resource-based policy to include in the simulation provided as a string. Each resource in the simulation is treated as if it had this policy attached. You can include only one resource-based policy in a simulation.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="ResourcePolicy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_policy: Option<String>,
 }
 
@@ -10674,13 +11468,19 @@ impl SimulateCustomPolicyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>SimulatePrincipalPolicy</a> or <a>SimulateCustomPolicy</a> request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SimulatePolicyResponse {
     #[doc="<p>The results of the simulation.</p>"]
+    #[serde(rename="EvaluationResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub evaluation_results: Option<Vec<EvaluationResult>>,
     #[doc="<p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>"]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="<p>When <code>IsTruncated</code> is <code>true</code>, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent pagination request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -10734,29 +11534,49 @@ impl SimulatePolicyResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SimulatePrincipalPolicyRequest {
     #[doc="<p>A list of names of API actions to evaluate in the simulation. Each action is evaluated for each resource. Each action must include the service identifier, such as <code>iam:CreateUser</code>.</p>"]
+    #[serde(rename="ActionNames")]
     pub action_names: Vec<String>,
     #[doc="<p>The ARN of the IAM user that you want to specify as the simulated caller of the APIs. If you do not specify a <code>CallerArn</code>, it defaults to the ARN of the user that you specify in <code>PolicySourceArn</code>, if you specified a user. If you include both a <code>PolicySourceArn</code> (for example, <code>arn:aws:iam::123456789012:user/David</code>) and a <code>CallerArn</code> (for example, <code>arn:aws:iam::123456789012:user/Bob</code>), the result is that you simulate calling the APIs as Bob, as if Bob had David's policies.</p> <p>You can specify only the ARN of an IAM user. You cannot specify the ARN of an assumed role, federated user, or a service principal.</p> <p> <code>CallerArn</code> is required if you include a <code>ResourcePolicy</code> and the <code>PolicySourceArn</code> is not the ARN for an IAM user. This is required so that the resource-based policy's <code>Principal</code> element has a value to use in evaluating the policy.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="CallerArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub caller_arn: Option<String>,
     #[doc="<p>A list of context keys and corresponding values for the simulation to use. Whenever a context key is evaluated in one of the simulated IAM permission policies, the corresponding value is supplied.</p>"]
+    #[serde(rename="ContextEntries")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub context_entries: Option<Vec<ContextEntry>>,
     #[doc="<p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) Use this only when paginating results to indicate the maximum number of items you want in the response. If additional items exist beyond the maximum you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p> <p>If you do not include this parameter, it defaults to 100. Note that IAM might return fewer results, even when there are more results available. In that case, the <code>IsTruncated</code> response element returns <code>true</code> and <code>Marker</code> contains a value to include in the subsequent call that tells the service where to continue from.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>An optional list of additional policy documents to include in the simulation. Each document is specified as a string containing the complete, valid JSON text of an IAM policy.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="PolicyInputList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy_input_list: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) of a user, group, or role whose policies you want to include in the simulation. If you specify a user, group, or role, the simulation includes all policies that are associated with that entity. If you specify a user, the simulation also includes all policies that are attached to any groups the user belongs to.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="PolicySourceArn")]
     pub policy_source_arn: String,
     #[doc="<p>A list of ARNs of AWS resources to include in the simulation. If this parameter is not provided then the value defaults to <code>*</code> (all resources). Each API in the <code>ActionNames</code> parameter is evaluated for each resource in this list. The simulation determines the access result (allowed or denied) of each combination and reports it in the response.</p> <p>The simulation does not automatically retrieve policies for the specified resources. If you want to include a resource policy in the simulation, then you must include the policy as a string in the <code>ResourcePolicy</code> parameter.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="ResourceArns")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_arns: Option<Vec<String>>,
     #[doc="<p>Specifies the type of simulation to run. Different APIs that support resource-based policies require different combinations of resources. By specifying the type of simulation to run, you enable the policy simulator to enforce the presence of the required resources to ensure reliable simulation results. If your simulation does not match one of the following scenarios, then you can omit this parameter. The following list shows each of the supported scenario values and the resources that you must define to run the simulation.</p> <p>Each of the EC2 scenarios requires that you specify instance, image, and security-group resources. If your scenario includes an EBS volume, then you must specify that volume as a resource. If the EC2 scenario includes VPC, then you must supply the network-interface resource. If it includes an IP subnet, then you must specify the subnet resource. For more information on the EC2 scenario options, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html\">Supported Platforms</a> in the <i>AWS EC2 User Guide</i>.</p> <ul> <li> <p> <b>EC2-Classic-InstanceStore</b> </p> <p>instance, image, security-group</p> </li> <li> <p> <b>EC2-Classic-EBS</b> </p> <p>instance, image, security-group, volume</p> </li> <li> <p> <b>EC2-VPC-InstanceStore</b> </p> <p>instance, image, security-group, network-interface</p> </li> <li> <p> <b>EC2-VPC-InstanceStore-Subnet</b> </p> <p>instance, image, security-group, network-interface, subnet</p> </li> <li> <p> <b>EC2-VPC-EBS</b> </p> <p>instance, image, security-group, network-interface, volume</p> </li> <li> <p> <b>EC2-VPC-EBS-Subnet</b> </p> <p>instance, image, security-group, network-interface, subnet, volume</p> </li> </ul>"]
+    #[serde(rename="ResourceHandlingOption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_handling_option: Option<String>,
     #[doc="<p>An AWS account ID that specifies the owner of any simulated resource that does not identify its owner in the resource ARN, such as an S3 bucket or object. If <code>ResourceOwner</code> is specified, it is also used as the account owner of any <code>ResourcePolicy</code> included in the simulation. If the <code>ResourceOwner</code> parameter is not specified, then the owner of the resources and the resource policy defaults to the account of the identity provided in <code>CallerArn</code>. This parameter is required only if you specify a resource-based policy and account that owns the resource is different from the account that owns the simulated calling user <code>CallerArn</code>.</p>"]
+    #[serde(rename="ResourceOwner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_owner: Option<String>,
     #[doc="<p>A resource-based policy to include in the simulation provided as a string. Each resource in the simulation is treated as if it had this policy attached. You can include only one resource-based policy in a simulation.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="ResourcePolicy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_policy: Option<String>,
 }
 
@@ -10833,15 +11653,23 @@ impl SimulationPolicyListTypeSerializer {
 }
 
 #[doc="<p>Contains a reference to a <code>Statement</code> element in a policy document that determines the result of the simulation.</p> <p>This data type is used by the <code>MatchedStatements</code> member of the <code> <a>EvaluationResult</a> </code> type.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Statement {
     #[doc="<p>The row and column of the end of a <code>Statement</code> in an IAM policy.</p>"]
+    #[serde(rename="EndPosition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_position: Option<Position>,
     #[doc="<p>The identifier of the policy that was provided as an input.</p>"]
+    #[serde(rename="SourcePolicyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_policy_id: Option<String>,
     #[doc="<p>The type of the policy.</p>"]
+    #[serde(rename="SourcePolicyType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_policy_type: Option<String>,
     #[doc="<p>The row and column of the beginning of the <code>Statement</code> in an IAM policy.</p>"]
+    #[serde(rename="StartPosition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_position: Option<Position>,
 }
 
@@ -11090,13 +11918,17 @@ impl ThumbprintTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAccessKeyRequest {
     #[doc="<p>The access key ID of the secret access key you want to update.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>"]
+    #[serde(rename="AccessKeyId")]
     pub access_key_id: String,
     #[doc="<p> The status you want to assign to the secret access key. <code>Active</code> means the key can be used for API calls to AWS, while <code>Inactive</code> means the key cannot be used.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The name of the user whose key you want to update.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -11122,25 +11954,43 @@ impl UpdateAccessKeyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAccountPasswordPolicyRequest {
     #[doc="<p> Allows all IAM users in your account to use the AWS Management Console to change their own passwords. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/HowToPwdIAMUser.html\">Letting IAM Users Change Their Own Passwords</a> in the <i>IAM User Guide</i>.</p> <p>Default value: false</p>"]
+    #[serde(rename="AllowUsersToChangePassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_users_to_change_password: Option<bool>,
     #[doc="<p>Prevents IAM users from setting a new password after their password has expired.</p> <p>Default value: false</p>"]
+    #[serde(rename="HardExpiry")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hard_expiry: Option<bool>,
     #[doc="<p>The number of days that an IAM user password is valid. The default value of 0 means IAM user passwords never expire.</p> <p>Default value: 0</p>"]
+    #[serde(rename="MaxPasswordAge")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_password_age: Option<i64>,
     #[doc="<p>The minimum number of characters allowed in an IAM user password.</p> <p>Default value: 6</p>"]
+    #[serde(rename="MinimumPasswordLength")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub minimum_password_length: Option<i64>,
     #[doc="<p>Specifies the number of previous passwords that IAM users are prevented from reusing. The default value of 0 means IAM users are not prevented from reusing previous passwords.</p> <p>Default value: 0</p>"]
+    #[serde(rename="PasswordReusePrevention")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password_reuse_prevention: Option<i64>,
     #[doc="<p>Specifies whether IAM user passwords must contain at least one lowercase character from the ISO basic Latin alphabet (a to z).</p> <p>Default value: false</p>"]
+    #[serde(rename="RequireLowercaseCharacters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub require_lowercase_characters: Option<bool>,
     #[doc="<p>Specifies whether IAM user passwords must contain at least one numeric character (0 to 9).</p> <p>Default value: false</p>"]
+    #[serde(rename="RequireNumbers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub require_numbers: Option<bool>,
     #[doc="<p>Specifies whether IAM user passwords must contain at least one of the following non-alphanumeric characters:</p> <p>! @ # $ % ^ &amp;amp; * ( ) _ + - = [ ] { } | '</p> <p>Default value: false</p>"]
+    #[serde(rename="RequireSymbols")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub require_symbols: Option<bool>,
     #[doc="<p>Specifies whether IAM user passwords must contain at least one uppercase character from the ISO basic Latin alphabet (A to Z).</p> <p>Default value: false</p>"]
+    #[serde(rename="RequireUppercaseCharacters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub require_uppercase_characters: Option<bool>,
 }
 
@@ -11194,11 +12044,13 @@ impl UpdateAccountPasswordPolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAssumeRolePolicyRequest {
     #[doc="<p>The policy that grants an entity permission to assume the role.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="PolicyDocument")]
     pub policy_document: String,
     #[doc="<p>The name of the role to update with the new policy.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -11220,13 +12072,18 @@ impl UpdateAssumeRolePolicyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGroupRequest {
     #[doc="<p>Name of the IAM group to update. If you're changing the name of the group, this is the original name.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="GroupName")]
     pub group_name: String,
     #[doc="<p>New name for the IAM group. Only include this if changing the group's name.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="NewGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_group_name: Option<String>,
     #[doc="<p>New path for the IAM group. Only include this if changing the group's path.</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="NewPath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_path: Option<String>,
 }
 
@@ -11254,13 +12111,18 @@ impl UpdateGroupRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateLoginProfileRequest {
     #[doc="<p>The new password for the specified IAM user.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D). However, the format can be further restricted by the account administrator by setting a password policy on the AWS account. For more information, see <a>UpdateAccountPasswordPolicy</a>.</p>"]
+    #[serde(rename="Password")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password: Option<String>,
     #[doc="<p>Allows this new password to be used only once by requiring the specified IAM user to set a new password on next sign-in.</p>"]
+    #[serde(rename="PasswordResetRequired")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password_reset_required: Option<bool>,
     #[doc="<p>The name of the user whose password you want to update.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -11288,11 +12150,13 @@ impl UpdateLoginProfileRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateOpenIDConnectProviderThumbprintRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM OIDC provider resource object for which you want to update the thumbprint. You can get a list of OIDC provider ARNs by using the <a>ListOpenIDConnectProviders</a> action.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="OpenIDConnectProviderArn")]
     pub open_id_connect_provider_arn: String,
     #[doc="<p>A list of certificate thumbprints that are associated with the specified IAM OpenID Connect provider. For more information, see <a>CreateOpenIDConnectProvider</a>. </p>"]
+    #[serde(rename="ThumbprintList")]
     pub thumbprint_list: Vec<String>,
 }
 
@@ -11317,11 +12181,13 @@ impl UpdateOpenIDConnectProviderThumbprintRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRoleDescriptionRequest {
     #[doc="<p>The new description that you want to apply to the specified role.</p>"]
+    #[serde(rename="Description")]
     pub description: String,
     #[doc="<p>The name of the role that you want to modify.</p>"]
+    #[serde(rename="RoleName")]
     pub role_name: String,
 }
 
@@ -11343,9 +12209,11 @@ impl UpdateRoleDescriptionRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRoleDescriptionResponse {
     #[doc="<p>A structure that contains details about the modified role.</p>"]
+    #[serde(rename="Role")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role: Option<Role>,
 }
 
@@ -11390,11 +12258,13 @@ impl UpdateRoleDescriptionResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSAMLProviderRequest {
     #[doc="<p>An XML document generated by an identity provider (IdP) that supports SAML 2.0. The document includes the issuer's name, expiration information, and keys that can be used to validate the SAML authentication response (assertions) that are received from the IdP. You must generate the metadata document using the identity management software that is used as your organization's IdP.</p>"]
+    #[serde(rename="SAMLMetadataDocument")]
     pub saml_metadata_document: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the SAML provider to update.</p> <p>For more information about ARNs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
+    #[serde(rename="SAMLProviderArn")]
     pub saml_provider_arn: String,
 }
 
@@ -11417,9 +12287,11 @@ impl UpdateSAMLProviderRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>UpdateSAMLProvider</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSAMLProviderResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the SAML provider that was updated.</p>"]
+    #[serde(rename="SAMLProviderArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub saml_provider_arn: Option<String>,
 }
 
@@ -11466,13 +12338,16 @@ impl UpdateSAMLProviderResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSSHPublicKeyRequest {
     #[doc="<p>The unique identifier for the SSH public key.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>"]
+    #[serde(rename="SSHPublicKeyId")]
     pub ssh_public_key_id: String,
     #[doc="<p>The status to assign to the SSH public key. <code>Active</code> means the key can be used for authentication with an AWS CodeCommit repository. <code>Inactive</code> means the key cannot be used.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The name of the IAM user associated with the SSH public key.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -11496,13 +12371,18 @@ impl UpdateSSHPublicKeyRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateServerCertificateRequest {
     #[doc="<p>The new path for the server certificate. Include this only if you are updating the server certificate's path.</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="NewPath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_path: Option<String>,
     #[doc="<p>The new name for the server certificate. Include this only if you are updating the server certificate's name. The name of the certificate cannot contain any spaces.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="NewServerCertificateName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_server_certificate_name: Option<String>,
     #[doc="<p>The name of the server certificate that you want to update.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="ServerCertificateName")]
     pub server_certificate_name: String,
 }
 
@@ -11530,13 +12410,17 @@ impl UpdateServerCertificateRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateServiceSpecificCredentialRequest {
     #[doc="<p>The unique identifier of the service-specific credential.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>"]
+    #[serde(rename="ServiceSpecificCredentialId")]
     pub service_specific_credential_id: String,
     #[doc="<p>The status to be assigned to the service-specific credential.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The name of the IAM user associated with the service-specific credential. If you do not specify this value, then the operation assumes the user whose credentials are used to call the operation.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -11562,13 +12446,17 @@ impl UpdateServiceSpecificCredentialRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSigningCertificateRequest {
     #[doc="<p>The ID of the signing certificate you want to update.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>"]
+    #[serde(rename="CertificateId")]
     pub certificate_id: String,
     #[doc="<p> The status you want to assign to the certificate. <code>Active</code> means the certificate can be used for API calls to AWS, while <code>Inactive</code> means the certificate cannot be used.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The name of the IAM user the signing certificate belongs to.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -11594,13 +12482,18 @@ impl UpdateSigningCertificateRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserRequest {
     #[doc="<p>New path for the IAM user. Include this parameter only if you're changing the user's path.</p> <p>This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>"]
+    #[serde(rename="NewPath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_path: Option<String>,
     #[doc="<p>New name for the user. Include this parameter only if you're changing the user's name.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="NewUserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_user_name: Option<String>,
     #[doc="<p>Name of the user to update. If you're changing the name of the user, this is the original user name.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -11628,11 +12521,13 @@ impl UpdateUserRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadSSHPublicKeyRequest {
     #[doc="<p>The SSH public key. The public key must be encoded in ssh-rsa format or PEM format.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="SSHPublicKeyBody")]
     pub ssh_public_key_body: String,
     #[doc="<p>The name of the IAM user to associate the SSH public key with.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -11655,9 +12550,11 @@ impl UploadSSHPublicKeyRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>UploadSSHPublicKey</a> request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadSSHPublicKeyResponse {
     #[doc="<p>Contains information about the SSH public key.</p>"]
+    #[serde(rename="SSHPublicKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssh_public_key: Option<SSHPublicKey>,
 }
 
@@ -11704,17 +12601,24 @@ impl UploadSSHPublicKeyResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadServerCertificateRequest {
     #[doc="<p>The contents of the public key certificate in PEM-encoded format.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="CertificateBody")]
     pub certificate_body: String,
     #[doc="<p>The contents of the certificate chain. This is typically a concatenation of the PEM-encoded public key certificates of the chain.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="CertificateChain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificate_chain: Option<String>,
     #[doc="<p>The path for the server certificate. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/). This paramater allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes, containing any ASCII character from the ! (\\u0021) thru the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p> <note> <p> If you are uploading a server certificate specifically for use with Amazon CloudFront distributions, you must specify a path using the <code>--path</code> option. The path must begin with <code>/cloudfront</code> and must include a trailing slash (for example, <code>/cloudfront/test/</code>).</p> </note>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
     #[doc="<p>The contents of the private key in PEM-encoded format.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="PrivateKey")]
     pub private_key: String,
     #[doc="<p>The name for the server certificate. Do not include the path in this value. The name of the certificate cannot contain any spaces.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="ServerCertificateName")]
     pub server_certificate_name: String,
 }
 
@@ -11747,9 +12651,11 @@ impl UploadServerCertificateRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>UploadServerCertificate</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadServerCertificateResponse {
     #[doc="<p>The meta information of the uploaded server certificate without its certificate body, certificate chain, and private key.</p>"]
+    #[serde(rename="ServerCertificateMetadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_certificate_metadata: Option<ServerCertificateMetadata>,
 }
 
@@ -11795,11 +12701,14 @@ impl UploadServerCertificateResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadSigningCertificateRequest {
     #[doc="<p>The contents of the signing certificate.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> used to validate this parameter is a string of characters consisting of any printable ASCII character ranging from the space character (\\u0020) through end of the ASCII character range as well as the printable characters in the Basic Latin and Latin-1 Supplement character set (through \\u00FF). It also includes the special characters tab (\\u0009), line feed (\\u000A), and carriage return (\\u000D).</p>"]
+    #[serde(rename="CertificateBody")]
     pub certificate_body: String,
     #[doc="<p>The name of the user the signing certificate is for.</p> <p>This parameter allows (per its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
 }
 
@@ -11824,9 +12733,10 @@ impl UploadSigningCertificateRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>UploadSigningCertificate</a> request. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadSigningCertificateResponse {
     #[doc="<p>Information about the certificate.</p>"]
+    #[serde(rename="Certificate")]
     pub certificate: SigningCertificate,
 }
 
@@ -11875,19 +12785,26 @@ impl UploadSigningCertificateResponseDeserializer {
     }
 }
 #[doc="<p>Contains information about an IAM user entity.</p> <p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateUser</a> </p> </li> <li> <p> <a>GetUser</a> </p> </li> <li> <p> <a>ListUsers</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct User {
     #[doc="<p>The Amazon Resource Name (ARN) that identifies the user. For more information about ARNs and how to use ARNs in policies, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="Arn")]
     pub arn: String,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the user was created.</p>"]
+    #[serde(rename="CreateDate")]
     pub create_date: String,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the user's password was last used to sign in to an AWS website. For a list of AWS websites that capture a user's last sign-in time, see the <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/credential-reports.html\">Credential Reports</a> topic in the <i>Using IAM</i> guide. If a password is used more than once in a five-minute span, only the first use is returned in this field. This field is null (not present) when:</p> <ul> <li> <p>The user does not have a password</p> </li> <li> <p>The password exists but has never been used (at least not since IAM started tracking this information on October 20th, 2014</p> </li> <li> <p>there is no sign-in data associated with the user</p> </li> </ul> <p>This value is returned only in the <a>GetUser</a> and <a>ListUsers</a> actions. </p>"]
+    #[serde(rename="PasswordLastUsed")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub password_last_used: Option<String>,
     #[doc="<p>The path to the user. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="Path")]
     pub path: String,
     #[doc="<p>The stable and unique string identifying the user. For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="UserId")]
     pub user_id: String,
     #[doc="<p>The friendly name identifying the user.</p>"]
+    #[serde(rename="UserName")]
     pub user_name: String,
 }
 
@@ -11952,22 +12869,38 @@ impl UserDeserializer {
     }
 }
 #[doc="<p>Contains information about an IAM user, including all the user's policies and all the IAM groups the user is in.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserDetail {
+    #[serde(rename="Arn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
     #[doc="<p>A list of the managed policies attached to the user.</p>"]
+    #[serde(rename="AttachedManagedPolicies")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attached_managed_policies: Option<Vec<AttachedPolicy>>,
     #[doc="<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the user was created.</p>"]
+    #[serde(rename="CreateDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_date: Option<String>,
     #[doc="<p>A list of IAM groups that the user is in.</p>"]
+    #[serde(rename="GroupList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub group_list: Option<Vec<String>>,
     #[doc="<p>The path to the user. For more information about paths, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="Path")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub path: Option<String>,
     #[doc="<p>The stable and unique string identifying the user. For more information about IDs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM Identifiers</a> in the <i>Using IAM</i> guide.</p>"]
+    #[serde(rename="UserId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_id: Option<String>,
     #[doc="<p>The friendly name identifying the user.</p>"]
+    #[serde(rename="UserName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_name: Option<String>,
     #[doc="<p>A list of the inline policies embedded in the user.</p>"]
+    #[serde(rename="UserPolicyList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_policy_list: Option<Vec<PolicyDetail>>,
 }
 
@@ -12138,17 +13071,34 @@ impl UserNameTypeDeserializer {
     }
 }
 #[doc="<p>Contains information about a virtual MFA device.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VirtualMFADevice {
     #[doc="<p> The Base32 seed defined as specified in <a href=\"https://tools.ietf.org/html/rfc3548.txt\">RFC3548</a>. The <code>Base32StringSeed</code> is Base64-encoded. </p>"]
+    #[serde(rename="Base32StringSeed")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub base_32_string_seed: Option<Vec<u8>>,
     #[doc="<p>The date and time on which the virtual MFA device was enabled.</p>"]
+    #[serde(rename="EnableDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_date: Option<String>,
     #[doc="<p> A QR code PNG image that encodes <code>otpauth://totp/$virtualMFADeviceName@$AccountName?secret=$Base32String</code> where <code>$virtualMFADeviceName</code> is one of the create call arguments, <code>AccountName</code> is the user name if set (otherwise, the account ID otherwise), and <code>Base32String</code> is the seed in Base32 format. The <code>Base32String</code> value is Base64-encoded. </p>"]
+    #[serde(rename="QRCodePNG")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub qr_code_png: Option<Vec<u8>>,
     #[doc="<p>The serial number associated with <code>VirtualMFADevice</code>.</p>"]
+    #[serde(rename="SerialNumber")]
     pub serial_number: String,
     #[doc="<p>The IAM user associated with this virtual MFA device.</p>"]
+    #[serde(rename="User")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user: Option<User>,
 }
 

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -40,9 +40,13 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="A discrete item that contains the description and URL of an artifact (such as a PDF)."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Artifact {
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
+    #[serde(rename="URL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub url: Option<String>,
 }
 
@@ -134,9 +138,12 @@ impl ArtifactListDeserializer {
     }
 }
 #[doc="Input structure for the CancelJob operation."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelJobInput {
+    #[serde(rename="APIVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub api_version: Option<String>,
+    #[serde(rename="JobId")]
     pub job_id: String,
 }
 
@@ -161,8 +168,10 @@ impl CancelJobInputSerializer {
 }
 
 #[doc="Output structure for the CancelJob operation."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelJobOutput {
+    #[serde(rename="Success")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub success: Option<bool>,
 }
 
@@ -223,12 +232,19 @@ impl CarrierDeserializer {
     }
 }
 #[doc="Input structure for the CreateJob operation."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobInput {
+    #[serde(rename="APIVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub api_version: Option<String>,
+    #[serde(rename="JobType")]
     pub job_type: String,
+    #[serde(rename="Manifest")]
     pub manifest: String,
+    #[serde(rename="ManifestAddendum")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub manifest_addendum: Option<String>,
+    #[serde(rename="ValidateOnly")]
     pub validate_only: bool,
 }
 
@@ -261,13 +277,25 @@ impl CreateJobInputSerializer {
 }
 
 #[doc="Output structure for the CreateJob operation."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobOutput {
+    #[serde(rename="ArtifactList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub artifact_list: Option<Vec<Artifact>>,
+    #[serde(rename="JobId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub job_id: Option<String>,
+    #[serde(rename="JobType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub job_type: Option<String>,
+    #[serde(rename="Signature")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub signature: Option<String>,
+    #[serde(rename="SignatureFileContents")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub signature_file_contents: Option<String>,
+    #[serde(rename="WarningMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub warning_message: Option<String>,
 }
 
@@ -405,19 +433,42 @@ impl GenericStringDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetShippingLabelInput {
+    #[serde(rename="APIVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub api_version: Option<String>,
+    #[serde(rename="city")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub city: Option<String>,
+    #[serde(rename="company")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub company: Option<String>,
+    #[serde(rename="country")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub country: Option<String>,
+    #[serde(rename="jobIds")]
     pub job_ids: Vec<String>,
+    #[serde(rename="name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+    #[serde(rename="phoneNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub phone_number: Option<String>,
+    #[serde(rename="postalCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub postal_code: Option<String>,
+    #[serde(rename="stateOrProvince")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state_or_province: Option<String>,
+    #[serde(rename="street1")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub street_1: Option<String>,
+    #[serde(rename="street2")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub street_2: Option<String>,
+    #[serde(rename="street3")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub street_3: Option<String>,
 }
 
@@ -480,9 +531,13 @@ impl GetShippingLabelInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetShippingLabelOutput {
+    #[serde(rename="ShippingLabelURL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub shipping_label_url: Option<String>,
+    #[serde(rename="Warning")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub warning: Option<String>,
 }
 
@@ -534,9 +589,12 @@ impl GetShippingLabelOutputDeserializer {
     }
 }
 #[doc="Input structure for the GetStatus operation."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetStatusInput {
+    #[serde(rename="APIVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub api_version: Option<String>,
+    #[serde(rename="JobId")]
     pub job_id: String,
 }
 
@@ -561,23 +619,55 @@ impl GetStatusInputSerializer {
 }
 
 #[doc="Output structure for the GetStatus operation."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetStatusOutput {
+    #[serde(rename="ArtifactList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub artifact_list: Option<Vec<Artifact>>,
+    #[serde(rename="Carrier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub carrier: Option<String>,
+    #[serde(rename="CreationDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub creation_date: Option<String>,
+    #[serde(rename="CurrentManifest")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub current_manifest: Option<String>,
+    #[serde(rename="ErrorCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub error_count: Option<i64>,
+    #[serde(rename="JobId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub job_id: Option<String>,
+    #[serde(rename="JobType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub job_type: Option<String>,
+    #[serde(rename="LocationCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location_code: Option<String>,
+    #[serde(rename="LocationMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location_message: Option<String>,
+    #[serde(rename="LogBucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub log_bucket: Option<String>,
+    #[serde(rename="LogKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub log_key: Option<String>,
+    #[serde(rename="ProgressCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress_code: Option<String>,
+    #[serde(rename="ProgressMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress_message: Option<String>,
+    #[serde(rename="Signature")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub signature: Option<String>,
+    #[serde(rename="SignatureFileContents")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub signature_file_contents: Option<String>,
+    #[serde(rename="TrackingNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tracking_number: Option<String>,
 }
 
@@ -721,11 +811,19 @@ impl IsTruncatedDeserializer {
     }
 }
 #[doc="Representation of a job returned by the ListJobs operation."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Job {
+    #[serde(rename="CreationDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub creation_date: Option<String>,
+    #[serde(rename="IsCanceled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_canceled: Option<bool>,
+    #[serde(rename="JobId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub job_id: Option<String>,
+    #[serde(rename="JobType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub job_type: Option<String>,
 }
 
@@ -866,10 +964,16 @@ impl JobsListDeserializer {
     }
 }
 #[doc="Input structure for the ListJobs operation."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsInput {
+    #[serde(rename="APIVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub api_version: Option<String>,
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
+    #[serde(rename="MaxJobs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_jobs: Option<i64>,
 }
 
@@ -900,9 +1004,13 @@ impl ListJobsInputSerializer {
 }
 
 #[doc="Output structure for the ListJobs operation."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsOutput {
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
+    #[serde(rename="Jobs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub jobs: Option<Vec<Job>>,
 }
 
@@ -1107,12 +1215,18 @@ impl URLDeserializer {
     }
 }
 #[doc="Input structure for the UpateJob operation."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateJobInput {
+    #[serde(rename="APIVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub api_version: Option<String>,
+    #[serde(rename="JobId")]
     pub job_id: String,
+    #[serde(rename="JobType")]
     pub job_type: String,
+    #[serde(rename="Manifest")]
     pub manifest: String,
+    #[serde(rename="ValidateOnly")]
     pub validate_only: bool,
 }
 
@@ -1143,10 +1257,16 @@ impl UpdateJobInputSerializer {
 }
 
 #[doc="Output structure for the UpateJob operation."]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateJobOutput {
+    #[serde(rename="ArtifactList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub artifact_list: Option<Vec<Artifact>>,
+    #[serde(rename="Success")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub success: Option<bool>,
+    #[serde(rename="WarningMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub warning_message: Option<String>,
 }
 

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddAttributesToFindingsRequest {
     #[doc="<p>The array of attributes that you want to assign to specified findings.</p>"]
     #[serde(rename="attributes")]
@@ -38,7 +38,7 @@ pub struct AddAttributesToFindingsRequest {
     pub finding_arns: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddAttributesToFindingsResponse {
     #[doc="<p>Attribute details that cannot be described. An error code is provided for each failed item.</p>"]
     #[serde(rename="failedItems")]
@@ -46,16 +46,18 @@ pub struct AddAttributesToFindingsResponse {
 }
 
 #[doc="<p>Used in the exception error that is thrown if you start an assessment run for an assessment target that includes an EC2 instance that is already participating in another started assessment run.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AgentAlreadyRunningAssessment {
     #[doc="<p>ID of the agent that is running on an EC2 instance that is already participating in another started assessment run.</p>"]
+    #[serde(rename="agentId")]
     pub agent_id: String,
     #[doc="<p>The ARN of the assessment run that has already been started.</p>"]
+    #[serde(rename="assessmentRunArn")]
     pub assessment_run_arn: String,
 }
 
 #[doc="<p>Contains information about an Amazon Inspector agent. This data type is used as a request parameter in the <a>ListAssessmentRunAgents</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AgentFilter {
     #[doc="<p>The detailed health state of the agent. Values can be set to <b>IDLE</b>, <b>RUNNING</b>, <b>SHUTDOWN</b>, <b>UNHEALTHY</b>, <b>THROTTLED</b>, and <b>UNKNOWN</b>. </p>"]
     #[serde(rename="agentHealthCodes")]
@@ -66,7 +68,7 @@ pub struct AgentFilter {
 }
 
 #[doc="<p>Used as a response element in the <a>PreviewAgents</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AgentPreview {
     #[doc="<p>The ID of the EC2 instance where the agent is installed.</p>"]
     #[serde(rename="agentId")]
@@ -78,7 +80,7 @@ pub struct AgentPreview {
 }
 
 #[doc="<p>A snapshot of an Amazon Inspector assessment run that contains the findings of the assessment run .</p> <p>Used as the response element in the <a>DescribeAssessmentRuns</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssessmentRun {
     #[doc="<p>The ARN of the assessment run.</p>"]
     #[serde(rename="arn")]
@@ -130,7 +132,7 @@ pub struct AssessmentRun {
 }
 
 #[doc="<p>Contains information about an Amazon Inspector agent. This data type is used as a response element in the <a>ListAssessmentRunAgents</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssessmentRunAgent {
     #[doc="<p>The current health state of the agent.</p>"]
     #[serde(rename="agentHealth")]
@@ -158,7 +160,7 @@ pub struct AssessmentRunAgent {
 }
 
 #[doc="<p>Used as the request parameter in the <a>ListAssessmentRuns</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssessmentRunFilter {
     #[doc="<p>For a record to match a filter, the value that is specified for this data type property must inclusively match any value between the specified minimum and maximum values of the <b>completedAt</b> property of the <a>AssessmentRun</a> data type.</p>"]
     #[serde(rename="completionTimeRange")]
@@ -191,7 +193,7 @@ pub struct AssessmentRunFilter {
 }
 
 #[doc="<p>Used as one of the elements of the <a>AssessmentRun</a> data type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssessmentRunNotification {
     #[doc="<p>The date of the notification.</p>"]
     #[serde(rename="date")]
@@ -217,7 +219,7 @@ pub struct AssessmentRunNotification {
 }
 
 #[doc="<p>Used as one of the elements of the <a>AssessmentRun</a> data type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssessmentRunStateChange {
     #[doc="<p>The assessment run state.</p>"]
     #[serde(rename="state")]
@@ -228,7 +230,7 @@ pub struct AssessmentRunStateChange {
 }
 
 #[doc="<p>Contains information about an Amazon Inspector application. This data type is used as the response element in the <a>DescribeAssessmentTargets</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssessmentTarget {
     #[doc="<p>The ARN that specifies the Amazon Inspector assessment target.</p>"]
     #[serde(rename="arn")]
@@ -248,7 +250,7 @@ pub struct AssessmentTarget {
 }
 
 #[doc="<p>Used as the request parameter in the <a>ListAssessmentTargets</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssessmentTargetFilter {
     #[doc="<p>For a record to match a filter, an explicit value or a string that contains a wildcard that is specified for this data type property must match the value of the <b>assessmentTargetName</b> property of the <a>AssessmentTarget</a> data type.</p>"]
     #[serde(rename="assessmentTargetNamePattern")]
@@ -257,7 +259,7 @@ pub struct AssessmentTargetFilter {
 }
 
 #[doc="<p>Contains information about an Amazon Inspector assessment template. This data type is used as the response element in the <a>DescribeAssessmentTemplates</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssessmentTemplate {
     #[doc="<p>The ARN of the assessment template.</p>"]
     #[serde(rename="arn")]
@@ -283,7 +285,7 @@ pub struct AssessmentTemplate {
 }
 
 #[doc="<p>Used as the request parameter in the <a>ListAssessmentTemplates</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssessmentTemplateFilter {
     #[doc="<p>For a record to match a filter, the value specified for this data type property must inclusively match any value between the specified minimum and maximum values of the <b>durationInSeconds</b> property of the <a>AssessmentTemplate</a> data type.</p>"]
     #[serde(rename="durationRange")]
@@ -300,7 +302,7 @@ pub struct AssessmentTemplateFilter {
 }
 
 #[doc="<p>A collection of attributes of the host from which the finding is generated.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssetAttributes {
     #[doc="<p>The ID of the agent that is installed on the EC2 instance where the finding is generated.</p>"]
     #[serde(rename="agentId")]
@@ -339,7 +341,7 @@ pub struct Attribute {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAssessmentTargetRequest {
     #[doc="<p>The user-defined name that identifies the assessment target that you want to create. The name must be unique within the AWS account.</p>"]
     #[serde(rename="assessmentTargetName")]
@@ -349,14 +351,14 @@ pub struct CreateAssessmentTargetRequest {
     pub resource_group_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAssessmentTargetResponse {
     #[doc="<p>The ARN that specifies the assessment target that is created.</p>"]
     #[serde(rename="assessmentTargetArn")]
     pub assessment_target_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAssessmentTemplateRequest {
     #[doc="<p>The ARN that specifies the assessment target for which you want to create the assessment template.</p>"]
     #[serde(rename="assessmentTargetArn")]
@@ -376,56 +378,56 @@ pub struct CreateAssessmentTemplateRequest {
     pub user_attributes_for_findings: Option<Vec<Attribute>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAssessmentTemplateResponse {
     #[doc="<p>The ARN that specifies the assessment template that is created.</p>"]
     #[serde(rename="assessmentTemplateArn")]
     pub assessment_template_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateResourceGroupRequest {
     #[doc="<p>A collection of keys and an array of possible values, '[{\"key\":\"key1\",\"values\":[\"Value1\",\"Value2\"]},{\"key\":\"Key2\",\"values\":[\"Value3\"]}]'.</p> <p>For example,'[{\"key\":\"Name\",\"values\":[\"TestEC2Instance\"]}]'.</p>"]
     #[serde(rename="resourceGroupTags")]
     pub resource_group_tags: Vec<ResourceGroupTag>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateResourceGroupResponse {
     #[doc="<p>The ARN that specifies the resource group that is created.</p>"]
     #[serde(rename="resourceGroupArn")]
     pub resource_group_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAssessmentRunRequest {
     #[doc="<p>The ARN that specifies the assessment run that you want to delete.</p>"]
     #[serde(rename="assessmentRunArn")]
     pub assessment_run_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAssessmentTargetRequest {
     #[doc="<p>The ARN that specifies the assessment target that you want to delete.</p>"]
     #[serde(rename="assessmentTargetArn")]
     pub assessment_target_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAssessmentTemplateRequest {
     #[doc="<p>The ARN that specifies the assessment template that you want to delete.</p>"]
     #[serde(rename="assessmentTemplateArn")]
     pub assessment_template_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAssessmentRunsRequest {
     #[doc="<p>The ARN that specifies the assessment run that you want to describe.</p>"]
     #[serde(rename="assessmentRunArns")]
     pub assessment_run_arns: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAssessmentRunsResponse {
     #[doc="<p>Information about the assessment run.</p>"]
     #[serde(rename="assessmentRuns")]
@@ -435,14 +437,14 @@ pub struct DescribeAssessmentRunsResponse {
     pub failed_items: ::std::collections::HashMap<String, FailedItemDetails>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAssessmentTargetsRequest {
     #[doc="<p>The ARNs that specifies the assessment targets that you want to describe.</p>"]
     #[serde(rename="assessmentTargetArns")]
     pub assessment_target_arns: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAssessmentTargetsResponse {
     #[doc="<p>Information about the assessment targets.</p>"]
     #[serde(rename="assessmentTargets")]
@@ -452,13 +454,13 @@ pub struct DescribeAssessmentTargetsResponse {
     pub failed_items: ::std::collections::HashMap<String, FailedItemDetails>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAssessmentTemplatesRequest {
     #[serde(rename="assessmentTemplateArns")]
     pub assessment_template_arns: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAssessmentTemplatesResponse {
     #[doc="<p>Information about the assessment templates.</p>"]
     #[serde(rename="assessmentTemplates")]
@@ -468,7 +470,7 @@ pub struct DescribeAssessmentTemplatesResponse {
     pub failed_items: ::std::collections::HashMap<String, FailedItemDetails>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCrossAccountAccessRoleResponse {
     #[doc="<p>The date when the cross-account access role was registered.</p>"]
     #[serde(rename="registeredAt")]
@@ -481,7 +483,7 @@ pub struct DescribeCrossAccountAccessRoleResponse {
     pub valid: bool,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFindingsRequest {
     #[doc="<p>The ARN that specifies the finding that you want to describe.</p>"]
     #[serde(rename="findingArns")]
@@ -492,7 +494,7 @@ pub struct DescribeFindingsRequest {
     pub locale: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFindingsResponse {
     #[doc="<p>Finding details that cannot be described. An error code is provided for each failed item.</p>"]
     #[serde(rename="failedItems")]
@@ -502,14 +504,14 @@ pub struct DescribeFindingsResponse {
     pub findings: Vec<Finding>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeResourceGroupsRequest {
     #[doc="<p>The ARN that specifies the resource group that you want to describe.</p>"]
     #[serde(rename="resourceGroupArns")]
     pub resource_group_arns: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeResourceGroupsResponse {
     #[doc="<p>Resource group details that cannot be described. An error code is provided for each failed item.</p>"]
     #[serde(rename="failedItems")]
@@ -519,7 +521,7 @@ pub struct DescribeResourceGroupsResponse {
     pub resource_groups: Vec<ResourceGroup>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRulesPackagesRequest {
     #[doc="<p>The locale that you want to translate a rules package description into.</p>"]
     #[serde(rename="locale")]
@@ -530,7 +532,7 @@ pub struct DescribeRulesPackagesRequest {
     pub rules_package_arns: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRulesPackagesResponse {
     #[doc="<p>Rules package details that cannot be described. An error code is provided for each failed item.</p>"]
     #[serde(rename="failedItems")]
@@ -541,7 +543,7 @@ pub struct DescribeRulesPackagesResponse {
 }
 
 #[doc="<p>This data type is used in the <a>AssessmentTemplateFilter</a> data type.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DurationRange {
     #[doc="<p>The maximum value of the duration range. Must be less than or equal to 604800 seconds (1 week).</p>"]
     #[serde(rename="maxSeconds")]
@@ -554,7 +556,7 @@ pub struct DurationRange {
 }
 
 #[doc="<p>This data type is used in the <a>Subscription</a> data type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventSubscription {
     #[doc="<p>The event for which Amazon Simple Notification Service (SNS) notifications are sent.</p>"]
     #[serde(rename="event")]
@@ -565,7 +567,7 @@ pub struct EventSubscription {
 }
 
 #[doc="<p>Includes details about the failed items.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailedItemDetails {
     #[doc="<p>The status code of a failed item.</p>"]
     #[serde(rename="failureCode")]
@@ -576,7 +578,7 @@ pub struct FailedItemDetails {
 }
 
 #[doc="<p>Contains information about an Amazon Inspector finding. This data type is used as the response element in the <a>DescribeFindings</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Finding {
     #[doc="<p>The ARN that specifies the finding.</p>"]
     #[serde(rename="arn")]
@@ -648,7 +650,7 @@ pub struct Finding {
 }
 
 #[doc="<p>This data type is used as a request parameter in the <a>ListFindings</a> action.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FindingFilter {
     #[doc="<p>For a record to match a filter, one of the values that is specified for this data type property must be the exact match of the value of the <b>agentId</b> property of the <a>Finding</a> data type.</p>"]
     #[serde(rename="agentIds")]
@@ -684,7 +686,7 @@ pub struct FindingFilter {
     pub user_attributes: Option<Vec<Attribute>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAssessmentReportRequest {
     #[doc="<p>The ARN that specifies the assessment run for which you want to generate a report.</p>"]
     #[serde(rename="assessmentRunArn")]
@@ -697,7 +699,7 @@ pub struct GetAssessmentReportRequest {
     pub report_type: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAssessmentReportResponse {
     #[doc="<p>Specifies the status of the request to generate an assessment report. </p>"]
     #[serde(rename="status")]
@@ -708,14 +710,14 @@ pub struct GetAssessmentReportResponse {
     pub url: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTelemetryMetadataRequest {
     #[doc="<p>The ARN that specifies the assessment run that has the telemetry data that you want to obtain.</p>"]
     #[serde(rename="assessmentRunArn")]
     pub assessment_run_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTelemetryMetadataResponse {
     #[doc="<p>Telemetry details.</p>"]
     #[serde(rename="telemetryMetadata")]
@@ -723,7 +725,7 @@ pub struct GetTelemetryMetadataResponse {
 }
 
 #[doc="<p>This data type is used in the <a>Finding</a> data type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InspectorServiceAttributes {
     #[doc="<p>The ARN of the assessment run during which the finding is generated.</p>"]
     #[serde(rename="assessmentRunArn")]
@@ -738,7 +740,7 @@ pub struct InspectorServiceAttributes {
     pub schema_version: i64,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssessmentRunAgentsRequest {
     #[doc="<p>The ARN that specifies the assessment run whose agents you want to list.</p>"]
     #[serde(rename="assessmentRunArn")]
@@ -757,7 +759,7 @@ pub struct ListAssessmentRunAgentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssessmentRunAgentsResponse {
     #[doc="<p>A list of ARNs that specifies the agents returned by the action.</p>"]
     #[serde(rename="assessmentRunAgents")]
@@ -768,7 +770,7 @@ pub struct ListAssessmentRunAgentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssessmentRunsRequest {
     #[doc="<p>The ARNs that specify the assessment templates whose assessment runs you want to list.</p>"]
     #[serde(rename="assessmentTemplateArns")]
@@ -788,7 +790,7 @@ pub struct ListAssessmentRunsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssessmentRunsResponse {
     #[doc="<p>A list of ARNs that specifies the assessment runs that are returned by the action.</p>"]
     #[serde(rename="assessmentRunArns")]
@@ -799,7 +801,7 @@ pub struct ListAssessmentRunsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssessmentTargetsRequest {
     #[doc="<p>You can use this parameter to specify a subset of data to be included in the action's response.</p> <p>For a record to match a filter, all specified filter attributes must match. When multiple values are specified for a filter attribute, any of the values can match.</p>"]
     #[serde(rename="filter")]
@@ -815,7 +817,7 @@ pub struct ListAssessmentTargetsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssessmentTargetsResponse {
     #[doc="<p>A list of ARNs that specifies the assessment targets that are returned by the action.</p>"]
     #[serde(rename="assessmentTargetArns")]
@@ -826,7 +828,7 @@ pub struct ListAssessmentTargetsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssessmentTemplatesRequest {
     #[doc="<p>A list of ARNs that specifies the assessment targets whose assessment templates you want to list.</p>"]
     #[serde(rename="assessmentTargetArns")]
@@ -846,7 +848,7 @@ pub struct ListAssessmentTemplatesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssessmentTemplatesResponse {
     #[doc="<p>A list of ARNs that specifies the assessment templates returned by the action.</p>"]
     #[serde(rename="assessmentTemplateArns")]
@@ -857,7 +859,7 @@ pub struct ListAssessmentTemplatesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListEventSubscriptionsRequest {
     #[doc="<p>You can use this parameter to indicate the maximum number of items you want in the response. The default value is 10. The maximum value is 500.</p>"]
     #[serde(rename="maxResults")]
@@ -873,7 +875,7 @@ pub struct ListEventSubscriptionsRequest {
     pub resource_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListEventSubscriptionsResponse {
     #[doc="<p> When a response is generated, if there is more data to be listed, this parameter is present in the response and contains the value to use for the <b>nextToken</b> parameter in a subsequent pagination request. If there is no more data to be listed, this parameter is set to null.</p>"]
     #[serde(rename="nextToken")]
@@ -884,7 +886,7 @@ pub struct ListEventSubscriptionsResponse {
     pub subscriptions: Vec<Subscription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFindingsRequest {
     #[doc="<p>The ARNs of the assessment runs that generate the findings that you want to list.</p>"]
     #[serde(rename="assessmentRunArns")]
@@ -904,7 +906,7 @@ pub struct ListFindingsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFindingsResponse {
     #[doc="<p>A list of ARNs that specifies the findings returned by the action.</p>"]
     #[serde(rename="findingArns")]
@@ -915,7 +917,7 @@ pub struct ListFindingsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRulesPackagesRequest {
     #[doc="<p>You can use this parameter to indicate the maximum number of items you want in the response. The default value is 10. The maximum value is 500.</p>"]
     #[serde(rename="maxResults")]
@@ -927,7 +929,7 @@ pub struct ListRulesPackagesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRulesPackagesResponse {
     #[doc="<p> When a response is generated, if there is more data to be listed, this parameter is present in the response and contains the value to use for the <b>nextToken</b> parameter in a subsequent pagination request. If there is no more data to be listed, this parameter is set to null.</p>"]
     #[serde(rename="nextToken")]
@@ -938,21 +940,21 @@ pub struct ListRulesPackagesResponse {
     pub rules_package_arns: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceRequest {
     #[doc="<p>The ARN that specifies the assessment template whose tags you want to list.</p>"]
     #[serde(rename="resourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceResponse {
     #[doc="<p>A collection of key and value pairs.</p>"]
     #[serde(rename="tags")]
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PreviewAgentsRequest {
     #[doc="<p>You can use this parameter to indicate the maximum number of items you want in the response. The default value is 10. The maximum value is 500.</p>"]
     #[serde(rename="maxResults")]
@@ -967,7 +969,7 @@ pub struct PreviewAgentsRequest {
     pub preview_agents_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PreviewAgentsResponse {
     #[doc="<p>The resulting list of agents.</p>"]
     #[serde(rename="agentPreviews")]
@@ -978,14 +980,14 @@ pub struct PreviewAgentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterCrossAccountAccessRoleRequest {
     #[doc="<p>The ARN of the IAM role that Amazon Inspector uses to list your EC2 instances during the assessment run or when you call the <a>PreviewAgents</a> action. </p>"]
     #[serde(rename="roleArn")]
     pub role_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveAttributesFromFindingsRequest {
     #[doc="<p>The array of attribute keys that you want to remove from specified findings.</p>"]
     #[serde(rename="attributeKeys")]
@@ -995,7 +997,7 @@ pub struct RemoveAttributesFromFindingsRequest {
     pub finding_arns: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveAttributesFromFindingsResponse {
     #[doc="<p>Attributes details that cannot be described. An error code is provided for each failed item.</p>"]
     #[serde(rename="failedItems")]
@@ -1003,7 +1005,7 @@ pub struct RemoveAttributesFromFindingsResponse {
 }
 
 #[doc="<p>Contains information about a resource group. The resource group defines a set of tags that, when queried, identify the AWS resources that make up the assessment target. This data type is used as the response element in the <a>DescribeResourceGroups</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceGroup {
     #[doc="<p>The ARN of the resource group.</p>"]
     #[serde(rename="arn")]
@@ -1029,7 +1031,7 @@ pub struct ResourceGroupTag {
 }
 
 #[doc="<p>Contains information about an Amazon Inspector rules package. This data type is used as the response element in the <a>DescribeRulesPackages</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RulesPackage {
     #[doc="<p>The ARN of the rules package.</p>"]
     #[serde(rename="arn")]
@@ -1049,7 +1051,7 @@ pub struct RulesPackage {
     pub version: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetTagsForResourceRequest {
     #[doc="<p>The ARN of the assessment template that you want to set tags to.</p>"]
     #[serde(rename="resourceArn")]
@@ -1060,7 +1062,7 @@ pub struct SetTagsForResourceRequest {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartAssessmentRunRequest {
     #[doc="<p>You can specify the name for the assessment run. The name must be unique for the assessment template whose ARN is used to start the assessment run.</p>"]
     #[serde(rename="assessmentRunName")]
@@ -1071,14 +1073,14 @@ pub struct StartAssessmentRunRequest {
     pub assessment_template_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartAssessmentRunResponse {
     #[doc="<p>The ARN of the assessment run that has been started.</p>"]
     #[serde(rename="assessmentRunArn")]
     pub assessment_run_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopAssessmentRunRequest {
     #[doc="<p>The ARN of the assessment run that you want to stop.</p>"]
     #[serde(rename="assessmentRunArn")]
@@ -1089,7 +1091,7 @@ pub struct StopAssessmentRunRequest {
     pub stop_action: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubscribeToEventRequest {
     #[doc="<p>The event for which you want to receive SNS notifications.</p>"]
     #[serde(rename="event")]
@@ -1103,7 +1105,7 @@ pub struct SubscribeToEventRequest {
 }
 
 #[doc="<p>This data type is used as a response element in the <a>ListEventSubscriptions</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Subscription {
     #[doc="<p>The list of existing event subscriptions.</p>"]
     #[serde(rename="eventSubscriptions")]
@@ -1129,7 +1131,7 @@ pub struct Tag {
 }
 
 #[doc="<p>The metadata about the Amazon Inspector application data metrics collected by the agent. This data type is used as the response element in the <a>GetTelemetryMetadata</a> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TelemetryMetadata {
     #[doc="<p>The count of messages that the agent sends to the Amazon Inspector service.</p>"]
     #[serde(rename="count")]
@@ -1144,7 +1146,7 @@ pub struct TelemetryMetadata {
 }
 
 #[doc="<p>This data type is used in the <a>AssessmentRunFilter</a> data type.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TimestampRange {
     #[doc="<p>The minimum value of the timestamp range.</p>"]
     #[serde(rename="beginDate")]
@@ -1156,7 +1158,7 @@ pub struct TimestampRange {
     pub end_date: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnsubscribeFromEventRequest {
     #[doc="<p>The event for which you want to stop receiving SNS notifications.</p>"]
     #[serde(rename="event")]
@@ -1169,7 +1171,7 @@ pub struct UnsubscribeFromEventRequest {
     pub topic_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAssessmentTargetRequest {
     #[doc="<p>The ARN of the assessment target that you want to update.</p>"]
     #[serde(rename="assessmentTargetArn")]

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 #[doc="<p>The input for the AcceptCertificateTransfer operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptCertificateTransferRequest {
     #[doc="<p>The ID of the certificate.</p>"]
     #[serde(rename="certificateId")]
@@ -99,7 +99,7 @@ pub struct Action {
 }
 
 #[doc="<p>The input for the AttachPrincipalPolicy operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachPrincipalPolicyRequest {
     #[doc="<p>The policy name.</p>"]
     #[serde(rename="policyName")]
@@ -110,7 +110,7 @@ pub struct AttachPrincipalPolicyRequest {
 }
 
 #[doc="<p>The input for the AttachThingPrincipal operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachThingPrincipalRequest {
     #[doc="<p>The principal, such as a certificate or other credential.</p>"]
     #[serde(rename="principal")]
@@ -121,11 +121,11 @@ pub struct AttachThingPrincipalRequest {
 }
 
 #[doc="<p>The output from the AttachThingPrincipal operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachThingPrincipalResponse;
 
 #[doc="<p>The attribute payload.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttributePayload {
     #[doc="<p>A JSON string containing up to three key-value pair in JSON format. For example:</p> <p> <code>{\\\"attributes\\\":{\\\"string1\\\":\\\"string2\\\"}}</code> </p>"]
     #[serde(rename="attributes")]
@@ -138,7 +138,7 @@ pub struct AttributePayload {
 }
 
 #[doc="<p>A CA certificate.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CACertificate {
     #[doc="<p>The ARN of the CA certificate.</p>"]
     #[serde(rename="certificateArn")]
@@ -159,7 +159,7 @@ pub struct CACertificate {
 }
 
 #[doc="<p>Describes a CA certificate.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CACertificateDescription {
     #[doc="<p>Whether the CA certificate configured for auto registration of device certificates. Valid values are \"ENABLE\" and \"DISABLE\"</p>"]
     #[serde(rename="autoRegistrationStatus")]
@@ -192,7 +192,7 @@ pub struct CACertificateDescription {
 }
 
 #[doc="<p>The input for the CancelCertificateTransfer operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelCertificateTransferRequest {
     #[doc="<p>The ID of the certificate.</p>"]
     #[serde(rename="certificateId")]
@@ -200,7 +200,7 @@ pub struct CancelCertificateTransferRequest {
 }
 
 #[doc="<p>Information about a certificate.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Certificate {
     #[doc="<p>The ARN of the certificate.</p>"]
     #[serde(rename="certificateArn")]
@@ -221,7 +221,7 @@ pub struct Certificate {
 }
 
 #[doc="<p>Describes a certificate.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CertificateDescription {
     #[doc="<p>The certificate ID of the CA certificate used to sign this certificate.</p>"]
     #[serde(rename="caCertificateId")]
@@ -307,7 +307,7 @@ pub struct CloudwatchMetricAction {
 }
 
 #[doc="<p>The input for the CreateCertificateFromCsr operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCertificateFromCsrRequest {
     #[doc="<p>The certificate signing request (CSR).</p>"]
     #[serde(rename="certificateSigningRequest")]
@@ -319,7 +319,7 @@ pub struct CreateCertificateFromCsrRequest {
 }
 
 #[doc="<p>The output from the CreateCertificateFromCsr operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCertificateFromCsrResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the certificate. You can use the ARN as a principal for policy operations.</p>"]
     #[serde(rename="certificateArn")]
@@ -336,7 +336,7 @@ pub struct CreateCertificateFromCsrResponse {
 }
 
 #[doc="<p>The input for the CreateKeysAndCertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateKeysAndCertificateRequest {
     #[doc="<p>Specifies whether the certificate is active.</p>"]
     #[serde(rename="setAsActive")]
@@ -345,7 +345,7 @@ pub struct CreateKeysAndCertificateRequest {
 }
 
 #[doc="<p>The output of the CreateKeysAndCertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateKeysAndCertificateResponse {
     #[doc="<p>The ARN of the certificate.</p>"]
     #[serde(rename="certificateArn")]
@@ -366,7 +366,7 @@ pub struct CreateKeysAndCertificateResponse {
 }
 
 #[doc="<p>The input for the CreatePolicy operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePolicyRequest {
     #[doc="<p>The JSON document that describes the policy. <b>policyDocument</b> must have a minimum length of 1, with a maximum length of 2048, excluding whitespace.</p>"]
     #[serde(rename="policyDocument")]
@@ -377,7 +377,7 @@ pub struct CreatePolicyRequest {
 }
 
 #[doc="<p>The output from the CreatePolicy operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePolicyResponse {
     #[doc="<p>The policy ARN.</p>"]
     #[serde(rename="policyArn")]
@@ -398,7 +398,7 @@ pub struct CreatePolicyResponse {
 }
 
 #[doc="<p>The input for the CreatePolicyVersion operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePolicyVersionRequest {
     #[doc="<p>The JSON document that describes the policy. Minimum length of 1. Maximum length of 2048, excluding whitespaces</p>"]
     #[serde(rename="policyDocument")]
@@ -413,7 +413,7 @@ pub struct CreatePolicyVersionRequest {
 }
 
 #[doc="<p>The output of the CreatePolicyVersion operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePolicyVersionResponse {
     #[doc="<p>Specifies whether the policy version is the default.</p>"]
     #[serde(rename="isDefaultVersion")]
@@ -434,7 +434,7 @@ pub struct CreatePolicyVersionResponse {
 }
 
 #[doc="<p>The input for the CreateThing operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateThingRequest {
     #[doc="<p>The attribute payload, which consists of up to three name/value pairs in a JSON document. For example:</p> <p> <code>{\\\"attributes\\\":{\\\"string1\\\":\\\"string2\\\"}}</code> </p>"]
     #[serde(rename="attributePayload")]
@@ -450,7 +450,7 @@ pub struct CreateThingRequest {
 }
 
 #[doc="<p>The output of the CreateThing operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateThingResponse {
     #[doc="<p>The ARN of the new thing.</p>"]
     #[serde(rename="thingArn")]
@@ -463,7 +463,7 @@ pub struct CreateThingResponse {
 }
 
 #[doc="<p>The input for the CreateThingType operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateThingTypeRequest {
     #[doc="<p>The name of the thing type.</p>"]
     #[serde(rename="thingTypeName")]
@@ -475,7 +475,7 @@ pub struct CreateThingTypeRequest {
 }
 
 #[doc="<p>The output of the CreateThingType operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateThingTypeResponse {
     #[doc="<p>The Amazon Resource Name (ARN) of the thing type.</p>"]
     #[serde(rename="thingTypeArn")]
@@ -488,7 +488,7 @@ pub struct CreateThingTypeResponse {
 }
 
 #[doc="<p>The input for the CreateTopicRule operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTopicRuleRequest {
     #[doc="<p>The name of the rule.</p>"]
     #[serde(rename="ruleName")]
@@ -499,7 +499,7 @@ pub struct CreateTopicRuleRequest {
 }
 
 #[doc="<p>Input for the DeleteCACertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCACertificateRequest {
     #[doc="<p>The ID of the certificate to delete.</p>"]
     #[serde(rename="certificateId")]
@@ -507,11 +507,11 @@ pub struct DeleteCACertificateRequest {
 }
 
 #[doc="<p>The output for the DeleteCACertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCACertificateResponse;
 
 #[doc="<p>The input for the DeleteCertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCertificateRequest {
     #[doc="<p>The ID of the certificate.</p>"]
     #[serde(rename="certificateId")]
@@ -519,7 +519,7 @@ pub struct DeleteCertificateRequest {
 }
 
 #[doc="<p>The input for the DeletePolicy operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePolicyRequest {
     #[doc="<p>The name of the policy to delete.</p>"]
     #[serde(rename="policyName")]
@@ -527,7 +527,7 @@ pub struct DeletePolicyRequest {
 }
 
 #[doc="<p>The input for the DeletePolicyVersion operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePolicyVersionRequest {
     #[doc="<p>The name of the policy.</p>"]
     #[serde(rename="policyName")]
@@ -538,15 +538,15 @@ pub struct DeletePolicyVersionRequest {
 }
 
 #[doc="<p>The input for the DeleteRegistrationCode operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRegistrationCodeRequest;
 
 #[doc="<p>The output for the DeleteRegistrationCode operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRegistrationCodeResponse;
 
 #[doc="<p>The input for the DeleteThing operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteThingRequest {
     #[doc="<p>The expected version of the thing record in the registry. If the version of the record in the registry does not match the expected version specified in the request, the <code>DeleteThing</code> request is rejected with a <code>VersionConflictException</code>.</p>"]
     #[serde(rename="expectedVersion")]
@@ -558,11 +558,11 @@ pub struct DeleteThingRequest {
 }
 
 #[doc="<p>The output of the DeleteThing operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteThingResponse;
 
 #[doc="<p>The input for the DeleteThingType operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteThingTypeRequest {
     #[doc="<p>The name of the thing type.</p>"]
     #[serde(rename="thingTypeName")]
@@ -570,11 +570,11 @@ pub struct DeleteThingTypeRequest {
 }
 
 #[doc="<p>The output for the DeleteThingType operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteThingTypeResponse;
 
 #[doc="<p>The input for the DeleteTopicRule operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTopicRuleRequest {
     #[doc="<p>The name of the rule.</p>"]
     #[serde(rename="ruleName")]
@@ -582,7 +582,7 @@ pub struct DeleteTopicRuleRequest {
 }
 
 #[doc="<p>The input for the DeprecateThingType operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeprecateThingTypeRequest {
     #[doc="<p>The name of the thing type to deprecate.</p>"]
     #[serde(rename="thingTypeName")]
@@ -594,11 +594,11 @@ pub struct DeprecateThingTypeRequest {
 }
 
 #[doc="<p>The output for the DeprecateThingType operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeprecateThingTypeResponse;
 
 #[doc="<p>The input for the DescribeCACertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCACertificateRequest {
     #[doc="<p>The CA certificate identifier.</p>"]
     #[serde(rename="certificateId")]
@@ -606,7 +606,7 @@ pub struct DescribeCACertificateRequest {
 }
 
 #[doc="<p>The output from the DescribeCACertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCACertificateResponse {
     #[doc="<p>The CA certificate description.</p>"]
     #[serde(rename="certificateDescription")]
@@ -615,7 +615,7 @@ pub struct DescribeCACertificateResponse {
 }
 
 #[doc="<p>The input for the DescribeCertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCertificateRequest {
     #[doc="<p>The ID of the certificate.</p>"]
     #[serde(rename="certificateId")]
@@ -623,7 +623,7 @@ pub struct DescribeCertificateRequest {
 }
 
 #[doc="<p>The output of the DescribeCertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCertificateResponse {
     #[doc="<p>The description of the certificate.</p>"]
     #[serde(rename="certificateDescription")]
@@ -632,11 +632,11 @@ pub struct DescribeCertificateResponse {
 }
 
 #[doc="<p>The input for the DescribeEndpoint operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEndpointRequest;
 
 #[doc="<p>The output from the DescribeEndpoint operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEndpointResponse {
     #[doc="<p>The endpoint. The format of the endpoint is as follows: <i>identifier</i>.iot.<i>region</i>.amazonaws.com.</p>"]
     #[serde(rename="endpointAddress")]
@@ -645,7 +645,7 @@ pub struct DescribeEndpointResponse {
 }
 
 #[doc="<p>The input for the DescribeThing operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeThingRequest {
     #[doc="<p>The name of the thing.</p>"]
     #[serde(rename="thingName")]
@@ -653,7 +653,7 @@ pub struct DescribeThingRequest {
 }
 
 #[doc="<p>The output from the DescribeThing operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeThingResponse {
     #[doc="<p>The thing attributes.</p>"]
     #[serde(rename="attributes")]
@@ -678,7 +678,7 @@ pub struct DescribeThingResponse {
 }
 
 #[doc="<p>The input for the DescribeThingType operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeThingTypeRequest {
     #[doc="<p>The name of the thing type.</p>"]
     #[serde(rename="thingTypeName")]
@@ -686,7 +686,7 @@ pub struct DescribeThingTypeRequest {
 }
 
 #[doc="<p>The output for the DescribeThingType operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeThingTypeResponse {
     #[doc="<p>The ThingTypeMetadata contains additional information about the thing type including: creation date and time, a value indicating whether the thing type is deprecated, and a date and time when it was deprecated.</p>"]
     #[serde(rename="thingTypeMetadata")]
@@ -703,7 +703,7 @@ pub struct DescribeThingTypeResponse {
 }
 
 #[doc="<p>The input for the DetachPrincipalPolicy operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachPrincipalPolicyRequest {
     #[doc="<p>The name of the policy to detach.</p>"]
     #[serde(rename="policyName")]
@@ -714,7 +714,7 @@ pub struct DetachPrincipalPolicyRequest {
 }
 
 #[doc="<p>The input for the DetachThingPrincipal operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachThingPrincipalRequest {
     #[doc="<p>If the principal is a certificate, this value must be ARN of the certificate. If the principal is an Amazon Cognito identity, this value must be the ID of the Amazon Cognito identity.</p>"]
     #[serde(rename="principal")]
@@ -725,11 +725,11 @@ pub struct DetachThingPrincipalRequest {
 }
 
 #[doc="<p>The output from the DetachThingPrincipal operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachThingPrincipalResponse;
 
 #[doc="<p>The input for the DisableTopicRuleRequest operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableTopicRuleRequest {
     #[doc="<p>The name of the rule to disable.</p>"]
     #[serde(rename="ruleName")]
@@ -811,7 +811,7 @@ pub struct ElasticsearchAction {
 }
 
 #[doc="<p>The input for the EnableTopicRuleRequest operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableTopicRuleRequest {
     #[doc="<p>The name of the topic rule to enable.</p>"]
     #[serde(rename="ruleName")]
@@ -834,11 +834,11 @@ pub struct FirehoseAction {
 }
 
 #[doc="<p>The input for the GetLoggingOptions operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLoggingOptionsRequest;
 
 #[doc="<p>The output from the GetLoggingOptions operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLoggingOptionsResponse {
     #[doc="<p>The logging level.</p>"]
     #[serde(rename="logLevel")]
@@ -851,7 +851,7 @@ pub struct GetLoggingOptionsResponse {
 }
 
 #[doc="<p>The input for the GetPolicy operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPolicyRequest {
     #[doc="<p>The name of the policy.</p>"]
     #[serde(rename="policyName")]
@@ -859,7 +859,7 @@ pub struct GetPolicyRequest {
 }
 
 #[doc="<p>The output from the GetPolicy operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPolicyResponse {
     #[doc="<p>The default policy version ID.</p>"]
     #[serde(rename="defaultVersionId")]
@@ -880,7 +880,7 @@ pub struct GetPolicyResponse {
 }
 
 #[doc="<p>The input for the GetPolicyVersion operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPolicyVersionRequest {
     #[doc="<p>The name of the policy.</p>"]
     #[serde(rename="policyName")]
@@ -891,7 +891,7 @@ pub struct GetPolicyVersionRequest {
 }
 
 #[doc="<p>The output from the GetPolicyVersion operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPolicyVersionResponse {
     #[doc="<p>Specifies whether the policy version is the default.</p>"]
     #[serde(rename="isDefaultVersion")]
@@ -916,11 +916,11 @@ pub struct GetPolicyVersionResponse {
 }
 
 #[doc="<p>The input to the GetRegistrationCode operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRegistrationCodeRequest;
 
 #[doc="<p>The output from the GetRegistrationCode operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRegistrationCodeResponse {
     #[doc="<p>The CA certificate registration code.</p>"]
     #[serde(rename="registrationCode")]
@@ -929,7 +929,7 @@ pub struct GetRegistrationCodeResponse {
 }
 
 #[doc="<p>The input for the GetTopicRule operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTopicRuleRequest {
     #[doc="<p>The name of the rule.</p>"]
     #[serde(rename="ruleName")]
@@ -937,7 +937,7 @@ pub struct GetTopicRuleRequest {
 }
 
 #[doc="<p>The output from the GetTopicRule operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTopicRuleResponse {
     #[doc="<p>The rule.</p>"]
     #[serde(rename="rule")]
@@ -950,7 +950,7 @@ pub struct GetTopicRuleResponse {
 }
 
 #[doc="<p>Describes a key pair.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KeyPair {
     #[doc="<p>The private key.</p>"]
     #[serde(rename="PrivateKey")]
@@ -986,7 +986,7 @@ pub struct LambdaAction {
 }
 
 #[doc="<p>Input for the ListCACertificates operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCACertificatesRequest {
     #[doc="<p>Determines the order of the results.</p>"]
     #[serde(rename="ascendingOrder")]
@@ -1003,7 +1003,7 @@ pub struct ListCACertificatesRequest {
 }
 
 #[doc="<p>The output from the ListCACertificates operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCACertificatesResponse {
     #[doc="<p>The CA certificates registered in your AWS account.</p>"]
     #[serde(rename="certificates")]
@@ -1016,7 +1016,7 @@ pub struct ListCACertificatesResponse {
 }
 
 #[doc="<p>The input to the ListCertificatesByCA operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCertificatesByCARequest {
     #[doc="<p>Specifies the order for results. If True, the results are returned in ascending order, based on the creation date.</p>"]
     #[serde(rename="ascendingOrder")]
@@ -1036,7 +1036,7 @@ pub struct ListCertificatesByCARequest {
 }
 
 #[doc="<p>The output of the ListCertificatesByCA operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCertificatesByCAResponse {
     #[doc="<p>The device certificates signed by the specified CA certificate.</p>"]
     #[serde(rename="certificates")]
@@ -1049,7 +1049,7 @@ pub struct ListCertificatesByCAResponse {
 }
 
 #[doc="<p>The input for the ListCertificates operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCertificatesRequest {
     #[doc="<p>Specifies the order for results. If True, the results are returned in ascending order, based on the creation date.</p>"]
     #[serde(rename="ascendingOrder")]
@@ -1066,7 +1066,7 @@ pub struct ListCertificatesRequest {
 }
 
 #[doc="<p>The output of the ListCertificates operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCertificatesResponse {
     #[doc="<p>The descriptions of the certificates.</p>"]
     #[serde(rename="certificates")]
@@ -1079,7 +1079,7 @@ pub struct ListCertificatesResponse {
 }
 
 #[doc="<p>The input to the ListOutgoingCertificates operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOutgoingCertificatesRequest {
     #[doc="<p>Specifies the order for results. If True, the results are returned in ascending order, based on the creation date.</p>"]
     #[serde(rename="ascendingOrder")]
@@ -1096,7 +1096,7 @@ pub struct ListOutgoingCertificatesRequest {
 }
 
 #[doc="<p>The output from the ListOutgoingCertificates operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOutgoingCertificatesResponse {
     #[doc="<p>The marker for the next set of results.</p>"]
     #[serde(rename="nextMarker")]
@@ -1109,7 +1109,7 @@ pub struct ListOutgoingCertificatesResponse {
 }
 
 #[doc="<p>The input for the ListPolicies operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPoliciesRequest {
     #[doc="<p>Specifies the order for results. If true, the results are returned in ascending creation order.</p>"]
     #[serde(rename="ascendingOrder")]
@@ -1126,7 +1126,7 @@ pub struct ListPoliciesRequest {
 }
 
 #[doc="<p>The output from the ListPolicies operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPoliciesResponse {
     #[doc="<p>The marker for the next set of results, or null if there are no additional results.</p>"]
     #[serde(rename="nextMarker")]
@@ -1139,7 +1139,7 @@ pub struct ListPoliciesResponse {
 }
 
 #[doc="<p>The input for the ListPolicyPrincipals operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPolicyPrincipalsRequest {
     #[doc="<p>Specifies the order for results. If true, the results are returned in ascending creation order.</p>"]
     #[serde(rename="ascendingOrder")]
@@ -1159,7 +1159,7 @@ pub struct ListPolicyPrincipalsRequest {
 }
 
 #[doc="<p>The output from the ListPolicyPrincipals operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPolicyPrincipalsResponse {
     #[doc="<p>The marker for the next set of results, or null if there are no additional results.</p>"]
     #[serde(rename="nextMarker")]
@@ -1172,7 +1172,7 @@ pub struct ListPolicyPrincipalsResponse {
 }
 
 #[doc="<p>The input for the ListPolicyVersions operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPolicyVersionsRequest {
     #[doc="<p>The policy name.</p>"]
     #[serde(rename="policyName")]
@@ -1180,7 +1180,7 @@ pub struct ListPolicyVersionsRequest {
 }
 
 #[doc="<p>The output from the ListPolicyVersions operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPolicyVersionsResponse {
     #[doc="<p>The policy versions.</p>"]
     #[serde(rename="policyVersions")]
@@ -1189,7 +1189,7 @@ pub struct ListPolicyVersionsResponse {
 }
 
 #[doc="<p>The input for the ListPrincipalPolicies operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPrincipalPoliciesRequest {
     #[doc="<p>Specifies the order for results. If true, results are returned in ascending creation order.</p>"]
     #[serde(rename="ascendingOrder")]
@@ -1209,7 +1209,7 @@ pub struct ListPrincipalPoliciesRequest {
 }
 
 #[doc="<p>The output from the ListPrincipalPolicies operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPrincipalPoliciesResponse {
     #[doc="<p>The marker for the next set of results, or null if there are no additional results.</p>"]
     #[serde(rename="nextMarker")]
@@ -1222,7 +1222,7 @@ pub struct ListPrincipalPoliciesResponse {
 }
 
 #[doc="<p>The input for the ListPrincipalThings operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPrincipalThingsRequest {
     #[doc="<p>The maximum number of results to return in this operation.</p>"]
     #[serde(rename="maxResults")]
@@ -1238,7 +1238,7 @@ pub struct ListPrincipalThingsRequest {
 }
 
 #[doc="<p>The output from the ListPrincipalThings operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPrincipalThingsResponse {
     #[doc="<p>The token for the next set of results, or <b>null</b> if there are no additional results.</p>"]
     #[serde(rename="nextToken")]
@@ -1251,7 +1251,7 @@ pub struct ListPrincipalThingsResponse {
 }
 
 #[doc="<p>The input for the ListThingPrincipal operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListThingPrincipalsRequest {
     #[doc="<p>The name of the thing.</p>"]
     #[serde(rename="thingName")]
@@ -1259,7 +1259,7 @@ pub struct ListThingPrincipalsRequest {
 }
 
 #[doc="<p>The output from the ListThingPrincipals operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListThingPrincipalsResponse {
     #[doc="<p>The principals associated with the thing.</p>"]
     #[serde(rename="principals")]
@@ -1268,7 +1268,7 @@ pub struct ListThingPrincipalsResponse {
 }
 
 #[doc="<p>The input for the ListThingTypes operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListThingTypesRequest {
     #[doc="<p>The maximum number of results to return in this operation.</p>"]
     #[serde(rename="maxResults")]
@@ -1285,7 +1285,7 @@ pub struct ListThingTypesRequest {
 }
 
 #[doc="<p>The output for the ListThingTypes operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListThingTypesResponse {
     #[doc="<p>The token for the next set of results, or <b>null</b> if there are no additional results.</p>"]
     #[serde(rename="nextToken")]
@@ -1298,7 +1298,7 @@ pub struct ListThingTypesResponse {
 }
 
 #[doc="<p>The input for the ListThings operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListThingsRequest {
     #[doc="<p>The attribute name used to search for things.</p>"]
     #[serde(rename="attributeName")]
@@ -1323,7 +1323,7 @@ pub struct ListThingsRequest {
 }
 
 #[doc="<p>The output from the ListThings operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListThingsResponse {
     #[doc="<p>The token for the next set of results, or <b>null</b> if there are no additional results.</p>"]
     #[serde(rename="nextToken")]
@@ -1336,7 +1336,7 @@ pub struct ListThingsResponse {
 }
 
 #[doc="<p>The input for the ListTopicRules operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTopicRulesRequest {
     #[doc="<p>The maximum number of results to return.</p>"]
     #[serde(rename="maxResults")]
@@ -1357,7 +1357,7 @@ pub struct ListTopicRulesRequest {
 }
 
 #[doc="<p>The output from the ListTopicRules operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTopicRulesResponse {
     #[doc="<p>A token used to retrieve the next value.</p>"]
     #[serde(rename="nextToken")]
@@ -1370,7 +1370,7 @@ pub struct ListTopicRulesResponse {
 }
 
 #[doc="<p>Describes the logging options payload.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoggingOptionsPayload {
     #[doc="<p>The logging level.</p>"]
     #[serde(rename="logLevel")]
@@ -1382,7 +1382,7 @@ pub struct LoggingOptionsPayload {
 }
 
 #[doc="<p>A certificate that has been transfered but not yet accepted.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OutgoingCertificate {
     #[doc="<p>The certificate ARN.</p>"]
     #[serde(rename="certificateArn")]
@@ -1411,7 +1411,7 @@ pub struct OutgoingCertificate {
 }
 
 #[doc="<p>Describes an AWS IoT policy.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Policy {
     #[doc="<p>The policy ARN.</p>"]
     #[serde(rename="policyArn")]
@@ -1424,7 +1424,7 @@ pub struct Policy {
 }
 
 #[doc="<p>Describes a policy version.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyVersion {
     #[doc="<p>The date and time the policy was created.</p>"]
     #[serde(rename="createDate")]
@@ -1449,7 +1449,7 @@ pub struct PutItemInput {
 }
 
 #[doc="<p>The input to the RegisterCACertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterCACertificateRequest {
     #[doc="<p>Allows this CA certificate to be used for auto registration of device certificates.</p>"]
     #[serde(rename="allowAutoRegistration")]
@@ -1468,7 +1468,7 @@ pub struct RegisterCACertificateRequest {
 }
 
 #[doc="<p>The output from the RegisterCACertificateResponse operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterCACertificateResponse {
     #[doc="<p>The CA certificate ARN.</p>"]
     #[serde(rename="certificateArn")]
@@ -1481,7 +1481,7 @@ pub struct RegisterCACertificateResponse {
 }
 
 #[doc="<p>The input to the RegisterCertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterCertificateRequest {
     #[doc="<p>The CA certificate used to sign the device certificate being registered.</p>"]
     #[serde(rename="caCertificatePem")]
@@ -1497,7 +1497,7 @@ pub struct RegisterCertificateRequest {
 }
 
 #[doc="<p>The output from the RegisterCertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterCertificateResponse {
     #[doc="<p>The certificate ARN.</p>"]
     #[serde(rename="certificateArn")]
@@ -1510,7 +1510,7 @@ pub struct RegisterCertificateResponse {
 }
 
 #[doc="<p>The input for the RejectCertificateTransfer operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RejectCertificateTransferRequest {
     #[doc="<p>The ID of the certificate.</p>"]
     #[serde(rename="certificateId")]
@@ -1522,7 +1522,7 @@ pub struct RejectCertificateTransferRequest {
 }
 
 #[doc="<p>The input for the ReplaceTopicRule operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplaceTopicRuleRequest {
     #[doc="<p>The name of the rule.</p>"]
     #[serde(rename="ruleName")]
@@ -1573,7 +1573,7 @@ pub struct SalesforceAction {
 }
 
 #[doc="<p>The input for the SetDefaultPolicyVersion operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetDefaultPolicyVersionRequest {
     #[doc="<p>The policy name.</p>"]
     #[serde(rename="policyName")]
@@ -1584,7 +1584,7 @@ pub struct SetDefaultPolicyVersionRequest {
 }
 
 #[doc="<p>The input for the SetLoggingOptions operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetLoggingOptionsRequest {
     #[doc="<p>The logging options payload.</p>"]
     #[serde(rename="loggingOptionsPayload")]
@@ -1622,7 +1622,7 @@ pub struct SqsAction {
 }
 
 #[doc="<p>The properties of the thing, including thing name, thing type name, and a list of thing attributes.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ThingAttribute {
     #[doc="<p>A list of thing attributes which are name-value pairs.</p>"]
     #[serde(rename="attributes")]
@@ -1643,7 +1643,7 @@ pub struct ThingAttribute {
 }
 
 #[doc="<p>The definition of the thing type, including thing type name and description.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ThingTypeDefinition {
     #[doc="<p>The ThingTypeMetadata contains additional information about the thing type including: creation date and time, a value indicating whether the thing type is deprecated, and a date and time when it was deprecated.</p>"]
     #[serde(rename="thingTypeMetadata")]
@@ -1660,7 +1660,7 @@ pub struct ThingTypeDefinition {
 }
 
 #[doc="<p>The ThingTypeMetadata contains additional information about the thing type including: creation date and time, a value indicating whether the thing type is deprecated, and a date and time when time was deprecated.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ThingTypeMetadata {
     #[doc="<p>The date and time when the thing type was created.</p>"]
     #[serde(rename="creationDate")]
@@ -1690,7 +1690,7 @@ pub struct ThingTypeProperties {
 }
 
 #[doc="<p>Describes a rule.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TopicRule {
     #[doc="<p>The actions associated with the rule.</p>"]
     #[serde(rename="actions")]
@@ -1723,7 +1723,7 @@ pub struct TopicRule {
 }
 
 #[doc="<p>Describes a rule.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TopicRuleListItem {
     #[doc="<p>The date and time the rule was created.</p>"]
     #[serde(rename="createdAt")]
@@ -1748,7 +1748,7 @@ pub struct TopicRuleListItem {
 }
 
 #[doc="<p>Describes a rule.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TopicRulePayload {
     #[doc="<p>The actions associated with the rule.</p>"]
     #[serde(rename="actions")]
@@ -1771,7 +1771,7 @@ pub struct TopicRulePayload {
 }
 
 #[doc="<p>The input for the TransferCertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TransferCertificateRequest {
     #[doc="<p>The ID of the certificate.</p>"]
     #[serde(rename="certificateId")]
@@ -1786,7 +1786,7 @@ pub struct TransferCertificateRequest {
 }
 
 #[doc="<p>The output from the TransferCertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TransferCertificateResponse {
     #[doc="<p>The ARN of the certificate.</p>"]
     #[serde(rename="transferredCertificateArn")]
@@ -1795,7 +1795,7 @@ pub struct TransferCertificateResponse {
 }
 
 #[doc="<p>Data used to transfer a certificate to an AWS account.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TransferData {
     #[doc="<p>The date the transfer was accepted.</p>"]
     #[serde(rename="acceptDate")]
@@ -1820,7 +1820,7 @@ pub struct TransferData {
 }
 
 #[doc="<p>The input to the UpdateCACertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateCACertificateRequest {
     #[doc="<p>The CA certificate identifier.</p>"]
     #[serde(rename="certificateId")]
@@ -1836,7 +1836,7 @@ pub struct UpdateCACertificateRequest {
 }
 
 #[doc="<p>The input for the UpdateCertificate operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateCertificateRequest {
     #[doc="<p>The ID of the certificate.</p>"]
     #[serde(rename="certificateId")]
@@ -1847,7 +1847,7 @@ pub struct UpdateCertificateRequest {
 }
 
 #[doc="<p>The input for the UpdateThing operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateThingRequest {
     #[doc="<p>A list of thing attributes, a JSON string containing name-value pairs. For example:</p> <p> <code>{\\\"attributes\\\":{\\\"name1\\\":\\\"value2\\\"}}</code> </p> <p>This data is used to add new attributes or update existing attributes.</p>"]
     #[serde(rename="attributePayload")]
@@ -1871,7 +1871,7 @@ pub struct UpdateThingRequest {
 }
 
 #[doc="<p>The output from the UpdateThing operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateThingResponse;
 
 /// Errors returned by AcceptCertificateTransfer

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Represents the input for <code>AddTagsToStream</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToStreamInput {
     #[doc="<p>The name of the stream.</p>"]
     #[serde(rename="StreamName")]
@@ -40,7 +40,7 @@ pub struct AddTagsToStreamInput {
 }
 
 #[doc="<p>Represents the input for <code>CreateStream</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStreamInput {
     #[doc="<p>The number of shards that the stream will use. The throughput of the stream is a function of the number of shards; more shards are required for greater provisioned throughput.</p> <p>DefaultShardLimit;</p>"]
     #[serde(rename="ShardCount")]
@@ -51,7 +51,7 @@ pub struct CreateStreamInput {
 }
 
 #[doc="<p>Represents the input for <a>DecreaseStreamRetentionPeriod</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecreaseStreamRetentionPeriodInput {
     #[doc="<p>The new retention period of the stream, in hours. Must be less than the current retention period.</p>"]
     #[serde(rename="RetentionPeriodHours")]
@@ -62,17 +62,17 @@ pub struct DecreaseStreamRetentionPeriodInput {
 }
 
 #[doc="<p>Represents the input for <a>DeleteStream</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStreamInput {
     #[doc="<p>The name of the stream to delete.</p>"]
     #[serde(rename="StreamName")]
     pub stream_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLimitsInput;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLimitsOutput {
     #[doc="<p>The number of open shards.</p>"]
     #[serde(rename="OpenShardCount")]
@@ -83,7 +83,7 @@ pub struct DescribeLimitsOutput {
 }
 
 #[doc="<p>Represents the input for <code>DescribeStream</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStreamInput {
     #[doc="<p>The shard ID of the shard to start with.</p>"]
     #[serde(rename="ExclusiveStartShardId")]
@@ -99,7 +99,7 @@ pub struct DescribeStreamInput {
 }
 
 #[doc="<p>Represents the output for <code>DescribeStream</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStreamOutput {
     #[doc="<p>The current status of the stream, the stream ARN, an array of shard objects that comprise the stream, and whether there are more shards available.</p>"]
     #[serde(rename="StreamDescription")]
@@ -107,7 +107,7 @@ pub struct DescribeStreamOutput {
 }
 
 #[doc="<p>Represents the input for <a>DisableEnhancedMonitoring</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableEnhancedMonitoringInput {
     #[doc="<p>List of shard-level metrics to disable.</p> <p>The following are the valid shard-level metrics. The value \"<code>ALL</code>\" disables every metric.</p> <ul> <li> <p> <code>IncomingBytes</code> </p> </li> <li> <p> <code>IncomingRecords</code> </p> </li> <li> <p> <code>OutgoingBytes</code> </p> </li> <li> <p> <code>OutgoingRecords</code> </p> </li> <li> <p> <code>WriteProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>ReadProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>IteratorAgeMilliseconds</code> </p> </li> <li> <p> <code>ALL</code> </p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/kinesis/latest/dev/monitoring-with-cloudwatch.html\">Monitoring the Amazon Kinesis Streams Service with Amazon CloudWatch</a> in the <i>Amazon Kinesis Streams Developer Guide</i>.</p>"]
     #[serde(rename="ShardLevelMetrics")]
@@ -118,7 +118,7 @@ pub struct DisableEnhancedMonitoringInput {
 }
 
 #[doc="<p>Represents the input for <a>EnableEnhancedMonitoring</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableEnhancedMonitoringInput {
     #[doc="<p>List of shard-level metrics to enable.</p> <p>The following are the valid shard-level metrics. The value \"<code>ALL</code>\" enables every metric.</p> <ul> <li> <p> <code>IncomingBytes</code> </p> </li> <li> <p> <code>IncomingRecords</code> </p> </li> <li> <p> <code>OutgoingBytes</code> </p> </li> <li> <p> <code>OutgoingRecords</code> </p> </li> <li> <p> <code>WriteProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>ReadProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>IteratorAgeMilliseconds</code> </p> </li> <li> <p> <code>ALL</code> </p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/kinesis/latest/dev/monitoring-with-cloudwatch.html\">Monitoring the Amazon Kinesis Streams Service with Amazon CloudWatch</a> in the <i>Amazon Kinesis Streams Developer Guide</i>.</p>"]
     #[serde(rename="ShardLevelMetrics")]
@@ -129,7 +129,7 @@ pub struct EnableEnhancedMonitoringInput {
 }
 
 #[doc="<p>Represents enhanced metrics types.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnhancedMetrics {
     #[doc="<p>List of shard-level metrics.</p> <p>The following are the valid shard-level metrics. The value \"<code>ALL</code>\" enhances every metric.</p> <ul> <li> <p> <code>IncomingBytes</code> </p> </li> <li> <p> <code>IncomingRecords</code> </p> </li> <li> <p> <code>OutgoingBytes</code> </p> </li> <li> <p> <code>OutgoingRecords</code> </p> </li> <li> <p> <code>WriteProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>ReadProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>IteratorAgeMilliseconds</code> </p> </li> <li> <p> <code>ALL</code> </p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/kinesis/latest/dev/monitoring-with-cloudwatch.html\">Monitoring the Amazon Kinesis Streams Service with Amazon CloudWatch</a> in the <i>Amazon Kinesis Streams Developer Guide</i>.</p>"]
     #[serde(rename="ShardLevelMetrics")]
@@ -138,7 +138,7 @@ pub struct EnhancedMetrics {
 }
 
 #[doc="<p>Represents the output for <a>EnableEnhancedMonitoring</a> and <a>DisableEnhancedMonitoring</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnhancedMonitoringOutput {
     #[doc="<p>Represents the current state of the metrics that are in the enhanced state before the operation.</p>"]
     #[serde(rename="CurrentShardLevelMetrics")]
@@ -155,7 +155,7 @@ pub struct EnhancedMonitoringOutput {
 }
 
 #[doc="<p>Represents the input for <a>GetRecords</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRecordsInput {
     #[doc="<p>The maximum number of records to return. Specify a value of up to 10,000. If you specify a value that is greater than 10,000, <a>GetRecords</a> throws <code>InvalidArgumentException</code>.</p>"]
     #[serde(rename="Limit")]
@@ -167,7 +167,7 @@ pub struct GetRecordsInput {
 }
 
 #[doc="<p>Represents the output for <a>GetRecords</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRecordsOutput {
     #[doc="<p>The number of milliseconds the <a>GetRecords</a> response is from the tip of the stream, indicating how far behind current time the consumer is. A value of zero indicates record processing is caught up, and there are no new records to process at this moment.</p>"]
     #[serde(rename="MillisBehindLatest")]
@@ -183,7 +183,7 @@ pub struct GetRecordsOutput {
 }
 
 #[doc="<p>Represents the input for <code>GetShardIterator</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetShardIteratorInput {
     #[doc="<p>The shard ID of the Amazon Kinesis shard to get the iterator for.</p>"]
     #[serde(rename="ShardId")]
@@ -205,7 +205,7 @@ pub struct GetShardIteratorInput {
 }
 
 #[doc="<p>Represents the output for <code>GetShardIterator</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetShardIteratorOutput {
     #[doc="<p>The position in the shard from which to start reading data records sequentially. A shard iterator specifies this position using the sequence number of a data record in a shard.</p>"]
     #[serde(rename="ShardIterator")]
@@ -214,7 +214,7 @@ pub struct GetShardIteratorOutput {
 }
 
 #[doc="<p>The range of possible hash key values for the shard, which is a set of ordered contiguous positive integers.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HashKeyRange {
     #[doc="<p>The ending hash key of the hash key range.</p>"]
     #[serde(rename="EndingHashKey")]
@@ -225,7 +225,7 @@ pub struct HashKeyRange {
 }
 
 #[doc="<p>Represents the input for <a>IncreaseStreamRetentionPeriod</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IncreaseStreamRetentionPeriodInput {
     #[doc="<p>The new retention period of the stream, in hours. Must be more than the current retention period.</p>"]
     #[serde(rename="RetentionPeriodHours")]
@@ -236,7 +236,7 @@ pub struct IncreaseStreamRetentionPeriodInput {
 }
 
 #[doc="<p>Represents the input for <code>ListStreams</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStreamsInput {
     #[doc="<p>The name of the stream to start the list with.</p>"]
     #[serde(rename="ExclusiveStartStreamName")]
@@ -249,7 +249,7 @@ pub struct ListStreamsInput {
 }
 
 #[doc="<p>Represents the output for <code>ListStreams</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStreamsOutput {
     #[doc="<p>If set to <code>true</code>, there are more streams available to list.</p>"]
     #[serde(rename="HasMoreStreams")]
@@ -260,7 +260,7 @@ pub struct ListStreamsOutput {
 }
 
 #[doc="<p>Represents the input for <code>ListTagsForStream</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForStreamInput {
     #[doc="<p>The key to use as the starting point for the list of tags. If this parameter is set, <code>ListTagsForStream</code> gets all tags that occur after <code>ExclusiveStartTagKey</code>. </p>"]
     #[serde(rename="ExclusiveStartTagKey")]
@@ -276,7 +276,7 @@ pub struct ListTagsForStreamInput {
 }
 
 #[doc="<p>Represents the output for <code>ListTagsForStream</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForStreamOutput {
     #[doc="<p>If set to <code>true</code>, more tags are available. To request additional tags, set <code>ExclusiveStartTagKey</code> to the key of the last tag returned.</p>"]
     #[serde(rename="HasMoreTags")]
@@ -287,7 +287,7 @@ pub struct ListTagsForStreamOutput {
 }
 
 #[doc="<p>Represents the input for <code>MergeShards</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MergeShardsInput {
     #[doc="<p>The shard ID of the adjacent shard for the merge.</p>"]
     #[serde(rename="AdjacentShardToMerge")]
@@ -301,7 +301,7 @@ pub struct MergeShardsInput {
 }
 
 #[doc="<p>Represents the input for <code>PutRecord</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRecordInput {
     #[doc="<p>The data blob to put into the record, which is base64-encoded when the blob is serialized. When the data blob (the payload before base64-encoding) is added to the partition key size, the total size must not exceed the maximum record size (1 MB).</p>"]
     #[serde(rename="Data")]
@@ -328,7 +328,7 @@ pub struct PutRecordInput {
 }
 
 #[doc="<p>Represents the output for <code>PutRecord</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRecordOutput {
     #[doc="<p>The encryption type to use on the record. This parameter can be one of the following values:</p> <ul> <li> <p> <code>NONE</code>: Do not encrypt the records in the stream.</p> </li> <li> <p> <code>KMS</code>: Use server-side encryption on the records in the stream using a customer-managed KMS key.</p> </li> </ul>"]
     #[serde(rename="EncryptionType")]
@@ -343,7 +343,7 @@ pub struct PutRecordOutput {
 }
 
 #[doc="<p>A <code>PutRecords</code> request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRecordsInput {
     #[doc="<p>The records associated with the request.</p>"]
     #[serde(rename="Records")]
@@ -354,7 +354,7 @@ pub struct PutRecordsInput {
 }
 
 #[doc="<p> <code>PutRecords</code> results.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRecordsOutput {
     #[doc="<p>The encryption type used on the records. This parameter can be one of the following values:</p> <ul> <li> <p> <code>NONE</code>: Do not encrypt the records.</p> </li> <li> <p> <code>KMS</code>: Use server-side encryption on the records using a customer-managed KMS key.</p> </li> </ul>"]
     #[serde(rename="EncryptionType")]
@@ -370,7 +370,7 @@ pub struct PutRecordsOutput {
 }
 
 #[doc="<p>Represents the output for <code>PutRecords</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRecordsRequestEntry {
     #[doc="<p>The data blob to put into the record, which is base64-encoded when the blob is serialized. When the data blob (the payload before base64-encoding) is added to the partition key size, the total size must not exceed the maximum record size (1 MB).</p>"]
     #[serde(rename="Data")]
@@ -390,7 +390,7 @@ pub struct PutRecordsRequestEntry {
 }
 
 #[doc="<p>Represents the result of an individual record from a <code>PutRecords</code> request. A record that is successfully added to a stream includes <code>SequenceNumber</code> and <code>ShardId</code> in the result. A record that fails to be added to the stream includes <code>ErrorCode</code> and <code>ErrorMessage</code> in the result.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRecordsResultEntry {
     #[doc="<p>The error code for an individual record result. <code>ErrorCodes</code> can be either <code>ProvisionedThroughputExceededException</code> or <code>InternalFailure</code>.</p>"]
     #[serde(rename="ErrorCode")]
@@ -411,7 +411,7 @@ pub struct PutRecordsResultEntry {
 }
 
 #[doc="<p>The unit of data of the Amazon Kinesis stream, which is composed of a sequence number, a partition key, and a data blob.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Record {
     #[doc="<p>The approximate time that the record was inserted into the stream.</p>"]
     #[serde(rename="ApproximateArrivalTimestamp")]
@@ -438,7 +438,7 @@ pub struct Record {
 }
 
 #[doc="<p>Represents the input for <code>RemoveTagsFromStream</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromStreamInput {
     #[doc="<p>The name of the stream.</p>"]
     #[serde(rename="StreamName")]
@@ -449,7 +449,7 @@ pub struct RemoveTagsFromStreamInput {
 }
 
 #[doc="<p>The range of possible sequence numbers for the shard.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SequenceNumberRange {
     #[doc="<p>The ending sequence number for the range. Shards that are in the OPEN state have an ending sequence number of <code>null</code>.</p>"]
     #[serde(rename="EndingSequenceNumber")]
@@ -461,7 +461,7 @@ pub struct SequenceNumberRange {
 }
 
 #[doc="<p>A uniquely identified group of data records in an Amazon Kinesis stream.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Shard {
     #[doc="<p>The shard ID of the shard adjacent to the shard's parent.</p>"]
     #[serde(rename="AdjacentParentShardId")]
@@ -483,7 +483,7 @@ pub struct Shard {
 }
 
 #[doc="<p>Represents the input for <code>SplitShard</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SplitShardInput {
     #[doc="<p>A hash key value for the starting hash key of one of the child shards created by the split. The hash key range for a given shard constitutes a set of ordered contiguous positive integers. The value for <code>NewStartingHashKey</code> must be in the range of hash keys being mapped into the shard. The <code>NewStartingHashKey</code> hash key value and all higher hash key values in hash key range are distributed to one of the child shards. All the lower hash key values in the range are distributed to the other child shard.</p>"]
     #[serde(rename="NewStartingHashKey")]
@@ -496,7 +496,7 @@ pub struct SplitShardInput {
     pub stream_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartStreamEncryptionInput {
     #[doc="<p>The encryption type to use. This parameter can be one of the following values:</p> <ul> <li> <p> <code>NONE</code>: Not valid for this operation. An <code>InvalidOperationException</code> will be thrown.</p> </li> <li> <p> <code>KMS</code>: Use server-side encryption on the records in the stream using a customer-managed KMS key.</p> </li> </ul>"]
     #[serde(rename="EncryptionType")]
@@ -509,7 +509,7 @@ pub struct StartStreamEncryptionInput {
     pub stream_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopStreamEncryptionInput {
     #[doc="<p>The encryption type. This parameter can be one of the following values:</p> <ul> <li> <p> <code>NONE</code>: Not valid for this operation. An <code>InvalidOperationException</code> will be thrown.</p> </li> <li> <p> <code>KMS</code>: Use server-side encryption on the records in the stream using a customer-managed KMS key.</p> </li> </ul>"]
     #[serde(rename="EncryptionType")]
@@ -523,7 +523,7 @@ pub struct StopStreamEncryptionInput {
 }
 
 #[doc="<p>Represents the output for <a>DescribeStream</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StreamDescription {
     #[doc="<p>The server-side encryption type used on the stream. This parameter can be one of the following values:</p> <ul> <li> <p> <code>NONE</code>: Do not encrypt the records in the stream.</p> </li> <li> <p> <code>KMS</code>: Use server-side encryption on the records in the stream using a customer-managed KMS key.</p> </li> </ul>"]
     #[serde(rename="EncryptionType")]
@@ -560,7 +560,7 @@ pub struct StreamDescription {
 }
 
 #[doc="<p>Metadata assigned to the stream, consisting of a key-value pair.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>A unique identifier for the tag. Maximum length: 128 characters. Valid characters: Unicode letters, digits, white space, _ . / = + - % @</p>"]
     #[serde(rename="Key")]
@@ -571,7 +571,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateShardCountInput {
     #[doc="<p>The scaling type. Uniform scaling creates shards of equal size.</p>"]
     #[serde(rename="ScalingType")]
@@ -584,7 +584,7 @@ pub struct UpdateShardCountInput {
     pub target_shard_count: i64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateShardCountOutput {
     #[doc="<p>The current number of shards.</p>"]
     #[serde(rename="CurrentShardCount")]

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddApplicationCloudWatchLoggingOptionRequest {
     #[doc="<p>The Kinesis Analytics application name.</p>"]
     #[serde(rename="ApplicationName")]
@@ -41,11 +41,11 @@ pub struct AddApplicationCloudWatchLoggingOptionRequest {
     pub current_application_version_id: i64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddApplicationCloudWatchLoggingOptionResponse;
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddApplicationInputRequest {
     #[doc="<p>Name of your existing Amazon Kinesis Analytics application to which you want to add the streaming source.</p>"]
     #[serde(rename="ApplicationName")]
@@ -59,11 +59,11 @@ pub struct AddApplicationInputRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddApplicationInputResponse;
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddApplicationOutputRequest {
     #[doc="<p>Name of the application to which you want to add the output configuration.</p>"]
     #[serde(rename="ApplicationName")]
@@ -77,11 +77,11 @@ pub struct AddApplicationOutputRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddApplicationOutputResponse;
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddApplicationReferenceDataSourceRequest {
     #[doc="<p>Name of an existing application.</p>"]
     #[serde(rename="ApplicationName")]
@@ -95,11 +95,11 @@ pub struct AddApplicationReferenceDataSourceRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddApplicationReferenceDataSourceResponse;
 
 #[doc="<p>Provides a description of the application, including the application Amazon Resource Name (ARN), status, latest version, and input and output configuration.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationDetail {
     #[doc="<p>ARN of the application.</p>"]
     #[serde(rename="ApplicationARN")]
@@ -149,7 +149,7 @@ pub struct ApplicationDetail {
 }
 
 #[doc="<p>Provides application summary information, including the application Amazon Resource Name (ARN), name, and status.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationSummary {
     #[doc="<p>ARN of the application.</p>"]
     #[serde(rename="ApplicationARN")]
@@ -163,7 +163,7 @@ pub struct ApplicationSummary {
 }
 
 #[doc="<p>Describes updates to apply to an existing Amazon Kinesis Analytics application.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplicationUpdate {
     #[doc="<p>Describes application code updates.</p>"]
     #[serde(rename="ApplicationCodeUpdate")]
@@ -199,7 +199,7 @@ pub struct CSVMappingParameters {
 }
 
 #[doc="<p>Provides a description of CloudWatch logging options, including the log stream Amazon Resource Name (ARN) and the role ARN.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloudWatchLoggingOption {
     #[doc="<p>ARN of the CloudWatch log to receive application messages.</p>"]
     #[serde(rename="LogStreamARN")]
@@ -210,7 +210,7 @@ pub struct CloudWatchLoggingOption {
 }
 
 #[doc="<p>Description of the CloudWatch logging option.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloudWatchLoggingOptionDescription {
     #[doc="<p>ID of the CloudWatch logging option description.</p>"]
     #[serde(rename="CloudWatchLoggingOptionId")]
@@ -225,7 +225,7 @@ pub struct CloudWatchLoggingOptionDescription {
 }
 
 #[doc="<p>Describes CloudWatch logging option updates.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloudWatchLoggingOptionUpdate {
     #[doc="<p>ID of the CloudWatch logging option to update</p>"]
     #[serde(rename="CloudWatchLoggingOptionId")]
@@ -241,7 +241,7 @@ pub struct CloudWatchLoggingOptionUpdate {
 }
 
 #[doc="<p>TBD</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateApplicationRequest {
     #[doc="<p>One or more SQL statements that read input data, transform it, and generate output. For example, you can write a SQL statement that reads data from one in-application stream, generates a running average of the number of advertisement clicks by vendor, and insert resulting rows in another in-application stream using pumps. For more inforamtion about the typical pattern, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-app-code.html\">Application Code</a>. </p> <p>You can provide such series of SQL statements, where output of one statement can be used as the input for the next statement. You store intermediate results by creating in-application streams and pumps.</p> <p>Note that the application code must create the streams with names specified in the <code>Outputs</code>. For example, if your <code>Outputs</code> defines output streams named <code>ExampleOutputStream1</code> and <code>ExampleOutputStream2</code>, then your application code must create these streams. </p>"]
     #[serde(rename="ApplicationCode")]
@@ -269,14 +269,14 @@ pub struct CreateApplicationRequest {
 }
 
 #[doc="<p>TBD</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateApplicationResponse {
     #[doc="<p>In response to your <code>CreateApplication</code> request, Amazon Kinesis Analytics returns a response with a summary of the application it created, including the application Amazon Resource Name (ARN), name, and status.</p>"]
     #[serde(rename="ApplicationSummary")]
     pub application_summary: ApplicationSummary,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationCloudWatchLoggingOptionRequest {
     #[doc="<p>The Kinesis Analytics application name.</p>"]
     #[serde(rename="ApplicationName")]
@@ -289,11 +289,11 @@ pub struct DeleteApplicationCloudWatchLoggingOptionRequest {
     pub current_application_version_id: i64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationCloudWatchLoggingOptionResponse;
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationOutputRequest {
     #[doc="<p>Amazon Kinesis Analytics application name.</p>"]
     #[serde(rename="ApplicationName")]
@@ -307,10 +307,10 @@ pub struct DeleteApplicationOutputRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationOutputResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationReferenceDataSourceRequest {
     #[doc="<p>Name of an existing application.</p>"]
     #[serde(rename="ApplicationName")]
@@ -323,11 +323,11 @@ pub struct DeleteApplicationReferenceDataSourceRequest {
     pub reference_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationReferenceDataSourceResponse;
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationRequest {
     #[doc="<p>Name of the Amazon Kinesis Analytics application to delete.</p>"]
     #[serde(rename="ApplicationName")]
@@ -338,11 +338,11 @@ pub struct DeleteApplicationRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteApplicationResponse;
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeApplicationRequest {
     #[doc="<p>Name of the application.</p>"]
     #[serde(rename="ApplicationName")]
@@ -350,7 +350,7 @@ pub struct DescribeApplicationRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeApplicationResponse {
     #[doc="<p>Provides a description of the application, such as the application Amazon Resource Name (ARN), status, latest version, and input and output configuration details.</p>"]
     #[serde(rename="ApplicationDetail")]
@@ -367,7 +367,7 @@ pub struct DestinationSchema {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DiscoverInputSchemaRequest {
     #[doc="<p>Point at which you want Amazon Kinesis Analytics to start reading records from the specified streaming source discovery purposes.</p>"]
     #[serde(rename="InputStartingPositionConfiguration")]
@@ -381,7 +381,7 @@ pub struct DiscoverInputSchemaRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DiscoverInputSchemaResponse {
     #[doc="<p>Schema inferred from the streaming source. It identifies the format of the data in the streaming source and how each data element maps to corresponding columns in the in-application stream that you can create.</p>"]
     #[serde(rename="InputSchema")]
@@ -398,7 +398,7 @@ pub struct DiscoverInputSchemaResponse {
 }
 
 #[doc="<p>When you configure the application input, you specify the streaming source, the in-application stream name that is created, and the mapping between the two. For more information, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html\">Configuring Application Input</a>. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Input {
     #[doc="<p>Describes the number of in-application streams to create. </p> <p>Data from your source will be routed to these in-application input streams.</p> <p> (see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html\">Configuring Application Input</a>.</p>"]
     #[serde(rename="InputParallelism")]
@@ -421,7 +421,7 @@ pub struct Input {
 }
 
 #[doc="<p>When you start your application, you provide this configuration, which identifies the input source and the point in the input source at which you want the application to start processing records.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InputConfiguration {
     #[doc="<p>Input source ID. You can get this ID by calling the <a>DescribeApplication</a> operation.</p>"]
     #[serde(rename="Id")]
@@ -432,7 +432,7 @@ pub struct InputConfiguration {
 }
 
 #[doc="<p>Describes the application input configuration. For more information, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html\">Configuring Application Input</a>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InputDescription {
     #[doc="<p>Returns the in-application stream names that are mapped to the stream source.</p>"]
     #[serde(rename="InAppStreamNames")]
@@ -477,7 +477,7 @@ pub struct InputParallelism {
 }
 
 #[doc="<p>Provides updates to the parallelism count.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InputParallelismUpdate {
     #[doc="<p>Number of in-application streams to create for the specified streaming source.</p>"]
     #[serde(rename="CountUpdate")]
@@ -486,7 +486,7 @@ pub struct InputParallelismUpdate {
 }
 
 #[doc="<p> Describes updates for the application's input schema. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InputSchemaUpdate {
     #[doc="<p>A list of <code>RecordColumn</code> objects. Each object describes the mapping of the streaming source element to the corresponding column in the in-application stream. </p>"]
     #[serde(rename="RecordColumnUpdates")]
@@ -512,7 +512,7 @@ pub struct InputStartingPositionConfiguration {
 }
 
 #[doc="<p>Describes updates to a specific input configuration (identified by the <code>InputId</code> of an application). </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InputUpdate {
     #[doc="<p>Input ID of the application input to be updated.</p>"]
     #[serde(rename="InputId")]
@@ -548,7 +548,7 @@ pub struct JSONMappingParameters {
 }
 
 #[doc="<p> Identifies an Amazon Kinesis Firehose delivery stream as the streaming source. You provide the Firehose delivery stream's Amazon Resource Name (ARN) and an IAM role ARN that enables Amazon Kinesis Analytics to access the stream on your behalf.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisFirehoseInput {
     #[doc="<p>ARN of the input Firehose delivery stream.</p>"]
     #[serde(rename="ResourceARN")]
@@ -559,7 +559,7 @@ pub struct KinesisFirehoseInput {
 }
 
 #[doc="<p> Describes the Amazon Kinesis Firehose delivery stream that is configured as the streaming source in the application input configuration. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisFirehoseInputDescription {
     #[doc="<p>Amazon Resource Name (ARN) of the Amazon Kinesis Firehose delivery stream.</p>"]
     #[serde(rename="ResourceARN")]
@@ -572,7 +572,7 @@ pub struct KinesisFirehoseInputDescription {
 }
 
 #[doc="<p>When updating application input configuration, provides information about an Amazon Kinesis Firehose delivery stream as the streaming source.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisFirehoseInputUpdate {
     #[doc="<p>ARN of the input Amazon Kinesis Firehose delivery stream to read.</p>"]
     #[serde(rename="ResourceARNUpdate")]
@@ -585,7 +585,7 @@ pub struct KinesisFirehoseInputUpdate {
 }
 
 #[doc="<p>When configuring application output, identifies an Amazon Kinesis Firehose delivery stream as the destination. You provide the stream Amazon Resource Name (ARN) and an IAM role that enables Amazon Kinesis Analytics to write to the stream on your behalf.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisFirehoseOutput {
     #[doc="<p>ARN of the destination Amazon Kinesis Firehose delivery stream to write to.</p>"]
     #[serde(rename="ResourceARN")]
@@ -596,7 +596,7 @@ pub struct KinesisFirehoseOutput {
 }
 
 #[doc="<p> For an application output, describes the Amazon Kinesis Firehose delivery stream configured as its destination. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisFirehoseOutputDescription {
     #[doc="<p>Amazon Resource Name (ARN) of the Amazon Kinesis Firehose delivery stream.</p>"]
     #[serde(rename="ResourceARN")]
@@ -609,7 +609,7 @@ pub struct KinesisFirehoseOutputDescription {
 }
 
 #[doc="<p> When updating an output configuration using the <a>UpdateApplication</a> operation, provides information about an Amazon Kinesis Firehose delivery stream configured as the destination. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisFirehoseOutputUpdate {
     #[doc="<p>Amazon Resource Name (ARN) of the Amazon Kinesis Firehose delivery stream to write to.</p>"]
     #[serde(rename="ResourceARNUpdate")]
@@ -622,7 +622,7 @@ pub struct KinesisFirehoseOutputUpdate {
 }
 
 #[doc="<p> Identifies an Amazon Kinesis stream as the streaming source. You provide the stream's ARN and an IAM role ARN that enables Amazon Kinesis Analytics to access the stream on your behalf.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisStreamsInput {
     #[doc="<p>ARN of the input Amazon Kinesis stream to read.</p>"]
     #[serde(rename="ResourceARN")]
@@ -633,7 +633,7 @@ pub struct KinesisStreamsInput {
 }
 
 #[doc="<p> Describes the Amazon Kinesis stream that is configured as the streaming source in the application input configuration. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisStreamsInputDescription {
     #[doc="<p>Amazon Resource Name (ARN) of the Amazon Kinesis stream.</p>"]
     #[serde(rename="ResourceARN")]
@@ -646,7 +646,7 @@ pub struct KinesisStreamsInputDescription {
 }
 
 #[doc="<p>When updating application input configuration, provides information about an Amazon Kinesis stream as the streaming source.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisStreamsInputUpdate {
     #[doc="<p>Amazon Resource Name (ARN) of the input Amazon Kinesis stream to read.</p>"]
     #[serde(rename="ResourceARNUpdate")]
@@ -659,7 +659,7 @@ pub struct KinesisStreamsInputUpdate {
 }
 
 #[doc="<p>When configuring application output, identifies a Amazon Kinesis stream as the destination. You provide the stream Amazon Resource Name (ARN) and also an IAM role ARN that Amazon Kinesis Analytics can use to write to the stream on your behalf.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisStreamsOutput {
     #[doc="<p>ARN of the destination Amazon Kinesis stream to write to.</p>"]
     #[serde(rename="ResourceARN")]
@@ -670,7 +670,7 @@ pub struct KinesisStreamsOutput {
 }
 
 #[doc="<p> For an application output, describes the Amazon Kinesis stream configured as its destination. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisStreamsOutputDescription {
     #[doc="<p>Amazon Resource Name (ARN) of the Amazon Kinesis stream.</p>"]
     #[serde(rename="ResourceARN")]
@@ -683,7 +683,7 @@ pub struct KinesisStreamsOutputDescription {
 }
 
 #[doc="<p> When updating an output configuration using the <a>UpdateApplication</a> operation, provides information about an Amazon Kinesis stream configured as the destination. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisStreamsOutputUpdate {
     #[doc="<p>Amazon Resource Name (ARN) of the Amazon Kinesis stream where you want to write the output.</p>"]
     #[serde(rename="ResourceARNUpdate")]
@@ -696,7 +696,7 @@ pub struct KinesisStreamsOutputUpdate {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListApplicationsRequest {
     #[doc="<p>Name of the application to start the list with. When using pagination to retrieve the list, you don't need to specify this parameter in the first request. However, in subsequent requests, you add the last application name from the previous response to get the next page of applications.</p>"]
     #[serde(rename="ExclusiveStartApplicationName")]
@@ -709,7 +709,7 @@ pub struct ListApplicationsRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListApplicationsResponse {
     #[doc="<p>List of <code>ApplicationSummary</code> objects. </p>"]
     #[serde(rename="ApplicationSummaries")]
@@ -733,7 +733,7 @@ pub struct MappingParameters {
 }
 
 #[doc="<p> Describes application output configuration in which you identify an in-application stream and a destination where you want the in-application stream data to be written. The destination can be an Amazon Kinesis stream or an Amazon Kinesis Firehose delivery stream. </p> <p/> <p>For limits on how many destinations an application can write and other limitations, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/limits.html\">Limits</a>. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Output {
     #[serde(rename="DestinationSchema")]
     pub destination_schema: DestinationSchema,
@@ -751,7 +751,7 @@ pub struct Output {
 }
 
 #[doc="<p>Describes the application output configuration, which includes the in-application stream name and the destination where the stream data is written. The destination can be an Amazon Kinesis stream or an Amazon Kinesis Firehose delivery stream. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OutputDescription {
     #[doc="<p>Data format used for writing data to the destination.</p>"]
     #[serde(rename="DestinationSchema")]
@@ -776,7 +776,7 @@ pub struct OutputDescription {
 }
 
 #[doc="<p> Describes updates to the output configuration identified by the <code>OutputId</code>. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OutputUpdate {
     #[serde(rename="DestinationSchemaUpdate")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -825,7 +825,7 @@ pub struct RecordFormat {
 }
 
 #[doc="<p>Describes the reference data source by providing the source information (S3 bucket name and object key name), the resulting in-application table name that is created, and the necessary schema to map the data elements in the Amazon S3 object to the in-application table.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReferenceDataSource {
     #[serde(rename="ReferenceSchema")]
     pub reference_schema: SourceSchema,
@@ -838,7 +838,7 @@ pub struct ReferenceDataSource {
 }
 
 #[doc="<p>Describes the reference data source configured for an application.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReferenceDataSourceDescription {
     #[doc="<p>ID of the reference data source. This is the ID that Amazon Kinesis Analytics assigns when you add the reference data source to your application using the <a>AddApplicationReferenceDataSource</a> operation.</p>"]
     #[serde(rename="ReferenceId")]
@@ -855,7 +855,7 @@ pub struct ReferenceDataSourceDescription {
 }
 
 #[doc="<p>When you update a reference data source configuration for an application, this object provides all the updated values (such as the source bucket name and object key name), the in-application table name that is created, and updated mapping information that maps the data in the Amazon S3 object to the in-application reference table that is created.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReferenceDataSourceUpdate {
     #[doc="<p>ID of the reference data source being updated. You can use the <a>DescribeApplication</a> operation to get this value.</p>"]
     #[serde(rename="ReferenceId")]
@@ -874,7 +874,7 @@ pub struct ReferenceDataSourceUpdate {
 }
 
 #[doc="<p>Identifies the S3 bucket and object that contains the reference data. Also identifies the IAM role Amazon Kinesis Analytics can assume to read this object on your behalf.</p> <p>An Amazon Kinesis Analytics application loads reference data only once. If the data changes, you call the <a>UpdateApplication</a> operation to trigger reloading of data into your application.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3ReferenceDataSource {
     #[doc="<p>Amazon Resource Name (ARN) of the S3 bucket.</p>"]
     #[serde(rename="BucketARN")]
@@ -888,7 +888,7 @@ pub struct S3ReferenceDataSource {
 }
 
 #[doc="<p>Provides the bucket name and object key name that stores the reference data.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3ReferenceDataSourceDescription {
     #[doc="<p>Amazon Resource Name (ARN) of the S3 bucket.</p>"]
     #[serde(rename="BucketARN")]
@@ -902,7 +902,7 @@ pub struct S3ReferenceDataSourceDescription {
 }
 
 #[doc="<p>Describes the S3 bucket name, object key name, and IAM role that Amazon Kinesis Analytics can assume to read the Amazon S3 object on your behalf and populate the in-application reference table.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3ReferenceDataSourceUpdate {
     #[doc="<p>Amazon Resource Name (ARN) of the S3 bucket.</p>"]
     #[serde(rename="BucketARNUpdate")]
@@ -934,7 +934,7 @@ pub struct SourceSchema {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartApplicationRequest {
     #[doc="<p>Name of the application.</p>"]
     #[serde(rename="ApplicationName")]
@@ -945,11 +945,11 @@ pub struct StartApplicationRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartApplicationResponse;
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopApplicationRequest {
     #[doc="<p>Name of the running application to stop.</p>"]
     #[serde(rename="ApplicationName")]
@@ -957,10 +957,10 @@ pub struct StopApplicationRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopApplicationResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateApplicationRequest {
     #[doc="<p>Name of the Amazon Kinesis Analytics application to update.</p>"]
     #[serde(rename="ApplicationName")]
@@ -973,7 +973,7 @@ pub struct UpdateApplicationRequest {
     pub current_application_version_id: i64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateApplicationResponse;
 
 /// Errors returned by AddApplicationCloudWatchLoggingOption

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Contains information about an alias.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AliasListEntry {
     #[doc="<p>String that contains the key ARN.</p>"]
     #[serde(rename="AliasArn")]
@@ -45,14 +45,14 @@ pub struct AliasListEntry {
     pub target_key_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelKeyDeletionRequest {
     #[doc="<p>The unique identifier for the customer master key (CMK) for which to cancel deletion.</p> <p>To specify this value, use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: 1234abcd-12ab-34cd-56ef-1234567890ab</p> </li> <li> <p>Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</p> </li> </ul> <p>To obtain the unique key ID and key ARN for a given CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>"]
     #[serde(rename="KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelKeyDeletionResponse {
     #[doc="<p>The unique identifier of the master key for which deletion is canceled.</p>"]
     #[serde(rename="KeyId")]
@@ -60,7 +60,7 @@ pub struct CancelKeyDeletionResponse {
     pub key_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAliasRequest {
     #[doc="<p>String that contains the display name. The name must start with the word \"alias\" followed by a forward slash (alias/). Aliases that begin with \"alias/AWS\" are reserved.</p>"]
     #[serde(rename="AliasName")]
@@ -70,7 +70,7 @@ pub struct CreateAliasRequest {
     pub target_key_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGrantRequest {
     #[doc="<p>A structure that you can use to allow certain operations in the grant only when the desired encryption context is present. For more information about encryption context, see <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html\">Encryption Context</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>"]
     #[serde(rename="Constraints")]
@@ -100,7 +100,7 @@ pub struct CreateGrantRequest {
     pub retiring_principal: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateGrantResponse {
     #[doc="<p>The unique identifier for the grant.</p> <p>You can use the <code>GrantId</code> in a subsequent <a>RetireGrant</a> or <a>RevokeGrant</a> operation.</p>"]
     #[serde(rename="GrantId")]
@@ -112,7 +112,7 @@ pub struct CreateGrantResponse {
     pub grant_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateKeyRequest {
     #[doc="<p>A flag to indicate whether to bypass the key policy lockout safety check.</p> <important> <p>Setting this value to true increases the likelihood that the CMK becomes unmanageable. Do not set this value to true indiscriminately.</p> <p>For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </important> <p>Use this parameter only when you include a policy in the request and you intend to prevent the principal that is making the request from making a subsequent <a>PutKeyPolicy</a> request on the CMK.</p> <p>The default value is false.</p>"]
     #[serde(rename="BypassPolicyLockoutSafetyCheck")]
@@ -140,7 +140,7 @@ pub struct CreateKeyRequest {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateKeyResponse {
     #[doc="<p>Metadata associated with the CMK.</p>"]
     #[serde(rename="KeyMetadata")]
@@ -148,7 +148,7 @@ pub struct CreateKeyResponse {
     pub key_metadata: Option<KeyMetadata>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecryptRequest {
     #[doc="<p>Ciphertext to be decrypted. The blob includes metadata.</p>"]
     #[serde(rename="CiphertextBlob")]
@@ -168,7 +168,7 @@ pub struct DecryptRequest {
     pub grant_tokens: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecryptResponse {
     #[doc="<p>ARN of the key used to perform the decryption. This value is returned if no errors are encountered during the operation.</p>"]
     #[serde(rename="KeyId")]
@@ -184,21 +184,21 @@ pub struct DecryptResponse {
     pub plaintext: Option<Vec<u8>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAliasRequest {
     #[doc="<p>The alias to be deleted. The name must start with the word \"alias\" followed by a forward slash (alias/). Aliases that begin with \"alias/AWS\" are reserved.</p>"]
     #[serde(rename="AliasName")]
     pub alias_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteImportedKeyMaterialRequest {
     #[doc="<p>The identifier of the CMK whose key material to delete. The CMK's <code>Origin</code> must be <code>EXTERNAL</code>.</p> <p>A valid identifier is the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul>"]
     #[serde(rename="KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeKeyRequest {
     #[doc="<p>A list of grant tokens.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token\">Grant Tokens</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>"]
     #[serde(rename="GrantTokens")]
@@ -209,7 +209,7 @@ pub struct DescribeKeyRequest {
     pub key_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeKeyResponse {
     #[doc="<p>Metadata associated with the key.</p>"]
     #[serde(rename="KeyMetadata")]
@@ -217,35 +217,35 @@ pub struct DescribeKeyResponse {
     pub key_metadata: Option<KeyMetadata>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableKeyRequest {
     #[doc="<p>A unique identifier for the CMK.</p> <p>Use the CMK's unique identifier or its Amazon Resource Name (ARN). For example:</p> <ul> <li> <p>Unique ID: 1234abcd-12ab-34cd-56ef-1234567890ab</p> </li> <li> <p>ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</p> </li> </ul>"]
     #[serde(rename="KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableKeyRotationRequest {
     #[doc="<p>A unique identifier for the customer master key. This value can be a globally unique identifier or the fully specified ARN to a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul>"]
     #[serde(rename="KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableKeyRequest {
     #[doc="<p>A unique identifier for the customer master key. This value can be a globally unique identifier or the fully specified ARN to a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul>"]
     #[serde(rename="KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableKeyRotationRequest {
     #[doc="<p>A unique identifier for the customer master key. This value can be a globally unique identifier or the fully specified ARN to a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul>"]
     #[serde(rename="KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EncryptRequest {
     #[doc="<p>Name-value pair that specifies the encryption context to be used for authenticated encryption. If used here, the same value must be supplied to the <code>Decrypt</code> API or decryption will fail. For more information, see <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html\">Encryption Context</a>.</p>"]
     #[serde(rename="EncryptionContext")]
@@ -268,7 +268,7 @@ pub struct EncryptRequest {
     pub plaintext: Vec<u8>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EncryptResponse {
     #[doc="<p>The encrypted plaintext. If you are using the CLI, the value is Base64 encoded. Otherwise, it is not encoded.</p>"]
     #[serde(rename="CiphertextBlob")]
@@ -284,7 +284,7 @@ pub struct EncryptResponse {
     pub key_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenerateDataKeyRequest {
     #[doc="<p>A set of key-value pairs that represents additional authenticated data.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html\">Encryption Context</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>"]
     #[serde(rename="EncryptionContext")]
@@ -307,7 +307,7 @@ pub struct GenerateDataKeyRequest {
     pub number_of_bytes: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenerateDataKeyResponse {
     #[doc="<p>The encrypted data encryption key.</p>"]
     #[serde(rename="CiphertextBlob")]
@@ -331,7 +331,7 @@ pub struct GenerateDataKeyResponse {
     pub plaintext: Option<Vec<u8>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenerateDataKeyWithoutPlaintextRequest {
     #[doc="<p>A set of key-value pairs that represents additional authenticated data.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html\">Encryption Context</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>"]
     #[serde(rename="EncryptionContext")]
@@ -354,7 +354,7 @@ pub struct GenerateDataKeyWithoutPlaintextRequest {
     pub number_of_bytes: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenerateDataKeyWithoutPlaintextResponse {
     #[doc="<p>The encrypted data encryption key.</p>"]
     #[serde(rename="CiphertextBlob")]
@@ -370,7 +370,7 @@ pub struct GenerateDataKeyWithoutPlaintextResponse {
     pub key_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenerateRandomRequest {
     #[doc="<p>The length of the byte string.</p>"]
     #[serde(rename="NumberOfBytes")]
@@ -378,7 +378,7 @@ pub struct GenerateRandomRequest {
     pub number_of_bytes: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenerateRandomResponse {
     #[doc="<p>The random byte string.</p>"]
     #[serde(rename="Plaintext")]
@@ -390,7 +390,7 @@ pub struct GenerateRandomResponse {
     pub plaintext: Option<Vec<u8>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetKeyPolicyRequest {
     #[doc="<p>A unique identifier for the customer master key. This value can be a globally unique identifier or the fully specified ARN to a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul>"]
     #[serde(rename="KeyId")]
@@ -400,7 +400,7 @@ pub struct GetKeyPolicyRequest {
     pub policy_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetKeyPolicyResponse {
     #[doc="<p>A policy document in JSON format.</p>"]
     #[serde(rename="Policy")]
@@ -408,14 +408,14 @@ pub struct GetKeyPolicyResponse {
     pub policy: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetKeyRotationStatusRequest {
     #[doc="<p>A unique identifier for the customer master key. This value can be a globally unique identifier or the fully specified ARN to a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul>"]
     #[serde(rename="KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetKeyRotationStatusResponse {
     #[doc="<p>A Boolean value that specifies whether key rotation is enabled.</p>"]
     #[serde(rename="KeyRotationEnabled")]
@@ -423,7 +423,7 @@ pub struct GetKeyRotationStatusResponse {
     pub key_rotation_enabled: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetParametersForImportRequest {
     #[doc="<p>The identifier of the CMK into which you will import key material. The CMK's <code>Origin</code> must be <code>EXTERNAL</code>.</p> <p>A valid identifier is the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul>"]
     #[serde(rename="KeyId")]
@@ -436,7 +436,7 @@ pub struct GetParametersForImportRequest {
     pub wrapping_key_spec: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetParametersForImportResponse {
     #[doc="<p>The import token to send in a subsequent <a>ImportKeyMaterial</a> request.</p>"]
     #[serde(rename="ImportToken")]
@@ -478,7 +478,7 @@ pub struct GrantConstraints {
 }
 
 #[doc="<p>Contains information about an entry in a list of grants.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GrantListEntry {
     #[doc="<p>A list of key-value pairs that must be present in the encryption context of certain subsequent operations that the grant allows.</p>"]
     #[serde(rename="Constraints")]
@@ -518,7 +518,7 @@ pub struct GrantListEntry {
     pub retiring_principal: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportKeyMaterialRequest {
     #[doc="<p>The encrypted key material to import. It must be encrypted with the public key that you received in the response to a previous <a>GetParametersForImport</a> request, using the wrapping algorithm that you specified in that request.</p>"]
     #[serde(rename="EncryptedKeyMaterial")]
@@ -549,11 +549,11 @@ pub struct ImportKeyMaterialRequest {
     pub valid_to: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportKeyMaterialResponse;
 
 #[doc="<p>Contains information about each entry in the key list.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KeyListEntry {
     #[doc="<p>ARN of the key.</p>"]
     #[serde(rename="KeyArn")]
@@ -566,7 +566,7 @@ pub struct KeyListEntry {
 }
 
 #[doc="<p>Contains metadata about a customer master key (CMK).</p> <p>This data type is used as a response element for the <a>CreateKey</a> and <a>DescribeKey</a> operations.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KeyMetadata {
     #[doc="<p>The twelve-digit account ID of the AWS account that owns the CMK.</p>"]
     #[serde(rename="AWSAccountId")]
@@ -621,7 +621,7 @@ pub struct KeyMetadata {
     pub valid_to: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAliasesRequest {
     #[doc="<p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 100, inclusive. If you do not include a value, it defaults to 50.</p>"]
     #[serde(rename="Limit")]
@@ -633,7 +633,7 @@ pub struct ListAliasesRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAliasesResponse {
     #[doc="<p>A list of key aliases in the user's account.</p>"]
     #[serde(rename="Aliases")]
@@ -649,7 +649,7 @@ pub struct ListAliasesResponse {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGrantsRequest {
     #[doc="<p>A unique identifier for the customer master key. This value can be a globally unique identifier or the fully specified ARN to a key.</p> <ul> <li> <p>Key ARN Example - arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012</p> </li> <li> <p>Globally Unique Key ID Example - 12345678-1234-1234-1234-123456789012</p> </li> </ul>"]
     #[serde(rename="KeyId")]
@@ -664,7 +664,7 @@ pub struct ListGrantsRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGrantsResponse {
     #[doc="<p>A list of grants.</p>"]
     #[serde(rename="Grants")]
@@ -680,7 +680,7 @@ pub struct ListGrantsResponse {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListKeyPoliciesRequest {
     #[doc="<p>A unique identifier for the customer master key (CMK). You can use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul>"]
     #[serde(rename="KeyId")]
@@ -695,7 +695,7 @@ pub struct ListKeyPoliciesRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListKeyPoliciesResponse {
     #[doc="<p>When <code>Truncated</code> is true, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent request.</p>"]
     #[serde(rename="NextMarker")]
@@ -711,7 +711,7 @@ pub struct ListKeyPoliciesResponse {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListKeysRequest {
     #[doc="<p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 1000, inclusive. If you do not include a value, it defaults to 100.</p>"]
     #[serde(rename="Limit")]
@@ -723,7 +723,7 @@ pub struct ListKeysRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListKeysResponse {
     #[doc="<p>A list of keys.</p>"]
     #[serde(rename="Keys")]
@@ -739,7 +739,7 @@ pub struct ListKeysResponse {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourceTagsRequest {
     #[doc="<p>A unique identifier for the CMK whose tags you are listing. You can use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul>"]
     #[serde(rename="KeyId")]
@@ -754,7 +754,7 @@ pub struct ListResourceTagsRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourceTagsResponse {
     #[doc="<p>When <code>Truncated</code> is true, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent request.</p> <p>Do not assume or infer any information from this value.</p>"]
     #[serde(rename="NextMarker")]
@@ -770,7 +770,7 @@ pub struct ListResourceTagsResponse {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRetirableGrantsRequest {
     #[doc="<p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 100, inclusive. If you do not include a value, it defaults to 50.</p>"]
     #[serde(rename="Limit")]
@@ -785,7 +785,7 @@ pub struct ListRetirableGrantsRequest {
     pub retiring_principal: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutKeyPolicyRequest {
     #[doc="<p>A flag to indicate whether to bypass the key policy lockout safety check.</p> <important> <p>Setting this value to true increases the likelihood that the CMK becomes unmanageable. Do not set this value to true indiscriminately.</p> <p>For more information, refer to the scenario in the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </important> <p>Use this parameter only when you intend to prevent the principal that is making the request from making a subsequent <code>PutKeyPolicy</code> request on the CMK.</p> <p>The default value is false.</p>"]
     #[serde(rename="BypassPolicyLockoutSafetyCheck")]
@@ -802,7 +802,7 @@ pub struct PutKeyPolicyRequest {
     pub policy_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReEncryptRequest {
     #[doc="<p>Ciphertext of the data to reencrypt.</p>"]
     #[serde(rename="CiphertextBlob")]
@@ -829,7 +829,7 @@ pub struct ReEncryptRequest {
     pub source_encryption_context: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReEncryptResponse {
     #[doc="<p>The reencrypted data.</p>"]
     #[serde(rename="CiphertextBlob")]
@@ -849,7 +849,7 @@ pub struct ReEncryptResponse {
     pub source_key_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RetireGrantRequest {
     #[doc="<p>Unique identifier of the grant to retire. The grant ID is returned in the response to a <code>CreateGrant</code> operation.</p> <ul> <li> <p>Grant ID Example - 0123456789012345678901234567890123456789012345678901234567890123</p> </li> </ul>"]
     #[serde(rename="GrantId")]
@@ -865,7 +865,7 @@ pub struct RetireGrantRequest {
     pub key_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevokeGrantRequest {
     #[doc="<p>Identifier of the grant to be revoked.</p>"]
     #[serde(rename="GrantId")]
@@ -875,7 +875,7 @@ pub struct RevokeGrantRequest {
     pub key_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduleKeyDeletionRequest {
     #[doc="<p>The unique identifier for the customer master key (CMK) to delete.</p> <p>To specify this value, use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: 1234abcd-12ab-34cd-56ef-1234567890ab</p> </li> <li> <p>Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</p> </li> </ul> <p>To obtain the unique key ID and key ARN for a given CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>"]
     #[serde(rename="KeyId")]
@@ -886,7 +886,7 @@ pub struct ScheduleKeyDeletionRequest {
     pub pending_window_in_days: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduleKeyDeletionResponse {
     #[doc="<p>The date and time after which AWS KMS deletes the customer master key (CMK).</p>"]
     #[serde(rename="DeletionDate")]
@@ -909,7 +909,7 @@ pub struct Tag {
     pub tag_value: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceRequest {
     #[doc="<p>A unique identifier for the CMK you are tagging. You can use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul>"]
     #[serde(rename="KeyId")]
@@ -919,7 +919,7 @@ pub struct TagResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceRequest {
     #[doc="<p>A unique identifier for the CMK from which you are removing tags. You can use the unique key ID or the Amazon Resource Name (ARN) of the CMK. Examples:</p> <ul> <li> <p>Unique key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul>"]
     #[serde(rename="KeyId")]
@@ -929,7 +929,7 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAliasRequest {
     #[doc="<p>String that contains the name of the alias to be modified. The name must start with the word \"alias\" followed by a forward slash (alias/). Aliases that begin with \"alias/aws\" are reserved.</p>"]
     #[serde(rename="AliasName")]
@@ -939,7 +939,7 @@ pub struct UpdateAliasRequest {
     pub target_key_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateKeyDescriptionRequest {
     #[doc="<p>New description for the CMK.</p>"]
     #[serde(rename="Description")]

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 #[doc="<p>Provides limits of code size and concurrency associated with the current account and region.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountLimit {
     #[doc="<p>Size, in bytes, of code/dependencies that you can zip into a deployment package (uncompressed zip/jar size) for uploading. The default limit is 250 MB.</p>"]
     #[serde(rename="CodeSizeUnzipped")]
@@ -51,7 +51,7 @@ pub struct AccountLimit {
 }
 
 #[doc="<p>Provides code size usage and function count associated with the current account and region.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountUsage {
     #[doc="<p>The number of your account's existing functions per region.</p>"]
     #[serde(rename="FunctionCount")]
@@ -64,7 +64,7 @@ pub struct AccountUsage {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddPermissionRequest {
     #[doc="<p>The AWS Lambda action you want to allow in this statement. Each Lambda action is a string starting with <code>lambda:</code> followed by the API name . For example, <code>lambda:CreateFunction</code>. You can use wildcard (<code>lambda:*</code>) to grant permission for all AWS Lambda actions. </p>"]
     #[serde(rename="Action")]
@@ -97,7 +97,7 @@ pub struct AddPermissionRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddPermissionResponse {
     #[doc="<p>The permission statement you specified in the request. The response returns the same as a string using a backslash (\"\\\") as an escape character in the JSON.</p>"]
     #[serde(rename="Statement")]
@@ -106,7 +106,7 @@ pub struct AddPermissionResponse {
 }
 
 #[doc="<p>Provides configuration information about a Lambda function version alias.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AliasConfiguration {
     #[doc="<p>Lambda function ARN that is qualified using the alias name as the suffix. For example, if you create an alias called <code>BETA</code> that points to a helloworld function version, the ARN is <code>arn:aws:lambda:aws-regions:acct-id:function:helloworld:BETA</code>.</p>"]
     #[serde(rename="AliasArn")]
@@ -126,7 +126,7 @@ pub struct AliasConfiguration {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAliasRequest {
     #[doc="<p>Description of the alias.</p>"]
     #[serde(rename="Description")]
@@ -144,7 +144,7 @@ pub struct CreateAliasRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEventSourceMappingRequest {
     #[doc="<p>The largest number of records that AWS Lambda will retrieve from your event source at the time of invoking your function. Your function receives an event with all the retrieved records. The default is 100 records.</p>"]
     #[serde(rename="BatchSize")]
@@ -170,7 +170,7 @@ pub struct CreateEventSourceMappingRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFunctionRequest {
     #[doc="<p>The code for the Lambda function.</p>"]
     #[serde(rename="Code")]
@@ -237,7 +237,7 @@ pub struct DeadLetterConfig {
     pub target_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAliasRequest {
     #[doc="<p>The Lambda function name for which the alias is created. Deleting an alias does not delete the function version to which it is pointing. Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length.</p>"]
     #[serde(rename="FunctionName")]
@@ -248,14 +248,14 @@ pub struct DeleteAliasRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEventSourceMappingRequest {
     #[doc="<p>The event source mapping ID.</p>"]
     #[serde(rename="UUID")]
     pub uuid: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFunctionRequest {
     #[doc="<p>The Lambda function to delete.</p> <p> You can specify the function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). If you are using versioning, you can also provide a qualified function ARN (ARN that is qualified with function version or alias name as suffix). AWS Lambda also allows you to specify only the function name with the account ID qualifier (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>"]
     #[serde(rename="FunctionName")]
@@ -267,7 +267,7 @@ pub struct DeleteFunctionRequest {
 }
 
 #[doc="<p>The parent object that contains your environment's configuration settings.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Environment {
     #[doc="<p>The key-value pairs that represent your environment's configuration settings.</p>"]
     #[serde(rename="Variables")]
@@ -276,7 +276,7 @@ pub struct Environment {
 }
 
 #[doc="<p>The parent object that contains error information associated with your configuration settings.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentError {
     #[doc="<p>The error code returned by the environment error object.</p>"]
     #[serde(rename="ErrorCode")]
@@ -289,7 +289,7 @@ pub struct EnvironmentError {
 }
 
 #[doc="<p>The parent object returned that contains your environment's configuration settings or any error information associated with your configuration settings.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnvironmentResponse {
     #[serde(rename="Error")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -301,7 +301,7 @@ pub struct EnvironmentResponse {
 }
 
 #[doc="<p>Describes mapping between an Amazon Kinesis stream and a Lambda function.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventSourceMappingConfiguration {
     #[doc="<p>The largest number of records that AWS Lambda will retrieve from your event source at the time of invoking your function. Your function receives an event with all the retrieved records.</p>"]
     #[serde(rename="BatchSize")]
@@ -338,7 +338,7 @@ pub struct EventSourceMappingConfiguration {
 }
 
 #[doc="<p>The code for the Lambda function.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FunctionCode {
     #[doc="<p>Amazon S3 bucket name where the .zip file containing your deployment package is stored. This bucket must reside in the same AWS region where you are creating the Lambda function.</p>"]
     #[serde(rename="S3Bucket")]
@@ -363,7 +363,7 @@ pub struct FunctionCode {
 }
 
 #[doc="<p>The object for the Lambda function location.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FunctionCodeLocation {
     #[doc="<p>The presigned URL you can use to download the function's .zip file that you previously uploaded. The URL is valid for up to 10 minutes.</p>"]
     #[serde(rename="Location")]
@@ -376,7 +376,7 @@ pub struct FunctionCodeLocation {
 }
 
 #[doc="<p>A complex type that describes function metadata.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FunctionConfiguration {
     #[doc="<p>It is the SHA256 hash of your function deployment package.</p>"]
     #[serde(rename="CodeSha256")]
@@ -452,10 +452,10 @@ pub struct FunctionConfiguration {
     pub vpc_config: Option<VpcConfigResponse>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccountSettingsRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccountSettingsResponse {
     #[serde(rename="AccountLimit")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -465,7 +465,7 @@ pub struct GetAccountSettingsResponse {
     pub account_usage: Option<AccountUsage>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAliasRequest {
     #[doc="<p>Function name for which the alias is created. An alias is a subresource that exists only in the context of an existing Lambda function so you must specify the function name. Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length.</p>"]
     #[serde(rename="FunctionName")]
@@ -476,7 +476,7 @@ pub struct GetAliasRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetEventSourceMappingRequest {
     #[doc="<p>The AWS Lambda assigned ID of the event source mapping.</p>"]
     #[serde(rename="UUID")]
@@ -484,7 +484,7 @@ pub struct GetEventSourceMappingRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFunctionConfigurationRequest {
     #[doc="<p>The name of the Lambda function for which you want to retrieve the configuration information.</p> <p> You can specify a function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). AWS Lambda also allows you to specify a partial ARN (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>"]
     #[serde(rename="FunctionName")]
@@ -496,7 +496,7 @@ pub struct GetFunctionConfigurationRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFunctionRequest {
     #[doc="<p>The Lambda function name.</p> <p> You can specify a function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). AWS Lambda also allows you to specify a partial ARN (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>"]
     #[serde(rename="FunctionName")]
@@ -508,7 +508,7 @@ pub struct GetFunctionRequest {
 }
 
 #[doc="<p>This response contains the object for the Lambda function location (see <a>FunctionCodeLocation</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFunctionResponse {
     #[serde(rename="Code")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -523,7 +523,7 @@ pub struct GetFunctionResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPolicyRequest {
     #[doc="<p>Function name whose resource policy you want to retrieve.</p> <p> You can specify the function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). If you are using versioning, you can also provide a qualified function ARN (ARN that is qualified with function version or alias name as suffix). AWS Lambda also allows you to specify only the function name with the account ID qualifier (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>"]
     #[serde(rename="FunctionName")]
@@ -535,7 +535,7 @@ pub struct GetPolicyRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPolicyResponse {
     #[doc="<p>The resource policy associated with the specified function. The response returns the same as a string using a backslash (\"\\\") as an escape character in the JSON.</p>"]
     #[serde(rename="Policy")]
@@ -544,7 +544,7 @@ pub struct GetPolicyResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InvocationRequest {
     #[doc="<p>Using the <code>ClientContext</code> you can pass client-specific information to the Lambda function you are invoking. You can then process the client information in your Lambda function as you choose through the context variable. For an example of a <code>ClientContext</code> JSON, see <a href=\"http://docs.aws.amazon.com/mobileanalytics/latest/ug/PutEvents.html\">PutEvents</a> in the <i>Amazon Mobile Analytics API Reference and User Guide</i>.</p> <p>The ClientContext JSON must be base64-encoded.</p>"]
     #[serde(rename="ClientContext")]
@@ -576,20 +576,32 @@ pub struct InvocationRequest {
 }
 
 #[doc="<p>Upon success, returns an empty response. Otherwise, throws an exception.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InvocationResponse {
     #[doc="<p>Indicates whether an error occurred while executing the Lambda function. If an error occurred this field will have one of two values; <code>Handled</code> or <code>Unhandled</code>. <code>Handled</code> errors are errors that are reported by the function while the <code>Unhandled</code> errors are those detected and reported by AWS Lambda. Unhandled errors include out of memory errors and function timeouts. For information about how to report an <code>Handled</code> error, see <a href=\"http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html\">Programming Model</a>. </p>"]
+    #[serde(rename="FunctionError")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub function_error: Option<String>,
     #[doc="<p> It is the base64-encoded logs for the Lambda function invocation. This is present only if the invocation type is <code>RequestResponse</code> and the logs were requested. </p>"]
+    #[serde(rename="LogResult")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub log_result: Option<String>,
     #[doc="<p> It is the JSON representation of the object returned by the Lambda function. This is present only if the invocation type is <code>RequestResponse</code>. </p> <p>In the event of a function error this field contains a message describing the error. For the <code>Handled</code> errors the Lambda function will report this message. For <code>Unhandled</code> errors AWS Lambda reports the message. </p>"]
+    #[serde(rename="Payload")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub payload: Option<Vec<u8>>,
     #[doc="<p>The HTTP status code will be in the 200 range for successful request. For the <code>RequestResponse</code> invocation type this status code will be 200. For the <code>Event</code> invocation type this status code will be 202. For the <code>DryRun</code> invocation type the status code will be 204. </p>"]
+    #[serde(rename="StatusCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_code: Option<i64>,
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InvokeAsyncRequest {
     #[doc="<p>The Lambda function name. Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length.</p>"]
     #[serde(rename="FunctionName")]
@@ -605,7 +617,7 @@ pub struct InvokeAsyncRequest {
 }
 
 #[doc="<p>Upon success, it returns empty response. Otherwise, throws an exception.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InvokeAsyncResponse {
     #[doc="<p>It will be 202 upon success.</p>"]
     #[serde(rename="Status")]
@@ -613,7 +625,7 @@ pub struct InvokeAsyncResponse {
     pub status: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAliasesRequest {
     #[doc="<p>Lambda function name for which the alias is created. Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length.</p>"]
     #[serde(rename="FunctionName")]
@@ -632,7 +644,7 @@ pub struct ListAliasesRequest {
     pub max_items: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAliasesResponse {
     #[doc="<p>A list of aliases.</p>"]
     #[serde(rename="Aliases")]
@@ -645,7 +657,7 @@ pub struct ListAliasesResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListEventSourceMappingsRequest {
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon Kinesis stream. (This parameter is optional.)</p>"]
     #[serde(rename="EventSourceArn")]
@@ -666,7 +678,7 @@ pub struct ListEventSourceMappingsRequest {
 }
 
 #[doc="<p>Contains a list of event sources (see <a>EventSourceMappingConfiguration</a>)</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListEventSourceMappingsResponse {
     #[doc="<p>An array of <code>EventSourceMappingConfiguration</code> objects.</p>"]
     #[serde(rename="EventSourceMappings")]
@@ -679,7 +691,7 @@ pub struct ListEventSourceMappingsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFunctionsRequest {
     #[doc="<p>Optional string. If not specified, only the unqualified functions ARNs (Amazon Resource Names) will be returned.</p> <p>Valid value:</p> <p> <code>ALL</code> _ Will return all versions, including <code>$LATEST</code> which will have fully qualified ARNs (Amazon Resource Names).</p>"]
     #[serde(rename="FunctionVersion")]
@@ -700,7 +712,7 @@ pub struct ListFunctionsRequest {
 }
 
 #[doc="<p>Contains a list of AWS Lambda function configurations (see <a>FunctionConfiguration</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFunctionsResponse {
     #[doc="<p>A list of Lambda functions.</p>"]
     #[serde(rename="Functions")]
@@ -712,14 +724,14 @@ pub struct ListFunctionsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsRequest {
     #[doc="<p>The ARN (Amazon Resource Name) of the function.</p>"]
     #[serde(rename="Resource")]
     pub resource: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsResponse {
     #[doc="<p>The list of tags assigned to the function.</p>"]
     #[serde(rename="Tags")]
@@ -728,7 +740,7 @@ pub struct ListTagsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVersionsByFunctionRequest {
     #[doc="<p>Function name whose versions to list. You can specify a function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). AWS Lambda also allows you to specify a partial ARN (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>"]
     #[serde(rename="FunctionName")]
@@ -744,7 +756,7 @@ pub struct ListVersionsByFunctionRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVersionsByFunctionResponse {
     #[doc="<p>A string, present if there are more function versions.</p>"]
     #[serde(rename="NextMarker")]
@@ -757,7 +769,7 @@ pub struct ListVersionsByFunctionResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PublishVersionRequest {
     #[doc="<p>The SHA256 hash of the deployment package you want to publish. This provides validation on the code you are publishing. If you provide this parameter value must match the SHA256 of the $LATEST version for the publication to succeed.</p>"]
     #[serde(rename="CodeSha256")]
@@ -773,7 +785,7 @@ pub struct PublishVersionRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemovePermissionRequest {
     #[doc="<p>Lambda function whose resource policy you want to remove a permission from.</p> <p> You can specify a function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). AWS Lambda also allows you to specify a partial ARN (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>"]
     #[serde(rename="FunctionName")]
@@ -787,7 +799,7 @@ pub struct RemovePermissionRequest {
     pub statement_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceRequest {
     #[doc="<p>The ARN (Amazon Resource Name) of the Lambda function.</p>"]
     #[serde(rename="Resource")]
@@ -798,7 +810,7 @@ pub struct TagResourceRequest {
 }
 
 #[doc="<p>The parent object that contains your function's tracing settings.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TracingConfig {
     #[doc="<p>Can be either PassThrough or Active. If PassThrough, Lambda will only trace the request from an upstream service if it contains a tracing header with \"sampled=1\". If Active, Lambda will respect any tracing header it receives from an upstream service. If no tracing header is received, Lambda will call X-Ray for a tracing decision.</p>"]
     #[serde(rename="Mode")]
@@ -807,7 +819,7 @@ pub struct TracingConfig {
 }
 
 #[doc="<p>Parent object of the tracing information associated with your Lambda function.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TracingConfigResponse {
     #[doc="<p>The tracing mode associated with your Lambda function.</p>"]
     #[serde(rename="Mode")]
@@ -815,7 +827,7 @@ pub struct TracingConfigResponse {
     pub mode: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceRequest {
     #[doc="<p>The ARN (Amazon Resource Name) of the function.</p>"]
     #[serde(rename="Resource")]
@@ -825,7 +837,7 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAliasRequest {
     #[doc="<p>You can change the description of the alias using this parameter.</p>"]
     #[serde(rename="Description")]
@@ -844,7 +856,7 @@ pub struct UpdateAliasRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateEventSourceMappingRequest {
     #[doc="<p>The maximum number of stream records that can be sent to your Lambda function for a single invocation.</p>"]
     #[serde(rename="BatchSize")]
@@ -864,7 +876,7 @@ pub struct UpdateEventSourceMappingRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFunctionCodeRequest {
     #[doc="<p>This boolean parameter can be used to test your request to AWS Lambda to update the Lambda function and publish a version as an atomic operation. It will do all necessary computation and validation of your code but will not upload it or a publish a version. Each time this operation is invoked, the <code>CodeSha256</code> hash value the provided code will also be computed and returned in the response.</p>"]
     #[serde(rename="DryRun")]
@@ -900,7 +912,7 @@ pub struct UpdateFunctionCodeRequest {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFunctionConfigurationRequest {
     #[doc="<p>The parent object that contains the target ARN (Amazon Resource Name) of an Amazon SQS queue or Amazon SNS topic.</p>"]
     #[serde(rename="DeadLetterConfig")]
@@ -951,7 +963,7 @@ pub struct UpdateFunctionConfigurationRequest {
 }
 
 #[doc="<p>If your Lambda function accesses resources in a VPC, you provide this parameter identifying the list of security group IDs and subnet IDs. These must belong to the same VPC. You must provide at least one security group and one subnet ID.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcConfig {
     #[doc="<p>A list of one or more security groups IDs in your VPC.</p>"]
     #[serde(rename="SecurityGroupIds")]
@@ -964,7 +976,7 @@ pub struct VpcConfig {
 }
 
 #[doc="<p>VPC configuration associated with your Lambda function.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcConfigResponse {
     #[doc="<p>A list of security group IDs associated with the Lambda function.</p>"]
     #[serde(rename="SecurityGroupIds")]

--- a/rusoto/services/lex-models/src/generated.rs
+++ b/rusoto/services/lex-models/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 #[doc="<p>Provides information about a bot alias.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BotAliasMetadata {
     #[doc="<p>The name of the bot to which the alias points.</p>"]
     #[serde(rename="botName")]
@@ -63,7 +63,7 @@ pub struct BotAliasMetadata {
 }
 
 #[doc="<p>Represents an association between an Amazon Lex bot and an external messaging platform.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BotChannelAssociation {
     #[doc="<p>An alias pointing to the specific version of the Amazon Lex bot to which this association is being made. </p>"]
     #[serde(rename="botAlias")]
@@ -96,7 +96,7 @@ pub struct BotChannelAssociation {
 }
 
 #[doc="<p>Provides information about a bot. .</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BotMetadata {
     #[doc="<p>The date that the bot was created.</p>"]
     #[serde(rename="createdDate")]
@@ -125,7 +125,7 @@ pub struct BotMetadata {
 }
 
 #[doc="<p>Provides metadata for a built-in intent.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BuiltinIntentMetadata {
     #[doc="<p>A unique identifier for the built-in intent. To find the signature for an intent, see <a href=\"https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/standard-intents\">Standard Built-in Intents</a> in the <i>Alexa Skills Kit</i>.</p>"]
     #[serde(rename="signature")]
@@ -138,7 +138,7 @@ pub struct BuiltinIntentMetadata {
 }
 
 #[doc="<p>Provides information about a slot used in a built-in intent.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BuiltinIntentSlot {
     #[doc="<p>A list of the slots defined for the intent.</p>"]
     #[serde(rename="name")]
@@ -147,7 +147,7 @@ pub struct BuiltinIntentSlot {
 }
 
 #[doc="<p>Provides information about a built in slot type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BuiltinSlotTypeMetadata {
     #[doc="<p>A unique identifier for the built-in slot type. To find the signature for a slot type, see <a href=\"https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/slot-type-reference\">Slot Type Reference</a> in the <i>Alexa Skills Kit</i>.</p>"]
     #[serde(rename="signature")]
@@ -170,7 +170,7 @@ pub struct CodeHook {
     pub uri: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBotVersionRequest {
     #[doc="<p>Identifies a specific revision of the <code>$LATEST</code> version of the bot. If you specify a checksum and the <code>$LATEST</code> version of the bot has a different checksum, a <code>PreconditionFailedException</code> exception is returned and Amazon Lex doesn't publish a new version. If you don't specify a checksum, Amazon Lex publishes the <code>$LATEST</code> version.</p>"]
     #[serde(rename="checksum")]
@@ -181,7 +181,7 @@ pub struct CreateBotVersionRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBotVersionResponse {
     #[doc="<p>The message that Amazon Lex uses to abort a conversation. For more information, see <a>PutBot</a>.</p>"]
     #[serde(rename="abortStatement")]
@@ -245,7 +245,7 @@ pub struct CreateBotVersionResponse {
     pub voice_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateIntentVersionRequest {
     #[doc="<p>Checksum of the <code>$LATEST</code> version of the intent that should be used to create the new version. If you specify a checksum and the <code>$LATEST</code> version of the intent has a different checksum, Amazon Lex returns a <code>PreconditionFailedException</code> exception and doesn't publish a new version. If you don't specify a checksum, Amazon Lex publishes the <code>$LATEST</code> version.</p>"]
     #[serde(rename="checksum")]
@@ -256,7 +256,7 @@ pub struct CreateIntentVersionRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateIntentVersionResponse {
     #[doc="<p>Checksum of the intent version created.</p>"]
     #[serde(rename="checksum")]
@@ -320,7 +320,7 @@ pub struct CreateIntentVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSlotTypeVersionRequest {
     #[doc="<p>Checksum for the <code>$LATEST</code> version of the slot type that you want to publish. If you specify a checksum and the <code>$LATEST</code> version of the slot type has a different checksum, Amazon Lex returns a <code>PreconditionFailedException</code> exception and doesn't publish the new version. If you don't specify a checksum, Amazon Lex publishes the <code>$LATEST</code> version.</p>"]
     #[serde(rename="checksum")]
@@ -331,7 +331,7 @@ pub struct CreateSlotTypeVersionRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSlotTypeVersionResponse {
     #[doc="<p>Checksum of the <code>$LATEST</code> version of the slot type.</p>"]
     #[serde(rename="checksum")]
@@ -363,7 +363,7 @@ pub struct CreateSlotTypeVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBotAliasRequest {
     #[doc="<p>The name of the bot that the alias points to.</p>"]
     #[serde(rename="botName")]
@@ -373,7 +373,7 @@ pub struct DeleteBotAliasRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBotChannelAssociationRequest {
     #[doc="<p>An alias that points to the specific version of the Amazon Lex bot to which this association is being made.</p>"]
     #[serde(rename="botAlias")]
@@ -386,14 +386,14 @@ pub struct DeleteBotChannelAssociationRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBotRequest {
     #[doc="<p>The name of the bot. The name is case sensitive. </p>"]
     #[serde(rename="name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBotVersionRequest {
     #[doc="<p>The name of the bot.</p>"]
     #[serde(rename="name")]
@@ -403,14 +403,14 @@ pub struct DeleteBotVersionRequest {
     pub version: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIntentRequest {
     #[doc="<p>The name of the intent. The name is case sensitive. </p>"]
     #[serde(rename="name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIntentVersionRequest {
     #[doc="<p>The name of the intent.</p>"]
     #[serde(rename="name")]
@@ -420,14 +420,14 @@ pub struct DeleteIntentVersionRequest {
     pub version: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSlotTypeRequest {
     #[doc="<p>The name of the slot type. The name is case sensitive. </p>"]
     #[serde(rename="name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSlotTypeVersionRequest {
     #[doc="<p>The name of the slot type.</p>"]
     #[serde(rename="name")]
@@ -437,7 +437,7 @@ pub struct DeleteSlotTypeVersionRequest {
     pub version: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUtterancesRequest {
     #[doc="<p>The name of the bot that stored the utterances.</p>"]
     #[serde(rename="botName")]
@@ -478,7 +478,7 @@ pub struct FulfillmentActivity {
     pub type_: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotAliasRequest {
     #[doc="<p>The name of the bot.</p>"]
     #[serde(rename="botName")]
@@ -488,7 +488,7 @@ pub struct GetBotAliasRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotAliasResponse {
     #[doc="<p>The name of the bot that the alias points to.</p>"]
     #[serde(rename="botName")]
@@ -520,7 +520,7 @@ pub struct GetBotAliasResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotAliasesRequest {
     #[doc="<p>The name of the bot.</p>"]
     #[serde(rename="botName")]
@@ -539,7 +539,7 @@ pub struct GetBotAliasesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotAliasesResponse {
     #[doc="<p>An array of <code>BotAliasMetadata</code> objects, each describing a bot alias.</p>"]
     #[serde(rename="BotAliases")]
@@ -551,7 +551,7 @@ pub struct GetBotAliasesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotChannelAssociationRequest {
     #[doc="<p>An alias pointing to the specific version of the Amazon Lex bot to which this association is being made.</p>"]
     #[serde(rename="botAlias")]
@@ -564,7 +564,7 @@ pub struct GetBotChannelAssociationRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotChannelAssociationResponse {
     #[doc="<p>An alias pointing to the specific version of the Amazon Lex bot to which this association is being made.</p>"]
     #[serde(rename="botAlias")]
@@ -596,7 +596,7 @@ pub struct GetBotChannelAssociationResponse {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotChannelAssociationsRequest {
     #[doc="<p>An alias pointing to the specific version of the Amazon Lex bot to which this association is being made.</p>"]
     #[serde(rename="botAlias")]
@@ -618,7 +618,7 @@ pub struct GetBotChannelAssociationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotChannelAssociationsResponse {
     #[doc="<p>An array of objects, one for each association, that provides information about the Amazon Lex bot and its association with the channel. </p>"]
     #[serde(rename="botChannelAssociations")]
@@ -630,7 +630,7 @@ pub struct GetBotChannelAssociationsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotRequest {
     #[doc="<p>The name of the bot. The name is case sensitive. </p>"]
     #[serde(rename="name")]
@@ -640,7 +640,7 @@ pub struct GetBotRequest {
     pub version_or_alias: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotResponse {
     #[doc="<p>The message that Amazon Lex returns when the user elects to end the conversation without completing it. For more information, see <a>PutBot</a>.</p>"]
     #[serde(rename="abortStatement")]
@@ -704,7 +704,7 @@ pub struct GetBotResponse {
     pub voice_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotVersionsRequest {
     #[doc="<p>The maximum number of bot versions to return in the response. The default is 10.</p>"]
     #[serde(rename="maxResults")]
@@ -719,7 +719,7 @@ pub struct GetBotVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotVersionsResponse {
     #[doc="<p>An array of <code>BotMetadata</code> objects, one for each numbered version of the bot plus one for the <code>$LATEST</code> version.</p>"]
     #[serde(rename="bots")]
@@ -731,7 +731,7 @@ pub struct GetBotVersionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotsRequest {
     #[doc="<p>The maximum number of bots to return in the response that the request will return. The default is 10.</p>"]
     #[serde(rename="maxResults")]
@@ -747,7 +747,7 @@ pub struct GetBotsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBotsResponse {
     #[doc="<p>An array of <code>botMetadata</code> objects, with one entry for each bot. </p>"]
     #[serde(rename="bots")]
@@ -759,14 +759,14 @@ pub struct GetBotsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBuiltinIntentRequest {
     #[doc="<p>The unique identifier for a built-in intent. To find the signature for an intent, see <a href=\"https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/standard-intents\">Standard Built-in Intents</a> in the <i>Alexa Skills Kit</i>.</p>"]
     #[serde(rename="signature")]
     pub signature: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBuiltinIntentResponse {
     #[doc="<p>The unique identifier for a built-in intent.</p>"]
     #[serde(rename="signature")]
@@ -782,7 +782,7 @@ pub struct GetBuiltinIntentResponse {
     pub supported_locales: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBuiltinIntentsRequest {
     #[doc="<p>A list of locales that the intent supports.</p>"]
     #[serde(rename="locale")]
@@ -802,7 +802,7 @@ pub struct GetBuiltinIntentsRequest {
     pub signature_contains: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBuiltinIntentsResponse {
     #[doc="<p>An array of <code>builtinIntentMetadata</code> objects, one for each intent in the response.</p>"]
     #[serde(rename="intents")]
@@ -814,7 +814,7 @@ pub struct GetBuiltinIntentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBuiltinSlotTypesRequest {
     #[doc="<p>A list of locales that the slot type supports.</p>"]
     #[serde(rename="locale")]
@@ -834,7 +834,7 @@ pub struct GetBuiltinSlotTypesRequest {
     pub signature_contains: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBuiltinSlotTypesResponse {
     #[doc="<p>If the response is truncated, the response includes a pagination token that you can use in your next request to fetch the next page of slot types.</p>"]
     #[serde(rename="nextToken")]
@@ -846,7 +846,7 @@ pub struct GetBuiltinSlotTypesResponse {
     pub slot_types: Option<Vec<BuiltinSlotTypeMetadata>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIntentRequest {
     #[doc="<p>The name of the intent. The name is case sensitive. </p>"]
     #[serde(rename="name")]
@@ -856,7 +856,7 @@ pub struct GetIntentRequest {
     pub version: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIntentResponse {
     #[doc="<p>Checksum of the intent.</p>"]
     #[serde(rename="checksum")]
@@ -920,7 +920,7 @@ pub struct GetIntentResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIntentVersionsRequest {
     #[doc="<p>The maximum number of intent versions to return in the response. The default is 10.</p>"]
     #[serde(rename="maxResults")]
@@ -935,7 +935,7 @@ pub struct GetIntentVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIntentVersionsResponse {
     #[doc="<p>An array of <code>IntentMetadata</code> objects, one for each numbered version of the intent plus one for the <code>$LATEST</code> version.</p>"]
     #[serde(rename="intents")]
@@ -947,7 +947,7 @@ pub struct GetIntentVersionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIntentsRequest {
     #[doc="<p>The maximum number of intents to return in the response. The default is 10.</p>"]
     #[serde(rename="maxResults")]
@@ -963,7 +963,7 @@ pub struct GetIntentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIntentsResponse {
     #[doc="<p>An array of <code>Intent</code> objects. For more information, see <a>PutBot</a>.</p>"]
     #[serde(rename="intents")]
@@ -975,7 +975,7 @@ pub struct GetIntentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSlotTypeRequest {
     #[doc="<p>The name of the slot type. The name is case sensitive. </p>"]
     #[serde(rename="name")]
@@ -985,7 +985,7 @@ pub struct GetSlotTypeRequest {
     pub version: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSlotTypeResponse {
     #[doc="<p>Checksum of the <code>$LATEST</code> version of the slot type.</p>"]
     #[serde(rename="checksum")]
@@ -1017,7 +1017,7 @@ pub struct GetSlotTypeResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSlotTypeVersionsRequest {
     #[doc="<p>The maximum number of slot type versions to return in the response. The default is 10.</p>"]
     #[serde(rename="maxResults")]
@@ -1032,7 +1032,7 @@ pub struct GetSlotTypeVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSlotTypeVersionsResponse {
     #[doc="<p>A pagination token for fetching the next page of slot type versions. If the response to this call is truncated, Amazon Lex returns a pagination token in the response. To fetch the next page of versions, specify the pagination token in the next request. </p>"]
     #[serde(rename="nextToken")]
@@ -1044,7 +1044,7 @@ pub struct GetSlotTypeVersionsResponse {
     pub slot_types: Option<Vec<SlotTypeMetadata>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSlotTypesRequest {
     #[doc="<p>The maximum number of slot types to return in the response. The default is 10.</p>"]
     #[serde(rename="maxResults")]
@@ -1060,7 +1060,7 @@ pub struct GetSlotTypesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSlotTypesResponse {
     #[doc="<p>If the response is truncated, it includes a pagination token that you can specify in your next request to fetch the next page of slot types.</p>"]
     #[serde(rename="nextToken")]
@@ -1072,7 +1072,7 @@ pub struct GetSlotTypesResponse {
     pub slot_types: Option<Vec<SlotTypeMetadata>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUtterancesViewRequest {
     #[doc="<p>The name of the bot for which utterance information should be returned.</p>"]
     #[serde(rename="botName")]
@@ -1085,7 +1085,7 @@ pub struct GetUtterancesViewRequest {
     pub status_type: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetUtterancesViewResponse {
     #[doc="<p>The name of the bot for which utterance information was returned.</p>"]
     #[serde(rename="botName")]
@@ -1109,7 +1109,7 @@ pub struct Intent {
 }
 
 #[doc="<p>Provides information about an intent.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IntentMetadata {
     #[doc="<p>The date that the intent was created.</p>"]
     #[serde(rename="createdDate")]
@@ -1159,7 +1159,7 @@ pub struct Prompt {
     pub response_card: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutBotAliasRequest {
     #[doc="<p>The name of the bot.</p>"]
     #[serde(rename="botName")]
@@ -1180,7 +1180,7 @@ pub struct PutBotAliasRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutBotAliasResponse {
     #[doc="<p>The name of the bot that the alias points to.</p>"]
     #[serde(rename="botName")]
@@ -1212,7 +1212,7 @@ pub struct PutBotAliasResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutBotRequest {
     #[doc="<p>When Amazon Lex can't understand the user's input in context, it tries to elicit the information a few times. After that, Amazon Lex sends the message defined in <code>abortStatement</code> to the user, and then aborts the conversation. To set the number of retries, use the <code>valueElicitationPrompt</code> field for the slot type. </p> <p>For example, in a pizza ordering bot, Amazon Lex might ask a user \"What type of crust would you like?\" If the user's response is not one of the expected responses (for example, \"thin crust, \"deep dish,\" etc.), Amazon Lex tries to elicit a correct response a few more times. </p> <p>For example, in a pizza ordering application, <code>OrderPizza</code> might be one of the intents. This intent might require the <code>CrustType</code> slot. You specify the <code>valueElicitationPrompt</code> field when you create the <code>CrustType</code> slot.</p>"]
     #[serde(rename="abortStatement")]
@@ -1257,7 +1257,7 @@ pub struct PutBotRequest {
     pub voice_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutBotResponse {
     #[doc="<p>The message that Amazon Lex uses to abort a conversation. For more information, see <a>PutBot</a>.</p>"]
     #[serde(rename="abortStatement")]
@@ -1321,7 +1321,7 @@ pub struct PutBotResponse {
     pub voice_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutIntentRequest {
     #[doc="<p>Identifies a specific revision of the <code>$LATEST</code> version.</p> <p>When you create a new intent, leave the <code>checksum</code> field blank. If you specify a checksum you get a <code>BadRequestException</code> exception.</p> <p>When you want to update a intent, set the <code>checksum</code> field to the checksum of the most recent revision of the <code>$LATEST</code> version. If you don't specify the <code> checksum</code> field, or if the checksum does not match the <code>$LATEST</code> version, you get a <code>PreconditionFailedException</code> exception.</p>"]
     #[serde(rename="checksum")]
@@ -1372,7 +1372,7 @@ pub struct PutIntentRequest {
     pub slots: Option<Vec<Slot>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutIntentResponse {
     #[doc="<p>Checksum of the <code>$LATEST</code>version of the intent created or updated.</p>"]
     #[serde(rename="checksum")]
@@ -1436,7 +1436,7 @@ pub struct PutIntentResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutSlotTypeRequest {
     #[doc="<p>Identifies a specific revision of the <code>$LATEST</code> version.</p> <p>When you create a new slot type, leave the <code>checksum</code> field blank. If you specify a checksum you get a <code>BadRequestException</code> exception.</p> <p>When you want to update a slot type, set the <code>checksum</code> field to the checksum of the most recent revision of the <code>$LATEST</code> version. If you don't specify the <code> checksum</code> field, or if the checksum does not match the <code>$LATEST</code> version, you get a <code>PreconditionFailedException</code> exception.</p>"]
     #[serde(rename="checksum")]
@@ -1455,7 +1455,7 @@ pub struct PutSlotTypeRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutSlotTypeResponse {
     #[doc="<p>Checksum of the <code>$LATEST</code> version of the slot type.</p>"]
     #[serde(rename="checksum")]
@@ -1488,11 +1488,15 @@ pub struct PutSlotTypeResponse {
 }
 
 #[doc="<p>Describes the resource that refers to the resource that you are attempting to delete. This object is returned as part of the <code>ResourceInUseException</code> exception. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceReference {
     #[doc="<p>The name of the resource that is using the resource that you are trying to delete.</p>"]
+    #[serde(rename="name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The version of the resource that is using the resource that you are trying to delete.</p>"]
+    #[serde(rename="version")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version: Option<String>,
 }
 
@@ -1536,7 +1540,7 @@ pub struct Slot {
 }
 
 #[doc="<p>Provides information about a slot type..</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SlotTypeMetadata {
     #[doc="<p>The date that the slot type was created.</p>"]
     #[serde(rename="createdDate")]
@@ -1573,7 +1577,7 @@ pub struct Statement {
 }
 
 #[doc="<p>Provides information about a single utterance that was made to your bot. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UtteranceData {
     #[doc="<p>The number of times that the utterance was processed.</p>"]
     #[serde(rename="count")]
@@ -1598,7 +1602,7 @@ pub struct UtteranceData {
 }
 
 #[doc="<p>Provides a list of utterances that have been made to a specific version of your bot. The list contains a maximum of 100 utterances.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UtteranceList {
     #[doc="<p>The version of the bot that processed the list.</p>"]
     #[serde(rename="botVersion")]

--- a/rusoto/services/lex-runtime/src/generated.rs
+++ b/rusoto/services/lex-runtime/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 #[doc="<p>Represents an option to be shown on the client platform (Facebook, Slack, etc.)</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Button {
     #[doc="<p>Text that is visible to the user on the button.</p>"]
     #[serde(rename="text")]
@@ -40,7 +40,7 @@ pub struct Button {
 }
 
 #[doc="<p>Represents an option rendered to the user when a prompt is shown. It could be an image, a button, a link, or text. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenericAttachment {
     #[doc="<p>The URL of an attachment to the response card.</p>"]
     #[serde(rename="attachmentLinkUrl")]
@@ -64,7 +64,7 @@ pub struct GenericAttachment {
     pub title: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PostContentRequest {
     #[doc="<p> You pass this value as the <code>Accept</code> HTTP header. </p> <p> The message Amazon Lex returns in the response can be either text or speech based on the <code>Accept</code> HTTP header value in the request. </p> <ul> <li> <p> If the value is <code>text/plain; charset=utf-8</code>, Amazon Lex returns text in the response. </p> </li> <li> <p> If the value begins with <code>audio/</code>, Amazon Lex returns speech in the response. Amazon Lex uses Amazon Polly to generate the speech (using the configuration you specified in the <code>Accept</code> header). For example, if you specify <code>audio/mpeg</code> as the value, Amazon Lex returns speech in the MPEG format.</p> <p>The following are the accepted values:</p> <ul> <li> <p>audio/mpeg</p> </li> <li> <p>audio/ogg</p> </li> <li> <p>audio/pcm</p> </li> <li> <p>text/plain; charset=utf-8</p> </li> <li> <p>audio/* (defaults to mpeg)</p> </li> </ul> </li> </ul>"]
     #[serde(rename="accept")]
@@ -96,29 +96,51 @@ pub struct PostContentRequest {
     pub user_id: String,
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PostContentResponse {
     #[doc="<p>The prompt (or statement) to convey to the user. This is based on the bot configuration and context. For example, if Amazon Lex did not understand the user intent, it sends the <code>clarificationPrompt</code> configured for the bot. If the intent requires confirmation before taking the fulfillment action, it sends the <code>confirmationPrompt</code>. Another example: Suppose that the Lambda function successfully fulfilled the intent, and sent a message to convey to the user. Then Amazon Lex sends that message in the response. </p>"]
+    #[serde(rename="audioStream")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub audio_stream: Option<Vec<u8>>,
     #[doc="<p>Content type as specified in the <code>Accept</code> HTTP header in the request.</p>"]
+    #[serde(rename="contentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_type: Option<String>,
     #[doc="<p>Identifies the current state of the user interaction. Amazon Lex returns one of the following values as <code>dialogState</code>. The client can optionally use this information to customize the user interface. </p> <ul> <li> <p> <code>ElicitIntent</code> – Amazon Lex wants to elicit the user's intent. Consider the following examples: </p> <p> For example, a user might utter an intent (\"I want to order a pizza\"). If Amazon Lex cannot infer the user intent from this utterance, it will return this dialog state. </p> </li> <li> <p> <code>ConfirmIntent</code> – Amazon Lex is expecting a \"yes\" or \"no\" response. </p> <p>For example, Amazon Lex wants user confirmation before fulfilling an intent. Instead of a simple \"yes\" or \"no\" response, a user might respond with additional information. For example, \"yes, but make it a thick crust pizza\" or \"no, I want to order a drink.\" Amazon Lex can process such additional information (in these examples, update the crust type slot or change the intent from OrderPizza to OrderDrink). </p> </li> <li> <p> <code>ElicitSlot</code> – Amazon Lex is expecting the value of a slot for the current intent. </p> <p> For example, suppose that in the response Amazon Lex sends this message: \"What size pizza would you like?\". A user might reply with the slot value (e.g., \"medium\"). The user might also provide additional information in the response (e.g., \"medium thick crust pizza\"). Amazon Lex can process such additional information appropriately. </p> </li> <li> <p> <code>Fulfilled</code> – Conveys that the Lambda function has successfully fulfilled the intent. </p> </li> <li> <p> <code>ReadyForFulfillment</code> – Conveys that the client has to fullfill the request. </p> </li> <li> <p> <code>Failed</code> – Conveys that the conversation with the user failed. </p> <p> This can happen for various reasons, including that the user does not provide an appropriate response to prompts from the service (you can configure how many times Amazon Lex can prompt a user for specific information), or if the Lambda function fails to fulfill the intent. </p> </li> </ul>"]
+    #[serde(rename="dialogState")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dialog_state: Option<String>,
     #[doc="<p>Transcript of the voice input to the operation.</p>"]
+    #[serde(rename="inputTranscript")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub input_transcript: Option<String>,
     #[doc="<p>Current user intent that Amazon Lex is aware of.</p>"]
+    #[serde(rename="intentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub intent_name: Option<String>,
     #[doc="<p> Message to convey to the user. It can come from the bot's configuration or a code hook (Lambda function). If the current intent is not configured with a code hook or if the code hook returned <code>Delegate</code> as the <code>dialogAction.type</code> in its response, then Amazon Lex decides the next course of action and selects an appropriate message from the bot configuration based on the current user interaction context. For example, if Amazon Lex is not able to understand the user input, it uses a clarification prompt message (For more information, see the Error Handling section in the Amazon Lex console). Another example: if the intent requires confirmation before fulfillment, then Amazon Lex uses the confirmation prompt message in the intent configuration. If the code hook returns a message, Amazon Lex passes it as-is in its response to the client. </p>"]
+    #[serde(rename="message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
     #[doc="<p> Map of key/value pairs representing the session-specific context information. </p>"]
+    #[serde(rename="sessionAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub session_attributes: Option<String>,
     #[doc="<p> If the <code>dialogState</code> value is <code>ElicitSlot</code>, returns the name of the slot for which Amazon Lex is eliciting a value. </p>"]
+    #[serde(rename="slotToElicit")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub slot_to_elicit: Option<String>,
     #[doc="<p>Map of zero or more intent slots (name/value pairs) Amazon Lex detected from the user input during the conversation.</p>"]
+    #[serde(rename="slots")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub slots: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PostTextRequest {
     #[doc="<p>The alias of the Amazon Lex bot.</p>"]
     #[serde(rename="botAlias")]
@@ -138,7 +160,7 @@ pub struct PostTextRequest {
     pub user_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PostTextResponse {
     #[doc="<p> Identifies the current state of the user interaction. Amazon Lex returns one of the following values as <code>dialogState</code>. The client can optionally use this information to customize the user interface. </p> <ul> <li> <p> <code>ElicitIntent</code> – Amazon Lex wants to elicit user intent. </p> <p>For example, a user might utter an intent (\"I want to order a pizza\"). If Amazon Lex cannot infer the user intent from this utterance, it will return this dialogState.</p> </li> <li> <p> <code>ConfirmIntent</code> – Amazon Lex is expecting a \"yes\" or \"no\" response. </p> <p> For example, Amazon Lex wants user confirmation before fulfilling an intent. </p> <p>Instead of a simple \"yes\" or \"no,\" a user might respond with additional information. For example, \"yes, but make it thick crust pizza\" or \"no, I want to order a drink\". Amazon Lex can process such additional information (in these examples, update the crust type slot value, or change intent from OrderPizza to OrderDrink).</p> </li> <li> <p> <code>ElicitSlot</code> – Amazon Lex is expecting a slot value for the current intent. </p> <p>For example, suppose that in the response Amazon Lex sends this message: \"What size pizza would you like?\". A user might reply with the slot value (e.g., \"medium\"). The user might also provide additional information in the response (e.g., \"medium thick crust pizza\"). Amazon Lex can process such additional information appropriately. </p> </li> <li> <p> <code>Fulfilled</code> – Conveys that the Lambda function configured for the intent has successfully fulfilled the intent. </p> </li> <li> <p> <code>ReadyForFulfillment</code> – Conveys that the client has to fulfill the intent. </p> </li> <li> <p> <code>Failed</code> – Conveys that the conversation with the user failed. </p> <p> This can happen for various reasons including that the user did not provide an appropriate response to prompts from the service (you can configure how many times Amazon Lex can prompt a user for specific information), or the Lambda function failed to fulfill the intent. </p> </li> </ul>"]
     #[serde(rename="dialogState")]
@@ -171,7 +193,7 @@ pub struct PostTextResponse {
 }
 
 #[doc="<p>If you configure a response card when creating your bots, Amazon Lex substitutes the session attributes and slot values that are available, and then returns it. The response card can also come from a Lambda function ( <code>dialogCodeHook</code> and <code>fulfillmentActivity</code> on an intent).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResponseCard {
     #[doc="<p>The content type of the response.</p>"]
     #[serde(rename="contentType")]

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -28,14 +28,14 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AllocateStaticIpRequest {
     #[doc="<p>The name of the static IP address.</p>"]
     #[serde(rename="staticIpName")]
     pub static_ip_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AllocateStaticIpResult {
     #[doc="<p>An array of key-value pairs containing information about the static IP address you allocated.</p>"]
     #[serde(rename="operations")]
@@ -43,7 +43,7 @@ pub struct AllocateStaticIpResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachStaticIpRequest {
     #[doc="<p>The instance name to which you want to attach the static IP address.</p>"]
     #[serde(rename="instanceName")]
@@ -53,7 +53,7 @@ pub struct AttachStaticIpRequest {
     pub static_ip_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachStaticIpResult {
     #[doc="<p>An array of key-value pairs containing information about your API operations.</p>"]
     #[serde(rename="operations")]
@@ -62,7 +62,7 @@ pub struct AttachStaticIpResult {
 }
 
 #[doc="<p>Describes an Availability Zone.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AvailabilityZone {
     #[doc="<p>The state of the Availability Zone.</p>"]
     #[serde(rename="state")]
@@ -75,7 +75,7 @@ pub struct AvailabilityZone {
 }
 
 #[doc="<p>Describes a blueprint (a virtual private server image).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Blueprint {
     #[doc="<p>The ID for the virtual private server image (e.g., <code>app_wordpress_4_4</code> or <code>app_lamp_7_0</code>).</p>"]
     #[serde(rename="blueprintId")]
@@ -124,7 +124,7 @@ pub struct Blueprint {
 }
 
 #[doc="<p>Describes a bundle, which is a set of specs describing your virtual private server (or <i>instance</i>).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Bundle {
     #[doc="<p>The bundle ID (e.g., <code>micro_1_0</code>).</p>"]
     #[serde(rename="bundleId")]
@@ -168,7 +168,7 @@ pub struct Bundle {
     pub transfer_per_month_in_gb: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloseInstancePublicPortsRequest {
     #[doc="<p>The name of the instance on which you're attempting to close the public ports.</p>"]
     #[serde(rename="instanceName")]
@@ -178,7 +178,7 @@ pub struct CloseInstancePublicPortsRequest {
     pub port_info: PortInfo,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloseInstancePublicPortsResult {
     #[doc="<p>An array of key-value pairs that contains information about the operation.</p>"]
     #[serde(rename="operation")]
@@ -186,7 +186,7 @@ pub struct CloseInstancePublicPortsResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDomainEntryRequest {
     #[doc="<p>An array of key-value pairs containing information about the domain entry request.</p>"]
     #[serde(rename="domainEntry")]
@@ -196,7 +196,7 @@ pub struct CreateDomainEntryRequest {
     pub domain_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDomainEntryResult {
     #[doc="<p>An array of key-value pairs containing information about the operation.</p>"]
     #[serde(rename="operation")]
@@ -204,14 +204,14 @@ pub struct CreateDomainEntryResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDomainRequest {
     #[doc="<p>The domain name to manage (e.g., <code>example.com</code>).</p> <note> <p>You cannot register a new domain name using Lightsail. You must register a domain name using Amazon Route 53 or another domain name registrar. If you have already registered your domain, you can enter its name in this parameter to manage the DNS records for that domain.</p> </note>"]
     #[serde(rename="domainName")]
     pub domain_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDomainResult {
     #[doc="<p>An array of key-value pairs containing information about the domain resource you created.</p>"]
     #[serde(rename="operation")]
@@ -219,7 +219,7 @@ pub struct CreateDomainResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstanceSnapshotRequest {
     #[doc="<p>The Lightsail instance on which to base your snapshot.</p>"]
     #[serde(rename="instanceName")]
@@ -229,7 +229,7 @@ pub struct CreateInstanceSnapshotRequest {
     pub instance_snapshot_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstanceSnapshotResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your create instances snapshot request.</p>"]
     #[serde(rename="operations")]
@@ -237,7 +237,7 @@ pub struct CreateInstanceSnapshotResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstancesFromSnapshotRequest {
     #[doc="<p>The Availability Zone where you want to create your instances. Use the following formatting: <code>us-east-1a</code> (case sensitive). You can get a list of availability zones by using the <a href=\"http://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_GetRegions.html\">get regions</a> operation. Be sure to add the <code>include availability zones</code> parameter to your request.</p>"]
     #[serde(rename="availabilityZone")]
@@ -261,7 +261,7 @@ pub struct CreateInstancesFromSnapshotRequest {
     pub user_data: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstancesFromSnapshotResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your create instances from snapshot request.</p>"]
     #[serde(rename="operations")]
@@ -269,7 +269,7 @@ pub struct CreateInstancesFromSnapshotResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstancesRequest {
     #[doc="<p>The Availability Zone in which to create your instance. Use the following format: <code>us-east-1a</code> (case sensitive). You can get a list of availability zones by using the <a href=\"http://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_GetRegions.html\">get regions</a> operation. Be sure to add the <code>include availability zones</code> parameter to your request.</p>"]
     #[serde(rename="availabilityZone")]
@@ -293,7 +293,7 @@ pub struct CreateInstancesRequest {
     pub user_data: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstancesResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your create instances request.</p>"]
     #[serde(rename="operations")]
@@ -301,14 +301,14 @@ pub struct CreateInstancesResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateKeyPairRequest {
     #[doc="<p>The name for your new key pair.</p>"]
     #[serde(rename="keyPairName")]
     pub key_pair_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateKeyPairResult {
     #[doc="<p>An array of key-value pairs containing information about the new key pair you just created.</p>"]
     #[serde(rename="keyPair")]
@@ -328,7 +328,7 @@ pub struct CreateKeyPairResult {
     pub public_key_base_64: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDomainEntryRequest {
     #[doc="<p>An array of key-value pairs containing information about your domain entries.</p>"]
     #[serde(rename="domainEntry")]
@@ -338,7 +338,7 @@ pub struct DeleteDomainEntryRequest {
     pub domain_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDomainEntryResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your delete domain entry request.</p>"]
     #[serde(rename="operation")]
@@ -346,14 +346,14 @@ pub struct DeleteDomainEntryResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDomainRequest {
     #[doc="<p>The specific domain name to delete.</p>"]
     #[serde(rename="domainName")]
     pub domain_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDomainResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your delete domain request.</p>"]
     #[serde(rename="operation")]
@@ -361,14 +361,14 @@ pub struct DeleteDomainResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteInstanceRequest {
     #[doc="<p>The name of the instance to delete.</p>"]
     #[serde(rename="instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteInstanceResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your delete instance request.</p>"]
     #[serde(rename="operations")]
@@ -376,14 +376,14 @@ pub struct DeleteInstanceResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteInstanceSnapshotRequest {
     #[doc="<p>The name of the snapshot to delete.</p>"]
     #[serde(rename="instanceSnapshotName")]
     pub instance_snapshot_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteInstanceSnapshotResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your delete instance snapshot request.</p>"]
     #[serde(rename="operations")]
@@ -391,14 +391,14 @@ pub struct DeleteInstanceSnapshotResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteKeyPairRequest {
     #[doc="<p>The name of the key pair to delete.</p>"]
     #[serde(rename="keyPairName")]
     pub key_pair_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteKeyPairResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your delete key pair request.</p>"]
     #[serde(rename="operation")]
@@ -406,14 +406,14 @@ pub struct DeleteKeyPairResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachStaticIpRequest {
     #[doc="<p>The name of the static IP to detach from the instance.</p>"]
     #[serde(rename="staticIpName")]
     pub static_ip_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachStaticIpResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your detach static IP request.</p>"]
     #[serde(rename="operations")]
@@ -422,7 +422,7 @@ pub struct DetachStaticIpResult {
 }
 
 #[doc="<p>Describes the hard disk (an SSD).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Disk {
     #[doc="<p>The Amazon Resource Name (ARN) of the disk.</p>"]
     #[serde(rename="arn")]
@@ -483,7 +483,7 @@ pub struct Disk {
 }
 
 #[doc="<p>Describes a domain where you are storing recordsets in Lightsail.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Domain {
     #[doc="<p>The Amazon Resource Name (ARN) of the domain recordset (e.g., <code>arn:aws:lightsail:global:123456789101:Domain/824cede0-abc7-4f84-8dbc-12345EXAMPLE</code>).</p>"]
     #[serde(rename="arn")]
@@ -540,10 +540,10 @@ pub struct DomainEntry {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DownloadDefaultKeyPairRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DownloadDefaultKeyPairResult {
     #[doc="<p>A base64-encoded RSA private key.</p>"]
     #[serde(rename="privateKeyBase64")]
@@ -555,7 +555,7 @@ pub struct DownloadDefaultKeyPairResult {
     pub public_key_base_64: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetActiveNamesRequest {
     #[doc="<p>A token used for paginating results from your get active names request.</p>"]
     #[serde(rename="pageToken")]
@@ -563,7 +563,7 @@ pub struct GetActiveNamesRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetActiveNamesResult {
     #[doc="<p>The list of active names returned by the get active names request.</p>"]
     #[serde(rename="activeNames")]
@@ -575,7 +575,7 @@ pub struct GetActiveNamesResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBlueprintsRequest {
     #[doc="<p>A Boolean value indicating whether to include inactive results in your request.</p>"]
     #[serde(rename="includeInactive")]
@@ -587,7 +587,7 @@ pub struct GetBlueprintsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBlueprintsResult {
     #[doc="<p>An array of key-value pairs that contains information about the available blueprints.</p>"]
     #[serde(rename="blueprints")]
@@ -599,7 +599,7 @@ pub struct GetBlueprintsResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBundlesRequest {
     #[doc="<p>A Boolean value that indicates whether to include inactive bundle results in your request.</p>"]
     #[serde(rename="includeInactive")]
@@ -611,7 +611,7 @@ pub struct GetBundlesRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBundlesResult {
     #[doc="<p>An array of key-value pairs that contains information about the available bundles.</p>"]
     #[serde(rename="bundles")]
@@ -623,14 +623,14 @@ pub struct GetBundlesResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDomainRequest {
     #[doc="<p>The domain name for which your want to return information about.</p>"]
     #[serde(rename="domainName")]
     pub domain_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDomainResult {
     #[doc="<p>An array of key-value pairs containing information about your get domain request.</p>"]
     #[serde(rename="domain")]
@@ -638,7 +638,7 @@ pub struct GetDomainResult {
     pub domain: Option<Domain>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDomainsRequest {
     #[doc="<p>A token used for advancing to the next page of results from your get domains request.</p>"]
     #[serde(rename="pageToken")]
@@ -646,7 +646,7 @@ pub struct GetDomainsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDomainsResult {
     #[doc="<p>An array of key-value pairs containing information about each of the domain entries in the user's account.</p>"]
     #[serde(rename="domains")]
@@ -658,7 +658,7 @@ pub struct GetDomainsResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceAccessDetailsRequest {
     #[doc="<p>The name of the instance to access.</p>"]
     #[serde(rename="instanceName")]
@@ -669,7 +669,7 @@ pub struct GetInstanceAccessDetailsRequest {
     pub protocol: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceAccessDetailsResult {
     #[doc="<p>An array of key-value pairs containing information about a get instance access request.</p>"]
     #[serde(rename="accessDetails")]
@@ -677,7 +677,7 @@ pub struct GetInstanceAccessDetailsResult {
     pub access_details: Option<InstanceAccessDetails>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceMetricDataRequest {
     #[doc="<p>The end time of the time period.</p>"]
     #[serde(rename="endTime")]
@@ -702,7 +702,7 @@ pub struct GetInstanceMetricDataRequest {
     pub unit: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceMetricDataResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your get instance metric data request.</p>"]
     #[serde(rename="metricData")]
@@ -714,14 +714,14 @@ pub struct GetInstanceMetricDataResult {
     pub metric_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstancePortStatesRequest {
     #[doc="<p>The name of the instance.</p>"]
     #[serde(rename="instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstancePortStatesResult {
     #[doc="<p>Information about the port states resulting from your request.</p>"]
     #[serde(rename="portStates")]
@@ -729,14 +729,14 @@ pub struct GetInstancePortStatesResult {
     pub port_states: Option<Vec<InstancePortState>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceRequest {
     #[doc="<p>The name of the instance.</p>"]
     #[serde(rename="instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceResult {
     #[doc="<p>An array of key-value pairs containing information about the specified instance.</p>"]
     #[serde(rename="instance")]
@@ -744,14 +744,14 @@ pub struct GetInstanceResult {
     pub instance: Option<Instance>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceSnapshotRequest {
     #[doc="<p>The name of the snapshot for which you are requesting information.</p>"]
     #[serde(rename="instanceSnapshotName")]
     pub instance_snapshot_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceSnapshotResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your get instance snapshot request.</p>"]
     #[serde(rename="instanceSnapshot")]
@@ -759,7 +759,7 @@ pub struct GetInstanceSnapshotResult {
     pub instance_snapshot: Option<InstanceSnapshot>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceSnapshotsRequest {
     #[doc="<p>A token used for advancing to the next page of results from your get instance snapshots request.</p>"]
     #[serde(rename="pageToken")]
@@ -767,7 +767,7 @@ pub struct GetInstanceSnapshotsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceSnapshotsResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your get instance snapshots request.</p>"]
     #[serde(rename="instanceSnapshots")]
@@ -779,14 +779,14 @@ pub struct GetInstanceSnapshotsResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceStateRequest {
     #[doc="<p>The name of the instance to get state information about.</p>"]
     #[serde(rename="instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstanceStateResult {
     #[doc="<p>The state of the instance.</p>"]
     #[serde(rename="state")]
@@ -794,7 +794,7 @@ pub struct GetInstanceStateResult {
     pub state: Option<InstanceState>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstancesRequest {
     #[doc="<p>A token used for advancing to the next page of results from your get instances request.</p>"]
     #[serde(rename="pageToken")]
@@ -802,7 +802,7 @@ pub struct GetInstancesRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInstancesResult {
     #[doc="<p>An array of key-value pairs containing information about your instances.</p>"]
     #[serde(rename="instances")]
@@ -814,14 +814,14 @@ pub struct GetInstancesResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetKeyPairRequest {
     #[doc="<p>The name of the key pair for which you are requesting information.</p>"]
     #[serde(rename="keyPairName")]
     pub key_pair_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetKeyPairResult {
     #[doc="<p>An array of key-value pairs containing information about the key pair.</p>"]
     #[serde(rename="keyPair")]
@@ -829,7 +829,7 @@ pub struct GetKeyPairResult {
     pub key_pair: Option<KeyPair>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetKeyPairsRequest {
     #[doc="<p>A token used for advancing to the next page of results from your get key pairs request.</p>"]
     #[serde(rename="pageToken")]
@@ -837,7 +837,7 @@ pub struct GetKeyPairsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetKeyPairsResult {
     #[doc="<p>An array of key-value pairs containing information about the key pairs.</p>"]
     #[serde(rename="keyPairs")]
@@ -849,14 +849,14 @@ pub struct GetKeyPairsResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOperationRequest {
     #[doc="<p>A GUID used to identify the operation.</p>"]
     #[serde(rename="operationId")]
     pub operation_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOperationResult {
     #[doc="<p>An array of key-value pairs containing information about the results of your get operation request.</p>"]
     #[serde(rename="operation")]
@@ -864,7 +864,7 @@ pub struct GetOperationResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOperationsForResourceRequest {
     #[doc="<p>A token used for advancing to the next page of results from your get operations for resource request.</p>"]
     #[serde(rename="pageToken")]
@@ -875,7 +875,7 @@ pub struct GetOperationsForResourceRequest {
     pub resource_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOperationsForResourceResult {
     #[doc="<p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>"]
     #[serde(rename="nextPageToken")]
@@ -887,7 +887,7 @@ pub struct GetOperationsForResourceResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOperationsRequest {
     #[doc="<p>A token used for advancing to the next page of results from your get operations request.</p>"]
     #[serde(rename="pageToken")]
@@ -895,7 +895,7 @@ pub struct GetOperationsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOperationsResult {
     #[doc="<p>A token used for advancing to the next page of results from your get operations request.</p>"]
     #[serde(rename="nextPageToken")]
@@ -907,7 +907,7 @@ pub struct GetOperationsResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRegionsRequest {
     #[doc="<p>A Boolean value indicating whether to also include Availability Zones in your get regions request. Availability Zones are indicated with a letter: e.g., <code>us-east-1a</code>.</p>"]
     #[serde(rename="includeAvailabilityZones")]
@@ -915,7 +915,7 @@ pub struct GetRegionsRequest {
     pub include_availability_zones: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRegionsResult {
     #[doc="<p>An array of key-value pairs containing information about your get regions request.</p>"]
     #[serde(rename="regions")]
@@ -923,14 +923,14 @@ pub struct GetRegionsResult {
     pub regions: Option<Vec<Region>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetStaticIpRequest {
     #[doc="<p>The name of the static IP in Lightsail.</p>"]
     #[serde(rename="staticIpName")]
     pub static_ip_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetStaticIpResult {
     #[doc="<p>An array of key-value pairs containing information about the requested static IP.</p>"]
     #[serde(rename="staticIp")]
@@ -938,7 +938,7 @@ pub struct GetStaticIpResult {
     pub static_ip: Option<StaticIp>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetStaticIpsRequest {
     #[doc="<p>A token used for advancing to the next page of results from your get static IPs request.</p>"]
     #[serde(rename="pageToken")]
@@ -946,7 +946,7 @@ pub struct GetStaticIpsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetStaticIpsResult {
     #[doc="<p>A token used for advancing to the next page of results from your get static IPs request.</p>"]
     #[serde(rename="nextPageToken")]
@@ -958,7 +958,7 @@ pub struct GetStaticIpsResult {
     pub static_ips: Option<Vec<StaticIp>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportKeyPairRequest {
     #[doc="<p>The name of the key pair for which you want to import the public key.</p>"]
     #[serde(rename="keyPairName")]
@@ -968,7 +968,7 @@ pub struct ImportKeyPairRequest {
     pub public_key_base_64: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportKeyPairResult {
     #[doc="<p>An array of key-value pairs containing information about the request operation.</p>"]
     #[serde(rename="operation")]
@@ -977,7 +977,7 @@ pub struct ImportKeyPairResult {
 }
 
 #[doc="<p>Describes an instance (a virtual private server).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Instance {
     #[doc="<p>The Amazon Resource Name (ARN) of the instance (e.g., <code>arn:aws:lightsail:us-east-1:123456789101:Instance/244ad76f-8aad-4741-809f-12345EXAMPLE</code>).</p>"]
     #[serde(rename="arn")]
@@ -1054,7 +1054,7 @@ pub struct Instance {
 }
 
 #[doc="<p>The parameters for gaining temporary access to one of your Amazon Lightsail instances.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceAccessDetails {
     #[doc="<p>For SSH access, the public key to use when accessing your instance For OpenSSH clients (e.g., command line SSH), you should save this value to <code>tempkey-cert.pub</code>.</p>"]
     #[serde(rename="certKey")]
@@ -1091,7 +1091,7 @@ pub struct InstanceAccessDetails {
 }
 
 #[doc="<p>Describes the hardware for the instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceHardware {
     #[doc="<p>The number of vCPUs the instance has.</p>"]
     #[serde(rename="cpuCount")]
@@ -1108,7 +1108,7 @@ pub struct InstanceHardware {
 }
 
 #[doc="<p>Describes monthly data transfer rates and port information for an instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceNetworking {
     #[doc="<p>The amount of data in GB allocated for monthly data transfers.</p>"]
     #[serde(rename="monthlyTransfer")]
@@ -1121,7 +1121,7 @@ pub struct InstanceNetworking {
 }
 
 #[doc="<p>Describes information about the instance ports.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstancePortInfo {
     #[doc="<p>The access direction (<code>inbound</code> or <code>outbound</code>).</p>"]
     #[serde(rename="accessDirection")]
@@ -1154,7 +1154,7 @@ pub struct InstancePortInfo {
 }
 
 #[doc="<p>Describes the port state.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstancePortState {
     #[doc="<p>The first port in the range.</p>"]
     #[serde(rename="fromPort")]
@@ -1175,7 +1175,7 @@ pub struct InstancePortState {
 }
 
 #[doc="<p>Describes the snapshot of the virtual private server, or <i>instance</i>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceSnapshot {
     #[doc="<p>The Amazon Resource Name (ARN) of the snapshot (e.g., <code>arn:aws:lightsail:us-east-1:123456789101:InstanceSnapshot/d23b5706-3322-4d83-81e5-12345EXAMPLE</code>).</p>"]
     #[serde(rename="arn")]
@@ -1232,7 +1232,7 @@ pub struct InstanceSnapshot {
 }
 
 #[doc="<p>Describes the virtual private server (or <i>instance</i>) status.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceState {
     #[doc="<p>The status code for the instance.</p>"]
     #[serde(rename="code")]
@@ -1244,10 +1244,10 @@ pub struct InstanceState {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IsVpcPeeredRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IsVpcPeeredResult {
     #[doc="<p>Returns <code>true</code> if the Lightsail VPC is peered; otherwise, <code>false</code>.</p>"]
     #[serde(rename="isPeered")]
@@ -1256,7 +1256,7 @@ pub struct IsVpcPeeredResult {
 }
 
 #[doc="<p>Describes the SSH key pair.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KeyPair {
     #[doc="<p>The Amazon Resource Name (ARN) of the key pair (e.g., <code>arn:aws:lightsail:us-east-1:123456789101:KeyPair/05859e3d-331d-48ba-9034-12345EXAMPLE</code>).</p>"]
     #[serde(rename="arn")]
@@ -1289,7 +1289,7 @@ pub struct KeyPair {
 }
 
 #[doc="<p>Describes the metric data point.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MetricDatapoint {
     #[doc="<p>The average.</p>"]
     #[serde(rename="average")]
@@ -1322,7 +1322,7 @@ pub struct MetricDatapoint {
 }
 
 #[doc="<p>Describes the monthly data transfer in and out of your virtual private server (or <i>instance</i>).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MonthlyTransfer {
     #[doc="<p>The amount allocated per month (in GB).</p>"]
     #[serde(rename="gbPerMonthAllocated")]
@@ -1330,7 +1330,7 @@ pub struct MonthlyTransfer {
     pub gb_per_month_allocated: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OpenInstancePublicPortsRequest {
     #[doc="<p>The name of the instance for which you want to open the public ports.</p>"]
     #[serde(rename="instanceName")]
@@ -1340,7 +1340,7 @@ pub struct OpenInstancePublicPortsRequest {
     pub port_info: PortInfo,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OpenInstancePublicPortsResult {
     #[doc="<p>An array of key-value pairs containing information about the request operation.</p>"]
     #[serde(rename="operation")]
@@ -1349,7 +1349,7 @@ pub struct OpenInstancePublicPortsResult {
 }
 
 #[doc="<p>Describes the API operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Operation {
     #[doc="<p>The timestamp when the operation was initialized (e.g., <code>1479816991.349</code>).</p>"]
     #[serde(rename="createdAt")]
@@ -1401,10 +1401,10 @@ pub struct Operation {
     pub status_changed_at: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PeerVpcRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PeerVpcResult {
     #[doc="<p>An array of key-value pairs containing information about the request operation.</p>"]
     #[serde(rename="operation")]
@@ -1413,7 +1413,7 @@ pub struct PeerVpcResult {
 }
 
 #[doc="<p>Describes information about the ports on your virtual private server (or <i>instance</i>).</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PortInfo {
     #[doc="<p>The first port in the range.</p>"]
     #[serde(rename="fromPort")]
@@ -1429,7 +1429,7 @@ pub struct PortInfo {
     pub to_port: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutInstancePublicPortsRequest {
     #[doc="<p>The Lightsail instance name of the public port(s) you are setting.</p>"]
     #[serde(rename="instanceName")]
@@ -1439,7 +1439,7 @@ pub struct PutInstancePublicPortsRequest {
     pub port_infos: Vec<PortInfo>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutInstancePublicPortsResult {
     #[doc="<p>Describes metadata about the operation you just executed.</p>"]
     #[serde(rename="operation")]
@@ -1447,14 +1447,14 @@ pub struct PutInstancePublicPortsResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootInstanceRequest {
     #[doc="<p>The name of the instance to reboot.</p>"]
     #[serde(rename="instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootInstanceResult {
     #[doc="<p>An array of key-value pairs containing information about the request operation.</p>"]
     #[serde(rename="operations")]
@@ -1463,7 +1463,7 @@ pub struct RebootInstanceResult {
 }
 
 #[doc="<p>Describes the AWS Region.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Region {
     #[doc="<p>The Availability Zones. Follows the format <code>us-east-1a</code> (case-sensitive).</p>"]
     #[serde(rename="availabilityZones")]
@@ -1487,14 +1487,14 @@ pub struct Region {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReleaseStaticIpRequest {
     #[doc="<p>The name of the static IP to delete.</p>"]
     #[serde(rename="staticIpName")]
     pub static_ip_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReleaseStaticIpResult {
     #[doc="<p>An array of key-value pairs containing information about the request operation.</p>"]
     #[serde(rename="operations")]
@@ -1503,7 +1503,7 @@ pub struct ReleaseStaticIpResult {
 }
 
 #[doc="<p>Describes the resource location.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceLocation {
     #[doc="<p>The Availability Zone. Follows the format <code>us-east-1a</code> (case-sensitive).</p>"]
     #[serde(rename="availabilityZone")]
@@ -1515,14 +1515,14 @@ pub struct ResourceLocation {
     pub region_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartInstanceRequest {
     #[doc="<p>The name of the instance (a virtual private server) to start.</p>"]
     #[serde(rename="instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartInstanceResult {
     #[doc="<p>An array of key-value pairs containing information about the request operation.</p>"]
     #[serde(rename="operations")]
@@ -1531,7 +1531,7 @@ pub struct StartInstanceResult {
 }
 
 #[doc="<p>Describes the static IP.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StaticIp {
     #[doc="<p>The Amazon Resource Name (ARN) of the static IP (e.g., <code>arn:aws:lightsail:us-east-1:123456789101:StaticIp/9cbb4a9e-f8e3-4dfe-b57e-12345EXAMPLE</code>).</p>"]
     #[serde(rename="arn")]
@@ -1571,14 +1571,14 @@ pub struct StaticIp {
     pub support_code: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopInstanceRequest {
     #[doc="<p>The name of the instance (a virtual private server) to stop.</p>"]
     #[serde(rename="instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopInstanceResult {
     #[doc="<p>An array of key-value pairs containing information about the request operation.</p>"]
     #[serde(rename="operations")]
@@ -1586,10 +1586,10 @@ pub struct StopInstanceResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnpeerVpcRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnpeerVpcResult {
     #[doc="<p>An array of key-value pairs containing information about the request operation.</p>"]
     #[serde(rename="operation")]
@@ -1597,7 +1597,7 @@ pub struct UnpeerVpcResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDomainEntryRequest {
     #[doc="<p>An array of key-value pairs containing information about the domain entry.</p>"]
     #[serde(rename="domainEntry")]
@@ -1607,7 +1607,7 @@ pub struct UpdateDomainEntryRequest {
     pub domain_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDomainEntryResult {
     #[doc="<p>An array of key-value pairs containing information about the request operation.</p>"]
     #[serde(rename="operations")]

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -28,14 +28,14 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelExportTaskRequest {
     #[doc="<p>The ID of the export task.</p>"]
     #[serde(rename="taskId")]
     pub task_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateExportTaskRequest {
     #[doc="<p>The name of S3 bucket for the exported log data. The bucket must be in the same AWS region.</p>"]
     #[serde(rename="destination")]
@@ -63,7 +63,7 @@ pub struct CreateExportTaskRequest {
     pub to: i64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateExportTaskResponse {
     #[doc="<p>The ID of the export task.</p>"]
     #[serde(rename="taskId")]
@@ -71,7 +71,7 @@ pub struct CreateExportTaskResponse {
     pub task_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLogGroupRequest {
     #[doc="<p>The name of the log group.</p>"]
     #[serde(rename="logGroupName")]
@@ -82,7 +82,7 @@ pub struct CreateLogGroupRequest {
     pub tags: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLogStreamRequest {
     #[doc="<p>The name of the log group.</p>"]
     #[serde(rename="logGroupName")]
@@ -92,21 +92,21 @@ pub struct CreateLogStreamRequest {
     pub log_stream_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDestinationRequest {
     #[doc="<p>The name of the destination.</p>"]
     #[serde(rename="destinationName")]
     pub destination_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLogGroupRequest {
     #[doc="<p>The name of the log group.</p>"]
     #[serde(rename="logGroupName")]
     pub log_group_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLogStreamRequest {
     #[doc="<p>The name of the log group.</p>"]
     #[serde(rename="logGroupName")]
@@ -116,7 +116,7 @@ pub struct DeleteLogStreamRequest {
     pub log_stream_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMetricFilterRequest {
     #[doc="<p>The name of the metric filter.</p>"]
     #[serde(rename="filterName")]
@@ -126,14 +126,14 @@ pub struct DeleteMetricFilterRequest {
     pub log_group_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRetentionPolicyRequest {
     #[doc="<p>The name of the log group.</p>"]
     #[serde(rename="logGroupName")]
     pub log_group_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSubscriptionFilterRequest {
     #[doc="<p>The name of the subscription filter.</p>"]
     #[serde(rename="filterName")]
@@ -143,7 +143,7 @@ pub struct DeleteSubscriptionFilterRequest {
     pub log_group_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDestinationsRequest {
     #[doc="<p>The prefix to match. If you don't specify a value, no prefix filter is applied.</p>"]
     #[serde(rename="DestinationNamePrefix")]
@@ -159,7 +159,7 @@ pub struct DescribeDestinationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDestinationsResponse {
     #[doc="<p>The destinations.</p>"]
     #[serde(rename="destinations")]
@@ -170,7 +170,7 @@ pub struct DescribeDestinationsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExportTasksRequest {
     #[doc="<p>The maximum number of items returned. If you don't specify a value, the default is up to 50 items.</p>"]
     #[serde(rename="limit")]
@@ -190,7 +190,7 @@ pub struct DescribeExportTasksRequest {
     pub task_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExportTasksResponse {
     #[doc="<p>The export tasks.</p>"]
     #[serde(rename="exportTasks")]
@@ -201,7 +201,7 @@ pub struct DescribeExportTasksResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLogGroupsRequest {
     #[doc="<p>The maximum number of items returned. If you don't specify a value, the default is up to 50 items.</p>"]
     #[serde(rename="limit")]
@@ -217,7 +217,7 @@ pub struct DescribeLogGroupsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLogGroupsResponse {
     #[doc="<p>The log groups.</p>"]
     #[serde(rename="logGroups")]
@@ -228,7 +228,7 @@ pub struct DescribeLogGroupsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLogStreamsRequest {
     #[doc="<p>If the value is true, results are returned in descending order. If the value is to false, results are returned in ascending order. The default value is false.</p>"]
     #[serde(rename="descending")]
@@ -255,7 +255,7 @@ pub struct DescribeLogStreamsRequest {
     pub order_by: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLogStreamsResponse {
     #[doc="<p>The log streams.</p>"]
     #[serde(rename="logStreams")]
@@ -266,7 +266,7 @@ pub struct DescribeLogStreamsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMetricFiltersRequest {
     #[doc="<p>The prefix to match.</p>"]
     #[serde(rename="filterNamePrefix")]
@@ -294,7 +294,7 @@ pub struct DescribeMetricFiltersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMetricFiltersResponse {
     #[doc="<p>The metric filters.</p>"]
     #[serde(rename="metricFilters")]
@@ -305,7 +305,7 @@ pub struct DescribeMetricFiltersResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSubscriptionFiltersRequest {
     #[doc="<p>The prefix to match. If you don't specify a value, no prefix filter is applied.</p>"]
     #[serde(rename="filterNamePrefix")]
@@ -324,7 +324,7 @@ pub struct DescribeSubscriptionFiltersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSubscriptionFiltersResponse {
     #[serde(rename="nextToken")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -336,7 +336,7 @@ pub struct DescribeSubscriptionFiltersResponse {
 }
 
 #[doc="<p>Represents a cross-account destination that receives subscription log events.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Destination {
     #[doc="<p>An IAM policy document that governs which AWS accounts can create subscription filters against this destination.</p>"]
     #[serde(rename="accessPolicy")]
@@ -365,7 +365,7 @@ pub struct Destination {
 }
 
 #[doc="<p>Represents an export task.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExportTask {
     #[doc="<p>The name of Amazon S3 bucket to which the log data was exported.</p>"]
     #[serde(rename="destination")]
@@ -406,7 +406,7 @@ pub struct ExportTask {
 }
 
 #[doc="<p>Represents the status of an export task.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExportTaskExecutionInfo {
     #[doc="<p>The completion time of the export task, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC.</p>"]
     #[serde(rename="completionTime")]
@@ -419,7 +419,7 @@ pub struct ExportTaskExecutionInfo {
 }
 
 #[doc="<p>Represents the status of an export task.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExportTaskStatus {
     #[doc="<p>The status code of the export task.</p>"]
     #[serde(rename="code")]
@@ -431,7 +431,7 @@ pub struct ExportTaskStatus {
     pub message: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FilterLogEventsRequest {
     #[doc="<p>The end of the time range, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC. Events with a timestamp later than this time are not returned.</p>"]
     #[serde(rename="endTime")]
@@ -466,7 +466,7 @@ pub struct FilterLogEventsRequest {
     pub start_time: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FilterLogEventsResponse {
     #[doc="<p>The matched events.</p>"]
     #[serde(rename="events")]
@@ -483,7 +483,7 @@ pub struct FilterLogEventsResponse {
 }
 
 #[doc="<p>Represents a matched event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FilteredLogEvent {
     #[doc="<p>The ID of the event.</p>"]
     #[serde(rename="eventId")]
@@ -507,7 +507,7 @@ pub struct FilteredLogEvent {
     pub timestamp: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLogEventsRequest {
     #[doc="<p>The end of the time range, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC. Events with a timestamp later than this time are not included.</p>"]
     #[serde(rename="endTime")]
@@ -537,7 +537,7 @@ pub struct GetLogEventsRequest {
     pub start_time: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLogEventsResponse {
     #[doc="<p>The events.</p>"]
     #[serde(rename="events")]
@@ -554,7 +554,7 @@ pub struct GetLogEventsResponse {
 }
 
 #[doc="<p>Represents a log event, which is a record of activity that was recorded by the application or resource being monitored.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InputLogEvent {
     #[doc="<p>The raw event message.</p>"]
     #[serde(rename="message")]
@@ -564,14 +564,14 @@ pub struct InputLogEvent {
     pub timestamp: i64,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsLogGroupRequest {
     #[doc="<p>The name of the log group.</p>"]
     #[serde(rename="logGroupName")]
     pub log_group_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsLogGroupResponse {
     #[doc="<p>The tags.</p>"]
     #[serde(rename="tags")]
@@ -580,7 +580,7 @@ pub struct ListTagsLogGroupResponse {
 }
 
 #[doc="<p>Represents a log group.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LogGroup {
     #[doc="<p>The Amazon Resource Name (ARN) of the log group.</p>"]
     #[serde(rename="arn")]
@@ -608,7 +608,7 @@ pub struct LogGroup {
 }
 
 #[doc="<p>Represents a log stream, which is a sequence of log events from a single emitter of logs.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LogStream {
     #[doc="<p>The Amazon Resource Name (ARN) of the log stream.</p>"]
     #[serde(rename="arn")]
@@ -645,7 +645,7 @@ pub struct LogStream {
 }
 
 #[doc="<p>Metric filters express how CloudWatch Logs would extract metric observations from ingested log events and transform them into metric data in a CloudWatch metric.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MetricFilter {
     #[doc="<p>The creation time of the metric filter, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC.</p>"]
     #[serde(rename="creationTime")]
@@ -669,7 +669,7 @@ pub struct MetricFilter {
 }
 
 #[doc="<p>Represents a matched event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MetricFilterMatchRecord {
     #[doc="<p>The raw event data.</p>"]
     #[serde(rename="eventMessage")]
@@ -704,7 +704,7 @@ pub struct MetricTransformation {
 }
 
 #[doc="<p>Represents a log event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OutputLogEvent {
     #[doc="<p>The time the event was ingested, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC.</p>"]
     #[serde(rename="ingestionTime")]
@@ -720,7 +720,7 @@ pub struct OutputLogEvent {
     pub timestamp: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutDestinationPolicyRequest {
     #[doc="<p>An IAM policy document that authorizes cross-account users to deliver their log events to the associated destination.</p>"]
     #[serde(rename="accessPolicy")]
@@ -730,7 +730,7 @@ pub struct PutDestinationPolicyRequest {
     pub destination_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutDestinationRequest {
     #[doc="<p>A name for the destination.</p>"]
     #[serde(rename="destinationName")]
@@ -743,7 +743,7 @@ pub struct PutDestinationRequest {
     pub target_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutDestinationResponse {
     #[doc="<p>The destination.</p>"]
     #[serde(rename="destination")]
@@ -751,7 +751,7 @@ pub struct PutDestinationResponse {
     pub destination: Option<Destination>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutLogEventsRequest {
     #[doc="<p>The log events.</p>"]
     #[serde(rename="logEvents")]
@@ -768,7 +768,7 @@ pub struct PutLogEventsRequest {
     pub sequence_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutLogEventsResponse {
     #[doc="<p>The next sequence token.</p>"]
     #[serde(rename="nextSequenceToken")]
@@ -780,7 +780,7 @@ pub struct PutLogEventsResponse {
     pub rejected_log_events_info: Option<RejectedLogEventsInfo>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutMetricFilterRequest {
     #[doc="<p>A name for the metric filter.</p>"]
     #[serde(rename="filterName")]
@@ -796,7 +796,7 @@ pub struct PutMetricFilterRequest {
     pub metric_transformations: Vec<MetricTransformation>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutRetentionPolicyRequest {
     #[doc="<p>The name of the log group.</p>"]
     #[serde(rename="logGroupName")]
@@ -805,7 +805,7 @@ pub struct PutRetentionPolicyRequest {
     pub retention_in_days: i64,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutSubscriptionFilterRequest {
     #[doc="<p>The ARN of the destination to deliver matching log events to. Currently, the supported destinations are:</p> <ul> <li> <p>An Amazon Kinesis stream belonging to the same account as the subscription filter, for same-account delivery.</p> </li> <li> <p>A logical destination (specified using an ARN) belonging to a different account, for cross-account delivery.</p> </li> <li> <p>An Amazon Kinesis Firehose stream belonging to the same account as the subscription filter, for same-account delivery.</p> </li> <li> <p>An AWS Lambda function belonging to the same account as the subscription filter, for same-account delivery.</p> </li> </ul>"]
     #[serde(rename="destinationArn")]
@@ -830,7 +830,7 @@ pub struct PutSubscriptionFilterRequest {
 }
 
 #[doc="<p>Represents the rejected events.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RejectedLogEventsInfo {
     #[doc="<p>The expired log events.</p>"]
     #[serde(rename="expiredLogEventEndIndex")]
@@ -847,7 +847,7 @@ pub struct RejectedLogEventsInfo {
 }
 
 #[doc="<p>Represents the search status of a log stream.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchedLogStream {
     #[doc="<p>The name of the log stream.</p>"]
     #[serde(rename="logStreamName")]
@@ -860,7 +860,7 @@ pub struct SearchedLogStream {
 }
 
 #[doc="<p>Represents a subscription filter.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubscriptionFilter {
     #[doc="<p>The creation time of the subscription filter, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC.</p>"]
     #[serde(rename="creationTime")]
@@ -891,7 +891,7 @@ pub struct SubscriptionFilter {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagLogGroupRequest {
     #[doc="<p>The name of the log group.</p>"]
     #[serde(rename="logGroupName")]
@@ -901,7 +901,7 @@ pub struct TagLogGroupRequest {
     pub tags: ::std::collections::HashMap<String, String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestMetricFilterRequest {
     #[serde(rename="filterPattern")]
     pub filter_pattern: String,
@@ -910,7 +910,7 @@ pub struct TestMetricFilterRequest {
     pub log_event_messages: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TestMetricFilterResponse {
     #[doc="<p>The matched events.</p>"]
     #[serde(rename="matches")]
@@ -918,7 +918,7 @@ pub struct TestMetricFilterResponse {
     pub matches: Option<Vec<MetricFilterMatchRecord>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagLogGroupRequest {
     #[doc="<p>The name of the log group.</p>"]
     #[serde(rename="logGroupName")]

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsInput {
     #[doc="<p>The ID of the ML object to tag. For example, <code>exampleModelId</code>.</p>"]
     #[serde(rename="ResourceId")]
@@ -42,7 +42,7 @@ pub struct AddTagsInput {
 }
 
 #[doc="<p>Amazon ML returns the following elements. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsOutput {
     #[doc="<p>The ID of the ML object that was tagged.</p>"]
     #[serde(rename="ResourceId")]
@@ -55,7 +55,7 @@ pub struct AddTagsOutput {
 }
 
 #[doc="<p> Represents the output of a <code>GetBatchPrediction</code> operation.</p> <p> The content consists of the detailed metadata, the status, and the data file information of a <code>Batch Prediction</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchPrediction {
     #[doc="<p>The ID of the <code>DataSource</code> that points to the group of observations to predict.</p>"]
     #[serde(rename="BatchPredictionDataSourceId")]
@@ -118,7 +118,7 @@ pub struct BatchPrediction {
     pub total_record_count: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBatchPredictionInput {
     #[doc="<p>The ID of the <code>DataSource</code> that points to the group of observations to predict.</p>"]
     #[serde(rename="BatchPredictionDataSourceId")]
@@ -139,7 +139,7 @@ pub struct CreateBatchPredictionInput {
 }
 
 #[doc="<p> Represents the output of a <code>CreateBatchPrediction</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateBatchPrediction</code> operation is asynchronous. You can poll for status updates by using the <code>&gt;GetBatchPrediction</code> operation and checking the <code>Status</code> parameter of the result. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBatchPredictionOutput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>BatchPrediction</code>. This value is identical to the value of the <code>BatchPredictionId</code> in the request.</p>"]
     #[serde(rename="BatchPredictionId")]
@@ -147,7 +147,7 @@ pub struct CreateBatchPredictionOutput {
     pub batch_prediction_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDataSourceFromRDSInput {
     #[doc="<p>The compute statistics for a <code>DataSource</code>. The statistics are generated from the observation data referenced by a <code>DataSource</code>. Amazon ML uses the statistics internally during <code>MLModel</code> training. This parameter must be set to <code>true</code> if the <code></code>DataSource<code></code> needs to be used for <code>MLModel</code> training. </p>"]
     #[serde(rename="ComputeStatistics")]
@@ -169,7 +169,7 @@ pub struct CreateDataSourceFromRDSInput {
 }
 
 #[doc="<p> Represents the output of a <code>CreateDataSourceFromRDS</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateDataSourceFromRDS</code>&gt; operation is asynchronous. You can poll for updates by using the <code>GetBatchPrediction</code> operation and checking the <code>Status</code> parameter. You can inspect the <code>Message</code> when <code>Status</code> shows up as <code>FAILED</code>. You can also check the progress of the copy operation by going to the <code>DataPipeline</code> console and looking up the pipeline using the <code>pipelineId </code> from the describe call.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDataSourceFromRDSOutput {
     #[doc="<p>A user-supplied ID that uniquely identifies the datasource. This value should be identical to the value of the <code>DataSourceID</code> in the request. </p>"]
     #[serde(rename="DataSourceId")]
@@ -177,7 +177,7 @@ pub struct CreateDataSourceFromRDSOutput {
     pub data_source_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDataSourceFromRedshiftInput {
     #[doc="<p>The compute statistics for a <code>DataSource</code>. The statistics are generated from the observation data referenced by a <code>DataSource</code>. Amazon ML uses the statistics internally during <code>MLModel</code> training. This parameter must be set to <code>true</code> if the <code>DataSource</code> needs to be used for <code>MLModel</code> training.</p>"]
     #[serde(rename="ComputeStatistics")]
@@ -199,7 +199,7 @@ pub struct CreateDataSourceFromRedshiftInput {
 }
 
 #[doc="<p> Represents the output of a <code>CreateDataSourceFromRedshift</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateDataSourceFromRedshift</code> operation is asynchronous. You can poll for updates by using the <code>GetBatchPrediction</code> operation and checking the <code>Status</code> parameter. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDataSourceFromRedshiftOutput {
     #[doc="<p>A user-supplied ID that uniquely identifies the datasource. This value should be identical to the value of the <code>DataSourceID</code> in the request. </p>"]
     #[serde(rename="DataSourceId")]
@@ -207,7 +207,7 @@ pub struct CreateDataSourceFromRedshiftOutput {
     pub data_source_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDataSourceFromS3Input {
     #[doc="<p>The compute statistics for a <code>DataSource</code>. The statistics are generated from the observation data referenced by a <code>DataSource</code>. Amazon ML uses the statistics internally during <code>MLModel</code> training. This parameter must be set to <code>true</code> if the <code></code>DataSource<code></code> needs to be used for <code>MLModel</code> training.</p>"]
     #[serde(rename="ComputeStatistics")]
@@ -226,7 +226,7 @@ pub struct CreateDataSourceFromS3Input {
 }
 
 #[doc="<p> Represents the output of a <code>CreateDataSourceFromS3</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateDataSourceFromS3</code> operation is asynchronous. You can poll for updates by using the <code>GetBatchPrediction</code> operation and checking the <code>Status</code> parameter. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDataSourceFromS3Output {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>DataSource</code>. This value should be identical to the value of the <code>DataSourceID</code> in the request. </p>"]
     #[serde(rename="DataSourceId")]
@@ -234,7 +234,7 @@ pub struct CreateDataSourceFromS3Output {
     pub data_source_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEvaluationInput {
     #[doc="<p>The ID of the <code>DataSource</code> for the evaluation. The schema of the <code>DataSource</code> must match the schema used to create the <code>MLModel</code>.</p>"]
     #[serde(rename="EvaluationDataSourceId")]
@@ -252,7 +252,7 @@ pub struct CreateEvaluationInput {
 }
 
 #[doc="<p> Represents the output of a <code>CreateEvaluation</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p><code>CreateEvaluation</code> operation is asynchronous. You can poll for status updates by using the <code>GetEvcaluation</code> operation and checking the <code>Status</code> parameter. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEvaluationOutput {
     #[doc="<p>The user-supplied ID that uniquely identifies the <code>Evaluation</code>. This value should be identical to the value of the <code>EvaluationId</code> in the request.</p>"]
     #[serde(rename="EvaluationId")]
@@ -260,7 +260,7 @@ pub struct CreateEvaluationOutput {
     pub evaluation_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateMLModelInput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>MLModel</code>.</p>"]
     #[serde(rename="MLModelId")]
@@ -290,7 +290,7 @@ pub struct CreateMLModelInput {
 }
 
 #[doc="<p> Represents the output of a <code>CreateMLModel</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateMLModel</code> operation is asynchronous. You can poll for status updates by using the <code>GetMLModel</code> operation and checking the <code>Status</code> parameter. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateMLModelOutput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelId</code> in the request. </p>"]
     #[serde(rename="MLModelId")]
@@ -298,7 +298,7 @@ pub struct CreateMLModelOutput {
     pub ml_model_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRealtimeEndpointInput {
     #[doc="<p>The ID assigned to the <code>MLModel</code> during creation.</p>"]
     #[serde(rename="MLModelId")]
@@ -306,7 +306,7 @@ pub struct CreateRealtimeEndpointInput {
 }
 
 #[doc="<p>Represents the output of an <code>CreateRealtimeEndpoint</code> operation.</p> <p>The result contains the <code>MLModelId</code> and the endpoint information for the <code>MLModel</code>.</p> <note> <p>The endpoint information includes the URI of the <code>MLModel</code>; that is, the location to send online prediction requests for the specified <code>MLModel</code>.</p> </note>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRealtimeEndpointOutput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelId</code> in the request.</p>"]
     #[serde(rename="MLModelId")]
@@ -319,7 +319,7 @@ pub struct CreateRealtimeEndpointOutput {
 }
 
 #[doc="<p> Represents the output of the <code>GetDataSource</code> operation. </p> <p> The content consists of the detailed metadata and data file information and the current status of the <code>DataSource</code>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DataSource {
     #[doc="<p> The parameter is <code>true</code> if statistics need to be generated from the observation data. </p>"]
     #[serde(rename="ComputeStatistics")]
@@ -389,7 +389,7 @@ pub struct DataSource {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBatchPredictionInput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>BatchPrediction</code>.</p>"]
     #[serde(rename="BatchPredictionId")]
@@ -397,7 +397,7 @@ pub struct DeleteBatchPredictionInput {
 }
 
 #[doc="<p> Represents the output of a <code>DeleteBatchPrediction</code> operation.</p> <p>You can use the <code>GetBatchPrediction</code> operation and check the value of the <code>Status</code> parameter to see whether a <code>BatchPrediction</code> is marked as <code>DELETED</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBatchPredictionOutput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>BatchPrediction</code>. This value should be identical to the value of the <code>BatchPredictionID</code> in the request.</p>"]
     #[serde(rename="BatchPredictionId")]
@@ -405,7 +405,7 @@ pub struct DeleteBatchPredictionOutput {
     pub batch_prediction_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDataSourceInput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>DataSource</code>.</p>"]
     #[serde(rename="DataSourceId")]
@@ -413,7 +413,7 @@ pub struct DeleteDataSourceInput {
 }
 
 #[doc="<p> Represents the output of a <code>DeleteDataSource</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDataSourceOutput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>DataSource</code>. This value should be identical to the value of the <code>DataSourceID</code> in the request.</p>"]
     #[serde(rename="DataSourceId")]
@@ -421,7 +421,7 @@ pub struct DeleteDataSourceOutput {
     pub data_source_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEvaluationInput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>Evaluation</code> to delete.</p>"]
     #[serde(rename="EvaluationId")]
@@ -429,7 +429,7 @@ pub struct DeleteEvaluationInput {
 }
 
 #[doc="<p> Represents the output of a <code>DeleteEvaluation</code> operation. The output indicates that Amazon Machine Learning (Amazon ML) received the request.</p> <p>You can use the <code>GetEvaluation</code> operation and check the value of the <code>Status</code> parameter to see whether an <code>Evaluation</code> is marked as <code>DELETED</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEvaluationOutput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>Evaluation</code>. This value should be identical to the value of the <code>EvaluationId</code> in the request.</p>"]
     #[serde(rename="EvaluationId")]
@@ -437,7 +437,7 @@ pub struct DeleteEvaluationOutput {
     pub evaluation_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMLModelInput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>MLModel</code>.</p>"]
     #[serde(rename="MLModelId")]
@@ -445,7 +445,7 @@ pub struct DeleteMLModelInput {
 }
 
 #[doc="<p>Represents the output of a <code>DeleteMLModel</code> operation.</p> <p>You can use the <code>GetMLModel</code> operation and check the value of the <code>Status</code> parameter to see whether an <code>MLModel</code> is marked as <code>DELETED</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMLModelOutput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelID</code> in the request.</p>"]
     #[serde(rename="MLModelId")]
@@ -453,7 +453,7 @@ pub struct DeleteMLModelOutput {
     pub ml_model_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRealtimeEndpointInput {
     #[doc="<p>The ID assigned to the <code>MLModel</code> during creation.</p>"]
     #[serde(rename="MLModelId")]
@@ -461,7 +461,7 @@ pub struct DeleteRealtimeEndpointInput {
 }
 
 #[doc="<p>Represents the output of an <code>DeleteRealtimeEndpoint</code> operation.</p> <p>The result contains the <code>MLModelId</code> and the endpoint information for the <code>MLModel</code>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRealtimeEndpointOutput {
     #[doc="<p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelId</code> in the request.</p>"]
     #[serde(rename="MLModelId")]
@@ -473,7 +473,7 @@ pub struct DeleteRealtimeEndpointOutput {
     pub realtime_endpoint_info: Option<RealtimeEndpointInfo>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsInput {
     #[doc="<p>The ID of the tagged ML object. For example, <code>exampleModelId</code>.</p>"]
     #[serde(rename="ResourceId")]
@@ -487,7 +487,7 @@ pub struct DeleteTagsInput {
 }
 
 #[doc="<p>Amazon ML returns the following elements. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsOutput {
     #[doc="<p>The ID of the ML object from which tags were deleted.</p>"]
     #[serde(rename="ResourceId")]
@@ -499,7 +499,7 @@ pub struct DeleteTagsOutput {
     pub resource_type: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBatchPredictionsInput {
     #[doc="<p>The equal to operator. The <code>BatchPrediction</code> results will have <code>FilterVariable</code> values that exactly match the value specified with <code>EQ</code>.</p>"]
     #[serde(rename="EQ")]
@@ -548,7 +548,7 @@ pub struct DescribeBatchPredictionsInput {
 }
 
 #[doc="<p>Represents the output of a <code>DescribeBatchPredictions</code> operation. The content is essentially a list of <code>BatchPrediction</code>s.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBatchPredictionsOutput {
     #[doc="<p>The ID of the next page in the paginated results that indicates at least one more page follows.</p>"]
     #[serde(rename="NextToken")]
@@ -560,7 +560,7 @@ pub struct DescribeBatchPredictionsOutput {
     pub results: Option<Vec<BatchPrediction>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDataSourcesInput {
     #[doc="<p>The equal to operator. The <code>DataSource</code> results will have <code>FilterVariable</code> values that exactly match the value specified with <code>EQ</code>.</p>"]
     #[serde(rename="EQ")]
@@ -609,7 +609,7 @@ pub struct DescribeDataSourcesInput {
 }
 
 #[doc="<p>Represents the query results from a <a>DescribeDataSources</a> operation. The content is essentially a list of <code>DataSource</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDataSourcesOutput {
     #[doc="<p>An ID of the next page in the paginated results that indicates at least one more page follows.</p>"]
     #[serde(rename="NextToken")]
@@ -621,7 +621,7 @@ pub struct DescribeDataSourcesOutput {
     pub results: Option<Vec<DataSource>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEvaluationsInput {
     #[doc="<p>The equal to operator. The <code>Evaluation</code> results will have <code>FilterVariable</code> values that exactly match the value specified with <code>EQ</code>.</p>"]
     #[serde(rename="EQ")]
@@ -670,7 +670,7 @@ pub struct DescribeEvaluationsInput {
 }
 
 #[doc="<p>Represents the query results from a <code>DescribeEvaluations</code> operation. The content is essentially a list of <code>Evaluation</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEvaluationsOutput {
     #[doc="<p>The ID of the next page in the paginated results that indicates at least one more page follows.</p>"]
     #[serde(rename="NextToken")]
@@ -682,7 +682,7 @@ pub struct DescribeEvaluationsOutput {
     pub results: Option<Vec<Evaluation>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMLModelsInput {
     #[doc="<p>The equal to operator. The <code>MLModel</code> results will have <code>FilterVariable</code> values that exactly match the value specified with <code>EQ</code>.</p>"]
     #[serde(rename="EQ")]
@@ -731,7 +731,7 @@ pub struct DescribeMLModelsInput {
 }
 
 #[doc="<p>Represents the output of a <code>DescribeMLModels</code> operation. The content is essentially a list of <code>MLModel</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMLModelsOutput {
     #[doc="<p>The ID of the next page in the paginated results that indicates at least one more page follows.</p>"]
     #[serde(rename="NextToken")]
@@ -743,7 +743,7 @@ pub struct DescribeMLModelsOutput {
     pub results: Option<Vec<MLModel>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsInput {
     #[doc="<p>The ID of the ML object. For example, <code>exampleModelId</code>. </p>"]
     #[serde(rename="ResourceId")]
@@ -754,7 +754,7 @@ pub struct DescribeTagsInput {
 }
 
 #[doc="<p>Amazon ML returns the following elements. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsOutput {
     #[doc="<p>The ID of the tagged ML object.</p>"]
     #[serde(rename="ResourceId")]
@@ -771,7 +771,7 @@ pub struct DescribeTagsOutput {
 }
 
 #[doc="<p> Represents the output of <code>GetEvaluation</code> operation. </p> <p>The content consists of the detailed metadata and data file information and the current status of the <code>Evaluation</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Evaluation {
     #[serde(rename="ComputeTime")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -828,7 +828,7 @@ pub struct Evaluation {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBatchPredictionInput {
     #[doc="<p>An ID assigned to the <code>BatchPrediction</code> at creation.</p>"]
     #[serde(rename="BatchPredictionId")]
@@ -836,7 +836,7 @@ pub struct GetBatchPredictionInput {
 }
 
 #[doc="<p>Represents the output of a <code>GetBatchPrediction</code> operation and describes a <code>BatchPrediction</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetBatchPredictionOutput {
     #[doc="<p>The ID of the <code>DataSource</code> that was used to create the <code>BatchPrediction</code>. </p>"]
     #[serde(rename="BatchPredictionDataSourceId")]
@@ -908,7 +908,7 @@ pub struct GetBatchPredictionOutput {
     pub total_record_count: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDataSourceInput {
     #[doc="<p>The ID assigned to the <code>DataSource</code> at creation.</p>"]
     #[serde(rename="DataSourceId")]
@@ -920,7 +920,7 @@ pub struct GetDataSourceInput {
 }
 
 #[doc="<p>Represents the output of a <code>GetDataSource</code> operation and describes a <code>DataSource</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDataSourceOutput {
     #[doc="<p> The parameter is <code>true</code> if statistics need to be generated from the observation data. </p>"]
     #[serde(rename="ComputeStatistics")]
@@ -1001,7 +1001,7 @@ pub struct GetDataSourceOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetEvaluationInput {
     #[doc="<p>The ID of the <code>Evaluation</code> to retrieve. The evaluation of each <code>MLModel</code> is recorded and cataloged. The ID provides the means to access the information. </p>"]
     #[serde(rename="EvaluationId")]
@@ -1009,7 +1009,7 @@ pub struct GetEvaluationInput {
 }
 
 #[doc="<p>Represents the output of a <code>GetEvaluation</code> operation and describes an <code>Evaluation</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetEvaluationOutput {
     #[doc="<p>The approximate CPU time in milliseconds that Amazon Machine Learning spent processing the <code>Evaluation</code>, normalized and scaled on computation resources. <code>ComputeTime</code> is only available if the <code>Evaluation</code> is in the <code>COMPLETED</code> state.</p>"]
     #[serde(rename="ComputeTime")]
@@ -1073,7 +1073,7 @@ pub struct GetEvaluationOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMLModelInput {
     #[doc="<p>The ID assigned to the <code>MLModel</code> at creation.</p>"]
     #[serde(rename="MLModelId")]
@@ -1085,7 +1085,7 @@ pub struct GetMLModelInput {
 }
 
 #[doc="<p>Represents the output of a <code>GetMLModel</code> operation, and provides detailed information about a <code>MLModel</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMLModelOutput {
     #[doc="<p>The approximate CPU time in milliseconds that Amazon Machine Learning spent processing the <code>MLModel</code>, normalized and scaled on computation resources. <code>ComputeTime</code> is only available if the <code>MLModel</code> is in the <code>COMPLETED</code> state.</p>"]
     #[serde(rename="ComputeTime")]
@@ -1173,7 +1173,7 @@ pub struct GetMLModelOutput {
 }
 
 #[doc="<p> Represents the output of a <code>GetMLModel</code> operation. </p> <p>The content consists of the detailed metadata and the current status of the <code>MLModel</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MLModel {
     #[doc="<p>The algorithm used to train the <code>MLModel</code>. The following algorithm is supported:</p> <ul> <li> <code>SGD</code> -- Stochastic gradient descent. The goal of <code>SGD</code> is to minimize the gradient of the loss function. </li> </ul>"]
     #[serde(rename="Algorithm")]
@@ -1249,14 +1249,14 @@ pub struct MLModel {
 }
 
 #[doc="<p>Measurements of how well the <code>MLModel</code> performed on known observations. One of the following metrics is returned, based on the type of the <code>MLModel</code>: </p> <ul> <li> <p>BinaryAUC: The binary <code>MLModel</code> uses the Area Under the Curve (AUC) technique to measure performance. </p> </li> <li> <p>RegressionRMSE: The regression <code>MLModel</code> uses the Root Mean Square Error (RMSE) technique to measure performance. RMSE measures the difference between predicted and actual values for a single variable.</p> </li> <li> <p>MulticlassAvgFScore: The multiclass <code>MLModel</code> uses the F1 score technique to measure performance. </p> </li> </ul> <p> For more information about performance metrics, please see the <a href=\"http://docs.aws.amazon.com/machine-learning/latest/dg\">Amazon Machine Learning Developer Guide</a>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PerformanceMetrics {
     #[serde(rename="Properties")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub properties: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PredictInput {
     #[doc="<p>A unique identifier of the <code>MLModel</code>.</p>"]
     #[serde(rename="MLModelId")]
@@ -1267,7 +1267,7 @@ pub struct PredictInput {
     pub record: ::std::collections::HashMap<String, String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PredictOutput {
     #[serde(rename="Prediction")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1275,7 +1275,7 @@ pub struct PredictOutput {
 }
 
 #[doc="<p>The output from a <code>Predict</code> operation: </p> <ul> <li> <p> <code>Details</code> - Contains the following attributes: <code>DetailsAttributes.PREDICTIVE_MODEL_TYPE - REGRESSION | BINARY | MULTICLASS</code> <code>DetailsAttributes.ALGORITHM - SGD</code> </p> </li> <li> <p> <code>PredictedLabel</code> - Present for either a <code>BINARY</code> or <code>MULTICLASS</code> <code>MLModel</code> request. </p> </li> <li> <p> <code>PredictedScores</code> - Contains the raw classification score corresponding to each label. </p> </li> <li> <p> <code>PredictedValue</code> - Present for a <code>REGRESSION</code> <code>MLModel</code> request. </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Prediction {
     #[serde(rename="details")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1294,7 +1294,7 @@ pub struct Prediction {
 }
 
 #[doc="<p>The data specification of an Amazon Relational Database Service (Amazon RDS) <code>DataSource</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RDSDataSpec {
     #[doc="<p>A JSON string that represents the splitting and rearrangement processing to be applied to a <code>DataSource</code>. If the <code>DataRearrangement</code> parameter is not provided, all of the input data is used to create the <code>Datasource</code>.</p> <p>There are multiple parameters that control what data is used to create a datasource:</p> <ul> <li><p><b><code>percentBegin</code></b></p> <p>Use <code>percentBegin</code> to indicate the beginning of the range of the data used to create the Datasource. If you do not include <code>percentBegin</code> and <code>percentEnd</code>, Amazon ML includes all of the data when creating the datasource.</p></li> <li><p><b><code>percentEnd</code></b></p> <p>Use <code>percentEnd</code> to indicate the end of the range of the data used to create the Datasource. If you do not include <code>percentBegin</code> and <code>percentEnd</code>, Amazon ML includes all of the data when creating the datasource.</p></li> <li><p><b><code>complement</code></b></p> <p>The <code>complement</code> parameter instructs Amazon ML to use the data that is not included in the range of <code>percentBegin</code> to <code>percentEnd</code> to create a datasource. The <code>complement</code> parameter is useful if you need to create complementary datasources for training and evaluation. To create a complementary datasource, use the same values for <code>percentBegin</code> and <code>percentEnd</code>, along with the <code>complement</code> parameter.</p> <p>For example, the following two datasources do not share any data, and can be used to train and evaluate a model. The first datasource has 25 percent of the data, and the second one has 75 percent of the data.</p> <p>Datasource for evaluation: <code>{\"splitting\":{\"percentBegin\":0, \"percentEnd\":25}}</code></p> <p>Datasource for training: <code>{\"splitting\":{\"percentBegin\":0, \"percentEnd\":25, \"complement\":\"true\"}}</code></p> </li> <li><p><b><code>strategy</code></b></p> <p>To change how Amazon ML splits the data for a datasource, use the <code>strategy</code> parameter.</p> <p>The default value for the <code>strategy</code> parameter is <code>sequential</code>, meaning that Amazon ML takes all of the data records between the <code>percentBegin</code> and <code>percentEnd</code> parameters for the datasource, in the order that the records appear in the input data.</p> <p>The following two <code>DataRearrangement</code> lines are examples of sequentially ordered training and evaluation datasources:</p> <p>Datasource for evaluation: <code>{\"splitting\":{\"percentBegin\":70, \"percentEnd\":100, \"strategy\":\"sequential\"}}</code></p> <p>Datasource for training: <code>{\"splitting\":{\"percentBegin\":70, \"percentEnd\":100, \"strategy\":\"sequential\", \"complement\":\"true\"}}</code></p> <p>To randomly split the input data into the proportions indicated by the percentBegin and percentEnd parameters, set the <code>strategy</code> parameter to <code>random</code> and provide a string that is used as the seed value for the random data splitting (for example, you can use the S3 path to your data as the random seed string). If you choose the random split strategy, Amazon ML assigns each row of data a pseudo-random number between 0 and 100, and then selects the rows that have an assigned number between <code>percentBegin</code> and <code>percentEnd</code>. Pseudo-random numbers are assigned using both the input seed string value and the byte offset as a seed, so changing the data results in a different split. Any existing ordering is preserved. The random splitting strategy ensures that variables in the training and evaluation data are distributed similarly. It is useful in the cases where the input data may have an implicit sort order, which would otherwise result in training and evaluation datasources containing non-similar data records.</p> <p>The following two <code>DataRearrangement</code> lines are examples of non-sequentially ordered training and evaluation datasources:</p> <p>Datasource for evaluation: <code>{\"splitting\":{\"percentBegin\":70, \"percentEnd\":100, \"strategy\":\"random\", \"randomSeed\"=\"s3://my_s3_path/bucket/file.csv\"}}</code></p> <p>Datasource for training: <code>{\"splitting\":{\"percentBegin\":70, \"percentEnd\":100, \"strategy\":\"random\", \"randomSeed\"=\"s3://my_s3_path/bucket/file.csv\", \"complement\":\"true\"}}</code></p> </li> </ul>"]
     #[serde(rename="DataRearrangement")]
@@ -1345,7 +1345,7 @@ pub struct RDSDatabase {
 }
 
 #[doc="<p>The database credentials to connect to a database on an RDS DB instance.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RDSDatabaseCredentials {
     #[serde(rename="Password")]
     pub password: String,
@@ -1354,7 +1354,7 @@ pub struct RDSDatabaseCredentials {
 }
 
 #[doc="<p>The datasource details that are specific to Amazon RDS.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RDSMetadata {
     #[doc="<p>The ID of the Data Pipeline instance that is used to carry to copy data from Amazon RDS to Amazon S3. You can use the ID to find details about the instance in the Data Pipeline console.</p>"]
     #[serde(rename="DataPipelineId")]
@@ -1382,7 +1382,7 @@ pub struct RDSMetadata {
 }
 
 #[doc="<p> Describes the real-time endpoint information for an <code>MLModel</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RealtimeEndpointInfo {
     #[doc="<p>The time that the request to create the real-time endpoint for the <code>MLModel</code> was received. The time is expressed in epoch time.</p>"]
     #[serde(rename="CreatedAt")]
@@ -1403,7 +1403,7 @@ pub struct RealtimeEndpointInfo {
 }
 
 #[doc="<p>Describes the data specification of an Amazon Redshift <code>DataSource</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RedshiftDataSpec {
     #[doc="<p>A JSON string that represents the splitting and rearrangement processing to be applied to a <code>DataSource</code>. If the <code>DataRearrangement</code> parameter is not provided, all of the input data is used to create the <code>Datasource</code>.</p> <p>There are multiple parameters that control what data is used to create a datasource:</p> <ul> <li><p><b><code>percentBegin</code></b></p> <p>Use <code>percentBegin</code> to indicate the beginning of the range of the data used to create the Datasource. If you do not include <code>percentBegin</code> and <code>percentEnd</code>, Amazon ML includes all of the data when creating the datasource.</p></li> <li><p><b><code>percentEnd</code></b></p> <p>Use <code>percentEnd</code> to indicate the end of the range of the data used to create the Datasource. If you do not include <code>percentBegin</code> and <code>percentEnd</code>, Amazon ML includes all of the data when creating the datasource.</p></li> <li><p><b><code>complement</code></b></p> <p>The <code>complement</code> parameter instructs Amazon ML to use the data that is not included in the range of <code>percentBegin</code> to <code>percentEnd</code> to create a datasource. The <code>complement</code> parameter is useful if you need to create complementary datasources for training and evaluation. To create a complementary datasource, use the same values for <code>percentBegin</code> and <code>percentEnd</code>, along with the <code>complement</code> parameter.</p> <p>For example, the following two datasources do not share any data, and can be used to train and evaluate a model. The first datasource has 25 percent of the data, and the second one has 75 percent of the data.</p> <p>Datasource for evaluation: <code>{\"splitting\":{\"percentBegin\":0, \"percentEnd\":25}}</code></p> <p>Datasource for training: <code>{\"splitting\":{\"percentBegin\":0, \"percentEnd\":25, \"complement\":\"true\"}}</code></p> </li> <li><p><b><code>strategy</code></b></p> <p>To change how Amazon ML splits the data for a datasource, use the <code>strategy</code> parameter.</p> <p>The default value for the <code>strategy</code> parameter is <code>sequential</code>, meaning that Amazon ML takes all of the data records between the <code>percentBegin</code> and <code>percentEnd</code> parameters for the datasource, in the order that the records appear in the input data.</p> <p>The following two <code>DataRearrangement</code> lines are examples of sequentially ordered training and evaluation datasources:</p> <p>Datasource for evaluation: <code>{\"splitting\":{\"percentBegin\":70, \"percentEnd\":100, \"strategy\":\"sequential\"}}</code></p> <p>Datasource for training: <code>{\"splitting\":{\"percentBegin\":70, \"percentEnd\":100, \"strategy\":\"sequential\", \"complement\":\"true\"}}</code></p> <p>To randomly split the input data into the proportions indicated by the percentBegin and percentEnd parameters, set the <code>strategy</code> parameter to <code>random</code> and provide a string that is used as the seed value for the random data splitting (for example, you can use the S3 path to your data as the random seed string). If you choose the random split strategy, Amazon ML assigns each row of data a pseudo-random number between 0 and 100, and then selects the rows that have an assigned number between <code>percentBegin</code> and <code>percentEnd</code>. Pseudo-random numbers are assigned using both the input seed string value and the byte offset as a seed, so changing the data results in a different split. Any existing ordering is preserved. The random splitting strategy ensures that variables in the training and evaluation data are distributed similarly. It is useful in the cases where the input data may have an implicit sort order, which would otherwise result in training and evaluation datasources containing non-similar data records.</p> <p>The following two <code>DataRearrangement</code> lines are examples of non-sequentially ordered training and evaluation datasources:</p> <p>Datasource for evaluation: <code>{\"splitting\":{\"percentBegin\":70, \"percentEnd\":100, \"strategy\":\"random\", \"randomSeed\"=\"s3://my_s3_path/bucket/file.csv\"}}</code></p> <p>Datasource for training: <code>{\"splitting\":{\"percentBegin\":70, \"percentEnd\":100, \"strategy\":\"random\", \"randomSeed\"=\"s3://my_s3_path/bucket/file.csv\", \"complement\":\"true\"}}</code></p> </li> </ul>"]
     #[serde(rename="DataRearrangement")]
@@ -1441,7 +1441,7 @@ pub struct RedshiftDatabase {
 }
 
 #[doc="<p> Describes the database credentials for connecting to a database on an Amazon Redshift cluster.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RedshiftDatabaseCredentials {
     #[serde(rename="Password")]
     pub password: String,
@@ -1450,7 +1450,7 @@ pub struct RedshiftDatabaseCredentials {
 }
 
 #[doc="<p>Describes the <code>DataSource</code> details specific to Amazon Redshift.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RedshiftMetadata {
     #[serde(rename="DatabaseUserName")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1465,7 +1465,7 @@ pub struct RedshiftMetadata {
 }
 
 #[doc="<p> Describes the data specification of a <code>DataSource</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3DataSpec {
     #[doc="<p>The location of the data file(s) used by a <code>DataSource</code>. The URI specifies a data file or an Amazon Simple Storage Service (Amazon S3) directory or bucket containing data files.</p>"]
     #[serde(rename="DataLocationS3")]
@@ -1497,7 +1497,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateBatchPredictionInput {
     #[doc="<p>The ID assigned to the <code>BatchPrediction</code> during creation.</p>"]
     #[serde(rename="BatchPredictionId")]
@@ -1508,7 +1508,7 @@ pub struct UpdateBatchPredictionInput {
 }
 
 #[doc="<p>Represents the output of an <code>UpdateBatchPrediction</code> operation.</p> <p>You can see the updated content by using the <code>GetBatchPrediction</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateBatchPredictionOutput {
     #[doc="<p>The ID assigned to the <code>BatchPrediction</code> during creation. This value should be identical to the value of the <code>BatchPredictionId</code> in the request.</p>"]
     #[serde(rename="BatchPredictionId")]
@@ -1516,7 +1516,7 @@ pub struct UpdateBatchPredictionOutput {
     pub batch_prediction_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDataSourceInput {
     #[doc="<p>The ID assigned to the <code>DataSource</code> during creation.</p>"]
     #[serde(rename="DataSourceId")]
@@ -1527,7 +1527,7 @@ pub struct UpdateDataSourceInput {
 }
 
 #[doc="<p>Represents the output of an <code>UpdateDataSource</code> operation.</p> <p>You can see the updated content by using the <code>GetBatchPrediction</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDataSourceOutput {
     #[doc="<p>The ID assigned to the <code>DataSource</code> during creation. This value should be identical to the value of the <code>DataSourceID</code> in the request.</p>"]
     #[serde(rename="DataSourceId")]
@@ -1535,7 +1535,7 @@ pub struct UpdateDataSourceOutput {
     pub data_source_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateEvaluationInput {
     #[doc="<p>The ID assigned to the <code>Evaluation</code> during creation.</p>"]
     #[serde(rename="EvaluationId")]
@@ -1546,7 +1546,7 @@ pub struct UpdateEvaluationInput {
 }
 
 #[doc="<p>Represents the output of an <code>UpdateEvaluation</code> operation.</p> <p>You can see the updated content by using the <code>GetEvaluation</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateEvaluationOutput {
     #[doc="<p>The ID assigned to the <code>Evaluation</code> during creation. This value should be identical to the value of the <code>Evaluation</code> in the request.</p>"]
     #[serde(rename="EvaluationId")]
@@ -1554,7 +1554,7 @@ pub struct UpdateEvaluationOutput {
     pub evaluation_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMLModelInput {
     #[doc="<p>The ID assigned to the <code>MLModel</code> during creation.</p>"]
     #[serde(rename="MLModelId")]
@@ -1570,7 +1570,7 @@ pub struct UpdateMLModelInput {
 }
 
 #[doc="<p>Represents the output of an <code>UpdateMLModel</code> operation.</p> <p>You can see the updated content by using the <code>GetMLModel</code> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMLModelOutput {
     #[doc="<p>The ID assigned to the <code>MLModel</code> during creation. This value should be identical to the value of the <code>MLModelID</code> in the request.</p>"]
     #[serde(rename="MLModelId")]

--- a/rusoto/services/marketplace-entitlement/src/generated.rs
+++ b/rusoto/services/marketplace-entitlement/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>An entitlement represents capacity in a product owned by the customer. For example, a customer might own some number of users or seats in an SaaS application or some amount of data capacity in a multi-tenant database.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Entitlement {
     #[doc="<p>The customer identifier is a handle to each unique customer in an application. Customer identifiers are obtained through the ResolveCustomer operation in AWS Marketplace Metering Service.</p>"]
     #[serde(rename="CustomerIdentifier")]
@@ -54,7 +54,7 @@ pub struct Entitlement {
 }
 
 #[doc="<p>The EntitlementValue represents the amount of capacity that the customer is entitled to for the product.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EntitlementValue {
     #[doc="<p>The BooleanValue field will be populated with a boolean value when the entitlement is a boolean type. Otherwise, the field will not be set.</p>"]
     #[serde(rename="BooleanValue")]
@@ -75,7 +75,7 @@ pub struct EntitlementValue {
 }
 
 #[doc="<p>The GetEntitlementsRequest contains parameters for the GetEntitlements operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetEntitlementsRequest {
     #[doc="<p>Filter is used to return entitlements for a specific customer or for a specific dimension. Filters are described as keys mapped to a lists of values. Filtered requests are <i>unioned</i> for each value in the value list, and then <i>intersected</i> for each filter key.</p>"]
     #[serde(rename="Filter")]
@@ -95,7 +95,7 @@ pub struct GetEntitlementsRequest {
 }
 
 #[doc="<p>The GetEntitlementsRequest contains results from the GetEntitlements operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetEntitlementsResult {
     #[doc="<p>The set of entitlements found through the GetEntitlements operation. If the result contains an empty set of entitlements, NextToken might still be present and should be used.</p>"]
     #[serde(rename="Entitlements")]

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="Container for the parameters to the GenerateDataSet operation."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenerateDataSetRequest {
     #[doc="(Optional) Key-value pairs which will be returned, unmodified, in the Amazon SNS notification message and the data set metadata file. These key-value pairs can be used to correlated responses with tracking information from other systems."]
     #[serde(rename="customerDefinedValues")]
@@ -57,7 +57,7 @@ pub struct GenerateDataSetRequest {
 }
 
 #[doc="Container for the result of the GenerateDataSet operation."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GenerateDataSetResult {
     #[doc="A unique identifier representing a specific request to the GenerateDataSet operation. This identifier can be used to correlate a request with notifications from the SNS topic."]
     #[serde(rename="dataSetRequestId")]
@@ -66,7 +66,7 @@ pub struct GenerateDataSetResult {
 }
 
 #[doc="Container for the parameters to the StartSupportDataExport operation."]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartSupportDataExportRequest {
     #[doc="(Optional) Key-value pairs which will be returned, unmodified, in the Amazon SNS notification message and the data set metadata file."]
     #[serde(rename="customerDefinedValues")]
@@ -94,7 +94,7 @@ pub struct StartSupportDataExportRequest {
 }
 
 #[doc="Container for the result of the StartSupportDataExport operation."]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartSupportDataExportResult {
     #[doc="A unique identifier representing a specific request to the StartSupportDataExport operation. This identifier can be used to correlate a request with notifications from the SNS topic."]
     #[serde(rename="dataSetRequestId")]

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>A BatchMeterUsageRequest contains UsageRecords, which indicate quantities of usage within your application.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchMeterUsageRequest {
     #[doc="<p>Product code is used to uniquely identify a product in AWS Marketplace. The product code should be the same as the one used during the publishing of a new product.</p>"]
     #[serde(rename="ProductCode")]
@@ -40,7 +40,7 @@ pub struct BatchMeterUsageRequest {
 }
 
 #[doc="<p>Contains the UsageRecords processed by BatchMeterUsage and any records that have failed due to transient error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchMeterUsageResult {
     #[doc="<p>Contains all UsageRecords processed by BatchMeterUsage. These records were either honored by AWS Marketplace Metering Service or were invalid.</p>"]
     #[serde(rename="Results")]
@@ -52,7 +52,7 @@ pub struct BatchMeterUsageResult {
     pub unprocessed_records: Option<Vec<UsageRecord>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MeterUsageRequest {
     #[doc="<p>Checks whether you have the permissions required for the action, but does not make the request. If you have the permissions, the request returns DryRunOperation; otherwise, it returns UnauthorizedException.</p>"]
     #[serde(rename="DryRun")]
@@ -71,7 +71,7 @@ pub struct MeterUsageRequest {
     pub usage_quantity: i64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MeterUsageResult {
     #[serde(rename="MeteringRecordId")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -79,7 +79,7 @@ pub struct MeterUsageResult {
 }
 
 #[doc="<p>Contains input to the ResolveCustomer operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResolveCustomerRequest {
     #[doc="<p>When a buyer visits your website during the registration process, the buyer submits a registration token through the browser. The registration token is resolved to obtain a CustomerIdentifier and product code.</p>"]
     #[serde(rename="RegistrationToken")]
@@ -87,7 +87,7 @@ pub struct ResolveCustomerRequest {
 }
 
 #[doc="<p>The result of the ResolveCustomer operation. Contains the CustomerIdentifier and product code.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResolveCustomerResult {
     #[doc="<p>The CustomerIdentifier is used to identify an individual customer in your application. Calls to BatchMeterUsage require CustomerIdentifiers for each UsageRecord.</p>"]
     #[serde(rename="CustomerIdentifier")]
@@ -117,7 +117,7 @@ pub struct UsageRecord {
 }
 
 #[doc="<p>A UsageRecordResult indicates the status of a given UsageRecord processed by BatchMeterUsage.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UsageRecordResult {
     #[doc="<p>The MeteringRecordId is a unique identifier for this metering event.</p>"]
     #[serde(rename="MeteringRecordId")]

--- a/rusoto/services/mgh/src/generated.rs
+++ b/rusoto/services/mgh/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateCreatedArtifactRequest {
     #[doc="<p>An ARN of the AWS resource related to the migration (e.g., AMI, EC2 instance, RDS instance, etc.) </p>"]
     #[serde(rename="CreatedArtifact")]
@@ -45,10 +45,10 @@ pub struct AssociateCreatedArtifactRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateCreatedArtifactResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateDiscoveredResourceRequest {
     #[doc="<p>Object representing a Resource.</p>"]
     #[serde(rename="DiscoveredResource")]
@@ -65,10 +65,10 @@ pub struct AssociateDiscoveredResourceRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateDiscoveredResourceResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProgressUpdateStreamRequest {
     #[doc="<p>Optional boolean flag to indicate whether any effect should take place. Used to test if the caller has permission to make the call.</p>"]
     #[serde(rename="DryRun")]
@@ -79,7 +79,7 @@ pub struct CreateProgressUpdateStreamRequest {
     pub progress_update_stream_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProgressUpdateStreamResult;
 
 #[doc="<p>An ARN of the AWS cloud resource target receiving the migration (e.g., AMI, EC2 instance, RDS instance, etc.).</p>"]
@@ -94,7 +94,7 @@ pub struct CreatedArtifact {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProgressUpdateStreamRequest {
     #[doc="<p>Optional boolean flag to indicate whether any effect should take place. Used to test if the caller has permission to make the call.</p>"]
     #[serde(rename="DryRun")]
@@ -105,17 +105,17 @@ pub struct DeleteProgressUpdateStreamRequest {
     pub progress_update_stream_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProgressUpdateStreamResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeApplicationStateRequest {
     #[doc="<p>The configurationId in ADS that uniquely identifies the grouped application.</p>"]
     #[serde(rename="ApplicationId")]
     pub application_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeApplicationStateResult {
     #[doc="<p>Status of the application - Not Started, In-Progress, Complete.</p>"]
     #[serde(rename="ApplicationStatus")]
@@ -127,7 +127,7 @@ pub struct DescribeApplicationStateResult {
     pub last_updated_time: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMigrationTaskRequest {
     #[doc="<p>The identifier given to the MigrationTask.</p>"]
     #[serde(rename="MigrationTaskName")]
@@ -137,7 +137,7 @@ pub struct DescribeMigrationTaskRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMigrationTaskResult {
     #[doc="<p>Object encapsulating information about the migration task.</p>"]
     #[serde(rename="MigrationTask")]
@@ -145,7 +145,7 @@ pub struct DescribeMigrationTaskResult {
     pub migration_task: Option<MigrationTask>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateCreatedArtifactRequest {
     #[doc="<p>An ARN of the AWS resource related to the migration (e.g., AMI, EC2 instance, RDS instance, etc.)</p>"]
     #[serde(rename="CreatedArtifactName")]
@@ -162,10 +162,10 @@ pub struct DisassociateCreatedArtifactRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateCreatedArtifactResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateDiscoveredResourceRequest {
     #[doc="<p>ConfigurationId of the ADS resource to be disassociated.</p>"]
     #[serde(rename="ConfigurationId")]
@@ -182,7 +182,7 @@ pub struct DisassociateDiscoveredResourceRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateDiscoveredResourceResult;
 
 #[doc="<p>Object representing the on-premises resource being migrated.</p>"]
@@ -197,7 +197,7 @@ pub struct DiscoveredResource {
     pub description: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportMigrationTaskRequest {
     #[doc="<p>Optional boolean flag to indicate whether any effect should take place. Used to test if the caller has permission to make the call.</p>"]
     #[serde(rename="DryRun")]
@@ -211,10 +211,10 @@ pub struct ImportMigrationTaskRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportMigrationTaskResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCreatedArtifactsRequest {
     #[doc="<p>Maximum number of results to be returned per page.</p>"]
     #[serde(rename="MaxResults")]
@@ -232,7 +232,7 @@ pub struct ListCreatedArtifactsRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCreatedArtifactsResult {
     #[doc="<p>List of created artifacts up to the maximum number of results specified in the request.</p>"]
     #[serde(rename="CreatedArtifactList")]
@@ -244,7 +244,7 @@ pub struct ListCreatedArtifactsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDiscoveredResourcesRequest {
     #[doc="<p>The maximum number of results returned per page.</p>"]
     #[serde(rename="MaxResults")]
@@ -262,7 +262,7 @@ pub struct ListDiscoveredResourcesRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDiscoveredResourcesResult {
     #[doc="<p>Returned list of discovered resources associated with the given MigrationTask.</p>"]
     #[serde(rename="DiscoveredResourceList")]
@@ -274,7 +274,7 @@ pub struct ListDiscoveredResourcesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListMigrationTasksRequest {
     #[doc="<p>Value to specify how many results are returned per page.</p>"]
     #[serde(rename="MaxResults")]
@@ -290,7 +290,7 @@ pub struct ListMigrationTasksRequest {
     pub resource_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListMigrationTasksResult {
     #[doc="<p>Lists the migration task's summary which includes: <code>MigrationTaskName</code>, <code>ProgressPercent</code>, <code>ProgressUpdateStream</code>, <code>Status</code>, and the <code>UpdateDateTime</code> for each task.</p>"]
     #[serde(rename="MigrationTaskSummaryList")]
@@ -302,7 +302,7 @@ pub struct ListMigrationTasksResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProgressUpdateStreamsRequest {
     #[doc="<p>Filter to limit the maximum number of results to list per page.</p>"]
     #[serde(rename="MaxResults")]
@@ -314,7 +314,7 @@ pub struct ListProgressUpdateStreamsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProgressUpdateStreamsResult {
     #[doc="<p>If there are more streams created than the max result, return the next token to be passed to the next call as a bookmark of where to start from.</p>"]
     #[serde(rename="NextToken")]
@@ -327,7 +327,7 @@ pub struct ListProgressUpdateStreamsResult {
 }
 
 #[doc="<p>Represents a migration task in a migration tool.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MigrationTask {
     #[doc="<p>Unique identifier that references the migration task.</p>"]
     #[serde(rename="MigrationTaskName")]
@@ -352,7 +352,7 @@ pub struct MigrationTask {
 }
 
 #[doc="<p>MigrationTaskSummary includes <code>MigrationTaskName</code>, <code>ProgressPercent</code>, <code>ProgressUpdateStream</code>, <code>Status</code>, and <code>UpdateDateTime</code> for each task.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MigrationTaskSummary {
     #[doc="<p>Unique identifier that references the migration task.</p>"]
     #[serde(rename="MigrationTaskName")]
@@ -380,7 +380,7 @@ pub struct MigrationTaskSummary {
     pub update_date_time: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotifyApplicationStateRequest {
     #[doc="<p>The configurationId in ADS that uniquely identifies the grouped application.</p>"]
     #[serde(rename="ApplicationId")]
@@ -394,10 +394,10 @@ pub struct NotifyApplicationStateRequest {
     pub status: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotifyApplicationStateResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotifyMigrationTaskStateRequest {
     #[doc="<p>Optional boolean flag to indicate whether any effect should take place. Used to test if the caller has permission to make the call.</p>"]
     #[serde(rename="DryRun")]
@@ -420,11 +420,11 @@ pub struct NotifyMigrationTaskStateRequest {
     pub update_date_time: f64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotifyMigrationTaskStateResult;
 
 #[doc="<p>Summary of the AWS resource used for access control that is implicitly linked to your AWS account.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProgressUpdateStreamSummary {
     #[doc="<p>The name of the ProgressUpdateStream. </p>"]
     #[serde(rename="ProgressUpdateStreamName")]
@@ -432,7 +432,7 @@ pub struct ProgressUpdateStreamSummary {
     pub progress_update_stream_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutResourceAttributesRequest {
     #[doc="<p>Optional boolean flag to indicate whether any effect should take place. Used to test if the caller has permission to make the call.</p>"]
     #[serde(rename="DryRun")]
@@ -449,7 +449,7 @@ pub struct PutResourceAttributesRequest {
     pub resource_attribute_list: Vec<ResourceAttribute>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutResourceAttributesResult;
 
 #[doc="<p>Attribute associated with a resource.</p>"]

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptQualificationRequestRequest {
     #[doc="<p> The value of the Qualification. You can omit this value if you are using the presence or absence of the Qualification as the basis for a HIT requirement. </p>"]
     #[serde(rename="IntegerValue")]
@@ -39,10 +39,10 @@ pub struct AcceptQualificationRequestRequest {
     pub qualification_request_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptQualificationRequestResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApproveAssignmentRequest {
     #[doc="<p> The ID of the assignment. The assignment must correspond to a HIT created by the Requester. </p>"]
     #[serde(rename="AssignmentId")]
@@ -57,11 +57,11 @@ pub struct ApproveAssignmentRequest {
     pub requester_feedback: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApproveAssignmentResponse;
 
 #[doc="<p> The Assignment data structure represents a single assignment of a HIT to a Worker. The assignment tracks the Worker's efforts to complete the HIT, and contains the results for later retrieval. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Assignment {
     #[doc="<p> The date and time the Worker accepted the assignment.</p>"]
     #[serde(rename="AcceptTime")]
@@ -113,7 +113,7 @@ pub struct Assignment {
     pub worker_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateQualificationWithWorkerRequest {
     #[doc="<p>The value of the Qualification to assign.</p>"]
     #[serde(rename="IntegerValue")]
@@ -131,11 +131,11 @@ pub struct AssociateQualificationWithWorkerRequest {
     pub worker_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateQualificationWithWorkerResponse;
 
 #[doc="<p>An object representing a Bonus payment paid to a Worker.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BonusPayment {
     #[doc="<p>The ID of the assignment associated with this bonus payment.</p>"]
     #[serde(rename="AssignmentId")]
@@ -158,7 +158,7 @@ pub struct BonusPayment {
     pub worker_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAdditionalAssignmentsForHITRequest {
     #[doc="<p>The ID of the HIT to extend.</p>"]
     #[serde(rename="HITId")]
@@ -173,10 +173,10 @@ pub struct CreateAdditionalAssignmentsForHITRequest {
     pub unique_request_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAdditionalAssignmentsForHITResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHITRequest {
     #[doc="<p> The amount of time, in seconds, that a Worker has to complete the HIT after accepting it. If a Worker does not complete the assignment within the specified duration, the assignment is considered abandoned. If the HIT is still active (that is, its lifetime has not elapsed), the assignment becomes available for other users to find and accept. </p>"]
     #[serde(rename="AssignmentDurationInSeconds")]
@@ -239,7 +239,7 @@ pub struct CreateHITRequest {
     pub unique_request_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHITResponse {
     #[doc="<p> Contains the newly created HIT data. For a description of the HIT data structure as it appears in responses, see the HIT Data Structure documentation. </p>"]
     #[serde(rename="HIT")]
@@ -247,7 +247,7 @@ pub struct CreateHITResponse {
     pub hit: Option<HIT>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHITTypeRequest {
     #[doc="<p> The amount of time, in seconds, that a Worker has to complete the HIT after accepting it. If a Worker does not complete the assignment within the specified duration, the assignment is considered abandoned. If the HIT is still active (that is, its lifetime has not elapsed), the assignment becomes available for other users to find and accept. </p>"]
     #[serde(rename="AssignmentDurationInSeconds")]
@@ -275,7 +275,7 @@ pub struct CreateHITTypeRequest {
     pub title: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHITTypeResponse {
     #[doc="<p> The ID of the newly registered HIT type.</p>"]
     #[serde(rename="HITTypeId")]
@@ -283,7 +283,7 @@ pub struct CreateHITTypeResponse {
     pub hit_type_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHITWithHITTypeRequest {
     #[doc="<p> The Assignment-level Review Policy applies to the assignments under the HIT. You can specify for Mechanical Turk to take various actions based on the policy. </p>"]
     #[serde(rename="AssignmentReviewPolicy")]
@@ -325,7 +325,7 @@ pub struct CreateHITWithHITTypeRequest {
     pub unique_request_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHITWithHITTypeResponse {
     #[doc="<p> Contains the newly created HIT data. For a description of the HIT data structure as it appears in responses, see the HIT Data Structure documentation. </p>"]
     #[serde(rename="HIT")]
@@ -333,7 +333,7 @@ pub struct CreateHITWithHITTypeResponse {
     pub hit: Option<HIT>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateQualificationTypeRequest {
     #[doc="<p>The answers to the Qualification test specified in the Test parameter, in the form of an AnswerKey data structure.</p> <p>Constraints: Must not be longer than 65535 bytes.</p> <p>Constraints: None. If not specified, you must process Qualification requests manually.</p>"]
     #[serde(rename="AnswerKey")]
@@ -374,7 +374,7 @@ pub struct CreateQualificationTypeRequest {
     pub test_duration_in_seconds: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateQualificationTypeResponse {
     #[doc="<p>The created Qualification type, returned as a QualificationType data structure.</p>"]
     #[serde(rename="QualificationType")]
@@ -382,7 +382,7 @@ pub struct CreateQualificationTypeResponse {
     pub qualification_type: Option<QualificationType>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateWorkerBlockRequest {
     #[doc="<p>A message explaining the reason for blocking the Worker. This parameter enables you to keep track of your Workers. The Worker does not see this message.</p>"]
     #[serde(rename="Reason")]
@@ -392,30 +392,30 @@ pub struct CreateWorkerBlockRequest {
     pub worker_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateWorkerBlockResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteHITRequest {
     #[doc="<p>The ID of the HIT to be deleted.</p>"]
     #[serde(rename="HITId")]
     pub hit_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteHITResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteQualificationTypeRequest {
     #[doc="<p>The ID of the QualificationType to dispose.</p>"]
     #[serde(rename="QualificationTypeId")]
     pub qualification_type_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteQualificationTypeResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteWorkerBlockRequest {
     #[doc="<p>A message that explains the reason for unblocking the Worker. The Worker does not see this message.</p>"]
     #[serde(rename="Reason")]
@@ -426,10 +426,10 @@ pub struct DeleteWorkerBlockRequest {
     pub worker_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteWorkerBlockResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateQualificationFromWorkerRequest {
     #[doc="<p>The ID of the Qualification type of the Qualification to be revoked.</p>"]
     #[serde(rename="QualificationTypeId")]
@@ -443,13 +443,13 @@ pub struct DisassociateQualificationFromWorkerRequest {
     pub worker_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateQualificationFromWorkerResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccountBalanceRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAccountBalanceResponse {
     #[serde(rename="AvailableBalance")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -459,14 +459,14 @@ pub struct GetAccountBalanceResponse {
     pub on_hold_balance: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAssignmentRequest {
     #[doc="<p>The ID of the Assignment to be retrieved.</p>"]
     #[serde(rename="AssignmentId")]
     pub assignment_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAssignmentResponse {
     #[doc="<p> The assignment. The response includes one Assignment element. </p>"]
     #[serde(rename="Assignment")]
@@ -478,7 +478,7 @@ pub struct GetAssignmentResponse {
     pub hit: Option<HIT>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFileUploadURLRequest {
     #[doc="<p>The ID of the assignment that contains the question with a FileUploadAnswer.</p>"]
     #[serde(rename="AssignmentId")]
@@ -488,7 +488,7 @@ pub struct GetFileUploadURLRequest {
     pub question_identifier: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFileUploadURLResponse {
     #[doc="<p> A temporary URL for the file that the Worker uploaded for the answer. </p>"]
     #[serde(rename="FileUploadURL")]
@@ -496,14 +496,14 @@ pub struct GetFileUploadURLResponse {
     pub file_upload_url: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetHITRequest {
     #[doc="<p>The ID of the HIT to be retrieved.</p>"]
     #[serde(rename="HITId")]
     pub hit_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetHITResponse {
     #[doc="<p> Contains the requested HIT data.</p>"]
     #[serde(rename="HIT")]
@@ -511,7 +511,7 @@ pub struct GetHITResponse {
     pub hit: Option<HIT>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQualificationScoreRequest {
     #[doc="<p>The ID of the QualificationType.</p>"]
     #[serde(rename="QualificationTypeId")]
@@ -521,7 +521,7 @@ pub struct GetQualificationScoreRequest {
     pub worker_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQualificationScoreResponse {
     #[doc="<p> The Qualification data structure of the Qualification assigned to a user, including the Qualification type and the value (score). </p>"]
     #[serde(rename="Qualification")]
@@ -529,14 +529,14 @@ pub struct GetQualificationScoreResponse {
     pub qualification: Option<Qualification>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQualificationTypeRequest {
     #[doc="<p>The ID of the QualificationType.</p>"]
     #[serde(rename="QualificationTypeId")]
     pub qualification_type_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQualificationTypeResponse {
     #[doc="<p> The returned Qualification Type</p>"]
     #[serde(rename="QualificationType")]
@@ -545,7 +545,7 @@ pub struct GetQualificationTypeResponse {
 }
 
 #[doc="<p> The HIT data structure represents a single HIT, including all the information necessary for a Worker to accept and complete the HIT.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HIT {
     #[doc="<p> The length of time, in seconds, that a Worker has to complete the HIT after accepting it.</p>"]
     #[serde(rename="AssignmentDurationInSeconds")]
@@ -633,7 +633,7 @@ pub struct HIT {
 }
 
 #[doc="<p> The HITLayoutParameter data structure defines parameter values used with a HITLayout. A HITLayout is a reusable Amazon Mechanical Turk project template used to provide Human Intelligence Task (HIT) question data for CreateHIT. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HITLayoutParameter {
     #[doc="<p> The name of the parameter in the HITLayout. </p>"]
     #[serde(rename="Name")]
@@ -645,7 +645,7 @@ pub struct HITLayoutParameter {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssignmentsForHITRequest {
     #[doc="<p>The status of the assignments to return: Submitted | Approved | Rejected</p>"]
     #[serde(rename="AssignmentStatuses")]
@@ -663,7 +663,7 @@ pub struct ListAssignmentsForHITRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssignmentsForHITResponse {
     #[doc="<p> The collection of Assignment data structures returned by this call.</p>"]
     #[serde(rename="Assignments")]
@@ -678,7 +678,7 @@ pub struct ListAssignmentsForHITResponse {
     pub num_results: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBonusPaymentsRequest {
     #[doc="<p>The ID of the assignment associated with the bonus payments to retrieve. If specified, only bonus payments for the given assignment are returned. Either the HITId parameter or the AssignmentId parameter must be specified</p>"]
     #[serde(rename="AssignmentId")]
@@ -697,7 +697,7 @@ pub struct ListBonusPaymentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListBonusPaymentsResponse {
     #[doc="<p>A successful request to the ListBonusPayments operation returns a list of BonusPayment objects. </p>"]
     #[serde(rename="BonusPayments")]
@@ -712,7 +712,7 @@ pub struct ListBonusPaymentsResponse {
     pub num_results: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHITsForQualificationTypeRequest {
     #[doc="<p> Limit the number of results returned. </p>"]
     #[serde(rename="MaxResults")]
@@ -727,7 +727,7 @@ pub struct ListHITsForQualificationTypeRequest {
     pub qualification_type_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHITsForQualificationTypeResponse {
     #[doc="<p> The list of HIT elements returned by the query.</p>"]
     #[serde(rename="HITs")]
@@ -742,7 +742,7 @@ pub struct ListHITsForQualificationTypeResponse {
     pub num_results: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHITsRequest {
     #[serde(rename="MaxResults")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -753,7 +753,7 @@ pub struct ListHITsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHITsResponse {
     #[doc="<p> The list of HIT elements returned by the query.</p>"]
     #[serde(rename="HITs")]
@@ -768,7 +768,7 @@ pub struct ListHITsResponse {
     pub num_results: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListQualificationRequestsRequest {
     #[doc="<p> The maximum number of results to return in a single call. </p>"]
     #[serde(rename="MaxResults")]
@@ -783,7 +783,7 @@ pub struct ListQualificationRequestsRequest {
     pub qualification_type_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListQualificationRequestsResponse {
     #[serde(rename="NextToken")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -798,7 +798,7 @@ pub struct ListQualificationRequestsResponse {
     pub qualification_requests: Option<Vec<QualificationRequest>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListQualificationTypesRequest {
     #[doc="<p> The maximum number of results to return in a single call. </p>"]
     #[serde(rename="MaxResults")]
@@ -820,7 +820,7 @@ pub struct ListQualificationTypesRequest {
     pub query: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListQualificationTypesResponse {
     #[serde(rename="NextToken")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -835,7 +835,7 @@ pub struct ListQualificationTypesResponse {
     pub qualification_types: Option<Vec<QualificationType>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListReviewPolicyResultsForHITRequest {
     #[doc="<p>The unique identifier of the HIT to retrieve review results for.</p>"]
     #[serde(rename="HITId")]
@@ -862,7 +862,7 @@ pub struct ListReviewPolicyResultsForHITRequest {
     pub retrieve_results: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListReviewPolicyResultsForHITResponse {
     #[doc="<p> The name of the Assignment-level Review Policy. This contains only the PolicyName element. </p>"]
     #[serde(rename="AssignmentReviewPolicy")]
@@ -889,7 +889,7 @@ pub struct ListReviewPolicyResultsForHITResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListReviewableHITsRequest {
     #[doc="<p> The ID of the HIT type of the HITs to consider for the query. If not specified, all HITs for the Reviewer are considered </p>"]
     #[serde(rename="HITTypeId")]
@@ -909,7 +909,7 @@ pub struct ListReviewableHITsRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListReviewableHITsResponse {
     #[doc="<p> The list of HIT elements returned by the query.</p>"]
     #[serde(rename="HITs")]
@@ -924,7 +924,7 @@ pub struct ListReviewableHITsResponse {
     pub num_results: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListWorkerBlocksRequest {
     #[serde(rename="MaxResults")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -935,7 +935,7 @@ pub struct ListWorkerBlocksRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListWorkerBlocksResponse {
     #[serde(rename="NextToken")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -950,7 +950,7 @@ pub struct ListWorkerBlocksResponse {
     pub worker_blocks: Option<Vec<WorkerBlock>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListWorkersWithQualificationTypeRequest {
     #[doc="<p> Limit the number of results returned. </p>"]
     #[serde(rename="MaxResults")]
@@ -969,7 +969,7 @@ pub struct ListWorkersWithQualificationTypeRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListWorkersWithQualificationTypeResponse {
     #[serde(rename="NextToken")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -997,7 +997,7 @@ pub struct Locale {
 }
 
 #[doc="<p>The NotificationSpecification data structure describes a HIT event notification for a HIT type.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotificationSpecification {
     #[doc="<p> The destination for notification messages. or email notifications (if Transport is Email), this is an email address. For Amazon Simple Queue Service (Amazon SQS) notifications (if Transport is SQS), this is the URL for your Amazon SQS queue. </p>"]
     #[serde(rename="Destination")]
@@ -1016,7 +1016,7 @@ pub struct NotificationSpecification {
 }
 
 #[doc="<p> When MTurk encounters an issue with notifying the Workers you specified, it returns back this object with failure details. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotifyWorkersFailureStatus {
     #[doc="<p> Encoded value for the failure type. </p>"]
     #[serde(rename="NotifyWorkersFailureCode")]
@@ -1032,7 +1032,7 @@ pub struct NotifyWorkersFailureStatus {
     pub worker_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotifyWorkersRequest {
     #[doc="<p>The text of the email message to send. Can include up to 4,096 characters</p>"]
     #[serde(rename="MessageText")]
@@ -1045,7 +1045,7 @@ pub struct NotifyWorkersRequest {
     pub worker_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NotifyWorkersResponse {
     #[doc="<p> When MTurk sends notifications to the list of Workers, it returns back any failures it encounters in this list of NotifyWorkersFailureStatus objects. </p>"]
     #[serde(rename="NotifyWorkersFailureStatuses")]
@@ -1084,7 +1084,7 @@ pub struct PolicyParameter {
 }
 
 #[doc="<p>The Qualification data structure represents a Qualification assigned to a user, including the Qualification type and the value (score).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Qualification {
     #[doc="<p> The date and time the Qualification was granted to the Worker. If the Worker's Qualification was revoked, and then re-granted based on a new Qualification request, GrantTime is the date and time of the last call to the AcceptQualificationRequest operation.</p>"]
     #[serde(rename="GrantTime")]
@@ -1112,7 +1112,7 @@ pub struct Qualification {
 }
 
 #[doc="<p> The QualificationRequest data structure represents a request a Worker has made for a Qualification. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct QualificationRequest {
     #[doc="<p> The Worker's answers for the Qualification type's test contained in a QuestionFormAnswers document, if the type has a test and the Worker has submitted answers. If the Worker does not provide any answers, Answer may be empty. </p>"]
     #[serde(rename="Answer")]
@@ -1164,7 +1164,7 @@ pub struct QualificationRequirement {
 }
 
 #[doc="<p> The QualificationType data structure represents a Qualification type, a description of a property of a Worker that must match the requirements of a HIT for the Worker to be able to accept the HIT. The type also describes how a Worker can obtain a Qualification of that type, such as through a Qualification test. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct QualificationType {
     #[doc="<p>The answers to the Qualification test specified in the Test parameter.</p>"]
     #[serde(rename="AnswerKey")]
@@ -1220,7 +1220,7 @@ pub struct QualificationType {
     pub test_duration_in_seconds: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RejectAssignmentRequest {
     #[doc="<p> The ID of the assignment. The assignment must correspond to a HIT created by the Requester. </p>"]
     #[serde(rename="AssignmentId")]
@@ -1231,10 +1231,10 @@ pub struct RejectAssignmentRequest {
     pub requester_feedback: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RejectAssignmentResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RejectQualificationRequestRequest {
     #[doc="<p> The ID of the Qualification request, as returned by the <code>ListQualificationRequests</code> operation. </p>"]
     #[serde(rename="QualificationRequestId")]
@@ -1245,11 +1245,11 @@ pub struct RejectQualificationRequestRequest {
     pub reason: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RejectQualificationRequestResponse;
 
 #[doc="<p> Both the AssignmentReviewReport and the HITReviewReport elements contains the ReviewActionDetail data structure. This structure is returned multiple times for each action specified in the Review Policy. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReviewActionDetail {
     #[doc="<p>The unique identifier for the action.</p>"]
     #[serde(rename="ActionId")]
@@ -1299,7 +1299,7 @@ pub struct ReviewPolicy {
 }
 
 #[doc="<p> Contains both ReviewResult and ReviewAction elements for a particular HIT. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReviewReport {
     #[doc="<p> A list of ReviewAction objects for each action specified in the Review Policy. </p>"]
     #[serde(rename="ReviewActions")]
@@ -1312,7 +1312,7 @@ pub struct ReviewReport {
 }
 
 #[doc="<p> This data structure is returned multiple times for each result specified in the Review Policy. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReviewResultDetail {
     #[doc="<p> A unique identifier of the Review action result. </p>"]
     #[serde(rename="ActionId")]
@@ -1340,7 +1340,7 @@ pub struct ReviewResultDetail {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendBonusRequest {
     #[doc="<p>The ID of the assignment for which this bonus is paid.</p>"]
     #[serde(rename="AssignmentId")]
@@ -1361,10 +1361,10 @@ pub struct SendBonusRequest {
     pub worker_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendBonusResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendTestEventNotificationRequest {
     #[doc="<p> The notification specification to test. This value is identical to the value you would provide to the UpdateNotificationSettings operation when you establish the notification specification for a HIT type. </p>"]
     #[serde(rename="Notification")]
@@ -1374,10 +1374,10 @@ pub struct SendTestEventNotificationRequest {
     pub test_event_type: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendTestEventNotificationResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateExpirationForHITRequest {
     #[doc="<p> The date and time at which you want the HIT to expire </p>"]
     #[serde(rename="ExpireAt")]
@@ -1388,10 +1388,10 @@ pub struct UpdateExpirationForHITRequest {
     pub hit_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateExpirationForHITResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateHITReviewStatusRequest {
     #[doc="<p> The ID of the HIT to update. </p>"]
     #[serde(rename="HITId")]
@@ -1402,10 +1402,10 @@ pub struct UpdateHITReviewStatusRequest {
     pub revert: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateHITReviewStatusResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateHITTypeOfHITRequest {
     #[doc="<p>The HIT to update.</p>"]
     #[serde(rename="HITId")]
@@ -1415,10 +1415,10 @@ pub struct UpdateHITTypeOfHITRequest {
     pub hit_type_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateHITTypeOfHITResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateNotificationSettingsRequest {
     #[doc="<p> Specifies whether notifications are sent for HITs of this HIT type, according to the notification specification. You must specify either the Notification parameter or the Active parameter for the call to UpdateNotificationSettings to succeed. </p>"]
     #[serde(rename="Active")]
@@ -1433,10 +1433,10 @@ pub struct UpdateNotificationSettingsRequest {
     pub notification: Option<NotificationSpecification>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateNotificationSettingsResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateQualificationTypeRequest {
     #[doc="<p>The answers to the Qualification test specified in the Test parameter, in the form of an AnswerKey data structure.</p>"]
     #[serde(rename="AnswerKey")]
@@ -1475,7 +1475,7 @@ pub struct UpdateQualificationTypeRequest {
     pub test_duration_in_seconds: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateQualificationTypeResponse {
     #[doc="<p> Contains a QualificationType data structure.</p>"]
     #[serde(rename="QualificationType")]
@@ -1484,7 +1484,7 @@ pub struct UpdateQualificationTypeResponse {
 }
 
 #[doc="<p> The WorkerBlock data structure represents a Worker who has been blocked. It has two elements: the WorkerId and the Reason for the block. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkerBlock {
     #[doc="<p> A message explaining the reason the Worker was blocked. </p>"]
     #[serde(rename="Reason")]

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Describes an agent version.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AgentVersion {
     #[doc="<p>The configuration manager.</p>"]
     #[serde(rename="ConfigurationManager")]
@@ -42,7 +42,7 @@ pub struct AgentVersion {
 }
 
 #[doc="<p>A description of the app.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct App {
     #[doc="<p>The app ID.</p>"]
     #[serde(rename="AppId")]
@@ -102,7 +102,7 @@ pub struct App {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssignInstanceRequest {
     #[doc="<p>The instance ID.</p>"]
     #[serde(rename="InstanceId")]
@@ -112,7 +112,7 @@ pub struct AssignInstanceRequest {
     pub layer_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssignVolumeRequest {
     #[doc="<p>The instance ID.</p>"]
     #[serde(rename="InstanceId")]
@@ -123,7 +123,7 @@ pub struct AssignVolumeRequest {
     pub volume_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateElasticIpRequest {
     #[doc="<p>The Elastic IP address.</p>"]
     #[serde(rename="ElasticIp")]
@@ -134,7 +134,7 @@ pub struct AssociateElasticIpRequest {
     pub instance_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachElasticLoadBalancerRequest {
     #[doc="<p>The Elastic Load Balancing instance's name.</p>"]
     #[serde(rename="ElasticLoadBalancerName")]
@@ -211,7 +211,7 @@ pub struct ChefConfiguration {
     pub manage_berkshelf: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloneStackRequest {
     #[doc="<p>The default AWS OpsWorks Stacks agent version. You have the following options:</p> <ul> <li> <p>Auto-update - Set this parameter to <code>LATEST</code>. AWS OpsWorks Stacks automatically installs new agent versions on the stack's instances as soon as they are available.</p> </li> <li> <p>Fixed version - Set this parameter to your preferred agent version. To update the agent version, you must edit the stack configuration and specify a new version. AWS OpsWorks Stacks then automatically installs that version on the stack's instances.</p> </li> </ul> <p>The default setting is <code>LATEST</code>. To specify an agent version, you must use the complete version number, not the abbreviated number shown on the console. For a list of available agent version numbers, call <a>DescribeAgentVersions</a>. AgentVersion cannot be set to Chef 12.2.</p> <note> <p>You can also specify an agent version when you create or update an instance, which overrides the stack's default setting.</p> </note>"]
     #[serde(rename="AgentVersion")]
@@ -301,7 +301,7 @@ pub struct CloneStackRequest {
 }
 
 #[doc="<p>Contains the response to a <code>CloneStack</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloneStackResult {
     #[doc="<p>The cloned stack ID.</p>"]
     #[serde(rename="StackId")]
@@ -372,7 +372,7 @@ pub struct CloudWatchLogsLogStream {
 }
 
 #[doc="<p>Describes a command.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Command {
     #[doc="<p>Date and time when the command was acknowledged.</p>"]
     #[serde(rename="AcknowledgedAt")]
@@ -416,7 +416,7 @@ pub struct Command {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAppRequest {
     #[doc="<p>A <code>Source</code> object that specifies the app repository.</p>"]
     #[serde(rename="AppSource")]
@@ -466,7 +466,7 @@ pub struct CreateAppRequest {
 }
 
 #[doc="<p>Contains the response to a <code>CreateApp</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAppResult {
     #[doc="<p>The app ID.</p>"]
     #[serde(rename="AppId")]
@@ -474,7 +474,7 @@ pub struct CreateAppResult {
     pub app_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeploymentRequest {
     #[doc="<p>The app ID. This parameter is required for app deployments, but not for other deployment commands.</p>"]
     #[serde(rename="AppId")]
@@ -505,7 +505,7 @@ pub struct CreateDeploymentRequest {
 }
 
 #[doc="<p>Contains the response to a <code>CreateDeployment</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDeploymentResult {
     #[doc="<p>The deployment ID, which can be used with other requests to identify the deployment.</p>"]
     #[serde(rename="DeploymentId")]
@@ -513,7 +513,7 @@ pub struct CreateDeploymentResult {
     pub deployment_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstanceRequest {
     #[doc="<p>The default AWS OpsWorks Stacks agent version. You have the following options:</p> <ul> <li> <p> <code>INHERIT</code> - Use the stack's default agent version setting.</p> </li> <li> <p> <i>version_number</i> - Use the specified agent version. This value overrides the stack's default setting. To update the agent version, edit the instance configuration and specify a new version. AWS OpsWorks Stacks then automatically installs that version on the instance.</p> </li> </ul> <p>The default setting is <code>INHERIT</code>. To specify an agent version, you must use the complete version number, not the abbreviated number shown on the console. For a list of available agent version numbers, call <a>DescribeAgentVersions</a>. AgentVersion cannot be set to Chef 12.2.</p>"]
     #[serde(rename="AgentVersion")]
@@ -587,7 +587,7 @@ pub struct CreateInstanceRequest {
 }
 
 #[doc="<p>Contains the response to a <code>CreateInstance</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateInstanceResult {
     #[doc="<p>The instance ID.</p>"]
     #[serde(rename="InstanceId")]
@@ -595,7 +595,7 @@ pub struct CreateInstanceResult {
     pub instance_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLayerRequest {
     #[doc="<p>One or more user-defined key-value pairs to be added to the stack attributes.</p> <p>To create a cluster layer, set the <code>EcsClusterArn</code> attribute to the cluster's ARN.</p>"]
     #[serde(rename="Attributes")]
@@ -668,7 +668,7 @@ pub struct CreateLayerRequest {
 }
 
 #[doc="<p>Contains the response to a <code>CreateLayer</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLayerResult {
     #[doc="<p>The layer ID.</p>"]
     #[serde(rename="LayerId")]
@@ -676,7 +676,7 @@ pub struct CreateLayerResult {
     pub layer_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStackRequest {
     #[doc="<p>The default AWS OpsWorks Stacks agent version. You have the following options:</p> <ul> <li> <p>Auto-update - Set this parameter to <code>LATEST</code>. AWS OpsWorks Stacks automatically installs new agent versions on the stack's instances as soon as they are available.</p> </li> <li> <p>Fixed version - Set this parameter to your preferred agent version. To update the agent version, you must edit the stack configuration and specify a new version. AWS OpsWorks Stacks then automatically installs that version on the stack's instances.</p> </li> </ul> <p>The default setting is the most recent release of the agent. To specify an agent version, you must use the complete version number, not the abbreviated number shown on the console. For a list of available agent version numbers, call <a>DescribeAgentVersions</a>. AgentVersion cannot be set to Chef 12.2.</p> <note> <p>You can also specify an agent version when you create or update an instance, which overrides the stack's default setting.</p> </note>"]
     #[serde(rename="AgentVersion")]
@@ -752,7 +752,7 @@ pub struct CreateStackRequest {
 }
 
 #[doc="<p>Contains the response to a <code>CreateStack</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStackResult {
     #[doc="<p>The stack ID, which is an opaque string that you use to identify the stack when performing actions such as <code>DescribeStacks</code>.</p>"]
     #[serde(rename="StackId")]
@@ -760,7 +760,7 @@ pub struct CreateStackResult {
     pub stack_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserProfileRequest {
     #[doc="<p>Whether users can specify their own SSH public key through the My Settings page. For more information, see <a href=\"http://docs.aws.amazon.com/opsworks/latest/userguide/security-settingsshkey.html\">Setting an IAM User's Public SSH Key</a>.</p>"]
     #[serde(rename="AllowSelfManagement")]
@@ -780,7 +780,7 @@ pub struct CreateUserProfileRequest {
 }
 
 #[doc="<p>Contains the response to a <code>CreateUserProfile</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserProfileResult {
     #[doc="<p>The user's IAM ARN.</p>"]
     #[serde(rename="IamUserArn")]
@@ -805,14 +805,14 @@ pub struct DataSource {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAppRequest {
     #[doc="<p>The app ID.</p>"]
     #[serde(rename="AppId")]
     pub app_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteInstanceRequest {
     #[doc="<p>Whether to delete the instance Elastic IP address.</p>"]
     #[serde(rename="DeleteElasticIp")]
@@ -827,21 +827,21 @@ pub struct DeleteInstanceRequest {
     pub instance_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLayerRequest {
     #[doc="<p>The layer ID.</p>"]
     #[serde(rename="LayerId")]
     pub layer_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStackRequest {
     #[doc="<p>The stack ID.</p>"]
     #[serde(rename="StackId")]
     pub stack_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserProfileRequest {
     #[doc="<p>The user's IAM ARN. This can also be a federated user's ARN.</p>"]
     #[serde(rename="IamUserArn")]
@@ -849,7 +849,7 @@ pub struct DeleteUserProfileRequest {
 }
 
 #[doc="<p>Describes a deployment of a stack or app.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Deployment {
     #[doc="<p>The app ID.</p>"]
     #[serde(rename="AppId")]
@@ -912,42 +912,42 @@ pub struct DeploymentCommand {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterEcsClusterRequest {
     #[doc="<p>The cluster's ARN.</p>"]
     #[serde(rename="EcsClusterArn")]
     pub ecs_cluster_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterElasticIpRequest {
     #[doc="<p>The Elastic IP address.</p>"]
     #[serde(rename="ElasticIp")]
     pub elastic_ip: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterInstanceRequest {
     #[doc="<p>The instance ID.</p>"]
     #[serde(rename="InstanceId")]
     pub instance_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterRdsDbInstanceRequest {
     #[doc="<p>The Amazon RDS instance's ARN.</p>"]
     #[serde(rename="RdsDbInstanceArn")]
     pub rds_db_instance_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterVolumeRequest {
     #[doc="<p>The AWS OpsWorks Stacks volume ID, which is the GUID that AWS OpsWorks Stacks assigned to the instance when you registered the volume with the stack, not the Amazon EC2 volume ID.</p>"]
     #[serde(rename="VolumeId")]
     pub volume_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAgentVersionsRequest {
     #[doc="<p>The configuration manager.</p>"]
     #[serde(rename="ConfigurationManager")]
@@ -960,7 +960,7 @@ pub struct DescribeAgentVersionsRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeAgentVersions</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAgentVersionsResult {
     #[doc="<p>The agent versions for the specified stack or configuration manager. Note that this value is the complete version number, not the abbreviated number used by the console.</p>"]
     #[serde(rename="AgentVersions")]
@@ -968,7 +968,7 @@ pub struct DescribeAgentVersionsResult {
     pub agent_versions: Option<Vec<AgentVersion>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAppsRequest {
     #[doc="<p>An array of app IDs for the apps to be described. If you use this parameter, <code>DescribeApps</code> returns a description of the specified apps. Otherwise, it returns a description of every app.</p>"]
     #[serde(rename="AppIds")]
@@ -981,7 +981,7 @@ pub struct DescribeAppsRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeApps</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAppsResult {
     #[doc="<p>An array of <code>App</code> objects that describe the specified apps. </p>"]
     #[serde(rename="Apps")]
@@ -989,7 +989,7 @@ pub struct DescribeAppsResult {
     pub apps: Option<Vec<App>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCommandsRequest {
     #[doc="<p>An array of command IDs. If you include this parameter, <code>DescribeCommands</code> returns a description of the specified commands. Otherwise, it returns a description of every command.</p>"]
     #[serde(rename="CommandIds")]
@@ -1006,7 +1006,7 @@ pub struct DescribeCommandsRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeCommands</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCommandsResult {
     #[doc="<p>An array of <code>Command</code> objects that describe each of the specified commands.</p>"]
     #[serde(rename="Commands")]
@@ -1014,7 +1014,7 @@ pub struct DescribeCommandsResult {
     pub commands: Option<Vec<Command>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDeploymentsRequest {
     #[doc="<p>The app ID. If you include this parameter, <code>DescribeDeployments</code> returns a description of the commands associated with the specified app.</p>"]
     #[serde(rename="AppId")]
@@ -1031,7 +1031,7 @@ pub struct DescribeDeploymentsRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeDeployments</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDeploymentsResult {
     #[doc="<p>An array of <code>Deployment</code> objects that describe the deployments.</p>"]
     #[serde(rename="Deployments")]
@@ -1039,7 +1039,7 @@ pub struct DescribeDeploymentsResult {
     pub deployments: Option<Vec<Deployment>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEcsClustersRequest {
     #[doc="<p>A list of ARNs, one for each cluster to be described.</p>"]
     #[serde(rename="EcsClusterArns")]
@@ -1060,7 +1060,7 @@ pub struct DescribeEcsClustersRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeEcsClusters</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEcsClustersResult {
     #[doc="<p>A list of <code>EcsCluster</code> objects containing the cluster descriptions.</p>"]
     #[serde(rename="EcsClusters")]
@@ -1072,7 +1072,7 @@ pub struct DescribeEcsClustersResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeElasticIpsRequest {
     #[doc="<p>The instance ID. If you include this parameter, <code>DescribeElasticIps</code> returns a description of the Elastic IP addresses associated with the specified instance.</p>"]
     #[serde(rename="InstanceId")]
@@ -1089,7 +1089,7 @@ pub struct DescribeElasticIpsRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeElasticIps</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeElasticIpsResult {
     #[doc="<p>An <code>ElasticIps</code> object that describes the specified Elastic IP addresses.</p>"]
     #[serde(rename="ElasticIps")]
@@ -1097,7 +1097,7 @@ pub struct DescribeElasticIpsResult {
     pub elastic_ips: Option<Vec<ElasticIp>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeElasticLoadBalancersRequest {
     #[doc="<p>A list of layer IDs. The action describes the Elastic Load Balancing instances for the specified layers.</p>"]
     #[serde(rename="LayerIds")]
@@ -1110,7 +1110,7 @@ pub struct DescribeElasticLoadBalancersRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeElasticLoadBalancers</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeElasticLoadBalancersResult {
     #[doc="<p>A list of <code>ElasticLoadBalancer</code> objects that describe the specified Elastic Load Balancing instances.</p>"]
     #[serde(rename="ElasticLoadBalancers")]
@@ -1118,7 +1118,7 @@ pub struct DescribeElasticLoadBalancersResult {
     pub elastic_load_balancers: Option<Vec<ElasticLoadBalancer>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancesRequest {
     #[doc="<p>An array of instance IDs to be described. If you use this parameter, <code>DescribeInstances</code> returns a description of the specified instances. Otherwise, it returns a description of every instance.</p>"]
     #[serde(rename="InstanceIds")]
@@ -1135,7 +1135,7 @@ pub struct DescribeInstancesRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeInstances</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancesResult {
     #[doc="<p>An array of <code>Instance</code> objects that describe the instances.</p>"]
     #[serde(rename="Instances")]
@@ -1143,7 +1143,7 @@ pub struct DescribeInstancesResult {
     pub instances: Option<Vec<Instance>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLayersRequest {
     #[doc="<p>An array of layer IDs that specify the layers to be described. If you omit this parameter, <code>DescribeLayers</code> returns a description of every layer in the specified stack.</p>"]
     #[serde(rename="LayerIds")]
@@ -1156,7 +1156,7 @@ pub struct DescribeLayersRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeLayers</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLayersResult {
     #[doc="<p>An array of <code>Layer</code> objects that describe the layers.</p>"]
     #[serde(rename="Layers")]
@@ -1164,7 +1164,7 @@ pub struct DescribeLayersResult {
     pub layers: Option<Vec<Layer>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBasedAutoScalingRequest {
     #[doc="<p>An array of layer IDs.</p>"]
     #[serde(rename="LayerIds")]
@@ -1172,7 +1172,7 @@ pub struct DescribeLoadBasedAutoScalingRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeLoadBasedAutoScaling</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoadBasedAutoScalingResult {
     #[doc="<p>An array of <code>LoadBasedAutoScalingConfiguration</code> objects that describe each layer's configuration.</p>"]
     #[serde(rename="LoadBasedAutoScalingConfigurations")]
@@ -1181,7 +1181,7 @@ pub struct DescribeLoadBasedAutoScalingResult {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeMyUserProfile</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMyUserProfileResult {
     #[doc="<p>A <code>UserProfile</code> object that describes the user's SSH information.</p>"]
     #[serde(rename="UserProfile")]
@@ -1189,7 +1189,7 @@ pub struct DescribeMyUserProfileResult {
     pub user_profile: Option<SelfUserProfile>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePermissionsRequest {
     #[doc="<p>The user's IAM ARN. This can also be a federated user's ARN. For more information about IAM ARNs, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">Using Identifiers</a>.</p>"]
     #[serde(rename="IamUserArn")]
@@ -1202,7 +1202,7 @@ pub struct DescribePermissionsRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribePermissions</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePermissionsResult {
     #[doc="<p>An array of <code>Permission</code> objects that describe the stack permissions.</p> <ul> <li> <p>If the request object contains only a stack ID, the array contains a <code>Permission</code> object with permissions for each of the stack IAM ARNs.</p> </li> <li> <p>If the request object contains only an IAM ARN, the array contains a <code>Permission</code> object with permissions for each of the user's stack IDs.</p> </li> <li> <p>If the request contains a stack ID and an IAM ARN, the array contains a single <code>Permission</code> object with permissions for the specified stack and IAM ARN.</p> </li> </ul>"]
     #[serde(rename="Permissions")]
@@ -1210,7 +1210,7 @@ pub struct DescribePermissionsResult {
     pub permissions: Option<Vec<Permission>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRaidArraysRequest {
     #[doc="<p>The instance ID. If you use this parameter, <code>DescribeRaidArrays</code> returns descriptions of the RAID arrays associated with the specified instance. </p>"]
     #[serde(rename="InstanceId")]
@@ -1227,7 +1227,7 @@ pub struct DescribeRaidArraysRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeRaidArrays</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRaidArraysResult {
     #[doc="<p>A <code>RaidArrays</code> object that describes the specified RAID arrays.</p>"]
     #[serde(rename="RaidArrays")]
@@ -1235,7 +1235,7 @@ pub struct DescribeRaidArraysResult {
     pub raid_arrays: Option<Vec<RaidArray>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRdsDbInstancesRequest {
     #[doc="<p>An array containing the ARNs of the instances to be described.</p>"]
     #[serde(rename="RdsDbInstanceArns")]
@@ -1247,7 +1247,7 @@ pub struct DescribeRdsDbInstancesRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeRdsDbInstances</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRdsDbInstancesResult {
     #[doc="<p>An a array of <code>RdsDbInstance</code> objects that describe the instances.</p>"]
     #[serde(rename="RdsDbInstances")]
@@ -1255,7 +1255,7 @@ pub struct DescribeRdsDbInstancesResult {
     pub rds_db_instances: Option<Vec<RdsDbInstance>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeServiceErrorsRequest {
     #[doc="<p>The instance ID. If you use this parameter, <code>DescribeServiceErrors</code> returns descriptions of the errors associated with the specified instance.</p>"]
     #[serde(rename="InstanceId")]
@@ -1272,7 +1272,7 @@ pub struct DescribeServiceErrorsRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeServiceErrors</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeServiceErrorsResult {
     #[doc="<p>An array of <code>ServiceError</code> objects that describe the specified service errors.</p>"]
     #[serde(rename="ServiceErrors")]
@@ -1280,7 +1280,7 @@ pub struct DescribeServiceErrorsResult {
     pub service_errors: Option<Vec<ServiceError>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackProvisioningParametersRequest {
     #[doc="<p>The stack ID</p>"]
     #[serde(rename="StackId")]
@@ -1288,7 +1288,7 @@ pub struct DescribeStackProvisioningParametersRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeStackProvisioningParameters</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackProvisioningParametersResult {
     #[doc="<p>The AWS OpsWorks Stacks agent installer's URL.</p>"]
     #[serde(rename="AgentInstallerUrl")]
@@ -1300,7 +1300,7 @@ pub struct DescribeStackProvisioningParametersResult {
     pub parameters: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackSummaryRequest {
     #[doc="<p>The stack ID.</p>"]
     #[serde(rename="StackId")]
@@ -1308,7 +1308,7 @@ pub struct DescribeStackSummaryRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeStackSummary</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStackSummaryResult {
     #[doc="<p>A <code>StackSummary</code> object that contains the results.</p>"]
     #[serde(rename="StackSummary")]
@@ -1316,7 +1316,7 @@ pub struct DescribeStackSummaryResult {
     pub stack_summary: Option<StackSummary>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStacksRequest {
     #[doc="<p>An array of stack IDs that specify the stacks to be described. If you omit this parameter, <code>DescribeStacks</code> returns a description of every stack.</p>"]
     #[serde(rename="StackIds")]
@@ -1325,7 +1325,7 @@ pub struct DescribeStacksRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeStacks</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStacksResult {
     #[doc="<p>An array of <code>Stack</code> objects that describe the stacks.</p>"]
     #[serde(rename="Stacks")]
@@ -1333,7 +1333,7 @@ pub struct DescribeStacksResult {
     pub stacks: Option<Vec<Stack>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTimeBasedAutoScalingRequest {
     #[doc="<p>An array of instance IDs.</p>"]
     #[serde(rename="InstanceIds")]
@@ -1341,7 +1341,7 @@ pub struct DescribeTimeBasedAutoScalingRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeTimeBasedAutoScaling</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTimeBasedAutoScalingResult {
     #[doc="<p>An array of <code>TimeBasedAutoScalingConfiguration</code> objects that describe the configuration for the specified instances.</p>"]
     #[serde(rename="TimeBasedAutoScalingConfigurations")]
@@ -1349,7 +1349,7 @@ pub struct DescribeTimeBasedAutoScalingResult {
     pub time_based_auto_scaling_configurations: Option<Vec<TimeBasedAutoScalingConfiguration>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserProfilesRequest {
     #[doc="<p>An array of IAM or federated user ARNs that identify the users to be described.</p>"]
     #[serde(rename="IamUserArns")]
@@ -1358,7 +1358,7 @@ pub struct DescribeUserProfilesRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeUserProfiles</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUserProfilesResult {
     #[doc="<p>A <code>Users</code> object that describes the specified users.</p>"]
     #[serde(rename="UserProfiles")]
@@ -1366,7 +1366,7 @@ pub struct DescribeUserProfilesResult {
     pub user_profiles: Option<Vec<UserProfile>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVolumesRequest {
     #[doc="<p>The instance ID. If you use this parameter, <code>DescribeVolumes</code> returns descriptions of the volumes associated with the specified instance.</p>"]
     #[serde(rename="InstanceId")]
@@ -1387,7 +1387,7 @@ pub struct DescribeVolumesRequest {
 }
 
 #[doc="<p>Contains the response to a <code>DescribeVolumes</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVolumesResult {
     #[doc="<p>An array of volume IDs.</p>"]
     #[serde(rename="Volumes")]
@@ -1395,7 +1395,7 @@ pub struct DescribeVolumesResult {
     pub volumes: Option<Vec<Volume>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachElasticLoadBalancerRequest {
     #[doc="<p>The Elastic Load Balancing instance's name.</p>"]
     #[serde(rename="ElasticLoadBalancerName")]
@@ -1405,7 +1405,7 @@ pub struct DetachElasticLoadBalancerRequest {
     pub layer_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateElasticIpRequest {
     #[doc="<p>The Elastic IP address.</p>"]
     #[serde(rename="ElasticIp")]
@@ -1438,7 +1438,7 @@ pub struct EbsBlockDevice {
 }
 
 #[doc="<p>Describes a registered Amazon ECS cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EcsCluster {
     #[doc="<p>The cluster's ARN.</p>"]
     #[serde(rename="EcsClusterArn")]
@@ -1459,7 +1459,7 @@ pub struct EcsCluster {
 }
 
 #[doc="<p>Describes an Elastic IP address.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticIp {
     #[doc="<p>The domain.</p>"]
     #[serde(rename="Domain")]
@@ -1484,7 +1484,7 @@ pub struct ElasticIp {
 }
 
 #[doc="<p>Describes an Elastic Load Balancing instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticLoadBalancer {
     #[doc="<p>A list of Availability Zones.</p>"]
     #[serde(rename="AvailabilityZones")]
@@ -1539,7 +1539,7 @@ pub struct EnvironmentVariable {
     pub value: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetHostnameSuggestionRequest {
     #[doc="<p>The layer ID.</p>"]
     #[serde(rename="LayerId")]
@@ -1547,7 +1547,7 @@ pub struct GetHostnameSuggestionRequest {
 }
 
 #[doc="<p>Contains the response to a <code>GetHostnameSuggestion</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetHostnameSuggestionResult {
     #[doc="<p>The generated host name.</p>"]
     #[serde(rename="Hostname")]
@@ -1559,7 +1559,7 @@ pub struct GetHostnameSuggestionResult {
     pub layer_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GrantAccessRequest {
     #[doc="<p>The instance's AWS OpsWorks Stacks ID.</p>"]
     #[serde(rename="InstanceId")]
@@ -1571,7 +1571,7 @@ pub struct GrantAccessRequest {
 }
 
 #[doc="<p>Contains the response to a <code>GrantAccess</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GrantAccessResult {
     #[doc="<p>A <code>TemporaryCredential</code> object that contains the data needed to log in to the instance by RDP clients, such as the Microsoft Remote Desktop Connection.</p>"]
     #[serde(rename="TemporaryCredential")]
@@ -1580,7 +1580,7 @@ pub struct GrantAccessResult {
 }
 
 #[doc="<p>Describes an instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Instance {
     #[doc="<p>The agent version. This parameter is set to <code>INHERIT</code> if the instance inherits the default stack setting or to a a version number for a fixed agent version.</p>"]
     #[serde(rename="AgentVersion")]
@@ -1748,7 +1748,7 @@ pub struct Instance {
 }
 
 #[doc="<p>Contains a description of an Amazon EC2 instance from the Amazon EC2 metadata service. For more information, see <a href=\"http://docs.aws.amazon.com/sdkfornet/latest/apidocs/Index.html\">Instance Metadata and User Data</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceIdentity {
     #[doc="<p>A JSON document that contains the metadata.</p>"]
     #[serde(rename="Document")]
@@ -1761,7 +1761,7 @@ pub struct InstanceIdentity {
 }
 
 #[doc="<p>Describes how many instances a stack has for each status.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstancesCount {
     #[doc="<p>The number of instances in the Assigning state.</p>"]
     #[serde(rename="Assigning")]
@@ -1842,7 +1842,7 @@ pub struct InstancesCount {
 }
 
 #[doc="<p>Describes a layer.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Layer {
     #[serde(rename="Arn")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1945,7 +1945,7 @@ pub struct LifecycleEventConfiguration {
     pub shutdown: Option<ShutdownEventConfiguration>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsRequest {
     #[doc="<p>Do not use. A validation exception occurs if you add a <code>MaxResults</code> parameter to a <code>ListTagsRequest</code> call. </p>"]
     #[serde(rename="MaxResults")]
@@ -1961,7 +1961,7 @@ pub struct ListTagsRequest {
 }
 
 #[doc="<p>Contains the response to a <code>ListTags</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsResult {
     #[doc="<p>If a paginated request does not return all of the remaining results, this parameter is set to a token that you can assign to the request object's <code>NextToken</code> parameter to get the next set of results. If the previous paginated request returned all of the remaining results, this parameter is set to <code>null</code>. </p>"]
     #[serde(rename="NextToken")]
@@ -1974,7 +1974,7 @@ pub struct ListTagsResult {
 }
 
 #[doc="<p>Describes a layer's load-based auto scaling configuration.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoadBasedAutoScalingConfiguration {
     #[doc="<p>An <code>AutoScalingThresholds</code> object that describes the downscaling configuration, which defines how and when AWS OpsWorks Stacks reduces the number of instances.</p>"]
     #[serde(rename="DownScaling")]
@@ -1995,7 +1995,7 @@ pub struct LoadBasedAutoScalingConfiguration {
 }
 
 #[doc="<p>Describes stack or user permissions.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Permission {
     #[doc="<p>Whether the user can use SSH.</p>"]
     #[serde(rename="AllowSsh")]
@@ -2020,7 +2020,7 @@ pub struct Permission {
 }
 
 #[doc="<p>Describes an instance's RAID array.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RaidArray {
     #[doc="<p>The array's Availability Zone. For more information, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html\">Regions and Endpoints</a>.</p>"]
     #[serde(rename="AvailabilityZone")]
@@ -2077,7 +2077,7 @@ pub struct RaidArray {
 }
 
 #[doc="<p>Describes an Amazon RDS instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RdsDbInstance {
     #[doc="<p>The instance's address.</p>"]
     #[serde(rename="Address")]
@@ -2117,7 +2117,7 @@ pub struct RdsDbInstance {
     pub stack_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootInstanceRequest {
     #[doc="<p>The instance ID.</p>"]
     #[serde(rename="InstanceId")]
@@ -2149,7 +2149,7 @@ pub struct Recipes {
     pub undeploy: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterEcsClusterRequest {
     #[doc="<p>The cluster's ARN.</p>"]
     #[serde(rename="EcsClusterArn")]
@@ -2160,7 +2160,7 @@ pub struct RegisterEcsClusterRequest {
 }
 
 #[doc="<p>Contains the response to a <code>RegisterEcsCluster</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterEcsClusterResult {
     #[doc="<p>The cluster's ARN.</p>"]
     #[serde(rename="EcsClusterArn")]
@@ -2168,7 +2168,7 @@ pub struct RegisterEcsClusterResult {
     pub ecs_cluster_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterElasticIpRequest {
     #[doc="<p>The Elastic IP address.</p>"]
     #[serde(rename="ElasticIp")]
@@ -2179,7 +2179,7 @@ pub struct RegisterElasticIpRequest {
 }
 
 #[doc="<p>Contains the response to a <code>RegisterElasticIp</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterElasticIpResult {
     #[doc="<p>The Elastic IP address.</p>"]
     #[serde(rename="ElasticIp")]
@@ -2187,7 +2187,7 @@ pub struct RegisterElasticIpResult {
     pub elastic_ip: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterInstanceRequest {
     #[doc="<p>The instance's hostname.</p>"]
     #[serde(rename="Hostname")]
@@ -2219,7 +2219,7 @@ pub struct RegisterInstanceRequest {
 }
 
 #[doc="<p>Contains the response to a <code>RegisterInstanceResult</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterInstanceResult {
     #[doc="<p>The registered instance's AWS OpsWorks Stacks ID.</p>"]
     #[serde(rename="InstanceId")]
@@ -2227,7 +2227,7 @@ pub struct RegisterInstanceResult {
     pub instance_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterRdsDbInstanceRequest {
     #[doc="<p>The database password.</p>"]
     #[serde(rename="DbPassword")]
@@ -2243,7 +2243,7 @@ pub struct RegisterRdsDbInstanceRequest {
     pub stack_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterVolumeRequest {
     #[doc="<p>The Amazon EBS volume ID.</p>"]
     #[serde(rename="Ec2VolumeId")]
@@ -2255,7 +2255,7 @@ pub struct RegisterVolumeRequest {
 }
 
 #[doc="<p>Contains the response to a <code>RegisterVolume</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterVolumeResult {
     #[doc="<p>The volume ID.</p>"]
     #[serde(rename="VolumeId")]
@@ -2264,7 +2264,7 @@ pub struct RegisterVolumeResult {
 }
 
 #[doc="<p>A registered instance's reported operating system.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReportedOs {
     #[doc="<p>The operating system family.</p>"]
     #[serde(rename="Family")]
@@ -2281,7 +2281,7 @@ pub struct ReportedOs {
 }
 
 #[doc="<p>Describes a user's SSH information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SelfUserProfile {
     #[doc="<p>The user's IAM ARN.</p>"]
     #[serde(rename="IamUserArn")]
@@ -2302,7 +2302,7 @@ pub struct SelfUserProfile {
 }
 
 #[doc="<p>Describes an AWS OpsWorks Stacks service error.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ServiceError {
     #[doc="<p>When the error occurred.</p>"]
     #[serde(rename="CreatedAt")]
@@ -2330,7 +2330,7 @@ pub struct ServiceError {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetLoadBasedAutoScalingRequest {
     #[doc="<p>An <code>AutoScalingThresholds</code> object with the downscaling threshold configuration. If the load falls below these thresholds for a specified amount of time, AWS OpsWorks Stacks stops a specified number of instances.</p>"]
     #[serde(rename="DownScaling")]
@@ -2349,7 +2349,7 @@ pub struct SetLoadBasedAutoScalingRequest {
     pub up_scaling: Option<AutoScalingThresholds>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetPermissionRequest {
     #[doc="<p>The user is allowed to use SSH to communicate with the instance.</p>"]
     #[serde(rename="AllowSsh")]
@@ -2371,7 +2371,7 @@ pub struct SetPermissionRequest {
     pub stack_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetTimeBasedAutoScalingRequest {
     #[doc="<p>An <code>AutoScalingSchedule</code> with the instance schedule.</p>"]
     #[serde(rename="AutoScalingSchedule")]
@@ -2440,7 +2440,7 @@ pub struct SslConfiguration {
 }
 
 #[doc="<p>Describes a stack.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Stack {
     #[doc="<p>The agent version. This parameter is set to <code>LATEST</code> for auto-update. or a version number for a fixed agent version.</p>"]
     #[serde(rename="AgentVersion")]
@@ -2545,7 +2545,7 @@ pub struct StackConfigurationManager {
 }
 
 #[doc="<p>Summarizes the number of layers, instances, and apps in a stack.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StackSummary {
     #[doc="<p>The number of apps.</p>"]
     #[serde(rename="AppsCount")]
@@ -2573,35 +2573,35 @@ pub struct StackSummary {
     pub stack_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartInstanceRequest {
     #[doc="<p>The instance ID.</p>"]
     #[serde(rename="InstanceId")]
     pub instance_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartStackRequest {
     #[doc="<p>The stack ID.</p>"]
     #[serde(rename="StackId")]
     pub stack_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopInstanceRequest {
     #[doc="<p>The instance ID.</p>"]
     #[serde(rename="InstanceId")]
     pub instance_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopStackRequest {
     #[doc="<p>The stack ID.</p>"]
     #[serde(rename="StackId")]
     pub stack_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourceRequest {
     #[doc="<p>The stack or layer's Amazon Resource Number (ARN).</p>"]
     #[serde(rename="ResourceArn")]
@@ -2612,7 +2612,7 @@ pub struct TagResourceRequest {
 }
 
 #[doc="<p>Contains the data needed by RDP clients such as the Microsoft Remote Desktop Connection to log in to the instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TemporaryCredential {
     #[doc="<p>The instance's AWS OpsWorks Stacks ID.</p>"]
     #[serde(rename="InstanceId")]
@@ -2633,7 +2633,7 @@ pub struct TemporaryCredential {
 }
 
 #[doc="<p>Describes an instance's time-based auto scaling configuration.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TimeBasedAutoScalingConfiguration {
     #[doc="<p>A <code>WeeklyAutoScalingSchedule</code> object with the instance schedule.</p>"]
     #[serde(rename="AutoScalingSchedule")]
@@ -2645,21 +2645,21 @@ pub struct TimeBasedAutoScalingConfiguration {
     pub instance_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnassignInstanceRequest {
     #[doc="<p>The instance ID.</p>"]
     #[serde(rename="InstanceId")]
     pub instance_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnassignVolumeRequest {
     #[doc="<p>The volume ID.</p>"]
     #[serde(rename="VolumeId")]
     pub volume_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourceRequest {
     #[doc="<p>The stack or layer's Amazon Resource Number (ARN).</p>"]
     #[serde(rename="ResourceArn")]
@@ -2669,7 +2669,7 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAppRequest {
     #[doc="<p>The app ID.</p>"]
     #[serde(rename="AppId")]
@@ -2716,7 +2716,7 @@ pub struct UpdateAppRequest {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateElasticIpRequest {
     #[doc="<p>The address.</p>"]
     #[serde(rename="ElasticIp")]
@@ -2727,7 +2727,7 @@ pub struct UpdateElasticIpRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateInstanceRequest {
     #[doc="<p>The default AWS OpsWorks Stacks agent version. You have the following options:</p> <ul> <li> <p> <code>INHERIT</code> - Use the stack's default agent version setting.</p> </li> <li> <p> <i>version_number</i> - Use the specified agent version. This value overrides the stack's default setting. To update the agent version, you must edit the instance configuration and specify a new version. AWS OpsWorks Stacks then automatically installs that version on the instance.</p> </li> </ul> <p>The default setting is <code>INHERIT</code>. To specify an agent version, you must use the complete version number, not the abbreviated number shown on the console. For a list of available agent version numbers, call <a>DescribeAgentVersions</a>.</p> <p>AgentVersion cannot be set to Chef 12.2.</p>"]
     #[serde(rename="AgentVersion")]
@@ -2778,7 +2778,7 @@ pub struct UpdateInstanceRequest {
     pub ssh_key_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateLayerRequest {
     #[doc="<p>One or more user-defined key/value pairs to be added to the stack attributes.</p>"]
     #[serde(rename="Attributes")]
@@ -2849,7 +2849,7 @@ pub struct UpdateLayerRequest {
     pub volume_configurations: Option<Vec<VolumeConfiguration>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMyUserProfileRequest {
     #[doc="<p>The user's SSH public key.</p>"]
     #[serde(rename="SshPublicKey")]
@@ -2857,7 +2857,7 @@ pub struct UpdateMyUserProfileRequest {
     pub ssh_public_key: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRdsDbInstanceRequest {
     #[doc="<p>The database password.</p>"]
     #[serde(rename="DbPassword")]
@@ -2872,7 +2872,7 @@ pub struct UpdateRdsDbInstanceRequest {
     pub rds_db_instance_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateStackRequest {
     #[doc="<p>The default AWS OpsWorks Stacks agent version. You have the following options:</p> <ul> <li> <p>Auto-update - Set this parameter to <code>LATEST</code>. AWS OpsWorks Stacks automatically installs new agent versions on the stack's instances as soon as they are available.</p> </li> <li> <p>Fixed version - Set this parameter to your preferred agent version. To update the agent version, you must edit the stack configuration and specify a new version. AWS OpsWorks Stacks then automatically installs that version on the stack's instances.</p> </li> </ul> <p>The default setting is <code>LATEST</code>. To specify an agent version, you must use the complete version number, not the abbreviated number shown on the console. For a list of available agent version numbers, call <a>DescribeAgentVersions</a>. AgentVersion cannot be set to Chef 12.2.</p> <note> <p>You can also specify an agent version when you create or update an instance, which overrides the stack's default setting.</p> </note>"]
     #[serde(rename="AgentVersion")]
@@ -2946,7 +2946,7 @@ pub struct UpdateStackRequest {
     pub use_opsworks_security_groups: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserProfileRequest {
     #[doc="<p>Whether users can specify their own SSH public key through the My Settings page. For more information, see <a href=\"http://docs.aws.amazon.com/opsworks/latest/userguide/security-settingsshkey.html\">Managing User Permissions</a>.</p>"]
     #[serde(rename="AllowSelfManagement")]
@@ -2965,7 +2965,7 @@ pub struct UpdateUserProfileRequest {
     pub ssh_username: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateVolumeRequest {
     #[doc="<p>The new mount point.</p>"]
     #[serde(rename="MountPoint")]
@@ -2981,7 +2981,7 @@ pub struct UpdateVolumeRequest {
 }
 
 #[doc="<p>Describes a user's SSH information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserProfile {
     #[doc="<p>Whether users can specify their own SSH public key through the My Settings page. For more information, see <a href=\"http://docs.aws.amazon.com/opsworks/latest/userguide/security-settingsshkey.html\">Managing User Permissions</a>.</p>"]
     #[serde(rename="AllowSelfManagement")]
@@ -3006,7 +3006,7 @@ pub struct UserProfile {
 }
 
 #[doc="<p>Describes an instance's Amazon EBS volume.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Volume {
     #[doc="<p>The volume Availability Zone. For more information, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html\">Regions and Endpoints</a>.</p>"]
     #[serde(rename="AvailabilityZone")]

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Stores account attributes. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountAttribute {
     #[doc="<p> The maximum allowed value. </p>"]
     #[serde(rename="Maximum")]
@@ -45,7 +45,7 @@ pub struct AccountAttribute {
     pub used: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateNodeRequest {
     #[doc="<p>Engine attributes used for associating the node. </p> <p class=\"title\"> <b>Attributes accepted in a AssociateNode request:</b> </p> <ul> <li> <p> <code>CHEF_ORGANIZATION</code>: The Chef organization with which the node is associated. By default only one organization named <code>default</code> can exist. </p> </li> <li> <p> <code>CHEF_NODE_PUBLIC_KEY</code>: A PEM-formatted public key. This key is required for the <code>chef-client</code> agent to access the Chef API. </p> </li> </ul>"]
     #[serde(rename="EngineAttributes")]
@@ -58,7 +58,7 @@ pub struct AssociateNodeRequest {
     pub server_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateNodeResponse {
     #[doc="<p>Contains a token which can be passed to the <code>DescribeNodeAssociationStatus</code> API call to get the status of the association request. </p>"]
     #[serde(rename="NodeAssociationStatusToken")]
@@ -67,7 +67,7 @@ pub struct AssociateNodeResponse {
 }
 
 #[doc="<p>Describes a single backup. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Backup {
     #[doc="<p>The ARN of the backup. </p>"]
     #[serde(rename="BackupArn")]
@@ -159,7 +159,7 @@ pub struct Backup {
     pub user_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBackupRequest {
     #[doc="<p> A user-defined description of the backup. </p>"]
     #[serde(rename="Description")]
@@ -170,7 +170,7 @@ pub struct CreateBackupRequest {
     pub server_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateBackupResponse {
     #[doc="<p>Backup created by request.</p>"]
     #[serde(rename="Backup")]
@@ -178,7 +178,7 @@ pub struct CreateBackupResponse {
     pub backup: Option<Backup>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateServerRequest {
     #[doc="<p> Associate a public IP address with a server that you are launching. Valid values are <code>true</code> or <code>false</code>. The default value is <code>true</code>. </p>"]
     #[serde(rename="AssociatePublicIpAddress")]
@@ -246,7 +246,7 @@ pub struct CreateServerRequest {
     pub subnet_ids: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateServerResponse {
     #[doc="<p>The server that is created by the request. </p>"]
     #[serde(rename="Server")]
@@ -254,30 +254,30 @@ pub struct CreateServerResponse {
     pub server: Option<Server>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBackupRequest {
     #[doc="<p>The ID of the backup to delete. Run the DescribeBackups command to get a list of backup IDs. Backup IDs are in the format <code>ServerName-yyyyMMddHHmmssSSS</code>. </p>"]
     #[serde(rename="BackupId")]
     pub backup_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBackupResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteServerRequest {
     #[doc="<p>The ID of the server to delete.</p>"]
     #[serde(rename="ServerName")]
     pub server_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteServerResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountAttributesRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountAttributesResponse {
     #[doc="<p> The attributes that are currently set for the account. </p>"]
     #[serde(rename="Attributes")]
@@ -285,7 +285,7 @@ pub struct DescribeAccountAttributesResponse {
     pub attributes: Option<Vec<AccountAttribute>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBackupsRequest {
     #[doc="<p>Describes a single backup. </p>"]
     #[serde(rename="BackupId")]
@@ -305,7 +305,7 @@ pub struct DescribeBackupsRequest {
     pub server_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBackupsResponse {
     #[doc="<p>Contains the response to a <code>DescribeBackups</code> request. </p>"]
     #[serde(rename="Backups")]
@@ -317,7 +317,7 @@ pub struct DescribeBackupsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsRequest {
     #[doc="<p>To receive a paginated response, use this parameter to specify the maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results. </p>"]
     #[serde(rename="MaxResults")]
@@ -332,7 +332,7 @@ pub struct DescribeEventsRequest {
     pub server_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsResponse {
     #[doc="<p>NextToken is a string that is returned in some command responses. It indicates that not all entries have been returned, and that you must run at least one more request to get remaining items. To get remaining results, call <code>DescribeEvents</code> again, and assign the token from the previous results as the value of the <code>nextToken</code> parameter. If there are no more results, the response object's <code>nextToken</code> parameter value is <code>null</code>. Setting a <code>nextToken</code> value that was not returned in your previous results causes an <code>InvalidNextTokenException</code> to occur. </p>"]
     #[serde(rename="NextToken")]
@@ -344,7 +344,7 @@ pub struct DescribeEventsResponse {
     pub server_events: Option<Vec<ServerEvent>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNodeAssociationStatusRequest {
     #[serde(rename="NodeAssociationStatusToken")]
     pub node_association_status_token: String,
@@ -353,7 +353,7 @@ pub struct DescribeNodeAssociationStatusRequest {
     pub server_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNodeAssociationStatusResponse {
     #[doc="<p>The status of the association or disassociation request. </p> <p class=\"title\"> <b>Possible values:</b> </p> <ul> <li> <p> <code>SUCCESS</code>: The association or disassociation succeeded. </p> </li> <li> <p> <code>FAILED</code>: The association or disassociation failed. </p> </li> <li> <p> <code>IN_PROGRESS</code>: The association or disassociation is still in progress. </p> </li> </ul>"]
     #[serde(rename="NodeAssociationStatus")]
@@ -361,7 +361,7 @@ pub struct DescribeNodeAssociationStatusResponse {
     pub node_association_status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeServersRequest {
     #[doc="<p>To receive a paginated response, use this parameter to specify the maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results. </p>"]
     #[serde(rename="MaxResults")]
@@ -377,7 +377,7 @@ pub struct DescribeServersRequest {
     pub server_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeServersResponse {
     #[doc="<p>NextToken is a string that is returned in some command responses. It indicates that not all entries have been returned, and that you must run at least one more request to get remaining items. To get remaining results, call <code>DescribeServers</code> again, and assign the token from the previous results as the value of the <code>nextToken</code> parameter. If there are no more results, the response object's <code>nextToken</code> parameter value is <code>null</code>. Setting a <code>nextToken</code> value that was not returned in your previous results causes an <code>InvalidNextTokenException</code> to occur. </p>"]
     #[serde(rename="NextToken")]
@@ -389,7 +389,7 @@ pub struct DescribeServersResponse {
     pub servers: Option<Vec<Server>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateNodeRequest {
     #[doc="<p>Engine attributes used for disassociating the node. </p> <p class=\"title\"> <b>Attributes accepted in a DisassociateNode request:</b> </p> <ul> <li> <p> <code>CHEF_ORGANIZATION</code>: The Chef organization with which the node was associated. By default only one organization named <code>default</code> can exist. </p> </li> </ul>"]
     #[serde(rename="EngineAttributes")]
@@ -403,7 +403,7 @@ pub struct DisassociateNodeRequest {
     pub server_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateNodeResponse {
     #[doc="<p>Contains a token which can be passed to the <code>DescribeNodeAssociationStatus</code> API call to get the status of the disassociation request. </p>"]
     #[serde(rename="NodeAssociationStatusToken")]
@@ -424,7 +424,7 @@ pub struct EngineAttribute {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreServerRequest {
     #[doc="<p> The ID of the backup that you want to use to restore a server. </p>"]
     #[serde(rename="BackupId")]
@@ -442,11 +442,11 @@ pub struct RestoreServerRequest {
     pub server_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreServerResponse;
 
 #[doc="<p>Describes a configuration management server. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Server {
     #[doc="<p>Associate a public IP address with a server that you are launching. </p>"]
     #[serde(rename="AssociatePublicIpAddress")]
@@ -543,7 +543,7 @@ pub struct Server {
 }
 
 #[doc="<p>An event that is related to the server, such as the start of maintenance or backup. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ServerEvent {
     #[doc="<p>The time when the event occurred. </p>"]
     #[serde(rename="CreatedAt")]
@@ -563,14 +563,14 @@ pub struct ServerEvent {
     pub server_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartMaintenanceRequest {
     #[doc="<p>The name of the server on which to run maintenance. </p>"]
     #[serde(rename="ServerName")]
     pub server_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartMaintenanceResponse {
     #[doc="<p>Contains the response to a <code>StartMaintenance</code> request. </p>"]
     #[serde(rename="Server")]
@@ -578,7 +578,7 @@ pub struct StartMaintenanceResponse {
     pub server: Option<Server>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateServerEngineAttributesRequest {
     #[doc="<p>The name of the engine attribute to update. </p>"]
     #[serde(rename="AttributeName")]
@@ -592,7 +592,7 @@ pub struct UpdateServerEngineAttributesRequest {
     pub server_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateServerEngineAttributesResponse {
     #[doc="<p>Contains the response to an <code>UpdateServerEngineAttributes</code> request. </p>"]
     #[serde(rename="Server")]
@@ -600,7 +600,7 @@ pub struct UpdateServerEngineAttributesResponse {
     pub server: Option<Server>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateServerRequest {
     #[doc="<p>Sets the number of automated backups that you want to keep. </p>"]
     #[serde(rename="BackupRetentionCount")]
@@ -621,7 +621,7 @@ pub struct UpdateServerRequest {
     pub server_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateServerResponse {
     #[doc="<p>Contains the response to a <code>UpdateServer</code> request. </p>"]
     #[serde(rename="Server")]

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -28,14 +28,14 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptHandshakeRequest {
     #[doc="<p>The unique identifier (ID) of the handshake that you want to accept.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for handshake ID string requires \"h-\" followed by from 8 to 32 lower-case letters or digits.</p>"]
     #[serde(rename="HandshakeId")]
     pub handshake_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptHandshakeResponse {
     #[doc="<p>A structure that contains details about the accepted handshake.</p>"]
     #[serde(rename="Handshake")]
@@ -44,7 +44,7 @@ pub struct AcceptHandshakeResponse {
 }
 
 #[doc="<p>Contains information about an AWS account that is a member of an organization.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Account {
     #[doc="<p>The Amazon Resource Name (ARN) of the account.</p> <p>For more information about ARNs in Organizations, see <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns\">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>"]
     #[serde(rename="Arn")]
@@ -76,7 +76,7 @@ pub struct Account {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachPolicyRequest {
     #[doc="<p>The unique identifier (ID) of the policy that you want to attach to the target. You can get the ID for the policy by calling the <a>ListPolicies</a> operation.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for a policy ID string requires \"p-\" followed by from 8 to 128 lower-case letters or digits.</p>"]
     #[serde(rename="PolicyId")]
@@ -86,14 +86,14 @@ pub struct AttachPolicyRequest {
     pub target_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelHandshakeRequest {
     #[doc="<p>The unique identifier (ID) of the handshake that you want to cancel. You can get the ID from the <a>ListHandshakesForOrganization</a> operation.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for handshake ID string requires \"h-\" followed by from 8 to 32 lower-case letters or digits.</p>"]
     #[serde(rename="HandshakeId")]
     pub handshake_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelHandshakeResponse {
     #[doc="<p>A structure that contains details about the handshake that you canceled.</p>"]
     #[serde(rename="Handshake")]
@@ -102,7 +102,7 @@ pub struct CancelHandshakeResponse {
 }
 
 #[doc="<p>Contains a list of child entities, either OUs or accounts.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Child {
     #[doc="<p>The unique identifier (ID) of this child entity.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for a child ID string requires one of the following:</p> <ul> <li> <p>Account: a string that consists of exactly 12 digits.</p> </li> <li> <p>Organizational unit (OU): a string that begins with \"ou-\" followed by from 4 to 32 lower-case letters or digits (the ID of the root that contains the OU) followed by a second \"-\" dash and from 8 to 32 additional lower-case letters or digits.</p> </li> </ul>"]
     #[serde(rename="Id")]
@@ -114,7 +114,7 @@ pub struct Child {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAccountRequest {
     #[doc="<p>The friendly name of the member account.</p>"]
     #[serde(rename="AccountName")]
@@ -132,7 +132,7 @@ pub struct CreateAccountRequest {
     pub role_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAccountResponse {
     #[doc="<p>A structure that contains details about the request to create an account. This response structure might not be fully populated when you first receive it because account creation is an asynchronous process. You can pass the returned CreateAccountStatus ID as a parameter to <code> <a>DescribeCreateAccountStatus</a> </code> to get status about the progress of the request at later times. </p>"]
     #[serde(rename="CreateAccountStatus")]
@@ -141,7 +141,7 @@ pub struct CreateAccountResponse {
 }
 
 #[doc="<p>Contains the status about a <a>CreateAccount</a> request to create an AWS account in an organization.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAccountStatus {
     #[doc="<p>If the account was created successfully, the unique identifier (ID) of the new account.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for an account ID string requires exactly 12 digits.</p>"]
     #[serde(rename="AccountId")]
@@ -173,7 +173,7 @@ pub struct CreateAccountStatus {
     pub state: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateOrganizationRequest {
     #[doc="<p>Specifies the feature set supported by the new organization. Each feature set supports different levels of functionality.</p> <ul> <li> <p> <i>CONSOLIDATED_BILLING</i>: All member accounts have their bills consolidated to and paid by the master account. For more information, see <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_getting-started_concepts.html#feature-set-cb-only\">Consolidated Billing</a> in the <i>AWS Organizations User Guide</i>.</p> </li> <li> <p> <i>ALL</i>: In addition to all the features supported by the consolidated billing feature set, the master account can also apply any type of policy to any member account in the organization. For more information, see <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_getting-started_concepts.html#feature-set-all\">All features</a> in the <i>AWS Organizations User Guide</i>.</p> </li> </ul>"]
     #[serde(rename="FeatureSet")]
@@ -181,7 +181,7 @@ pub struct CreateOrganizationRequest {
     pub feature_set: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateOrganizationResponse {
     #[doc="<p>A structure that contains details about the newly created organization.</p>"]
     #[serde(rename="Organization")]
@@ -189,7 +189,7 @@ pub struct CreateOrganizationResponse {
     pub organization: Option<Organization>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateOrganizationalUnitRequest {
     #[doc="<p>The friendly name to assign to the new OU.</p>"]
     #[serde(rename="Name")]
@@ -199,7 +199,7 @@ pub struct CreateOrganizationalUnitRequest {
     pub parent_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateOrganizationalUnitResponse {
     #[doc="<p>A structure that contains details about the newly created OU.</p>"]
     #[serde(rename="OrganizationalUnit")]
@@ -207,7 +207,7 @@ pub struct CreateOrganizationalUnitResponse {
     pub organizational_unit: Option<OrganizationalUnit>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePolicyRequest {
     #[doc="<p>The policy content to add to the new policy. For example, if you create a <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html\">service control policy</a> (SCP), this string must be JSON text that specifies the permissions that admins in attached accounts can delegate to their users, groups, and roles. For more information about the SCP syntax, see <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_scp-syntax.html\">Service Control Policy Syntax</a> in the <i>AWS Organizations User Guide</i>.</p>"]
     #[serde(rename="Content")]
@@ -223,7 +223,7 @@ pub struct CreatePolicyRequest {
     pub type_: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePolicyResponse {
     #[doc="<p>A structure that contains details about the newly created policy.</p>"]
     #[serde(rename="Policy")]
@@ -231,14 +231,14 @@ pub struct CreatePolicyResponse {
     pub policy: Option<Policy>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeclineHandshakeRequest {
     #[doc="<p>The unique identifier (ID) of the handshake that you want to decline. You can get the ID from the <a>ListHandshakesForAccount</a> operation.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for handshake ID string requires \"h-\" followed by from 8 to 32 lower-case letters or digits.</p>"]
     #[serde(rename="HandshakeId")]
     pub handshake_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeclineHandshakeResponse {
     #[doc="<p>A structure that contains details about the declined handshake. The state is updated to show the value <code>DECLINED</code>.</p>"]
     #[serde(rename="Handshake")]
@@ -246,28 +246,28 @@ pub struct DeclineHandshakeResponse {
     pub handshake: Option<Handshake>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteOrganizationalUnitRequest {
     #[doc="<p>The unique identifier (ID) of the organizational unit that you want to delete. You can get the ID from the <a>ListOrganizationalUnitsForParent</a> operation.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for an organizational unit ID string requires \"ou-\" followed by from 4 to 32 lower-case letters or digits (the ID of the root that contains the OU) followed by a second \"-\" dash and from 8 to 32 additional lower-case letters or digits.</p>"]
     #[serde(rename="OrganizationalUnitId")]
     pub organizational_unit_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePolicyRequest {
     #[doc="<p>The unique identifier (ID) of the policy that you want to delete. You can get the ID from the <a>ListPolicies</a> or <a>ListPoliciesForTarget</a> operations.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for a policy ID string requires \"p-\" followed by from 8 to 128 lower-case letters or digits.</p>"]
     #[serde(rename="PolicyId")]
     pub policy_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountRequest {
     #[doc="<p>The unique identifier (ID) of the AWS account that you want information about. You can get the ID from the <a>ListAccounts</a> or <a>ListAccountsForParent</a> operations.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for an account ID string requires exactly 12 digits.</p>"]
     #[serde(rename="AccountId")]
     pub account_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountResponse {
     #[doc="<p>A structure that contains information about the requested account.</p>"]
     #[serde(rename="Account")]
@@ -275,14 +275,14 @@ pub struct DescribeAccountResponse {
     pub account: Option<Account>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCreateAccountStatusRequest {
     #[doc="<p>Specifies the <code>operationId</code> that uniquely identifies the request. You can get the ID from the response to an earlier <a>CreateAccount</a> request, or from the <a>ListCreateAccountStatus</a> operation.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for an create account request ID string requires \"car-\" followed by from 8 to 32 lower-case letters or digits.</p>"]
     #[serde(rename="CreateAccountRequestId")]
     pub create_account_request_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCreateAccountStatusResponse {
     #[doc="<p>A structure that contains the current status of an account creation request.</p>"]
     #[serde(rename="CreateAccountStatus")]
@@ -290,14 +290,14 @@ pub struct DescribeCreateAccountStatusResponse {
     pub create_account_status: Option<CreateAccountStatus>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHandshakeRequest {
     #[doc="<p>The unique identifier (ID) of the handshake that you want information about. You can get the ID from the original call to <a>InviteAccountToOrganization</a>, or from a call to <a>ListHandshakesForAccount</a> or <a>ListHandshakesForOrganization</a>.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for handshake ID string requires \"h-\" followed by from 8 to 32 lower-case letters or digits.</p>"]
     #[serde(rename="HandshakeId")]
     pub handshake_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHandshakeResponse {
     #[doc="<p>A structure that contains information about the specified handshake.</p>"]
     #[serde(rename="Handshake")]
@@ -305,7 +305,7 @@ pub struct DescribeHandshakeResponse {
     pub handshake: Option<Handshake>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeOrganizationResponse {
     #[doc="<p>A structure that contains information about the organization.</p>"]
     #[serde(rename="Organization")]
@@ -313,14 +313,14 @@ pub struct DescribeOrganizationResponse {
     pub organization: Option<Organization>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeOrganizationalUnitRequest {
     #[doc="<p>The unique identifier (ID) of the organizational unit that you want details about. You can get the ID from the <a>ListOrganizationalUnitsForParent</a> operation.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for an organizational unit ID string requires \"ou-\" followed by from 4 to 32 lower-case letters or digits (the ID of the root that contains the OU) followed by a second \"-\" dash and from 8 to 32 additional lower-case letters or digits.</p>"]
     #[serde(rename="OrganizationalUnitId")]
     pub organizational_unit_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeOrganizationalUnitResponse {
     #[doc="<p>A structure that contains details about the specified OU.</p>"]
     #[serde(rename="OrganizationalUnit")]
@@ -328,14 +328,14 @@ pub struct DescribeOrganizationalUnitResponse {
     pub organizational_unit: Option<OrganizationalUnit>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePolicyRequest {
     #[doc="<p>The unique identifier (ID) of the policy that you want details about. You can get the ID from the <a>ListPolicies</a> or <a>ListPoliciesForTarget</a> operations.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for a policy ID string requires \"p-\" followed by from 8 to 128 lower-case letters or digits.</p>"]
     #[serde(rename="PolicyId")]
     pub policy_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePolicyResponse {
     #[doc="<p>A structure that contains details about the specified policy.</p>"]
     #[serde(rename="Policy")]
@@ -343,7 +343,7 @@ pub struct DescribePolicyResponse {
     pub policy: Option<Policy>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetachPolicyRequest {
     #[doc="<p>The unique identifier (ID) of the policy you want to detach. You can get the ID from the <a>ListPolicies</a> or <a>ListPoliciesForTarget</a> operations.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for a policy ID string requires \"p-\" followed by from 8 to 128 lower-case letters or digits.</p>"]
     #[serde(rename="PolicyId")]
@@ -353,7 +353,7 @@ pub struct DetachPolicyRequest {
     pub target_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisablePolicyTypeRequest {
     #[doc="<p>The policy type that you want to disable in this root.</p>"]
     #[serde(rename="PolicyType")]
@@ -363,7 +363,7 @@ pub struct DisablePolicyTypeRequest {
     pub root_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisablePolicyTypeResponse {
     #[doc="<p>A structure that shows the root with the updated list of enabled policy types.</p>"]
     #[serde(rename="Root")]
@@ -371,10 +371,10 @@ pub struct DisablePolicyTypeResponse {
     pub root: Option<Root>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableAllFeaturesRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableAllFeaturesResponse {
     #[doc="<p>A structure that contains details about the handshake created to support this request to enable all features in the organization.</p>"]
     #[serde(rename="Handshake")]
@@ -382,7 +382,7 @@ pub struct EnableAllFeaturesResponse {
     pub handshake: Option<Handshake>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnablePolicyTypeRequest {
     #[doc="<p>The policy type that you want to enable.</p>"]
     #[serde(rename="PolicyType")]
@@ -392,7 +392,7 @@ pub struct EnablePolicyTypeRequest {
     pub root_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnablePolicyTypeResponse {
     #[doc="<p>A structure that shows the root with the updated list of enabled policy types.</p>"]
     #[serde(rename="Root")]
@@ -401,7 +401,7 @@ pub struct EnablePolicyTypeResponse {
 }
 
 #[doc="<p>Contains information that must be exchanged to securely establish a relationship between two accounts (an <i>originator</i> and a <i>recipient</i>). For example, when a master account (the originator) invites another account (the recipient) to join its organization, the two accounts exchange information as a series of handshake requests and responses.</p> <p> <b>Note:</b> Handshakes that are CANCELED, ACCEPTED, or DECLINED show up in lists for only 30 days after entering that state After that they are deleted.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Handshake {
     #[doc="<p>The type of handshake, indicating what action occurs when the recipient accepts the handshake.</p>"]
     #[serde(rename="Action")]
@@ -438,7 +438,7 @@ pub struct Handshake {
 }
 
 #[doc="<p>Specifies the criteria that are used to select the handshakes for the operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HandshakeFilter {
     #[doc="<p>Specifies the type of handshake action.</p> <p>If you specify <code>ActionType</code>, you cannot also specify <code>ParentHandshakeId</code>.</p>"]
     #[serde(rename="ActionType")]
@@ -464,7 +464,7 @@ pub struct HandshakeParty {
 }
 
 #[doc="<p>Contains additional data that is needed to process a handshake.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HandshakeResource {
     #[doc="<p>When needed, contains an additional array of <code>HandshakeResource</code> objects.</p>"]
     #[serde(rename="Resources")]
@@ -480,7 +480,7 @@ pub struct HandshakeResource {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InviteAccountToOrganizationRequest {
     #[doc="<p>Additional information that you want to include in the generated email to the recipient account owner.</p>"]
     #[serde(rename="Notes")]
@@ -491,7 +491,7 @@ pub struct InviteAccountToOrganizationRequest {
     pub target: HandshakeParty,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InviteAccountToOrganizationResponse {
     #[doc="<p>A structure that contains details about the handshake that is created to support this invitation request.</p>"]
     #[serde(rename="Handshake")]
@@ -499,7 +499,7 @@ pub struct InviteAccountToOrganizationResponse {
     pub handshake: Option<Handshake>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAccountsForParentRequest {
     #[doc="<p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>"]
     #[serde(rename="MaxResults")]
@@ -514,7 +514,7 @@ pub struct ListAccountsForParentRequest {
     pub parent_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAccountsForParentResponse {
     #[doc="<p>A list of the accounts in the specified root or OU.</p>"]
     #[serde(rename="Accounts")]
@@ -526,7 +526,7 @@ pub struct ListAccountsForParentResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAccountsRequest {
     #[doc="<p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>"]
     #[serde(rename="MaxResults")]
@@ -538,7 +538,7 @@ pub struct ListAccountsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAccountsResponse {
     #[doc="<p>A list of objects in the organization.</p>"]
     #[serde(rename="Accounts")]
@@ -550,7 +550,7 @@ pub struct ListAccountsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListChildrenRequest {
     #[doc="<p>Filters the output to include only the specified child type.</p>"]
     #[serde(rename="ChildType")]
@@ -568,7 +568,7 @@ pub struct ListChildrenRequest {
     pub parent_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListChildrenResponse {
     #[doc="<p>The list of children of the specified parent container.</p>"]
     #[serde(rename="Children")]
@@ -580,7 +580,7 @@ pub struct ListChildrenResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCreateAccountStatusRequest {
     #[doc="<p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>"]
     #[serde(rename="MaxResults")]
@@ -596,7 +596,7 @@ pub struct ListCreateAccountStatusRequest {
     pub states: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCreateAccountStatusResponse {
     #[doc="<p>A list of objects with details about the requests. Certain elements, such as the accountId number, are present in the output only after the account has been successfully created.</p>"]
     #[serde(rename="CreateAccountStatuses")]
@@ -608,7 +608,7 @@ pub struct ListCreateAccountStatusResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHandshakesForAccountRequest {
     #[doc="<p>Filters the handshakes that you want included in the response. The default is all types. Use the <code>ActionType</code> element to limit the output to only a specified type, such as <code>INVITE</code>, <code>ENABLE-FULL-CONTROL</code>, or <code>APPROVE-FULL-CONTROL</code>. Alternatively, for the <code>ENABLE-FULL-CONTROL</code> handshake that generates a separate child handshake for each member account, you can specify <code>ParentHandshakeId</code> to see only the handshakes that were generated by that parent request.</p>"]
     #[serde(rename="Filter")]
@@ -624,7 +624,7 @@ pub struct ListHandshakesForAccountRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHandshakesForAccountResponse {
     #[doc="<p>A list of <a>Handshake</a> objects with details about each of the handshakes that is associated with the specified account.</p>"]
     #[serde(rename="Handshakes")]
@@ -636,7 +636,7 @@ pub struct ListHandshakesForAccountResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHandshakesForOrganizationRequest {
     #[doc="<p>A filter of the handshakes that you want included in the response. The default is all types. Use the <code>ActionType</code> element to limit the output to only a specified type, such as <code>INVITE</code>, <code>ENABLE-ALL-FEATURES</code>, or <code>APPROVE-ALL-FEATURES</code>. Alternatively, for the <code>ENABLE-ALL-FEATURES</code> handshake that generates a separate child handshake for each member account, you can specify the <code>ParentHandshakeId</code> to see only the handshakes that were generated by that parent request.</p>"]
     #[serde(rename="Filter")]
@@ -652,7 +652,7 @@ pub struct ListHandshakesForOrganizationRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListHandshakesForOrganizationResponse {
     #[doc="<p>A list of <a>Handshake</a> objects with details about each of the handshakes that are associated with an organization.</p>"]
     #[serde(rename="Handshakes")]
@@ -664,7 +664,7 @@ pub struct ListHandshakesForOrganizationResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOrganizationalUnitsForParentRequest {
     #[doc="<p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>"]
     #[serde(rename="MaxResults")]
@@ -679,7 +679,7 @@ pub struct ListOrganizationalUnitsForParentRequest {
     pub parent_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOrganizationalUnitsForParentResponse {
     #[doc="<p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>"]
     #[serde(rename="NextToken")]
@@ -691,7 +691,7 @@ pub struct ListOrganizationalUnitsForParentResponse {
     pub organizational_units: Option<Vec<OrganizationalUnit>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListParentsRequest {
     #[doc="<p>The unique identifier (ID) of the OU or account whose parent containers you want to list. Do not specify a root.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for a child ID string requires one of the following:</p> <ul> <li> <p>Account: a string that consists of exactly 12 digits.</p> </li> <li> <p>Organizational unit (OU): a string that begins with \"ou-\" followed by from 4 to 32 lower-case letters or digits (the ID of the root that contains the OU) followed by a second \"-\" dash and from 8 to 32 additional lower-case letters or digits.</p> </li> </ul>"]
     #[serde(rename="ChildId")]
@@ -706,7 +706,7 @@ pub struct ListParentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListParentsResponse {
     #[doc="<p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>"]
     #[serde(rename="NextToken")]
@@ -718,7 +718,7 @@ pub struct ListParentsResponse {
     pub parents: Option<Vec<Parent>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPoliciesForTargetRequest {
     #[doc="<p>The type of policy that you want to include in the returned list.</p>"]
     #[serde(rename="Filter")]
@@ -736,7 +736,7 @@ pub struct ListPoliciesForTargetRequest {
     pub target_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPoliciesForTargetResponse {
     #[doc="<p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>"]
     #[serde(rename="NextToken")]
@@ -748,7 +748,7 @@ pub struct ListPoliciesForTargetResponse {
     pub policies: Option<Vec<PolicySummary>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPoliciesRequest {
     #[doc="<p>Specifies the type of policy that you want to include in the response.</p>"]
     #[serde(rename="Filter")]
@@ -763,7 +763,7 @@ pub struct ListPoliciesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPoliciesResponse {
     #[doc="<p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>"]
     #[serde(rename="NextToken")]
@@ -775,7 +775,7 @@ pub struct ListPoliciesResponse {
     pub policies: Option<Vec<PolicySummary>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRootsRequest {
     #[doc="<p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>"]
     #[serde(rename="MaxResults")]
@@ -787,7 +787,7 @@ pub struct ListRootsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRootsResponse {
     #[doc="<p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>"]
     #[serde(rename="NextToken")]
@@ -799,7 +799,7 @@ pub struct ListRootsResponse {
     pub roots: Option<Vec<Root>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTargetsForPolicyRequest {
     #[doc="<p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>"]
     #[serde(rename="MaxResults")]
@@ -814,7 +814,7 @@ pub struct ListTargetsForPolicyRequest {
     pub policy_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTargetsForPolicyResponse {
     #[doc="<p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>"]
     #[serde(rename="NextToken")]
@@ -826,7 +826,7 @@ pub struct ListTargetsForPolicyResponse {
     pub targets: Option<Vec<PolicyTargetSummary>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MoveAccountRequest {
     #[doc="<p>The unique identifier (ID) of the account that you want to move.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for an account ID string requires exactly 12 digits.</p>"]
     #[serde(rename="AccountId")]
@@ -840,7 +840,7 @@ pub struct MoveAccountRequest {
 }
 
 #[doc="<p>Contains details about an organization. An organization is a collection of accounts that are centrally managed together using consolidated billing, organized hierarchically with organizational units (OUs), and controlled with policies .</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Organization {
     #[doc="<p>The Amazon Resource Name (ARN) of an organization.</p> <p>For more information about ARNs in Organizations, see <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns\">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>"]
     #[serde(rename="Arn")]
@@ -873,7 +873,7 @@ pub struct Organization {
 }
 
 #[doc="<p>Contains details about an organizational unit (OU). An OU is a container of AWS accounts within a root of an organization. Policies that are attached to an OU apply to all accounts contained in that OU and in any child OUs.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OrganizationalUnit {
     #[doc="<p>The Amazon Resource Name (ARN) of this OU.</p> <p>For more information about ARNs in Organizations, see <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns\">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>"]
     #[serde(rename="Arn")]
@@ -890,7 +890,7 @@ pub struct OrganizationalUnit {
 }
 
 #[doc="<p>Contains information about either a root or an organizational unit (OU) that can contain OUs or accounts in an organization.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Parent {
     #[doc="<p>The unique identifier (ID) of the parent entity.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for a parent ID string requires one of the following:</p> <ul> <li> <p>Root: a string that begins with \"r-\" followed by from 4 to 32 lower-case letters or digits.</p> </li> <li> <p>Organizational unit (OU): a string that begins with \"ou-\" followed by from 4 to 32 lower-case letters or digits (the ID of the root that the OU is in) followed by a second \"-\" dash and from 8 to 32 additional lower-case letters or digits.</p> </li> </ul>"]
     #[serde(rename="Id")]
@@ -903,7 +903,7 @@ pub struct Parent {
 }
 
 #[doc="<p>Contains rules to be applied to the affected accounts. Policies can be attached directly to accounts, or to roots and OUs to affect all accounts in those hierarchies.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Policy {
     #[doc="<p>The text content of the policy.</p>"]
     #[serde(rename="Content")]
@@ -916,7 +916,7 @@ pub struct Policy {
 }
 
 #[doc="<p>Contains information about a policy, but does not include the content. To see the content of a policy, see <a>DescribePolicy</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicySummary {
     #[doc="<p>The Amazon Resource Name (ARN) of the policy.</p> <p>For more information about ARNs in Organizations, see <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns\">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>"]
     #[serde(rename="Arn")]
@@ -945,7 +945,7 @@ pub struct PolicySummary {
 }
 
 #[doc="<p>Contains information about a root, OU, or account that a policy is attached to.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyTargetSummary {
     #[doc="<p>The Amazon Resource Name (ARN) of the policy target.</p> <p>For more information about ARNs in Organizations, see <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns\">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>"]
     #[serde(rename="Arn")]
@@ -966,7 +966,7 @@ pub struct PolicyTargetSummary {
 }
 
 #[doc="<p>Contains information about a policy type and its status in the associated root.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PolicyTypeSummary {
     #[doc="<p>The status of the policy type as it relates to the associated root. To attach a policy of the specified type to a root or to an OU or account in that root, it must be available in the organization and enabled for that root.</p>"]
     #[serde(rename="Status")]
@@ -978,7 +978,7 @@ pub struct PolicyTypeSummary {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveAccountFromOrganizationRequest {
     #[doc="<p>The unique identifier (ID) of the member account that you want to remove from the organization.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> for an account ID string requires exactly 12 digits.</p>"]
     #[serde(rename="AccountId")]
@@ -986,7 +986,7 @@ pub struct RemoveAccountFromOrganizationRequest {
 }
 
 #[doc="<p>Contains details about a root. A root is a top-level parent node in the hierarchy of an organization that can contain organizational units (OUs) and accounts. Every root contains every AWS account in the organization. Each root enables the accounts to be organized in a different way and to have different policy types enabled for use in that root.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Root {
     #[doc="<p>The Amazon Resource Name (ARN) of the root.</p> <p>For more information about ARNs in Organizations, see <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns\">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>"]
     #[serde(rename="Arn")]
@@ -1006,7 +1006,7 @@ pub struct Root {
     pub policy_types: Option<Vec<PolicyTypeSummary>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateOrganizationalUnitRequest {
     #[doc="<p>The new name that you want to assign to the OU.</p> <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> that is used to validate this parameter is a string of any of the characters in the ASCII character range.</p>"]
     #[serde(rename="Name")]
@@ -1017,7 +1017,7 @@ pub struct UpdateOrganizationalUnitRequest {
     pub organizational_unit_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateOrganizationalUnitResponse {
     #[doc="<p>A structure that contains the details about the specified OU, including its new name.</p>"]
     #[serde(rename="OrganizationalUnit")]
@@ -1025,7 +1025,7 @@ pub struct UpdateOrganizationalUnitResponse {
     pub organizational_unit: Option<OrganizationalUnit>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePolicyRequest {
     #[doc="<p>If provided, the new content for the policy. The text must be correctly formatted JSON that complies with the syntax for the policy's type. For more information, see <a href=\"http://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_scp-syntax.html\">Service Control Policy Syntax</a> in the <i>AWS Organizations User Guide</i>.</p>"]
     #[serde(rename="Content")]
@@ -1044,7 +1044,7 @@ pub struct UpdatePolicyRequest {
     pub policy_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePolicyResponse {
     #[doc="<p>A structure that contains details about the updated policy, showing the requested changes.</p>"]
     #[serde(rename="Policy")]

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -29,17 +29,17 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLexiconInput {
     #[doc="<p>The name of the lexicon to delete. Must be an existing lexicon in the region.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLexiconOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVoicesInput {
     #[doc="<p> The language identification tag (ISO 639 code for the language name-ISO 3166 country code) for filtering the list of voices returned. If you don't specify this optional parameter, all available voices are returned. </p>"]
     #[serde(rename="LanguageCode")]
@@ -51,7 +51,7 @@ pub struct DescribeVoicesInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVoicesOutput {
     #[doc="<p>The pagination token to use in the next request to continue the listing of voices. <code>NextToken</code> is returned only if the response is truncated.</p>"]
     #[serde(rename="NextToken")]
@@ -63,14 +63,14 @@ pub struct DescribeVoicesOutput {
     pub voices: Option<Vec<Voice>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLexiconInput {
     #[doc="<p>Name of the lexicon.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetLexiconOutput {
     #[doc="<p>Lexicon object that provides name and the string content of the lexicon. </p>"]
     #[serde(rename="Lexicon")]
@@ -83,7 +83,7 @@ pub struct GetLexiconOutput {
 }
 
 #[doc="<p>Provides lexicon name and lexicon content in string format. For more information, see <a href=\"https://www.w3.org/TR/pronunciation-lexicon/\">Pronunciation Lexicon Specification (PLS) Version 1.0</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Lexicon {
     #[doc="<p>Lexicon content in string format. The content of a lexicon must be in PLS format.</p>"]
     #[serde(rename="Content")]
@@ -96,7 +96,7 @@ pub struct Lexicon {
 }
 
 #[doc="<p>Contains metadata describing the lexicon such as the number of lexemes, language code, and so on. For more information, see <a href=\"http://docs.aws.amazon.com/polly/latest/dg/managing-lexicons.html\">Managing Lexicons</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LexiconAttributes {
     #[doc="<p>Phonetic alphabet used in the lexicon. Valid values are <code>ipa</code> and <code>x-sampa</code>.</p>"]
     #[serde(rename="Alphabet")]
@@ -125,7 +125,7 @@ pub struct LexiconAttributes {
 }
 
 #[doc="<p>Describes the content of the lexicon.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LexiconDescription {
     #[doc="<p>Provides lexicon metadata.</p>"]
     #[serde(rename="Attributes")]
@@ -137,7 +137,7 @@ pub struct LexiconDescription {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLexiconsInput {
     #[doc="<p>An opaque pagination token returned from previous <code>ListLexicons</code> operation. If present, indicates where to continue the list of lexicons.</p>"]
     #[serde(rename="NextToken")]
@@ -145,7 +145,7 @@ pub struct ListLexiconsInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLexiconsOutput {
     #[doc="<p>A list of lexicon names and attributes.</p>"]
     #[serde(rename="Lexicons")]
@@ -157,7 +157,7 @@ pub struct ListLexiconsOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutLexiconInput {
     #[doc="<p>Content of the PLS lexicon as string data.</p>"]
     #[serde(rename="Content")]
@@ -167,10 +167,10 @@ pub struct PutLexiconInput {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutLexiconOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SynthesizeSpeechInput {
     #[doc="<p>List of one or more pronunciation lexicon names you want the service to apply during synthesis. Lexicons are applied only if the language of the lexicon is the same as the language of the voice. For information about storing lexicons, see <a href=\"http://docs.aws.amazon.com/polly/latest/dg/API_PutLexicon.html\">PutLexicon</a>.</p>"]
     #[serde(rename="LexiconNames")]
@@ -199,18 +199,28 @@ pub struct SynthesizeSpeechInput {
     pub voice_id: String,
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SynthesizeSpeechOutput {
     #[doc="<p> Stream containing the synthesized speech. </p>"]
+    #[serde(rename="AudioStream")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub audio_stream: Option<Vec<u8>>,
     #[doc="<p> Specifies the type audio stream. This should reflect the <code>OutputFormat</code> parameter in your request. </p> <ul> <li> <p> If you request <code>mp3</code> as the <code>OutputFormat</code>, the <code>ContentType</code> returned is audio/mpeg. </p> </li> <li> <p> If you request <code>ogg_vorbis</code> as the <code>OutputFormat</code>, the <code>ContentType</code> returned is audio/ogg. </p> </li> <li> <p> If you request <code>pcm</code> as the <code>OutputFormat</code>, the <code>ContentType</code> returned is audio/pcm in a signed 16-bit, 1 channel (mono), little-endian format. </p> </li> <li> <p>If you request <code>json</code> as the <code>OutputFormat</code>, the <code>ContentType</code> returned is audio/json.</p> </li> </ul> <p> </p>"]
+    #[serde(rename="ContentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_type: Option<String>,
     #[doc="<p>Number of characters synthesized.</p>"]
+    #[serde(rename="RequestCharacters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_characters: Option<i64>,
 }
 
 #[doc="<p>Description of the voice.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Voice {
     #[doc="<p>Gender of the voice.</p>"]
     #[serde(rename="Gender")]

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -40,9 +40,11 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>Data returned by the <b>DescribeAccountAttributes</b> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountAttributesMessage {
     #[doc="<p>A list of <a>AccountQuota</a> objects. Within this list, each quota has a name, a count of usage toward the quota maximum, and a maximum value for the quota.</p>"]
+    #[serde(rename="AccountQuotas")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account_quotas: Option<Vec<AccountQuota>>,
 }
 
@@ -90,13 +92,19 @@ impl AccountAttributesMessageDeserializer {
     }
 }
 #[doc="<p>Describes a quota for an AWS account, for example, the number of DB instances allowed.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountQuota {
     #[doc="<p>The name of the Amazon RDS quota for this AWS account.</p>"]
+    #[serde(rename="AccountQuotaName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account_quota_name: Option<String>,
     #[doc="<p>The maximum allowed value for the quota.</p>"]
+    #[serde(rename="Max")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max: Option<i64>,
     #[doc="<p>The amount currently used toward the quota maximum.</p>"]
+    #[serde(rename="Used")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub used: Option<i64>,
 }
 
@@ -191,11 +199,13 @@ impl AccountQuotaListDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddRoleToDBClusterMessage {
     #[doc="<p>The name of the DB cluster to associate the IAM role with.</p>"]
+    #[serde(rename="DBClusterIdentifier")]
     pub db_cluster_identifier: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM role to associate with the Aurora DB cluster, for example <code>arn:aws:iam::123456789012:role/AuroraAccessRole</code>.</p>"]
+    #[serde(rename="RoleArn")]
     pub role_arn: String,
 }
 
@@ -218,11 +228,13 @@ impl AddRoleToDBClusterMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddSourceIdentifierToSubscriptionMessage {
     #[doc="<p>The identifier of the event source to be added. An identifier must begin with a letter and must contain only ASCII letters, digits, and hyphens; it cannot end with a hyphen or contain two consecutive hyphens.</p> <p>Constraints:</p> <ul> <li> <p>If the source type is a DB instance, then a <code>DBInstanceIdentifier</code> must be supplied.</p> </li> <li> <p>If the source type is a DB security group, a <code>DBSecurityGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB parameter group, a <code>DBParameterGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB snapshot, a <code>DBSnapshotIdentifier</code> must be supplied.</p> </li> </ul>"]
+    #[serde(rename="SourceIdentifier")]
     pub source_identifier: String,
     #[doc="<p>The name of the RDS event notification subscription you want to add a source identifier to.</p>"]
+    #[serde(rename="SubscriptionName")]
     pub subscription_name: String,
 }
 
@@ -244,8 +256,10 @@ impl AddSourceIdentifierToSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddSourceIdentifierToSubscriptionResult {
+    #[serde(rename="EventSubscription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_subscription: Option<EventSubscription>,
 }
 
@@ -294,11 +308,13 @@ impl AddSourceIdentifierToSubscriptionResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceMessage {
     #[doc="<p>The Amazon RDS resource the tags will be added to. This value is an Amazon Resource Name (ARN). For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>"]
+    #[serde(rename="ResourceName")]
     pub resource_name: String,
     #[doc="<p>The tags to be assigned to the Amazon RDS resource.</p>"]
+    #[serde(rename="Tags")]
     pub tags: Vec<Tag>,
 }
 
@@ -334,13 +350,16 @@ impl ApplyMethodDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplyPendingMaintenanceActionMessage {
     #[doc="<p>The pending maintenance action to apply to this resource.</p> <p>Valid values: <code>system-update</code>, <code>db-upgrade</code> </p>"]
+    #[serde(rename="ApplyAction")]
     pub apply_action: String,
     #[doc="<p>A value that specifies the type of opt-in request, or undoes an opt-in request. An opt-in request of type <code>immediate</code> cannot be undone.</p> <p>Valid values:</p> <ul> <li> <p> <code>immediate</code> - Apply the maintenance action immediately.</p> </li> <li> <p> <code>next-maintenance</code> - Apply the maintenance action during the next maintenance window for the resource.</p> </li> <li> <p> <code>undo-opt-in</code> - Cancel any existing <code>next-maintenance</code> opt-in requests.</p> </li> </ul>"]
+    #[serde(rename="OptInType")]
     pub opt_in_type: String,
     #[doc="<p>The RDS Amazon Resource Name (ARN) of the resource that the pending maintenance action applies to. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>"]
+    #[serde(rename="ResourceIdentifier")]
     pub resource_identifier: String,
 }
 
@@ -364,8 +383,10 @@ impl ApplyPendingMaintenanceActionMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ApplyPendingMaintenanceActionResult {
+    #[serde(rename="ResourcePendingMaintenanceActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_pending_maintenance_actions: Option<ResourcePendingMaintenanceActions>,
 }
 
@@ -465,17 +486,26 @@ impl AttributeValueListSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthorizeDBSecurityGroupIngressMessage {
     #[doc="<p>The IP range to authorize.</p>"]
+    #[serde(rename="CIDRIP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidrip: Option<String>,
     #[doc="<p>The name of the DB security group to add authorization to.</p>"]
+    #[serde(rename="DBSecurityGroupName")]
     pub db_security_group_name: String,
     #[doc="<p> Id of the EC2 security group to authorize. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, <code>EC2SecurityGroupOwnerId</code> and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>"]
+    #[serde(rename="EC2SecurityGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_id: Option<String>,
     #[doc="<p> Name of the EC2 security group to authorize. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, <code>EC2SecurityGroupOwnerId</code> and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>"]
+    #[serde(rename="EC2SecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_name: Option<String>,
     #[doc="<p> AWS account number of the owner of the EC2 security group specified in the <code>EC2SecurityGroupName</code> parameter. The AWS Access Key ID is not an acceptable value. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, <code>EC2SecurityGroupOwnerId</code> and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>"]
+    #[serde(rename="EC2SecurityGroupOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_owner_id: Option<String>,
 }
 
@@ -511,8 +541,10 @@ impl AuthorizeDBSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthorizeDBSecurityGroupIngressResult {
+    #[serde(rename="DBSecurityGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_group: Option<DBSecurityGroup>,
 }
 
@@ -561,9 +593,11 @@ impl AuthorizeDBSecurityGroupIngressResultDeserializer {
     }
 }
 #[doc="<p>Contains Availability Zone information.</p> <p> This data type is used as an element in the following data type:</p> <ul> <li> <p> <a>OrderableDBInstanceOption</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AvailabilityZone {
     #[doc="<p>The name of the availability zone.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -732,19 +766,31 @@ impl BooleanOptionalDeserializer {
     }
 }
 #[doc="<p>A CA certificate for an AWS account.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Certificate {
     #[doc="<p>The Amazon Resource Name (ARN) for the certificate.</p>"]
+    #[serde(rename="CertificateArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificate_arn: Option<String>,
     #[doc="<p>The unique key that identifies a certificate.</p>"]
+    #[serde(rename="CertificateIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificate_identifier: Option<String>,
     #[doc="<p>The type of the certificate.</p>"]
+    #[serde(rename="CertificateType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificate_type: Option<String>,
     #[doc="<p>The thumbprint of the certificate.</p>"]
+    #[serde(rename="Thumbprint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub thumbprint: Option<String>,
     #[doc="<p>The starting date from which the certificate is valid.</p>"]
+    #[serde(rename="ValidFrom")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub valid_from: Option<String>,
     #[doc="<p>The final date that the certificate continues to be valid.</p>"]
+    #[serde(rename="ValidTill")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub valid_till: Option<String>,
 }
 
@@ -855,11 +901,15 @@ impl CertificateListDeserializer {
     }
 }
 #[doc="<p>Data returned by the <b>DescribeCertificates</b> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CertificateMessage {
     #[doc="<p>The list of <a>Certificate</a> objects for the AWS account.</p>"]
+    #[serde(rename="Certificates")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificates: Option<Vec<Certificate>>,
     #[doc="<p> An optional pagination token provided by a previous <a>DescribeCertificates</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -911,11 +961,15 @@ impl CertificateMessageDeserializer {
     }
 }
 #[doc="<p> This data type is used as a response element in the action <a>DescribeDBEngineVersions</a>. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CharacterSet {
     #[doc="<p>The description of the character set.</p>"]
+    #[serde(rename="CharacterSetDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub character_set_description: Option<String>,
     #[doc="<p>The name of the character set.</p>"]
+    #[serde(rename="CharacterSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub character_set_name: Option<String>,
 }
 
@@ -967,14 +1021,19 @@ impl CharacterSetDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyDBClusterParameterGroupMessage {
     #[doc="<p>The identifier or Amazon Resource Name (ARN) for the source DB cluster parameter group. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid DB cluster parameter group.</p> </li> <li> <p>If the source DB cluster parameter group is in the same AWS Region as the copy, specify a valid DB parameter group identifier, for example <code>my-db-cluster-param-group</code>, or a valid ARN.</p> </li> <li> <p>If the source DB parameter group is in a different AWS Region than the copy, specify a valid DB cluster parameter group ARN, for example <code>arn:aws:rds:us-east-1:123456789012:cluster-pg:custom-cluster-group1</code>.</p> </li> </ul>"]
+    #[serde(rename="SourceDBClusterParameterGroupIdentifier")]
     pub source_db_cluster_parameter_group_identifier: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>A description for the copied DB cluster parameter group.</p>"]
+    #[serde(rename="TargetDBClusterParameterGroupDescription")]
     pub target_db_cluster_parameter_group_description: String,
     #[doc="<p>The identifier for the copied DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-cluster-param-group1</code> </p>"]
+    #[serde(rename="TargetDBClusterParameterGroupIdentifier")]
     pub target_db_cluster_parameter_group_identifier: String,
 }
 
@@ -1004,8 +1063,10 @@ impl CopyDBClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyDBClusterParameterGroupResult {
+    #[serde(rename="DBClusterParameterGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_group: Option<DBClusterParameterGroup>,
 }
 
@@ -1054,18 +1115,28 @@ impl CopyDBClusterParameterGroupResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyDBClusterSnapshotMessage {
     #[doc="<p>True to copy all tags from the source DB cluster snapshot to the target DB cluster snapshot; otherwise false. The default is false.</p>"]
+    #[serde(rename="CopyTags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_tags: Option<bool>,
     #[doc="<p>The AWS KMS key ID for an encrypted DB cluster snapshot. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key. </p> <p>If you copy an unencrypted DB cluster snapshot and specify a value for the <code>KmsKeyId</code> parameter, Amazon RDS encrypts the target DB cluster snapshot using the specified KMS encryption key. </p> <p>If you copy an encrypted DB cluster snapshot from your AWS account, you can specify a value for <code>KmsKeyId</code> to encrypt the copy with a new KMS encryption key. If you don't specify a value for <code>KmsKeyId</code>, then the copy of the DB cluster snapshot is encrypted with the same KMS key as the source DB cluster snapshot. </p> <p>If you copy an encrypted DB cluster snapshot that is shared from another AWS account, then you must specify a value for <code>KmsKeyId</code>. </p> <p>To copy an encrypted DB cluster snapshot to another AWS Region, you must set <code>KmsKeyId</code> to the KMS key ID you want to use to encrypt the copy of the DB cluster snapshot in the destination AWS Region. KMS encryption keys are specific to the AWS Region that they are created in, and you cannot use encryption keys from one AWS Region in another AWS Region.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The URL that contains a Signature Version 4 signed request for the <code>CopyDBClusterSnapshot</code> API action in the AWS Region that contains the source DB cluster snapshot to copy. The <code>PreSignedUrl</code> parameter must be used when copying an encrypted DB cluster snapshot from another AWS Region.</p> <p>The pre-signed URL must be a valid request for the <code>CopyDBSClusterSnapshot</code> API action that can be executed in the source AWS Region that contains the encrypted DB cluster snapshot to be copied. The pre-signed URL request must contain the following parameter values:</p> <ul> <li> <p> <code>KmsKeyId</code> - The KMS key identifier for the key to use to encrypt the copy of the DB cluster snapshot in the destination AWS Region. This is the same identifier for both the <code>CopyDBClusterSnapshot</code> action that is called in the destination AWS Region, and the action contained in the pre-signed URL.</p> </li> <li> <p> <code>DestinationRegion</code> - The name of the AWS Region that the DB cluster snapshot will be created in.</p> </li> <li> <p> <code>SourceDBClusterSnapshotIdentifier</code> - The DB cluster snapshot identifier for the encrypted DB cluster snapshot to be copied. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are copying an encrypted DB cluster snapshot from the us-west-2 region, then your <code>SourceDBClusterSnapshotIdentifier</code> looks like the following example: <code>arn:aws:rds:us-west-2:123456789012:cluster-snapshot:aurora-cluster1-snapshot-20161115</code>.</p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\"> Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\"> Signature Version 4 Signing Process</a>.</p>"]
+    #[serde(rename="PreSignedUrl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pre_signed_url: Option<String>,
     #[doc="<p>The identifier of the DB cluster snapshot to copy. This parameter is not case-sensitive.</p> <p>You cannot copy an encrypted, shared DB cluster snapshot from one AWS Region to another.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> <li> <p>Must specify a valid system snapshot in the \"available\" state.</p> </li> <li> <p>If the source snapshot is in the same AWS Region as the copy, specify a valid DB snapshot identifier.</p> </li> <li> <p>If the source snapshot is in a different AWS Region than the copy, specify a valid DB cluster snapshot ARN. For more information, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopySnapshot.html\"> Copying a DB Snapshot or DB Cluster Snapshot</a>.</p> </li> </ul> <p>Example: <code>my-cluster-snapshot1</code> </p>"]
+    #[serde(rename="SourceDBClusterSnapshotIdentifier")]
     pub source_db_cluster_snapshot_identifier: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The identifier of the new DB cluster snapshot to create from the source DB cluster snapshot. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster-snapshot2</code> </p>"]
+    #[serde(rename="TargetDBClusterSnapshotIdentifier")]
     pub target_db_cluster_snapshot_identifier: String,
 }
 
@@ -1104,8 +1175,10 @@ impl CopyDBClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyDBClusterSnapshotResult {
+    #[serde(rename="DBClusterSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
@@ -1153,14 +1226,19 @@ impl CopyDBClusterSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyDBParameterGroupMessage {
     #[doc="<p> The identifier or ARN for the source DB parameter group. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid DB parameter group.</p> </li> <li> <p> Must specify a valid DB parameter group identifier, for example <code>my-db-param-group</code>, or a valid ARN.</p> </li> </ul>"]
+    #[serde(rename="SourceDBParameterGroupIdentifier")]
     pub source_db_parameter_group_identifier: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>A description for the copied DB parameter group.</p>"]
+    #[serde(rename="TargetDBParameterGroupDescription")]
     pub target_db_parameter_group_description: String,
     #[doc="<p>The identifier for the copied DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-db-parameter-group</code> </p>"]
+    #[serde(rename="TargetDBParameterGroupIdentifier")]
     pub target_db_parameter_group_identifier: String,
 }
 
@@ -1188,8 +1266,10 @@ impl CopyDBParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyDBParameterGroupResult {
+    #[serde(rename="DBParameterGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group: Option<DBParameterGroup>,
 }
 
@@ -1237,20 +1317,32 @@ impl CopyDBParameterGroupResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyDBSnapshotMessage {
     #[doc="<p>True to copy all tags from the source DB snapshot to the target DB snapshot; otherwise false. The default is false.</p>"]
+    #[serde(rename="CopyTags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_tags: Option<bool>,
     #[doc="<p>The AWS KMS key ID for an encrypted DB snapshot. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key. </p> <p>If you copy an encrypted DB snapshot from your AWS account, you can specify a value for this parameter to encrypt the copy with a new KMS encryption key. If you don't specify a value for this parameter, then the copy of the DB snapshot is encrypted with the same KMS key as the source DB snapshot. </p> <p>If you copy an encrypted DB snapshot that is shared from another AWS account, then you must specify a value for this parameter. </p> <p>If you specify this parameter when you copy an unencrypted snapshot, the copy is encrypted. </p> <p>If you copy an encrypted snapshot to a different AWS Region, then you must specify a KMS key for the destination AWS Region. KMS encryption keys are specific to the AWS Region that they are created in, and you cannot use encryption keys from one AWS Region in another AWS Region. </p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The name of an option group to associate with the copy of the snapshot.</p> <p>Specify this option if you are copying a snapshot from one AWS Region to another, and your DB instance uses a nondefault option group. If your source DB instance uses Transparent Data Encryption for Oracle or Microsoft SQL Server, you must specify this option when copying across regions. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopySnapshot.html#USER_CopySnapshot.Options\">Option Group Considerations</a>. </p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The URL that contains a Signature Version 4 signed request for the <code>CopyDBSnapshot</code> API action in the source AWS Region that contains the source DB snapshot to copy. </p> <p>You must specify this parameter when you copy an encrypted DB snapshot from another AWS Region by using the Amazon RDS API. You can specify the source region option instead of this parameter when you copy an encrypted DB snapshot from another AWS Region by using the AWS CLI. </p> <p>The presigned URL must be a valid request for the <code>CopyDBSnapshot</code> API action that can be executed in the source AWS Region that contains the encrypted DB snapshot to be copied. The presigned URL request must contain the following parameter values: </p> <ul> <li> <p> <code>DestinationRegion</code> - The AWS Region that the encrypted DB snapshot will be copied to. This AWS Region is the same one where the <code>CopyDBSnapshot</code> action is called that contains this presigned URL. </p> <p>For example, if you copy an encrypted DB snapshot from the us-west-2 region to the us-east-1 region, then you call the <code>CopyDBSnapshot</code> action in the us-east-1 region and provide a presigned URL that contains a call to the <code>CopyDBSnapshot</code> action in the us-west-2 region. For this example, the <code>DestinationRegion</code> in the presigned URL must be set to the us-east-1 region. </p> </li> <li> <p> <code>KmsKeyId</code> - The KMS key identifier for the key to use to encrypt the copy of the DB snapshot in the destination AWS Region. This is the same identifier for both the <code>CopyDBSnapshot</code> action that is called in the destination AWS Region, and the action contained in the presigned URL. </p> </li> <li> <p> <code>SourceDBSnapshotIdentifier</code> - The DB snapshot identifier for the encrypted snapshot to be copied. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are copying an encrypted DB snapshot from the us-west-2 region, then your <code>SourceDBSnapshotIdentifier</code> looks like the following example: <code>arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20161115</code>. </p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\">Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4 Signing Process</a>. </p>"]
+    #[serde(rename="PreSignedUrl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pre_signed_url: Option<String>,
     #[doc="<p>The identifier for the source DB snapshot.</p> <p>If the source snapshot is in the same AWS Region as the copy, specify a valid DB snapshot identifier. For example, you might specify <code>rds:mysql-instance1-snapshot-20130805</code>. </p> <p>If the source snapshot is in a different AWS Region than the copy, specify a valid DB snapshot ARN. For example, you might specify <code>arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20130805</code>. </p> <p>If you are copying from a shared manual DB snapshot, this parameter must be the Amazon Resource Name (ARN) of the shared DB snapshot. </p> <p>If you are copying an encrypted snapshot this parameter must be in the ARN format for the source AWS Region, and must match the <code>SourceDBSnapshotIdentifier</code> in the <code>PreSignedUrl</code> parameter. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid system snapshot in the \"available\" state.</p> </li> </ul> <p>Example: <code>rds:mydb-2012-04-02-00-01</code> </p> <p>Example: <code>arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20130805</code> </p>"]
+    #[serde(rename="SourceDBSnapshotIdentifier")]
     pub source_db_snapshot_identifier: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The identifier for the copy of the snapshot. </p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-db-snapshot</code> </p>"]
+    #[serde(rename="TargetDBSnapshotIdentifier")]
     pub target_db_snapshot_identifier: String,
 }
 
@@ -1291,8 +1383,10 @@ impl CopyDBSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyDBSnapshotResult {
+    #[serde(rename="DBSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot: Option<DBSnapshot>,
 }
 
@@ -1340,14 +1434,19 @@ impl CopyDBSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyOptionGroupMessage {
     #[doc="<p>The identifier or ARN for the source option group. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid option group.</p> </li> <li> <p>If the source option group is in the same AWS Region as the copy, specify a valid option group identifier, for example <code>my-option-group</code>, or a valid ARN.</p> </li> <li> <p>If the source option group is in a different AWS Region than the copy, specify a valid option group ARN, for example <code>arn:aws:rds:us-west-2:123456789012:og:special-options</code>.</p> </li> </ul>"]
+    #[serde(rename="SourceOptionGroupIdentifier")]
     pub source_option_group_identifier: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The description for the copied option group.</p>"]
+    #[serde(rename="TargetOptionGroupDescription")]
     pub target_option_group_description: String,
     #[doc="<p>The identifier for the copied option group.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-option-group</code> </p>"]
+    #[serde(rename="TargetOptionGroupIdentifier")]
     pub target_option_group_identifier: String,
 }
 
@@ -1374,8 +1473,10 @@ impl CopyOptionGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyOptionGroupResult {
+    #[serde(rename="OptionGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group: Option<OptionGroup>,
 }
 
@@ -1423,50 +1524,92 @@ impl CopyOptionGroupResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBClusterMessage {
     #[doc="<p>A list of EC2 Availability Zones that instances in the DB cluster can be created in. For information on regions and Availability Zones, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html\">Regions and Availability Zones</a>. </p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<String>>,
     #[doc="<p>The number of days for which automated backups are retained. You must specify a minimum value of 1.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 1 to 35</p> </li> </ul>"]
+    #[serde(rename="BackupRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub backup_retention_period: Option<i64>,
     #[doc="<p>A value that indicates that the DB cluster should be associated with the specified CharacterSet.</p>"]
+    #[serde(rename="CharacterSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub character_set_name: Option<String>,
     #[doc="<p>The DB cluster identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>"]
+    #[serde(rename="DBClusterIdentifier")]
     pub db_cluster_identifier: String,
     #[doc="<p> The name of the DB cluster parameter group to associate with this DB cluster. If this argument is omitted, <code>default.aurora5.6</code> will be used. </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBClusterParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_group_name: Option<String>,
     #[doc="<p>A DB subnet group to associate with this DB cluster.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>The name for your database of up to 64 alpha-numeric characters. If you do not provide a name, Amazon RDS will not create a database in the DB cluster you are creating.</p>"]
+    #[serde(rename="DatabaseName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub database_name: Option<String>,
     #[doc="<p>A Boolean value that is true to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EnableIAMDatabaseAuthentication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_iam_database_authentication: Option<bool>,
     #[doc="<p>The name of the database engine to be used for this DB cluster.</p> <p>Valid Values: <code>aurora</code> </p>"]
+    #[serde(rename="Engine")]
     pub engine: String,
     #[doc="<p>The version number of the database engine to use.</p> <p> <b>Aurora</b> </p> <p>Example: <code>5.6.10a</code> </p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>The KMS key identifier for an encrypted DB cluster.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are creating a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KMS encryption key.</p> <p>If the <code>StorageEncrypted</code> parameter is true, and you do not specify a value for the <code>KmsKeyId</code> parameter, then Amazon RDS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS Region.</p> <p>If you create a Read Replica of an encrypted DB cluster in another AWS Region, you must set <code>KmsKeyId</code> to a KMS key ID that is valid in the destination AWS Region. This key is used to encrypt the Read Replica in that AWS Region.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The password for the master database user. This password can contain any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p>Constraints: Must contain from 8 to 41 characters.</p>"]
+    #[serde(rename="MasterUserPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_user_password: Option<String>,
     #[doc="<p>The name of the master user for the DB cluster.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 16 alphanumeric characters.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul>"]
+    #[serde(rename="MasterUsername")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_username: Option<String>,
     #[doc="<p>A value that indicates that the DB cluster should be associated with the specified option group.</p> <p>Permanent options cannot be removed from an option group. The option group cannot be removed from a DB cluster once it is associated with a DB cluster.</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The port number on which the instances in the DB cluster accept connections.</p> <p> Default: <code>3306</code> </p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>A URL that contains a Signature Version 4 signed request for the <code>CreateDBCluster</code> action to be called in the source AWS Region where the DB cluster will be replicated from. You only need to specify <code>PreSignedUrl</code> when you are performing cross-region replication from an encrypted DB cluster.</p> <p>The pre-signed URL must be a valid request for the <code>CreateDBCluster</code> API action that can be executed in the source AWS Region that contains the encrypted DB cluster to be copied.</p> <p>The pre-signed URL request must contain the following parameter values:</p> <ul> <li> <p> <code>KmsKeyId</code> - The KMS key identifier for the key to use to encrypt the copy of the DB cluster in the destination AWS Region. This should refer to the same KMS key for both the <code>CreateDBCluster</code> action that is called in the destination AWS Region, and the action contained in the pre-signed URL.</p> </li> <li> <p> <code>DestinationRegion</code> - The name of the AWS Region that Aurora Read Replica will be created in.</p> </li> <li> <p> <code>ReplicationSourceIdentifier</code> - The DB cluster identifier for the encrypted DB cluster to be copied. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are copying an encrypted DB cluster from the us-west-2 region, then your <code>ReplicationSourceIdentifier</code> would look like Example: <code>arn:aws:rds:us-west-2:123456789012:cluster:aurora-cluster1</code>.</p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\"> Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\"> Signature Version 4 Signing Process</a>.</p>"]
+    #[serde(rename="PreSignedUrl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pre_signed_url: Option<String>,
     #[doc="<p>The daily time range during which automated backups are created if automated backups are enabled using the <code>BackupRetentionPeriod</code> parameter. </p> <p>Default: A 30-minute window selected at random from an 8-hour block of time per AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Times should be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>"]
+    #[serde(rename="PreferredBackupWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_backup_window: Option<String>,
     #[doc="<p>The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p> <p> Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p>Default: A 30-minute window selected at random from an 8-hour block of time per AWS Region, occurring on a random day of the week. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun</p> <p>Constraints: Minimum 30-minute window.</p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the source DB instance or DB cluster if this DB cluster is created as a Read Replica.</p>"]
+    #[serde(rename="ReplicationSourceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_source_identifier: Option<String>,
     #[doc="<p>Specifies whether the DB cluster is encrypted.</p>"]
+    #[serde(rename="StorageEncrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_encrypted: Option<bool>,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>A list of EC2 VPC security groups to associate with this DB cluster.</p>"]
+    #[serde(rename="VpcSecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_ids: Option<Vec<String>>,
 }
 
@@ -1572,14 +1715,19 @@ impl CreateDBClusterMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBClusterParameterGroupMessage {
     #[doc="<p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <note> <p>This value is stored as a lowercase string.</p> </note>"]
+    #[serde(rename="DBClusterParameterGroupName")]
     pub db_cluster_parameter_group_name: String,
     #[doc="<p>The DB cluster parameter group family name. A DB cluster parameter group can be associated with one and only one DB cluster parameter group family, and can be applied only to a DB cluster running a database engine and engine version compatible with that DB cluster parameter group family.</p>"]
+    #[serde(rename="DBParameterGroupFamily")]
     pub db_parameter_group_family: String,
     #[doc="<p>The description for the DB cluster parameter group.</p>"]
+    #[serde(rename="Description")]
     pub description: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -1606,8 +1754,10 @@ impl CreateDBClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBClusterParameterGroupResult {
+    #[serde(rename="DBClusterParameterGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_group: Option<DBClusterParameterGroup>,
 }
 
@@ -1655,8 +1805,10 @@ impl CreateDBClusterParameterGroupResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBClusterResult {
+    #[serde(rename="DBCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster: Option<DBCluster>,
 }
 
@@ -1703,13 +1855,17 @@ impl CreateDBClusterResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBClusterSnapshotMessage {
     #[doc="<p>The identifier of the DB cluster to create a snapshot for. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>"]
+    #[serde(rename="DBClusterIdentifier")]
     pub db_cluster_identifier: String,
     #[doc="<p>The identifier of the DB cluster snapshot. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1-snapshot1</code> </p>"]
+    #[serde(rename="DBClusterSnapshotIdentifier")]
     pub db_cluster_snapshot_identifier: String,
     #[doc="<p>The tags to be assigned to the DB cluster snapshot.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -1734,8 +1890,10 @@ impl CreateDBClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBClusterSnapshotResult {
+    #[serde(rename="DBClusterSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
@@ -1783,84 +1941,159 @@ impl CreateDBClusterSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBInstanceMessage {
     #[doc="<p>The amount of storage (in gigabytes) to be initially allocated for the database instance.</p> <p>Type: Integer</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. Aurora cluster volumes automatically grow as the amount of data in your database increases, though you are only charged for the space that you use in an Aurora cluster volume.</p> <p> <b>MySQL</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 5 to 6144.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 6144.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>MariaDB</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 5 to 6144.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 6144.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>PostgreSQL</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 5 to 6144.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 6144.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>Oracle</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 10 to 6144.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 6144.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 10 to 3072.</p> </li> </ul> <p> <b>SQL Server</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 16384.</p> </li> <li> <p>Web and Express editions: Must be an integer from 20 to 16384.</p> </li> </ul> </li> <li> <p>Provisioned IOPS storage (io1):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 16384.</p> </li> <li> <p>Web and Express editions: Must be an integer from 100 to 16384.</p> </li> </ul> </li> <li> <p>Magnetic storage (standard):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 1024.</p> </li> <li> <p>Web and Express editions: Must be an integer from 20 to 1024.</p> </li> </ul> </li> </ul>"]
+    #[serde(rename="AllocatedStorage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocated_storage: Option<i64>,
     #[doc="<p>Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window.</p> <p>Default: <code>true</code> </p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p> The EC2 Availability Zone that the database instance will be created in. For information on regions and Availability Zones, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html\">Regions and Availability Zones</a>. </p> <p>Default: A random, system-chosen Availability Zone in the endpoint's AWS Region.</p> <p> Example: <code>us-east-1d</code> </p> <p> Constraint: The AvailabilityZone parameter cannot be specified if the MultiAZ parameter is set to <code>true</code>. The specified Availability Zone must be in the same AWS Region as the current endpoint. </p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The retention period for automated backups is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 0 to 35</p> </li> <li> <p>Cannot be set to 0 if the DB instance is a source to Read Replicas</p> </li> </ul>"]
+    #[serde(rename="BackupRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub backup_retention_period: Option<i64>,
     #[doc="<p>For supported engines, indicates that the DB instance should be associated with the specified CharacterSet.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The character set is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p>"]
+    #[serde(rename="CharacterSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub character_set_name: Option<String>,
     #[doc="<p>True to copy all tags from the DB instance to snapshots of the DB instance; otherwise false. The default is false.</p>"]
+    #[serde(rename="CopyTagsToSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_tags_to_snapshot: Option<bool>,
     #[doc="<p>The identifier of the DB cluster that the instance will belong to.</p> <p>For information on creating a DB cluster, see <a>CreateDBCluster</a>.</p> <p>Type: String</p>"]
+    #[serde(rename="DBClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_identifier: Option<String>,
     #[doc="<p>The compute and memory capacity of the DB instance. Note that not all instance classes are available in all regions for all DB engines.</p> <p> Valid Values: <code>db.t1.micro | db.m1.small | db.m1.medium | db.m1.large | db.m1.xlarge | db.m2.xlarge |db.m2.2xlarge | db.m2.4xlarge | db.m3.medium | db.m3.large | db.m3.xlarge | db.m3.2xlarge | db.m4.large | db.m4.xlarge | db.m4.2xlarge | db.m4.4xlarge | db.m4.10xlarge | db.r3.large | db.r3.xlarge | db.r3.2xlarge | db.r3.4xlarge | db.r3.8xlarge | db.t2.micro | db.t2.small | db.t2.medium | db.t2.large</code> </p>"]
+    #[serde(rename="DBInstanceClass")]
     pub db_instance_class: String,
     #[doc="<p>The DB instance identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>mydbinstance</code> </p>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
     #[doc="<p>The meaning of this parameter differs according to the database engine you use.</p> <p>Type: String</p> <p> <b>MySQL</b> </p> <p>The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 64 alphanumeric characters</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul> <p> <b>MariaDB</b> </p> <p>The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 64 alphanumeric characters</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul> <p> <b>PostgreSQL</b> </p> <p>The name of the database to create when the DB instance is created. If this parameter is not specified, the default \"postgres\" database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 63 alphanumeric characters</p> </li> <li> <p>Must begin with a letter or an underscore. Subsequent characters can be letters, underscores, or digits (0-9).</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul> <p> <b>Oracle</b> </p> <p>The Oracle System ID (SID) of the created DB instance. If you specify <code>null</code>, the default value <code>ORCL</code> is used. You can't specify the string NULL, or any other reserved word, for <code>DBName</code>. </p> <p>Default: <code>ORCL</code> </p> <p>Constraints:</p> <ul> <li> <p>Cannot be longer than 8 characters</p> </li> </ul> <p> <b>SQL Server</b> </p> <p>Not applicable. Must be null.</p> <p> <b>Amazon Aurora</b> </p> <p>The name of the database to create when the primary instance of the DB cluster is created. If this parameter is not specified, no database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 64 alphanumeric characters</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul>"]
+    #[serde(rename="DBName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_name: Option<String>,
     #[doc="<p>The name of the DB parameter group to associate with this DB instance. If this argument is omitted, the default DBParameterGroup for the specified engine will be used.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_name: Option<String>,
     #[doc="<p>A list of DB security groups to associate with this DB instance.</p> <p>Default: The default DB security group for the database engine.</p>"]
+    #[serde(rename="DBSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_groups: Option<Vec<String>>,
     #[doc="<p>A DB subnet group to associate with this DB instance.</p> <p>If there is no DB subnet group, then it is a non-VPC DB instance.</p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>Specify the Active Directory Domain to create the instance in.</p>"]
+    #[serde(rename="Domain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain: Option<String>,
     #[doc="<p>Specify the name of the IAM role to be used when making API calls to the Directory Service.</p>"]
+    #[serde(rename="DomainIAMRoleName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain_iam_role_name: Option<String>,
     #[doc="<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts; otherwise false. </p> <p> You can enable IAM database authentication for the following database engines:</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. Mapping AWS IAM accounts to database accounts is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> <b>MySQL</b> </p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> </ul> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EnableIAMDatabaseAuthentication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_iam_database_authentication: Option<bool>,
     #[doc="<p>The name of the database engine to be used for this instance. </p> <p>Not every database engine is available for every AWS Region. </p> <p>Valid Values: </p> <ul> <li> <p> <code>aurora</code> </p> </li> <li> <p> <code>mariadb</code> </p> </li> <li> <p> <code>mysql</code> </p> </li> <li> <p> <code>oracle-ee</code> </p> </li> <li> <p> <code>oracle-se2</code> </p> </li> <li> <p> <code>oracle-se1</code> </p> </li> <li> <p> <code>oracle-se</code> </p> </li> <li> <p> <code>postgres</code> </p> </li> <li> <p> <code>sqlserver-ee</code> </p> </li> <li> <p> <code>sqlserver-se</code> </p> </li> <li> <p> <code>sqlserver-ex</code> </p> </li> <li> <p> <code>sqlserver-web</code> </p> </li> </ul>"]
+    #[serde(rename="Engine")]
     pub engine: String,
     #[doc="<p>The version number of the database engine to use.</p> <p>The following are the database engines and major and minor versions that are available with Amazon RDS. Not every database engine is available for every AWS Region.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The version number of the database engine to be used by the DB instance is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> <b>MariaDB</b> </p> <ul> <li> <p> <code>10.1.23</code> (supported in all AWS regions)</p> </li> <li> <p> <code>10.1.19</code> (supported in all AWS regions)</p> </li> <li> <p> <code>10.1.14</code> (supported in all regions except us-east-2)</p> </li> </ul> <p/> <ul> <li> <p> <code>10.0.31</code> (supported in all AWS regions)</p> </li> <li> <p> <code>10.0.28</code> (supported in all AWS regions)</p> </li> <li> <p> <code>10.0.24</code> (supported in all AWS regions)</p> </li> <li> <p> <code>10.0.17</code> (supported in all regions except us-east-2, ca-central-1, eu-west-2)</p> </li> </ul> <p> <b>Microsoft SQL Server 2016</b> </p> <ul> <li> <p> <code>13.00.4422.0.v1</code> (supported for all editions, and all AWS regions)</p> </li> <li> <p> <code>13.00.2164.0.v1</code> (supported for all editions, and all AWS regions)</p> </li> </ul> <p> <b>Microsoft SQL Server 2014</b> </p> <ul> <li> <p> <code>12.00.5546.0.v1</code> (supported for all editions, and all AWS regions)</p> </li> <li> <p> <code>12.00.5000.0.v1</code> (supported for all editions, and all AWS regions)</p> </li> <li> <p> <code>12.00.4422.0.v1</code> (supported for all editions except Enterprise Edition, and all AWS regions except ca-central-1 and eu-west-2)</p> </li> </ul> <p> <b>Microsoft SQL Server 2012</b> </p> <ul> <li> <p> <code>11.00.6594.0.v1</code> (supported for all editions, and all AWS regions)</p> </li> <li> <p> <code>11.00.6020.0.v1</code> (supported for all editions, and all AWS regions)</p> </li> <li> <p> <code>11.00.5058.0.v1</code> (supported for all editions, and all AWS regions except us-east-2, ca-central-1, and eu-west-2)</p> </li> <li> <p> <code>11.00.2100.60.v1</code> (supported for all editions, and all AWS regions except us-east-2, ca-central-1, and eu-west-2)</p> </li> </ul> <p> <b>Microsoft SQL Server 2008 R2</b> </p> <ul> <li> <p> <code>10.50.6529.0.v1</code> (supported for all editions, and all AWS regions except us-east-2, ca-central-1, and eu-west-2)</p> </li> <li> <p> <code>10.50.6000.34.v1</code> (supported for all editions, and all AWS regions except us-east-2, ca-central-1, and eu-west-2)</p> </li> <li> <p> <code>10.50.2789.0.v1</code> (supported for all editions, and all AWS regions except us-east-2, ca-central-1, and eu-west-2)</p> </li> </ul> <p> <b>MySQL</b> </p> <ul> <li> <p> <code>5.7.17</code> (supported in all AWS regions)</p> </li> <li> <p> <code>5.7.16</code> (supported in all AWS regions)</p> </li> <li> <p> <code>5.7.11</code> (supported in all AWS regions)</p> </li> </ul> <p/> <ul> <li> <p> <code>5.6.35</code> (supported in all AWS regions)</p> </li> <li> <p> <code>5.6.34</code> (supported in all AWS regions)</p> </li> <li> <p> <code>5.6.29</code> (supported in all AWS regions)</p> </li> <li> <p> <code>5.6.27</code> (supported in all regions except us-east-2, ca-central-1, eu-west-2)</p> </li> </ul> <p/> <ul> <li> <p> <code>5.5.54</code> (supported in all AWS regions)</p> </li> <li> <p> <code>5.5.53</code> (supported in all AWS regions)</p> </li> <li> <p> <code>5.5.46</code> (supported in all AWS regions)</p> </li> </ul> <p> <b>Oracle 12c</b> </p> <ul> <li> <p> <code>12.1.0.2.v8</code> (supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)</p> </li> <li> <p> <code>12.1.0.2.v7</code> (supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)</p> </li> <li> <p> <code>12.1.0.2.v6</code> (supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)</p> </li> <li> <p> <code>12.1.0.2.v5</code> (supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)</p> </li> <li> <p> <code>12.1.0.2.v4</code> (supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)</p> </li> <li> <p> <code>12.1.0.2.v3</code> (supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)</p> </li> <li> <p> <code>12.1.0.2.v2</code> (supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)</p> </li> <li> <p> <code>12.1.0.2.v1</code> (supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)</p> </li> </ul> <p> <b>Oracle 11g</b> </p> <ul> <li> <p> <code>11.2.0.4.v12</code> (supported for EE, SE1, and SE, in all AWS regions)</p> </li> <li> <p> <code>11.2.0.4.v11</code> (supported for EE, SE1, and SE, in all AWS regions)</p> </li> <li> <p> <code>11.2.0.4.v10</code> (supported for EE, SE1, and SE, in all AWS regions)</p> </li> <li> <p> <code>11.2.0.4.v9</code> (supported for EE, SE1, and SE, in all AWS regions)</p> </li> <li> <p> <code>11.2.0.4.v8</code> (supported for EE, SE1, and SE, in all AWS regions)</p> </li> <li> <p> <code>11.2.0.4.v7</code> (supported for EE, SE1, and SE, in all AWS regions)</p> </li> <li> <p> <code>11.2.0.4.v6</code> (supported for EE, SE1, and SE, in all AWS regions)</p> </li> <li> <p> <code>11.2.0.4.v5</code> (supported for EE, SE1, and SE, in all AWS regions)</p> </li> <li> <p> <code>11.2.0.4.v4</code> (supported for EE, SE1, and SE, in all AWS regions)</p> </li> <li> <p> <code>11.2.0.4.v3</code> (supported for EE, SE1, and SE, in all AWS regions)</p> </li> <li> <p> <code>11.2.0.4.v1</code> (supported for EE, SE1, and SE, in all AWS regions)</p> </li> </ul> <p> <b>PostgreSQL</b> </p> <ul> <li> <p> <b>Version 9.6.x:</b> <code> 9.6.1 | 9.6.2</code> </p> </li> <li> <p> <b>Version 9.5.x:</b> <code>9.5.6 | 9.5.4 | 9.5.2</code> </p> </li> <li> <p> <b>Version 9.4.x:</b> <code>9.4.11 | 9.4.9 | 9.4.7</code> </p> </li> <li> <p> <b>Version 9.3.x:</b> <code>9.3.16 | 9.3.14 | 9.3.12</code> </p> </li> </ul>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for the DB instance.</p> <p>Constraints: Must be a multiple between 3 and 10 of the storage amount for the DB instance. Must also be an integer multiple of 1000. For example, if the size of your DB instance is 500 GB, then your <code>Iops</code> value can be 2000, 3000, 4000, or 5000. </p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>The KMS key identifier for an encrypted DB instance.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are creating a DB instance with the same AWS account that owns the KMS encryption key used to encrypt the new DB instance, then you can use the KMS key alias instead of the ARN for the KM encryption key.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The KMS key identifier is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>If the <code>StorageEncrypted</code> parameter is true, and you do not specify a value for the <code>KmsKeyId</code> parameter, then Amazon RDS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS Region.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>License model information for this DB instance.</p> <p> Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>"]
+    #[serde(rename="LicenseModel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_model: Option<String>,
     #[doc="<p>The password for the master user. Can be any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The password for the master user is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> <b>MariaDB</b> </p> <p>Constraints: Must contain from 8 to 41 characters.</p> <p> <b>Microsoft SQL Server</b> </p> <p>Constraints: Must contain from 8 to 128 characters.</p> <p> <b>MySQL</b> </p> <p>Constraints: Must contain from 8 to 41 characters.</p> <p> <b>Oracle</b> </p> <p>Constraints: Must contain from 8 to 30 characters.</p> <p> <b>PostgreSQL</b> </p> <p>Constraints: Must contain from 8 to 128 characters.</p>"]
+    #[serde(rename="MasterUserPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_user_password: Option<String>,
     #[doc="<p>The name for the master user.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The name for the master user is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> <b>MariaDB</b> </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 16 alphanumeric characters.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>Microsoft SQL Server</b> </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 128 alphanumeric characters.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>MySQL</b> </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 16 alphanumeric characters.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>Oracle</b> </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 30 alphanumeric characters.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>PostgreSQL</b> </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 63 alphanumeric characters.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul>"]
+    #[serde(rename="MasterUsername")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_username: Option<String>,
     #[doc="<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0.</p> <p>If <code>MonitoringRoleArn</code> is specified, then you must also set <code>MonitoringInterval</code> to a value other than 0.</p> <p>Valid Values: <code>0, 1, 5, 10, 15, 30, 60</code> </p>"]
+    #[serde(rename="MonitoringInterval")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring_interval: Option<i64>,
     #[doc="<p>The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. For example, <code>arn:aws:iam:123456789012:role/emaccess</code>. For information on creating a monitoring role, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html#USER_Monitoring.OS.Enabling\">Setting Up and Enabling Enhanced Monitoring</a>.</p> <p>If <code>MonitoringInterval</code> is set to a value other than 0, then you must supply a <code>MonitoringRoleArn</code> value.</p>"]
+    #[serde(rename="MonitoringRoleArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring_role_arn: Option<String>,
     #[doc="<p>Specifies if the DB instance is a Multi-AZ deployment. You cannot set the AvailabilityZone parameter if the MultiAZ parameter is set to true.</p>"]
+    #[serde(rename="MultiAZ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az: Option<bool>,
     #[doc="<p>Indicates that the DB instance should be associated with the specified option group.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, cannot be removed from an option group, and that option group cannot be removed from a DB instance once it is associated with a DB instance</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The port number on which the database accepts connections.</p> <p> <b>MySQL</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>MariaDB</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>PostgreSQL</b> </p> <p> Default: <code>5432</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>Oracle</b> </p> <p> Default: <code>1521</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>SQL Server</b> </p> <p> Default: <code>1433</code> </p> <p> Valid Values: <code>1150-65535</code> except for <code>1434</code>, <code>3389</code>, <code>47001</code>, <code>49152</code>, and <code>49152</code> through <code>49156</code>. </p> <p> <b>Amazon Aurora</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p> The daily time range during which automated backups are created if automated backups are enabled, using the <code>BackupRetentionPeriod</code> parameter. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.BackingUpAndRestoringAmazonRDSInstances.html\">DB Instance Backups</a>. </p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The daily time range for creating automated backups is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> Default: A 30-minute window selected at random from an 8-hour block of time per AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#AdjustingTheMaintenanceWindow\"> Adjusting the Preferred DB Instance Maintenance Window</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Times should be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>"]
+    #[serde(rename="PreferredBackupWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_backup_window: Option<String>,
     #[doc="<p> The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC). For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBMaintenance.html\">DB Instance Maintenance</a>. </p> <p> Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p> Default: A 30-minute window selected at random from an 8-hour block of time per AWS Region, occurring on a random day of the week. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun</p> <p>Constraints: Minimum 30-minute window.</p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p> <p>Default: 1</p> <p>Valid Values: 0 - 15</p>"]
+    #[serde(rename="PromotionTier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub promotion_tier: Option<i64>,
     #[doc="<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b> true</p> </li> <li> <p> <b>VPC:</b> false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be private.</p>"]
+    #[serde(rename="PubliclyAccessible")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub publicly_accessible: Option<bool>,
     #[doc="<p>Specifies whether the DB instance is encrypted.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The encryption for DB instances is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>Default: false</p>"]
+    #[serde(rename="StorageEncrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_encrypted: Option<bool>,
     #[doc="<p>Specifies the storage type to be associated with the DB instance.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified; otherwise <code>standard</code> </p>"]
+    #[serde(rename="StorageType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_type: Option<String>,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The ARN from the Key Store with which to associate the instance for TDE encryption.</p>"]
+    #[serde(rename="TdeCredentialArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tde_credential_arn: Option<String>,
     #[doc="<p>The password for the given ARN from the Key Store in order to access the device.</p>"]
+    #[serde(rename="TdeCredentialPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tde_credential_password: Option<String>,
     #[doc="<p>The time zone of the DB instance. The time zone parameter is currently supported only by <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.TimeZone\">Microsoft SQL Server</a>. </p>"]
+    #[serde(rename="Timezone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timezone: Option<String>,
     #[doc="<p>A list of EC2 VPC security groups to associate with this DB instance.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The associated list of EC2 VPC security groups is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>Default: The default EC2 VPC security group for the DB subnet group's VPC.</p>"]
+    #[serde(rename="VpcSecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_ids: Option<Vec<String>>,
 }
 
@@ -2033,42 +2266,76 @@ impl CreateDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBInstanceReadReplicaMessage {
     #[doc="<p>Indicates that minor engine upgrades will be applied automatically to the Read Replica during the maintenance window.</p> <p>Default: Inherits from the source DB instance</p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p>The Amazon EC2 Availability Zone that the Read Replica will be created in.</p> <p>Default: A random, system-chosen Availability Zone in the endpoint's AWS Region.</p> <p> Example: <code>us-east-1d</code> </p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>True to copy all tags from the Read Replica to snapshots of the Read Replica; otherwise false. The default is false.</p>"]
+    #[serde(rename="CopyTagsToSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_tags_to_snapshot: Option<bool>,
     #[doc="<p>The compute and memory capacity of the Read Replica. Note that not all instance classes are available in all regions for all DB engines.</p> <p> Valid Values: <code>db.m1.small | db.m1.medium | db.m1.large | db.m1.xlarge | db.m2.xlarge |db.m2.2xlarge | db.m2.4xlarge | db.m3.medium | db.m3.large | db.m3.xlarge | db.m3.2xlarge | db.m4.large | db.m4.xlarge | db.m4.2xlarge | db.m4.4xlarge | db.m4.10xlarge | db.r3.large | db.r3.xlarge | db.r3.2xlarge | db.r3.4xlarge | db.r3.8xlarge | db.t2.micro | db.t2.small | db.t2.medium | db.t2.large</code> </p> <p>Default: Inherits from the source DB instance.</p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p>The DB instance identifier of the Read Replica. This identifier is the unique key that identifies a DB instance. This parameter is stored as a lowercase string.</p>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
     #[doc="<p>Specifies a DB subnet group for the DB instance. The new DB instance will be created in the VPC associated with the DB subnet group. If no DB subnet group is specified, then the new DB instance is not created in a VPC.</p> <p>Constraints:</p> <ul> <li> <p>Can only be specified if the source DB instance identifier specifies a DB instance in another AWS Region.</p> </li> <li> <p>The specified DB subnet group must be in the same AWS Region in which the operation is running.</p> </li> <li> <p>All Read Replicas in one AWS Region that are created from the same source DB instance must either:&gt;</p> <ul> <li> <p>Specify DB subnet groups from the same VPC. All these Read Replicas will be created in the same VPC.</p> </li> <li> <p>Not specify a DB subnet group. All these Read Replicas will be created outside of any VPC.</p> </li> </ul> </li> </ul> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts; otherwise false.</p> <p>You can enable IAM database authentication for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> <li> <p>Aurora 5.6 or higher.</p> </li> </ul> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EnableIAMDatabaseAuthentication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_iam_database_authentication: Option<bool>,
     #[doc="<p>The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for the DB instance.</p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>The AWS KMS key ID for an encrypted Read Replica. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key. </p> <p>If you specify this parameter when you create a Read Replica from an unencrypted DB instance, the Read Replica is encrypted. </p> <p>If you create an encrypted Read Replica in the same AWS Region as the source DB instance, then you do not have to specify a value for this parameter. The Read Replica is encrypted with the same KMS key as the source DB instance. </p> <p>If you create an encrypted Read Replica in a different AWS Region, then you must specify a KMS key for the destination AWS Region. KMS encryption keys are specific to the AWS Region that they are created in, and you cannot use encryption keys from one AWS Region in another AWS Region. </p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the Read Replica. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0.</p> <p>If <code>MonitoringRoleArn</code> is specified, then you must also set <code>MonitoringInterval</code> to a value other than 0.</p> <p>Valid Values: <code>0, 1, 5, 10, 15, 30, 60</code> </p>"]
+    #[serde(rename="MonitoringInterval")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring_interval: Option<i64>,
     #[doc="<p>The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. For example, <code>arn:aws:iam:123456789012:role/emaccess</code>. For information on creating a monitoring role, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html#USER_Monitoring.OS.IAMRole\">To create an IAM role for Amazon RDS Enhanced Monitoring</a>.</p> <p>If <code>MonitoringInterval</code> is set to a value other than 0, then you must supply a <code>MonitoringRoleArn</code> value.</p>"]
+    #[serde(rename="MonitoringRoleArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring_role_arn: Option<String>,
     #[doc="<p>The option group the DB instance will be associated with. If omitted, the default option group for the engine specified will be used.</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The port number that the DB instance uses for connections.</p> <p>Default: Inherits from the source DB instance</p> <p>Valid Values: <code>1150-65535</code> </p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The URL that contains a Signature Version 4 signed request for the <code>CreateDBInstanceReadReplica</code> API action in the source AWS Region that contains the source DB instance. </p> <p>You must specify this parameter when you create an encrypted Read Replica from another AWS Region by using the Amazon RDS API. You can specify the source region option instead of this parameter when you create an encrypted Read Replica from another AWS Region by using the AWS CLI. </p> <p>The presigned URL must be a valid request for the <code>CreateDBInstanceReadReplica</code> API action that can be executed in the source AWS Region that contains the encrypted source DB instance. The presigned URL request must contain the following parameter values: </p> <ul> <li> <p> <code>DestinationRegion</code> - The AWS Region that the encrypted Read Replica will be created in. This AWS Region is the same one where the <code>CreateDBInstanceReadReplica</code> action is called that contains this presigned URL. </p> <p>For example, if you create an encrypted DB instance in the us-west-1 region, from a source DB instance in the us-east-2 region, then you call the <code>CreateDBInstanceReadReplica</code> action in the us-east-1 region and provide a presigned URL that contains a call to the <code>CreateDBInstanceReadReplica</code> action in the us-west-2 region. For this example, the <code>DestinationRegion</code> in the presigned URL must be set to the us-east-1 region. </p> </li> <li> <p> <code>KmsKeyId</code> - The KMS key identifier for the key to use to encrypt the Read Replica in the destination AWS Region. This is the same identifier for both the <code>CreateDBInstanceReadReplica</code> action that is called in the destination AWS Region, and the action contained in the presigned URL. </p> </li> <li> <p> <code>SourceDBInstanceIdentifier</code> - The DB instance identifier for the encrypted DB instance to be replicated. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are creating an encrypted Read Replica from a DB instance in the us-west-2 region, then your <code>SourceDBInstanceIdentifier</code> looks like the following example: <code>arn:aws:rds:us-west-2:123456789012:instance:mysql-instance1-20161115</code>. </p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\">Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4 Signing Process</a>. </p>"]
+    #[serde(rename="PreSignedUrl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pre_signed_url: Option<String>,
     #[doc="<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b>true</p> </li> <li> <p> <b>VPC:</b>false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be private.</p>"]
+    #[serde(rename="PubliclyAccessible")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub publicly_accessible: Option<bool>,
     #[doc="<p>The identifier of the DB instance that will act as the source for the Read Replica. Each DB instance can have up to five Read Replicas.</p> <p>Constraints:</p> <ul> <li> <p>Must be the identifier of an existing MySQL, MariaDB, or PostgreSQL DB instance.</p> </li> <li> <p>Can specify a DB instance that is a MySQL Read Replica only if the source is running MySQL 5.6.</p> </li> <li> <p>Can specify a DB instance that is a PostgreSQL DB instance only if the source is running PostgreSQL 9.3.5 or later (9.4.7 and higher for cross region replication).</p> </li> <li> <p>The specified DB instance must have automatic backups enabled, its backup retention period must be greater than 0.</p> </li> <li> <p>If the source DB instance is in the same AWS Region as the Read Replica, specify a valid DB instance identifier.</p> </li> <li> <p>If the source DB instance is in a different AWS Region than the Read Replica, specify a valid DB instance ARN. For more information, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing a Amazon RDS Amazon Resource Name (ARN)</a>.</p> </li> </ul>"]
+    #[serde(rename="SourceDBInstanceIdentifier")]
     pub source_db_instance_identifier: String,
     #[doc="<p>Specifies the storage type to be associated with the Read Replica.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified; otherwise <code>standard</code> </p>"]
+    #[serde(rename="StorageType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_type: Option<String>,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2153,8 +2420,10 @@ impl CreateDBInstanceReadReplicaMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBInstanceReadReplicaResult {
+    #[serde(rename="DBInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance: Option<DBInstance>,
 }
 
@@ -2202,8 +2471,10 @@ impl CreateDBInstanceReadReplicaResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBInstanceResult {
+    #[serde(rename="DBInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance: Option<DBInstance>,
 }
 
@@ -2251,14 +2522,19 @@ impl CreateDBInstanceResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBParameterGroupMessage {
     #[doc="<p>The DB parameter group family name. A DB parameter group can be associated with one and only one DB parameter group family, and can be applied only to a DB instance running a database engine and engine version compatible with that DB parameter group family.</p>"]
+    #[serde(rename="DBParameterGroupFamily")]
     pub db_parameter_group_family: String,
     #[doc="<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <note> <p>This value is stored as a lowercase string.</p> </note>"]
+    #[serde(rename="DBParameterGroupName")]
     pub db_parameter_group_name: String,
     #[doc="<p>The description for the DB parameter group.</p>"]
+    #[serde(rename="Description")]
     pub description: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2285,8 +2561,10 @@ impl CreateDBParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBParameterGroupResult {
+    #[serde(rename="DBParameterGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group: Option<DBParameterGroup>,
 }
 
@@ -2334,12 +2612,16 @@ impl CreateDBParameterGroupResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBSecurityGroupMessage {
     #[doc="<p>The description for the DB security group.</p>"]
+    #[serde(rename="DBSecurityGroupDescription")]
     pub db_security_group_description: String,
     #[doc="<p>The name for the DB security group. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> <li> <p>Must not be \"Default\"</p> </li> </ul> <p>Example: <code>mysecuritygroup</code> </p>"]
+    #[serde(rename="DBSecurityGroupName")]
     pub db_security_group_name: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2364,8 +2646,10 @@ impl CreateDBSecurityGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBSecurityGroupResult {
+    #[serde(rename="DBSecurityGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_group: Option<DBSecurityGroup>,
 }
 
@@ -2413,12 +2697,16 @@ impl CreateDBSecurityGroupResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBSnapshotMessage {
     #[doc="<p>The DB instance identifier. This is the unique key that identifies a DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
     #[doc="<p>The identifier for the DB snapshot.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-snapshot-id</code> </p>"]
+    #[serde(rename="DBSnapshotIdentifier")]
     pub db_snapshot_identifier: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2443,8 +2731,10 @@ impl CreateDBSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBSnapshotResult {
+    #[serde(rename="DBSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot: Option<DBSnapshot>,
 }
 
@@ -2492,14 +2782,19 @@ impl CreateDBSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBSubnetGroupMessage {
     #[doc="<p>The description for the DB subnet group.</p>"]
+    #[serde(rename="DBSubnetGroupDescription")]
     pub db_subnet_group_description: String,
     #[doc="<p>The name for the DB subnet group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>"]
+    #[serde(rename="DBSubnetGroupName")]
     pub db_subnet_group_name: String,
     #[doc="<p>The EC2 Subnet IDs for the DB subnet group.</p>"]
+    #[serde(rename="SubnetIds")]
     pub subnet_ids: Vec<String>,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2527,8 +2822,10 @@ impl CreateDBSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDBSubnetGroupResult {
+    #[serde(rename="DBSubnetGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group: Option<DBSubnetGroup>,
 }
 
@@ -2576,20 +2873,32 @@ impl CreateDBSubnetGroupResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEventSubscriptionMessage {
     #[doc="<p> A Boolean value; set to <b>true</b> to activate the subscription, set to <b>false</b> to create the subscription but not active it. </p>"]
+    #[serde(rename="Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled: Option<bool>,
     #[doc="<p> A list of event categories for a SourceType that you want to subscribe to. You can see a list of the categories for a given SourceType in the <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html\">Events</a> topic in the Amazon RDS User Guide or by using the <b>DescribeEventCategories</b> action. </p>"]
+    #[serde(rename="EventCategories")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) of the SNS topic created for event notification. The ARN is created by Amazon SNS when you create a topic and subscribe to it.</p>"]
+    #[serde(rename="SnsTopicArn")]
     pub sns_topic_arn: String,
     #[doc="<p>The list of identifiers of the event sources for which events will be returned. If not specified, then all sources are included in the response. An identifier must begin with a letter and must contain only ASCII letters, digits, and hyphens; it cannot end with a hyphen or contain two consecutive hyphens.</p> <p>Constraints:</p> <ul> <li> <p>If SourceIds are supplied, SourceType must also be provided.</p> </li> <li> <p>If the source type is a DB instance, then a <code>DBInstanceIdentifier</code> must be supplied.</p> </li> <li> <p>If the source type is a DB security group, a <code>DBSecurityGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB parameter group, a <code>DBParameterGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB snapshot, a <code>DBSnapshotIdentifier</code> must be supplied.</p> </li> </ul>"]
+    #[serde(rename="SourceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_ids: Option<Vec<String>>,
     #[doc="<p>The type of source that will be generating the events. For example, if you want to be notified of events generated by a DB instance, you would set this parameter to db-instance. if this value is not specified, all events are returned.</p> <p>Valid values: <code>db-instance</code> | <code>db-cluster</code> | <code>db-parameter-group</code> | <code>db-security-group</code> | <code>db-snapshot</code> | <code>db-cluster-snapshot</code> </p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
     #[doc="<p>The name of the subscription.</p> <p>Constraints: The name must be less than 255 characters.</p>"]
+    #[serde(rename="SubscriptionName")]
     pub subscription_name: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2632,8 +2941,10 @@ impl CreateEventSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEventSubscriptionResult {
+    #[serde(rename="EventSubscription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_subscription: Option<EventSubscription>,
 }
 
@@ -2681,16 +2992,22 @@ impl CreateEventSubscriptionResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateOptionGroupMessage {
     #[doc="<p>Specifies the name of the engine that this option group should be associated with.</p>"]
+    #[serde(rename="EngineName")]
     pub engine_name: String,
     #[doc="<p>Specifies the major version of the engine that this option group should be associated with.</p>"]
+    #[serde(rename="MajorEngineVersion")]
     pub major_engine_version: String,
     #[doc="<p>The description of the option group.</p>"]
+    #[serde(rename="OptionGroupDescription")]
     pub option_group_description: String,
     #[doc="<p>Specifies the name of the option group to be created.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>myoptiongroup</code> </p>"]
+    #[serde(rename="OptionGroupName")]
     pub option_group_name: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2719,8 +3036,10 @@ impl CreateOptionGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateOptionGroupResult {
+    #[serde(rename="OptionGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group: Option<OptionGroup>,
 }
 
@@ -2768,77 +3087,147 @@ impl CreateOptionGroupResultDeserializer {
     }
 }
 #[doc="<p>Contains the result of a successful invocation of the following actions:</p> <ul> <li> <p> <a>CreateDBCluster</a> </p> </li> <li> <p> <a>DeleteDBCluster</a> </p> </li> <li> <p> <a>FailoverDBCluster</a> </p> </li> <li> <p> <a>ModifyDBCluster</a> </p> </li> <li> <p> <a>RestoreDBClusterFromSnapshot</a> </p> </li> <li> <p> <a>RestoreDBClusterToPointInTime</a> </p> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBClusters</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBCluster {
     #[doc="<p>For all database engines except Amazon Aurora, <code>AllocatedStorage</code> specifies the allocated storage size in gigabytes (GB). For Aurora, <code>AllocatedStorage</code> always returns 1, because Aurora DB cluster storage size is not fixed, but instead automatically adjusts as needed.</p>"]
+    #[serde(rename="AllocatedStorage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocated_storage: Option<i64>,
     #[doc="<p>Provides a list of the AWS Identity and Access Management (IAM) roles that are associated with the DB cluster. IAM roles that are associated with a DB cluster grant permission for the DB cluster to access other AWS services on your behalf.</p>"]
+    #[serde(rename="AssociatedRoles")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub associated_roles: Option<Vec<DBClusterRole>>,
     #[doc="<p>Provides the list of EC2 Availability Zones that instances in the DB cluster can be created in.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<String>>,
     #[doc="<p>Specifies the number of days for which automatic DB snapshots are retained.</p>"]
+    #[serde(rename="BackupRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub backup_retention_period: Option<i64>,
     #[doc="<p>If present, specifies the name of the character set that this cluster is associated with.</p>"]
+    #[serde(rename="CharacterSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub character_set_name: Option<String>,
     #[doc="<p>Identifies the clone group to which the DB cluster is associated.</p>"]
+    #[serde(rename="CloneGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub clone_group_id: Option<String>,
     #[doc="<p>Specifies the time when the DB cluster was created, in Universal Coordinated Time (UTC).</p>"]
+    #[serde(rename="ClusterCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_create_time: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) for the DB cluster.</p>"]
+    #[serde(rename="DBClusterArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_arn: Option<String>,
     #[doc="<p>Contains a user-supplied DB cluster identifier. This identifier is the unique key that identifies a DB cluster.</p>"]
+    #[serde(rename="DBClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_identifier: Option<String>,
     #[doc="<p>Provides the list of instances that make up the DB cluster.</p>"]
+    #[serde(rename="DBClusterMembers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_members: Option<Vec<DBClusterMember>>,
     #[doc="<p>Provides the list of option group memberships for this DB cluster.</p>"]
+    #[serde(rename="DBClusterOptionGroupMemberships")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_option_group_memberships: Option<Vec<DBClusterOptionGroupStatus>>,
     #[doc="<p>Specifies the name of the DB cluster parameter group for the DB cluster.</p>"]
+    #[serde(rename="DBClusterParameterGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_group: Option<String>,
     #[doc="<p>Specifies information on the subnet group associated with the DB cluster, including the name, description, and subnets in the subnet group.</p>"]
+    #[serde(rename="DBSubnetGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group: Option<String>,
     #[doc="<p>Contains the name of the initial database of this DB cluster that was provided at create time, if one was specified when the DB cluster was created. This same name is returned for the life of the DB cluster.</p>"]
+    #[serde(rename="DatabaseName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub database_name: Option<String>,
     #[doc="<p>The region-unique, immutable identifier for the DB cluster. This identifier is found in AWS CloudTrail log entries whenever the KMS key for the DB cluster is accessed.</p>"]
+    #[serde(rename="DbClusterResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_resource_id: Option<String>,
     #[doc="<p>Specifies the earliest time to which a database can be restored with point-in-time restore.</p>"]
+    #[serde(rename="EarliestRestorableTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub earliest_restorable_time: Option<String>,
     #[doc="<p>Specifies the connection endpoint for the primary instance of the DB cluster.</p>"]
+    #[serde(rename="Endpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoint: Option<String>,
     #[doc="<p>Provides the name of the database engine to be used for this DB cluster.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>Indicates the database engine version.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>Specifies the ID that Amazon Route 53 assigns when you create a hosted zone.</p>"]
+    #[serde(rename="HostedZoneId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hosted_zone_id: Option<String>,
     #[doc="<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled; otherwise false.</p>"]
+    #[serde(rename="IAMDatabaseAuthenticationEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_database_authentication_enabled: Option<bool>,
     #[doc="<p>If <code>StorageEncrypted</code> is true, the KMS key identifier for the encrypted DB cluster.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>Specifies the latest time to which a database can be restored with point-in-time restore.</p>"]
+    #[serde(rename="LatestRestorableTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub latest_restorable_time: Option<String>,
     #[doc="<p>Contains the master username for the DB cluster.</p>"]
+    #[serde(rename="MasterUsername")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_username: Option<String>,
     #[doc="<p>Specifies whether the DB cluster has instances in multiple Availability Zones.</p>"]
+    #[serde(rename="MultiAZ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az: Option<bool>,
     #[doc="<p>Specifies the progress of the operation as a percentage.</p>"]
+    #[serde(rename="PercentProgress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub percent_progress: Option<String>,
     #[doc="<p>Specifies the port that the database engine is listening on.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>Specifies the daily time range during which automated backups are created if automated backups are enabled, as determined by the <code>BackupRetentionPeriod</code>. </p>"]
+    #[serde(rename="PreferredBackupWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_backup_window: Option<String>,
     #[doc="<p>Specifies the weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>Contains one or more identifiers of the Read Replicas associated with this DB cluster.</p>"]
+    #[serde(rename="ReadReplicaIdentifiers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub read_replica_identifiers: Option<Vec<String>>,
     #[doc="<p>The reader endpoint for the DB cluster. The reader endpoint for a DB cluster load-balances connections across the Aurora Replicas that are available in a DB cluster. As clients request new connections to the reader endpoint, Aurora distributes the connection requests among the Aurora Replicas in the DB cluster. This functionality can help balance your read workload across multiple Aurora Replicas in your DB cluster. </p> <p>If a failover occurs, and the Aurora Replica that you are connected to is promoted to be the primary instance, your connection will be dropped. To continue sending your read workload to other Aurora Replicas in the cluster, you can then reconnect to the reader endpoint.</p>"]
+    #[serde(rename="ReaderEndpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reader_endpoint: Option<String>,
     #[doc="<p>Contains the identifier of the source DB cluster if this DB cluster is a Read Replica.</p>"]
+    #[serde(rename="ReplicationSourceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_source_identifier: Option<String>,
     #[doc="<p>Specifies the current state of this DB cluster.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>Specifies whether the DB cluster is encrypted.</p>"]
+    #[serde(rename="StorageEncrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_encrypted: Option<bool>,
     #[doc="<p>Provides a list of VPC security groups that the DB cluster belongs to.</p>"]
+    #[serde(rename="VpcSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_groups: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
@@ -3079,15 +3468,23 @@ impl DBClusterListDeserializer {
     }
 }
 #[doc="<p>Contains information about an instance that is part of a DB cluster.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterMember {
     #[doc="<p>Specifies the status of the DB cluster parameter group for this member of the DB cluster.</p>"]
+    #[serde(rename="DBClusterParameterGroupStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_group_status: Option<String>,
     #[doc="<p>Specifies the instance identifier for this member of the DB cluster.</p>"]
+    #[serde(rename="DBInstanceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_identifier: Option<String>,
     #[doc="<p>Value that is <code>true</code> if the cluster member is the primary instance for the DB cluster and <code>false</code> otherwise.</p>"]
+    #[serde(rename="IsClusterWriter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_cluster_writer: Option<bool>,
     #[doc="<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p>"]
+    #[serde(rename="PromotionTier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub promotion_tier: Option<i64>,
 }
 
@@ -3192,11 +3589,15 @@ impl DBClusterMemberListDeserializer {
     }
 }
 #[doc="<p>Contains the result of a successful invocation of the <a>DescribeDBClusters</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterMessage {
     #[doc="<p>Contains a list of DB clusters for the user.</p>"]
+    #[serde(rename="DBClusters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_clusters: Option<Vec<DBCluster>>,
     #[doc="<p>A pagination token that can be used in a subsequent DescribeDBClusters request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -3290,11 +3691,15 @@ impl DBClusterOptionGroupMembershipsDeserializer {
     }
 }
 #[doc="<p>Contains status information for a DB cluster option group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterOptionGroupStatus {
     #[doc="<p>Specifies the name of the DB cluster option group.</p>"]
+    #[serde(rename="DBClusterOptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_option_group_name: Option<String>,
     #[doc="<p>Specifies the status of the DB cluster option group.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -3346,15 +3751,23 @@ impl DBClusterOptionGroupStatusDeserializer {
     }
 }
 #[doc="<p>Contains the result of a successful invocation of the <a>CreateDBClusterParameterGroup</a> or <a>CopyDBClusterParameterGroup</a> action. </p> <p>This data type is used as a request parameter in the <a>DeleteDBClusterParameterGroup</a> action, and as a response element in the <a>DescribeDBClusterParameterGroups</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterParameterGroup {
     #[doc="<p>The Amazon Resource Name (ARN) for the DB cluster parameter group.</p>"]
+    #[serde(rename="DBClusterParameterGroupArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_group_arn: Option<String>,
     #[doc="<p>Provides the name of the DB cluster parameter group.</p>"]
+    #[serde(rename="DBClusterParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_group_name: Option<String>,
     #[doc="<p>Provides the name of the DB parameter group family that this DB cluster parameter group is compatible with.</p>"]
+    #[serde(rename="DBParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_family: Option<String>,
     #[doc="<p>Provides the customer-specified description for this DB cluster parameter group.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
 }
 
@@ -3416,11 +3829,15 @@ impl DBClusterParameterGroupDeserializer {
     }
 }
 #[doc="<p>Provides details about a DB cluster parameter group including the parameters in the DB cluster parameter group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterParameterGroupDetails {
     #[doc="<p> An optional pagination token provided by a previous DescribeDBClusterParameters request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>Provides a list of parameters for the DB cluster parameter group.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
 }
 
@@ -3513,9 +3930,11 @@ impl DBClusterParameterGroupListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterParameterGroupNameMessage {
     #[doc="<p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <note> <p>This value is stored as a lowercase string.</p> </note>"]
+    #[serde(rename="DBClusterParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_group_name: Option<String>,
 }
 
@@ -3564,11 +3983,15 @@ impl DBClusterParameterGroupNameMessageDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterParameterGroupsMessage {
     #[doc="<p>A list of DB cluster parameter groups.</p>"]
+    #[serde(rename="DBClusterParameterGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_groups: Option<Vec<DBClusterParameterGroup>>,
     #[doc="<p> An optional pagination token provided by a previous <code>DescribeDBClusterParameterGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -3619,11 +4042,15 @@ impl DBClusterParameterGroupsMessageDeserializer {
     }
 }
 #[doc="<p>Describes an AWS Identity and Access Management (IAM) role that is associated with a DB cluster.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterRole {
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM role that is associated with the DB cluster.</p>"]
+    #[serde(rename="RoleArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub role_arn: Option<String>,
     #[doc="<p>Describes the state of association between the IAM role and the DB cluster. The Status property returns one of the following values:</p> <ul> <li> <p> <code>ACTIVE</code> - the IAM role ARN is associated with the DB cluster and can be used to access other AWS services on your behalf.</p> </li> <li> <p> <code>PENDING</code> - the IAM role ARN is being associated with the DB cluster.</p> </li> <li> <p> <code>INVALID</code> - the IAM role ARN is associated with the DB cluster, but the DB cluster is unable to assume the IAM role in order to access other AWS services on your behalf.</p> </li> </ul>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -3716,47 +4143,87 @@ impl DBClusterRolesDeserializer {
     }
 }
 #[doc="<p>Contains the result of a successful invocation of the following actions:</p> <ul> <li> <p> <a>CreateDBClusterSnapshot</a> </p> </li> <li> <p> <a>DeleteDBClusterSnapshot</a> </p> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBClusterSnapshots</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterSnapshot {
     #[doc="<p>Specifies the allocated storage size in gigabytes (GB).</p>"]
+    #[serde(rename="AllocatedStorage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocated_storage: Option<i64>,
     #[doc="<p>Provides the list of EC2 Availability Zones that instances in the DB cluster snapshot can be restored in.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<String>>,
     #[doc="<p>Specifies the time when the DB cluster was created, in Universal Coordinated Time (UTC).</p>"]
+    #[serde(rename="ClusterCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_create_time: Option<String>,
     #[doc="<p>Specifies the DB cluster identifier of the DB cluster that this DB cluster snapshot was created from.</p>"]
+    #[serde(rename="DBClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_identifier: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) for the DB cluster snapshot.</p>"]
+    #[serde(rename="DBClusterSnapshotArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_snapshot_arn: Option<String>,
     #[doc="<p>Specifies the identifier for the DB cluster snapshot.</p>"]
+    #[serde(rename="DBClusterSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_snapshot_identifier: Option<String>,
     #[doc="<p>Specifies the name of the database engine.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>Provides the version of the database engine for this DB cluster snapshot.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled; otherwise false.</p>"]
+    #[serde(rename="IAMDatabaseAuthenticationEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_database_authentication_enabled: Option<bool>,
     #[doc="<p>If <code>StorageEncrypted</code> is true, the KMS key identifier for the encrypted DB cluster snapshot.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>Provides the license model information for this DB cluster snapshot.</p>"]
+    #[serde(rename="LicenseModel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_model: Option<String>,
     #[doc="<p>Provides the master username for the DB cluster snapshot.</p>"]
+    #[serde(rename="MasterUsername")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_username: Option<String>,
     #[doc="<p>Specifies the percentage of the estimated data that has been transferred.</p>"]
+    #[serde(rename="PercentProgress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub percent_progress: Option<i64>,
     #[doc="<p>Specifies the port that the DB cluster was listening on at the time of the snapshot.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>Provides the time when the snapshot was taken, in Universal Coordinated Time (UTC).</p>"]
+    #[serde(rename="SnapshotCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_create_time: Option<String>,
     #[doc="<p>Provides the type of the DB cluster snapshot.</p>"]
+    #[serde(rename="SnapshotType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_type: Option<String>,
     #[doc="<p>If the DB cluster snapshot was copied from a source DB cluster snapshot, the Amazon Resource Name (ARN) for the source DB cluster snapshot; otherwise, a null value.</p>"]
+    #[serde(rename="SourceDBClusterSnapshotArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_db_cluster_snapshot_arn: Option<String>,
     #[doc="<p>Specifies the status of this DB cluster snapshot.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>Specifies whether the DB cluster snapshot is encrypted.</p>"]
+    #[serde(rename="StorageEncrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_encrypted: Option<bool>,
     #[doc="<p>Provides the VPC ID associated with the DB cluster snapshot.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -3890,11 +4357,15 @@ impl DBClusterSnapshotDeserializer {
     }
 }
 #[doc="<p>Contains the name and values of a manual DB cluster snapshot attribute.</p> <p>Manual DB cluster snapshot attributes are used to authorize other AWS accounts to restore a manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterSnapshotAttribute {
     #[doc="<p>The name of the manual DB cluster snapshot attribute.</p> <p>The attribute named <code>restore</code> refers to the list of AWS accounts that have permission to copy or restore the manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>"]
+    #[serde(rename="AttributeName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_name: Option<String>,
     #[doc="<p>The value(s) for the manual DB cluster snapshot attribute.</p> <p>If the <code>AttributeName</code> field is set to <code>restore</code>, then this element returns a list of IDs of the AWS accounts that are authorized to copy or restore the manual DB cluster snapshot. If a value of <code>all</code> is in the list, then the manual DB cluster snapshot is public and available for any AWS account to copy or restore.</p>"]
+    #[serde(rename="AttributeValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_values: Option<Vec<String>>,
 }
 
@@ -3988,11 +4459,15 @@ impl DBClusterSnapshotAttributeListDeserializer {
     }
 }
 #[doc="<p>Contains the results of a successful call to the <a>DescribeDBClusterSnapshotAttributes</a> API action.</p> <p>Manual DB cluster snapshot attributes are used to authorize other AWS accounts to copy or restore a manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterSnapshotAttributesResult {
     #[doc="<p>The list of attributes and values for the manual DB cluster snapshot.</p>"]
+    #[serde(rename="DBClusterSnapshotAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_snapshot_attributes: Option<Vec<DBClusterSnapshotAttribute>>,
     #[doc="<p>The identifier of the manual DB cluster snapshot that the attributes apply to.</p>"]
+    #[serde(rename="DBClusterSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_snapshot_identifier: Option<String>,
 }
 
@@ -4085,11 +4560,15 @@ impl DBClusterSnapshotListDeserializer {
     }
 }
 #[doc="<p> Provides a list of DB cluster snapshots for the user as the result of a call to the <a>DescribeDBClusterSnapshots</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBClusterSnapshotMessage {
     #[doc="<p>Provides a list of DB cluster snapshots for the user.</p>"]
+    #[serde(rename="DBClusterSnapshots")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_snapshots: Option<Vec<DBClusterSnapshot>>,
     #[doc="<p> An optional pagination token provided by a previous <a>DescribeDBClusterSnapshots</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -4141,25 +4620,43 @@ impl DBClusterSnapshotMessageDeserializer {
     }
 }
 #[doc="<p> This data type is used as a response element in the action <a>DescribeDBEngineVersions</a>. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBEngineVersion {
     #[doc="<p>The description of the database engine.</p>"]
+    #[serde(rename="DBEngineDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_engine_description: Option<String>,
     #[doc="<p>The description of the database engine version.</p>"]
+    #[serde(rename="DBEngineVersionDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_engine_version_description: Option<String>,
     #[doc="<p>The name of the DB parameter group family for the database engine.</p>"]
+    #[serde(rename="DBParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_family: Option<String>,
     #[doc="<p> The default character set for new instances of this engine version, if the <code>CharacterSetName</code> parameter of the CreateDBInstance API is not specified. </p>"]
+    #[serde(rename="DefaultCharacterSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_character_set: Option<CharacterSet>,
     #[doc="<p>The name of the database engine.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>The version number of the database engine.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p> A list of the character sets supported by this engine for the <code>CharacterSetName</code> parameter of the <code>CreateDBInstance</code> action. </p>"]
+    #[serde(rename="SupportedCharacterSets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub supported_character_sets: Option<Vec<CharacterSet>>,
     #[doc="<p>A list of the time zones supported by this engine for the <code>Timezone</code> parameter of the <code>CreateDBInstance</code> action. </p>"]
+    #[serde(rename="SupportedTimezones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub supported_timezones: Option<Vec<Timezone>>,
     #[doc="<p>A list of engine versions that this database engine version can be upgraded to.</p>"]
+    #[serde(rename="ValidUpgradeTarget")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub valid_upgrade_target: Option<Vec<UpgradeTarget>>,
 }
 
@@ -4285,11 +4782,15 @@ impl DBEngineVersionListDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeDBEngineVersions</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBEngineVersionMessage {
     #[doc="<p> A list of <code>DBEngineVersion</code> elements. </p>"]
+    #[serde(rename="DBEngineVersions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_engine_versions: Option<Vec<DBEngineVersion>>,
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -4341,105 +4842,203 @@ impl DBEngineVersionMessageDeserializer {
     }
 }
 #[doc="<p>Contains the result of a successful invocation of the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>DeleteDBInstance</a> </p> </li> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>StopDBInstance</a> </p> </li> <li> <p> <a>StartDBInstance</a> </p> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBInstances</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBInstance {
     #[doc="<p>Specifies the allocated storage size specified in gigabytes.</p>"]
+    #[serde(rename="AllocatedStorage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocated_storage: Option<i64>,
     #[doc="<p>Indicates that minor version patches are applied automatically.</p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p>Specifies the name of the Availability Zone the DB instance is located in.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>Specifies the number of days for which automatic DB snapshots are retained.</p>"]
+    #[serde(rename="BackupRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub backup_retention_period: Option<i64>,
     #[doc="<p>The identifier of the CA certificate for this DB instance.</p>"]
+    #[serde(rename="CACertificateIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ca_certificate_identifier: Option<String>,
     #[doc="<p>If present, specifies the name of the character set that this instance is associated with.</p>"]
+    #[serde(rename="CharacterSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub character_set_name: Option<String>,
     #[doc="<p>Specifies whether tags are copied from the DB instance to snapshots of the DB instance.</p>"]
+    #[serde(rename="CopyTagsToSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_tags_to_snapshot: Option<bool>,
     #[doc="<p>If the DB instance is a member of a DB cluster, contains the name of the DB cluster that the DB instance is a member of.</p>"]
+    #[serde(rename="DBClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_identifier: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) for the DB instance.</p>"]
+    #[serde(rename="DBInstanceArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_arn: Option<String>,
     #[doc="<p>Contains the name of the compute and memory capacity class of the DB instance.</p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p>Contains a user-supplied database identifier. This identifier is the unique key that identifies a DB instance.</p>"]
+    #[serde(rename="DBInstanceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_identifier: Option<String>,
     #[doc="<p>Specifies the current state of this database.</p>"]
+    #[serde(rename="DBInstanceStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_status: Option<String>,
     #[doc="<p>The meaning of this parameter differs according to the database engine you use. For example, this value returns MySQL, MariaDB, or PostgreSQL information when returning values from CreateDBInstanceReadReplica since Read Replicas are only supported for these engines.</p> <p> <b>MySQL, MariaDB, SQL Server, PostgreSQL</b> </p> <p>Contains the name of the initial database of this instance that was provided at create time, if one was specified when the DB instance was created. This same name is returned for the life of the DB instance.</p> <p>Type: String</p> <p> <b>Oracle</b> </p> <p>Contains the Oracle System ID (SID) of the created DB instance. Not shown when the returned parameters do not apply to an Oracle DB instance.</p>"]
+    #[serde(rename="DBName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_name: Option<String>,
     #[doc="<p>Provides the list of DB parameter groups applied to this DB instance.</p>"]
+    #[serde(rename="DBParameterGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_groups: Option<Vec<DBParameterGroupStatus>>,
     #[doc="<p> Provides List of DB security group elements containing only <code>DBSecurityGroup.Name</code> and <code>DBSecurityGroup.Status</code> subelements. </p>"]
+    #[serde(rename="DBSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_groups: Option<Vec<DBSecurityGroupMembership>>,
     #[doc="<p>Specifies information on the subnet group associated with the DB instance, including the name, description, and subnets in the subnet group.</p>"]
+    #[serde(rename="DBSubnetGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group: Option<DBSubnetGroup>,
     #[doc="<p>Specifies the port that the DB instance listens on. If the DB instance is part of a DB cluster, this can be a different port than the DB cluster port.</p>"]
+    #[serde(rename="DbInstancePort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_port: Option<i64>,
     #[doc="<p>The region-unique, immutable identifier for the DB instance. This identifier is found in AWS CloudTrail log entries whenever the KMS key for the DB instance is accessed.</p>"]
+    #[serde(rename="DbiResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dbi_resource_id: Option<String>,
     #[doc="<p>The Active Directory Domain membership records associated with the DB instance.</p>"]
+    #[serde(rename="DomainMemberships")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain_memberships: Option<Vec<DomainMembership>>,
     #[doc="<p>Specifies the connection endpoint.</p>"]
+    #[serde(rename="Endpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoint: Option<Endpoint>,
     #[doc="<p>Provides the name of the database engine to be used for this DB instance.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>Indicates the database engine version.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon CloudWatch Logs log stream that receives the Enhanced Monitoring metrics data for the DB instance.</p>"]
+    #[serde(rename="EnhancedMonitoringResourceArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enhanced_monitoring_resource_arn: Option<String>,
     #[doc="<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled; otherwise false.</p> <p>IAM database authentication can be enabled for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> <li> <p>Aurora 5.6 or higher. To enable IAM database authentication for Aurora, see DBCluster Type.</p> </li> </ul>"]
+    #[serde(rename="IAMDatabaseAuthenticationEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_database_authentication_enabled: Option<bool>,
     #[doc="<p>Provides the date and time the DB instance was created.</p>"]
+    #[serde(rename="InstanceCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_create_time: Option<String>,
     #[doc="<p>Specifies the Provisioned IOPS (I/O operations per second) value.</p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p> If <code>StorageEncrypted</code> is true, the KMS key identifier for the encrypted DB instance. </p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>Specifies the latest time to which a database can be restored with point-in-time restore.</p>"]
+    #[serde(rename="LatestRestorableTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub latest_restorable_time: Option<String>,
     #[doc="<p>License model information for this DB instance.</p>"]
+    #[serde(rename="LicenseModel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_model: Option<String>,
     #[doc="<p>Contains the master username for the DB instance.</p>"]
+    #[serde(rename="MasterUsername")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_username: Option<String>,
     #[doc="<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance.</p>"]
+    #[serde(rename="MonitoringInterval")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring_interval: Option<i64>,
     #[doc="<p>The ARN for the IAM role that permits RDS to send Enhanced Monitoring metrics to CloudWatch Logs.</p>"]
+    #[serde(rename="MonitoringRoleArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring_role_arn: Option<String>,
     #[doc="<p>Specifies if the DB instance is a Multi-AZ deployment.</p>"]
+    #[serde(rename="MultiAZ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az: Option<bool>,
     #[doc="<p>Provides the list of option group memberships for this DB instance.</p>"]
+    #[serde(rename="OptionGroupMemberships")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_memberships: Option<Vec<OptionGroupMembership>>,
     #[doc="<p>Specifies that changes to the DB instance are pending. This element is only included when changes are pending. Specific changes are identified by subelements.</p>"]
+    #[serde(rename="PendingModifiedValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pending_modified_values: Option<PendingModifiedValues>,
     #[doc="<p> Specifies the daily time range during which automated backups are created if automated backups are enabled, as determined by the <code>BackupRetentionPeriod</code>. </p>"]
+    #[serde(rename="PreferredBackupWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_backup_window: Option<String>,
     #[doc="<p>Specifies the weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p>"]
+    #[serde(rename="PromotionTier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub promotion_tier: Option<i64>,
     #[doc="<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b>true</p> </li> <li> <p> <b>VPC:</b>false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be private.</p>"]
+    #[serde(rename="PubliclyAccessible")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub publicly_accessible: Option<bool>,
     #[doc="<p>Contains one or more identifiers of Aurora DB clusters that are Read Replicas of this DB instance.</p>"]
+    #[serde(rename="ReadReplicaDBClusterIdentifiers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub read_replica_db_cluster_identifiers: Option<Vec<String>>,
     #[doc="<p>Contains one or more identifiers of the Read Replicas associated with this DB instance.</p>"]
+    #[serde(rename="ReadReplicaDBInstanceIdentifiers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub read_replica_db_instance_identifiers: Option<Vec<String>>,
     #[doc="<p>Contains the identifier of the source DB instance if this DB instance is a Read Replica.</p>"]
+    #[serde(rename="ReadReplicaSourceDBInstanceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub read_replica_source_db_instance_identifier: Option<String>,
     #[doc="<p>If present, specifies the name of the secondary Availability Zone for a DB instance with multi-AZ support.</p>"]
+    #[serde(rename="SecondaryAvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub secondary_availability_zone: Option<String>,
     #[doc="<p>The status of a Read Replica. If the instance is not a Read Replica, this will be blank.</p>"]
+    #[serde(rename="StatusInfos")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_infos: Option<Vec<DBInstanceStatusInfo>>,
     #[doc="<p>Specifies whether the DB instance is encrypted.</p>"]
+    #[serde(rename="StorageEncrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_encrypted: Option<bool>,
     #[doc="<p>Specifies the storage type associated with DB instance.</p>"]
+    #[serde(rename="StorageType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_type: Option<String>,
     #[doc="<p>The ARN from the key store with which the instance is associated for TDE encryption.</p>"]
+    #[serde(rename="TdeCredentialArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tde_credential_arn: Option<String>,
     #[doc="<p>The time zone of the DB instance. In most cases, the <code>Timezone</code> element is empty. <code>Timezone</code> content appears only for Microsoft SQL Server DB instances that were created with a time zone specified. </p>"]
+    #[serde(rename="Timezone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timezone: Option<String>,
     #[doc="<p>Provides a list of VPC security group elements that the DB instance belongs to.</p>"]
+    #[serde(rename="VpcSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_groups: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
@@ -4742,11 +5341,15 @@ impl DBInstanceListDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeDBInstances</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBInstanceMessage {
     #[doc="<p> A list of <a>DBInstance</a> instances. </p>"]
+    #[serde(rename="DBInstances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instances: Option<Vec<DBInstance>>,
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -4798,15 +5401,23 @@ impl DBInstanceMessageDeserializer {
     }
 }
 #[doc="<p>Provides a list of status information for a DB instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBInstanceStatusInfo {
     #[doc="<p>Details of the error if there is an error for the instance. If the instance is not in an error state, this value is blank.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
     #[doc="<p>Boolean value that is true if the instance is operating normally, or false if the instance is in an error state.</p>"]
+    #[serde(rename="Normal")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub normal: Option<bool>,
     #[doc="<p>Status of the DB instance. For a StatusType of read replica, the values can be replicating, error, stopped, or terminated.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>This value is currently \"read replication.\"</p>"]
+    #[serde(rename="StatusType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_type: Option<String>,
 }
 
@@ -4906,15 +5517,23 @@ impl DBInstanceStatusInfoListDeserializer {
     }
 }
 #[doc="<p>Contains the result of a successful invocation of the <a>CreateDBParameterGroup</a> action. </p> <p>This data type is used as a request parameter in the <a>DeleteDBParameterGroup</a> action, and as a response element in the <a>DescribeDBParameterGroups</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBParameterGroup {
     #[doc="<p>The Amazon Resource Name (ARN) for the DB parameter group.</p>"]
+    #[serde(rename="DBParameterGroupArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_arn: Option<String>,
     #[doc="<p>Provides the name of the DB parameter group family that this DB parameter group is compatible with.</p>"]
+    #[serde(rename="DBParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_family: Option<String>,
     #[doc="<p>Provides the name of the DB parameter group.</p>"]
+    #[serde(rename="DBParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_name: Option<String>,
     #[doc="<p>Provides the customer-specified description for this DB parameter group.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
 }
 
@@ -4976,11 +5595,15 @@ impl DBParameterGroupDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeDBParameters</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBParameterGroupDetails {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> A list of <a>Parameter</a> values. </p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
 }
 
@@ -5074,9 +5697,11 @@ impl DBParameterGroupListDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>ModifyDBParameterGroup</a> or <a>ResetDBParameterGroup</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBParameterGroupNameMessage {
     #[doc="<p>Provides the name of the DB parameter group.</p>"]
+    #[serde(rename="DBParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_name: Option<String>,
 }
 
@@ -5124,11 +5749,15 @@ impl DBParameterGroupNameMessageDeserializer {
     }
 }
 #[doc="<p>The status of the DB parameter group.</p> <p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>CreateDBInstanceReadReplica</a> </p> </li> <li> <p> <a>DeleteDBInstance</a> </p> </li> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RebootDBInstance</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromDBSnapshot</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBParameterGroupStatus {
     #[doc="<p>The name of the DP parameter group.</p>"]
+    #[serde(rename="DBParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_name: Option<String>,
     #[doc="<p>The status of parameter updates.</p>"]
+    #[serde(rename="ParameterApplyStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_apply_status: Option<String>,
 }
 
@@ -5222,11 +5851,15 @@ impl DBParameterGroupStatusListDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeDBParameterGroups</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBParameterGroupsMessage {
     #[doc="<p> A list of <a>DBParameterGroup</a> instances. </p>"]
+    #[serde(rename="DBParameterGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_groups: Option<Vec<DBParameterGroup>>,
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5278,21 +5911,35 @@ impl DBParameterGroupsMessageDeserializer {
     }
 }
 #[doc="<p>Contains the result of a successful invocation of the following actions:</p> <ul> <li> <p> <a>DescribeDBSecurityGroups</a> </p> </li> <li> <p> <a>AuthorizeDBSecurityGroupIngress</a> </p> </li> <li> <p> <a>CreateDBSecurityGroup</a> </p> </li> <li> <p> <a>RevokeDBSecurityGroupIngress</a> </p> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBSecurityGroups</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBSecurityGroup {
     #[doc="<p>The Amazon Resource Name (ARN) for the DB security group.</p>"]
+    #[serde(rename="DBSecurityGroupArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_group_arn: Option<String>,
     #[doc="<p>Provides the description of the DB security group.</p>"]
+    #[serde(rename="DBSecurityGroupDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_group_description: Option<String>,
     #[doc="<p>Specifies the name of the DB security group.</p>"]
+    #[serde(rename="DBSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_group_name: Option<String>,
     #[doc="<p> Contains a list of <a>EC2SecurityGroup</a> elements. </p>"]
+    #[serde(rename="EC2SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_groups: Option<Vec<EC2SecurityGroup>>,
     #[doc="<p> Contains a list of <a>IPRange</a> elements. </p>"]
+    #[serde(rename="IPRanges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_ranges: Option<Vec<IPRange>>,
     #[doc="<p>Provides the AWS ID of the owner of a specific DB security group.</p>"]
+    #[serde(rename="OwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_id: Option<String>,
     #[doc="<p>Provides the VpcId of the DB security group.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -5367,11 +6014,15 @@ impl DBSecurityGroupDeserializer {
     }
 }
 #[doc="<p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RebootDBInstance</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromDBSnapshot</a> </p> </li> <li> <p> <a>RestoreDBInstanceToPointInTime</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBSecurityGroupMembership {
     #[doc="<p>The name of the DB security group.</p>"]
+    #[serde(rename="DBSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_group_name: Option<String>,
     #[doc="<p>The status of the DB security group.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -5464,11 +6115,15 @@ impl DBSecurityGroupMembershipListDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeDBSecurityGroups</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBSecurityGroupMessage {
     #[doc="<p> A list of <a>DBSecurityGroup</a> instances. </p>"]
+    #[serde(rename="DBSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_groups: Option<Vec<DBSecurityGroup>>,
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5574,59 +6229,111 @@ impl DBSecurityGroupsDeserializer {
     }
 }
 #[doc="<p>Contains the result of a successful invocation of the following actions:</p> <ul> <li> <p> <a>CreateDBSnapshot</a> </p> </li> <li> <p> <a>DeleteDBSnapshot</a> </p> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBSnapshots</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBSnapshot {
     #[doc="<p>Specifies the allocated storage size in gigabytes (GB).</p>"]
+    #[serde(rename="AllocatedStorage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocated_storage: Option<i64>,
     #[doc="<p>Specifies the name of the Availability Zone the DB instance was located in at the time of the DB snapshot.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>Specifies the DB instance identifier of the DB instance this DB snapshot was created from.</p>"]
+    #[serde(rename="DBInstanceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_identifier: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) for the DB snapshot.</p>"]
+    #[serde(rename="DBSnapshotArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot_arn: Option<String>,
     #[doc="<p>Specifies the identifier for the DB snapshot.</p>"]
+    #[serde(rename="DBSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot_identifier: Option<String>,
     #[doc="<p>Specifies whether the DB snapshot is encrypted.</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>Specifies the name of the database engine.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>Specifies the version of the database engine.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled; otherwise false.</p>"]
+    #[serde(rename="IAMDatabaseAuthenticationEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_database_authentication_enabled: Option<bool>,
     #[doc="<p>Specifies the time when the snapshot was taken, in Universal Coordinated Time (UTC).</p>"]
+    #[serde(rename="InstanceCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub instance_create_time: Option<String>,
     #[doc="<p>Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.</p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p> If <code>Encrypted</code> is true, the KMS key identifier for the encrypted DB snapshot. </p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>License model information for the restored DB instance.</p>"]
+    #[serde(rename="LicenseModel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_model: Option<String>,
     #[doc="<p>Provides the master username for the DB snapshot.</p>"]
+    #[serde(rename="MasterUsername")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_username: Option<String>,
     #[doc="<p>Provides the option group name for the DB snapshot.</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The percentage of the estimated data that has been transferred.</p>"]
+    #[serde(rename="PercentProgress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub percent_progress: Option<i64>,
     #[doc="<p>Specifies the port that the database engine was listening on at the time of the snapshot.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>Provides the time when the snapshot was taken, in Universal Coordinated Time (UTC).</p>"]
+    #[serde(rename="SnapshotCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_create_time: Option<String>,
     #[doc="<p>Provides the type of the DB snapshot.</p>"]
+    #[serde(rename="SnapshotType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_type: Option<String>,
     #[doc="<p>The DB snapshot Amazon Resource Name (ARN) that the DB snapshot was copied from. It only has value in case of cross-customer or cross-region copy.</p>"]
+    #[serde(rename="SourceDBSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_db_snapshot_identifier: Option<String>,
     #[doc="<p>The AWS Region that the DB snapshot was created in or copied from.</p>"]
+    #[serde(rename="SourceRegion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_region: Option<String>,
     #[doc="<p>Specifies the status of this DB snapshot.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>Specifies the storage type associated with DB snapshot.</p>"]
+    #[serde(rename="StorageType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_type: Option<String>,
     #[doc="<p>The ARN from the key store with which to associate the instance for TDE encryption.</p>"]
+    #[serde(rename="TdeCredentialArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tde_credential_arn: Option<String>,
     #[doc="<p>The time zone of the DB snapshot. In most cases, the <code>Timezone</code> element is empty. <code>Timezone</code> content appears only for snapshots taken from Microsoft SQL Server DB instances that were created with a time zone specified. </p>"]
+    #[serde(rename="Timezone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timezone: Option<String>,
     #[doc="<p>Provides the VPC ID associated with the DB snapshot.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -5784,11 +6491,15 @@ impl DBSnapshotDeserializer {
     }
 }
 #[doc="<p>Contains the name and values of a manual DB snapshot attribute</p> <p>Manual DB snapshot attributes are used to authorize other AWS accounts to restore a manual DB snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBSnapshotAttribute {
     #[doc="<p>The name of the manual DB snapshot attribute.</p> <p>The attribute named <code>restore</code> refers to the list of AWS accounts that have permission to copy or restore the manual DB cluster snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API action.</p>"]
+    #[serde(rename="AttributeName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_name: Option<String>,
     #[doc="<p>The value or values for the manual DB snapshot attribute.</p> <p>If the <code>AttributeName</code> field is set to <code>restore</code>, then this element returns a list of IDs of the AWS accounts that are authorized to copy or restore the manual DB snapshot. If a value of <code>all</code> is in the list, then the manual DB snapshot is public and available for any AWS account to copy or restore.</p>"]
+    #[serde(rename="AttributeValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_values: Option<Vec<String>>,
 }
 
@@ -5881,11 +6592,15 @@ impl DBSnapshotAttributeListDeserializer {
     }
 }
 #[doc="<p>Contains the results of a successful call to the <a>DescribeDBSnapshotAttributes</a> API action.</p> <p>Manual DB snapshot attributes are used to authorize other AWS accounts to copy or restore a manual DB snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBSnapshotAttributesResult {
     #[doc="<p>The list of attributes and values for the manual DB snapshot.</p>"]
+    #[serde(rename="DBSnapshotAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot_attributes: Option<Vec<DBSnapshotAttribute>>,
     #[doc="<p>The identifier of the manual DB snapshot that the attributes apply to.</p>"]
+    #[serde(rename="DBSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot_identifier: Option<String>,
 }
 
@@ -5979,11 +6694,15 @@ impl DBSnapshotListDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeDBSnapshots</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBSnapshotMessage {
     #[doc="<p> A list of <a>DBSnapshot</a> instances. </p>"]
+    #[serde(rename="DBSnapshots")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshots: Option<Vec<DBSnapshot>>,
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -6035,19 +6754,31 @@ impl DBSnapshotMessageDeserializer {
     }
 }
 #[doc="<p>Contains the result of a successful invocation of the following actions:</p> <ul> <li> <p> <a>CreateDBSubnetGroup</a> </p> </li> <li> <p> <a>ModifyDBSubnetGroup</a> </p> </li> <li> <p> <a>DescribeDBSubnetGroups</a> </p> </li> <li> <p> <a>DeleteDBSubnetGroup</a> </p> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBSubnetGroups</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBSubnetGroup {
     #[doc="<p>The Amazon Resource Name (ARN) for the DB subnet group.</p>"]
+    #[serde(rename="DBSubnetGroupArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_arn: Option<String>,
     #[doc="<p>Provides the description of the DB subnet group.</p>"]
+    #[serde(rename="DBSubnetGroupDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_description: Option<String>,
     #[doc="<p>The name of the DB subnet group.</p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>Provides the status of the DB subnet group.</p>"]
+    #[serde(rename="SubnetGroupStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_group_status: Option<String>,
     #[doc="<p> Contains a list of <a>Subnet</a> elements. </p>"]
+    #[serde(rename="Subnets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnets: Option<Vec<Subnet>>,
     #[doc="<p>Provides the VpcId of the DB subnet group.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -6118,11 +6849,15 @@ impl DBSubnetGroupDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeDBSubnetGroups</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DBSubnetGroupMessage {
     #[doc="<p> A list of <a>DBSubnetGroup</a> instances. </p>"]
+    #[serde(rename="DBSubnetGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_groups: Option<Vec<DBSubnetGroup>>,
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -6216,13 +6951,18 @@ impl DBSubnetGroupsDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBClusterMessage {
     #[doc="<p>The DB cluster identifier for the DB cluster to be deleted. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBClusterIdentifier")]
     pub db_cluster_identifier: String,
     #[doc="<p> The DB cluster snapshot identifier of the new DB cluster snapshot created when <code>SkipFinalSnapshot</code> is set to <code>false</code>. </p> <note> <p> Specifying this parameter and also setting the <code>SkipFinalShapshot</code> parameter to true results in an error. </p> </note> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="FinalDBSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub final_db_snapshot_identifier: Option<String>,
     #[doc="<p> Determines whether a final DB cluster snapshot is created before the DB cluster is deleted. If <code>true</code> is specified, no DB cluster snapshot is created. If <code>false</code> is specified, a DB cluster snapshot is created before the DB cluster is deleted. </p> <note> <p>You must specify a <code>FinalDBSnapshotIdentifier</code> parameter if <code>SkipFinalSnapshot</code> is <code>false</code>.</p> </note> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="SkipFinalSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub skip_final_snapshot: Option<bool>,
 }
 
@@ -6251,9 +6991,10 @@ impl DeleteDBClusterMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBClusterParameterGroupMessage {
     #[doc="<p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be the name of an existing DB cluster parameter group.</p> </li> <li> <p>You cannot delete a default DB cluster parameter group.</p> </li> <li> <p>Cannot be associated with any DB clusters.</p> </li> </ul>"]
+    #[serde(rename="DBClusterParameterGroupName")]
     pub db_cluster_parameter_group_name: String,
 }
 
@@ -6273,8 +7014,10 @@ impl DeleteDBClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBClusterResult {
+    #[serde(rename="DBCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster: Option<DBCluster>,
 }
 
@@ -6321,9 +7064,10 @@ impl DeleteDBClusterResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBClusterSnapshotMessage {
     #[doc="<p>The identifier of the DB cluster snapshot to delete.</p> <p>Constraints: Must be the name of an existing DB cluster snapshot in the <code>available</code> state.</p>"]
+    #[serde(rename="DBClusterSnapshotIdentifier")]
     pub db_cluster_snapshot_identifier: String,
 }
 
@@ -6343,8 +7087,10 @@ impl DeleteDBClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBClusterSnapshotResult {
+    #[serde(rename="DBClusterSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
@@ -6392,13 +7138,18 @@ impl DeleteDBClusterSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBInstanceMessage {
     #[doc="<p>The DB instance identifier for the DB instance to be deleted. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
     #[doc="<p> The DBSnapshotIdentifier of the new DBSnapshot created when SkipFinalSnapshot is set to <code>false</code>. </p> <note> <p>Specifying this parameter and also setting the SkipFinalShapshot parameter to true results in an error.</p> </note> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> <li> <p>Cannot be specified when deleting a Read Replica.</p> </li> </ul>"]
+    #[serde(rename="FinalDBSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub final_db_snapshot_identifier: Option<String>,
     #[doc="<p> Determines whether a final DB snapshot is created before the DB instance is deleted. If <code>true</code> is specified, no DBSnapshot is created. If <code>false</code> is specified, a DB snapshot is created before the DB instance is deleted. </p> <p>Note that when a DB instance is in a failure state and has a status of 'failed', 'incompatible-restore', or 'incompatible-network', it can only be deleted when the SkipFinalSnapshot parameter is set to \"true\".</p> <p>Specify <code>true</code> when deleting a Read Replica.</p> <note> <p>The FinalDBSnapshotIdentifier parameter must be specified if SkipFinalSnapshot is <code>false</code>.</p> </note> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="SkipFinalSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub skip_final_snapshot: Option<bool>,
 }
 
@@ -6426,8 +7177,10 @@ impl DeleteDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBInstanceResult {
+    #[serde(rename="DBInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance: Option<DBInstance>,
 }
 
@@ -6475,9 +7228,10 @@ impl DeleteDBInstanceResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBParameterGroupMessage {
     #[doc="<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be the name of an existing DB parameter group</p> </li> <li> <p>You cannot delete a default DB parameter group</p> </li> <li> <p>Cannot be associated with any DB instances</p> </li> </ul>"]
+    #[serde(rename="DBParameterGroupName")]
     pub db_parameter_group_name: String,
 }
 
@@ -6498,9 +7252,10 @@ impl DeleteDBParameterGroupMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBSecurityGroupMessage {
     #[doc="<p>The name of the DB security group to delete.</p> <note> <p>You cannot delete the default DB security group.</p> </note> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> <li> <p>Must not be \"Default\"</p> </li> </ul>"]
+    #[serde(rename="DBSecurityGroupName")]
     pub db_security_group_name: String,
 }
 
@@ -6521,9 +7276,10 @@ impl DeleteDBSecurityGroupMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBSnapshotMessage {
     #[doc="<p>The DBSnapshot identifier.</p> <p>Constraints: Must be the name of an existing DB snapshot in the <code>available</code> state.</p>"]
+    #[serde(rename="DBSnapshotIdentifier")]
     pub db_snapshot_identifier: String,
 }
 
@@ -6543,8 +7299,10 @@ impl DeleteDBSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBSnapshotResult {
+    #[serde(rename="DBSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot: Option<DBSnapshot>,
 }
 
@@ -6592,9 +7350,10 @@ impl DeleteDBSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDBSubnetGroupMessage {
     #[doc="<p>The name of the database subnet group to delete.</p> <note> <p>You cannot delete the default subnet group.</p> </note> <p>Constraints:</p> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>"]
+    #[serde(rename="DBSubnetGroupName")]
     pub db_subnet_group_name: String,
 }
 
@@ -6615,9 +7374,10 @@ impl DeleteDBSubnetGroupMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEventSubscriptionMessage {
     #[doc="<p>The name of the RDS event notification subscription you want to delete.</p>"]
+    #[serde(rename="SubscriptionName")]
     pub subscription_name: String,
 }
 
@@ -6637,8 +7397,10 @@ impl DeleteEventSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEventSubscriptionResult {
+    #[serde(rename="EventSubscription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_subscription: Option<EventSubscription>,
 }
 
@@ -6686,9 +7448,10 @@ impl DeleteEventSubscriptionResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteOptionGroupMessage {
     #[doc="<p>The name of the option group to be deleted.</p> <note> <p>You cannot delete default option groups.</p> </note>"]
+    #[serde(rename="OptionGroupName")]
     pub option_group_name: String,
 }
 
@@ -6709,7 +7472,7 @@ impl DeleteOptionGroupMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAccountAttributesMessage;
 
 
@@ -6728,15 +7491,23 @@ impl DescribeAccountAttributesMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCertificatesMessage {
     #[doc="<p>The user-supplied certificate identifier. If this parameter is specified, information for only the identified certificate is returned. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="CertificateIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub certificate_identifier: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <a>DescribeCertificates</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -6772,15 +7543,23 @@ impl DescribeCertificatesMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBClusterParameterGroupsMessage {
     #[doc="<p>The name of a specific DB cluster parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBClusterParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_group_name: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <code>DescribeDBClusterParameterGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -6816,17 +7595,26 @@ impl DescribeDBClusterParameterGroupsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBClusterParametersMessage {
     #[doc="<p>The name of a specific DB cluster parameter group to return parameter details for.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBClusterParameterGroupName")]
     pub db_cluster_parameter_group_name: String,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <code>DescribeDBClusterParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p> A value that indicates to return only parameters for a specific source. Parameter sources can be <code>engine</code>, <code>service</code>, or <code>customer</code>. </p>"]
+    #[serde(rename="Source")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source: Option<String>,
 }
 
@@ -6864,9 +7652,10 @@ impl DescribeDBClusterParametersMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBClusterSnapshotAttributesMessage {
     #[doc="<p>The identifier for the DB cluster snapshot to describe the attributes for.</p>"]
+    #[serde(rename="DBClusterSnapshotIdentifier")]
     pub db_cluster_snapshot_identifier: String,
 }
 
@@ -6888,8 +7677,10 @@ impl DescribeDBClusterSnapshotAttributesMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBClusterSnapshotAttributesResult {
+    #[serde(rename="DBClusterSnapshotAttributesResult")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_snapshot_attributes_result: Option<DBClusterSnapshotAttributesResult>,
 }
 
@@ -6936,23 +7727,39 @@ impl DescribeDBClusterSnapshotAttributesResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBClusterSnapshotsMessage {
     #[doc="<p>The ID of the DB cluster to retrieve the list of DB cluster snapshots for. This parameter cannot be used in conjunction with the <code>DBClusterSnapshotIdentifier</code> parameter. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_identifier: Option<String>,
     #[doc="<p>A specific DB cluster snapshot identifier to describe. This parameter cannot be used in conjunction with the <code>DBClusterIdentifier</code> parameter. This value is stored as a lowercase string. </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> <li> <p>If this identifier is for an automated snapshot, the <code>SnapshotType</code> parameter must also be specified.</p> </li> </ul>"]
+    #[serde(rename="DBClusterSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_snapshot_identifier: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>Set this value to <code>true</code> to include manual DB cluster snapshots that are public and can be copied or restored by any AWS account, otherwise set this value to <code>false</code>. The default is <code>false</code>. The default is false.</p> <p>You can share a manual DB cluster snapshot as public by using the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>"]
+    #[serde(rename="IncludePublic")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub include_public: Option<bool>,
     #[doc="<p>Set this value to <code>true</code> to include shared manual DB cluster snapshots from other AWS accounts that this AWS account has been given permission to copy or restore, otherwise set this value to <code>false</code>. The default is <code>false</code>.</p> <p>You can give an AWS account permission to restore a manual DB cluster snapshot from another AWS account by the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>"]
+    #[serde(rename="IncludeShared")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub include_shared: Option<bool>,
     #[doc="<p>An optional pagination token provided by a previous <code>DescribeDBClusterSnapshots</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The type of DB cluster snapshots to be returned. You can specify one of the following values:</p> <ul> <li> <p> <code>automated</code> - Return all DB cluster snapshots that have been automatically taken by Amazon RDS for my AWS account.</p> </li> <li> <p> <code>manual</code> - Return all DB cluster snapshots that have been taken by my AWS account.</p> </li> <li> <p> <code>shared</code> - Return all manual DB cluster snapshots that have been shared to my AWS account.</p> </li> <li> <p> <code>public</code> - Return all DB cluster snapshots that have been marked as public.</p> </li> </ul> <p>If you don't specify a <code>SnapshotType</code> value, then both automated and manual DB cluster snapshots are returned. You can include shared DB cluster snapshots with these results by setting the <code>IncludeShared</code> parameter to <code>true</code>. You can include public DB cluster snapshots with these results by setting the <code>IncludePublic</code> parameter to <code>true</code>.</p> <p>The <code>IncludeShared</code> and <code>IncludePublic</code> parameters don't apply for <code>SnapshotType</code> values of <code>manual</code> or <code>automated</code>. The <code>IncludePublic</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>shared</code>. The <code>IncludeShared</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>public</code>.</p>"]
+    #[serde(rename="SnapshotType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_type: Option<String>,
 }
 
@@ -7004,15 +7811,23 @@ impl DescribeDBClusterSnapshotsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBClustersMessage {
     #[doc="<p>The user-supplied DB cluster identifier. If this parameter is specified, information from only the specific DB cluster is returned. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_identifier: Option<String>,
     #[doc="<p>A filter that specifies one or more DB clusters to describe.</p> <p>Supported filters:</p> <ul> <li> <p> <code>db-cluster-id</code> - Accepts DB cluster identifiers and DB cluster Amazon Resource Names (ARNs). The results list will only include information about the DB clusters identified by these ARNs.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <a>DescribeDBClusters</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -7047,25 +7862,43 @@ impl DescribeDBClustersMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBEngineVersionsMessage {
     #[doc="<p>The name of a specific DB parameter group family to return details for.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_family: Option<String>,
     #[doc="<p>Indicates that only the default version of the specified engine or engine and major version combination is returned.</p>"]
+    #[serde(rename="DefaultOnly")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_only: Option<bool>,
     #[doc="<p>The database engine to return.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>The database engine version to return.</p> <p>Example: <code>5.1.49</code> </p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>Not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>If this parameter is specified and the requested engine supports the <code>CharacterSetName</code> parameter for <code>CreateDBInstance</code>, the response includes a list of supported character sets for each engine version. </p>"]
+    #[serde(rename="ListSupportedCharacterSets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub list_supported_character_sets: Option<bool>,
     #[doc="<p>If this parameter is specified and the requested engine supports the <code>TimeZone</code> parameter for <code>CreateDBInstance</code>, the response includes a list of supported time zones for each engine version. </p>"]
+    #[serde(rename="ListSupportedTimezones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub list_supported_timezones: Option<bool>,
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more than the <code>MaxRecords</code> value is available, a pagination token called a marker is included in the response so that the following results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -7121,15 +7954,23 @@ impl DescribeDBEngineVersionsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBInstancesMessage {
     #[doc="<p>The user-supplied instance identifier. If this parameter is specified, information from only the specific DB instance is returned. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBInstanceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_identifier: Option<String>,
     #[doc="<p>A filter that specifies one or more DB instances to describe.</p> <p>Supported filters:</p> <ul> <li> <p> <code>db-cluster-id</code> - Accepts DB cluster identifiers and DB cluster Amazon Resource Names (ARNs). The results list will only include information about the DB instances associated with the DB Clusters identified by these ARNs.</p> </li> <li> <p> <code>db-instance-id</code> - Accepts DB instance identifiers and DB instance Amazon Resource Names (ARNs). The results list will only include information about the DB instances identified by these ARNs.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <code>DescribeDBInstances</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -7165,13 +8006,19 @@ impl DescribeDBInstancesMessageSerializer {
 }
 
 #[doc="<p>This data type is used as a response element to <a>DescribeDBLogFiles</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBLogFilesDetails {
     #[doc="<p>A POSIX timestamp when the last log entry was written.</p>"]
+    #[serde(rename="LastWritten")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_written: Option<i64>,
     #[doc="<p>The name of the log file for the specified DB instance.</p>"]
+    #[serde(rename="LogFileName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub log_file_name: Option<String>,
     #[doc="<p>The size, in bytes, of the log file for the specified DB instance.</p>"]
+    #[serde(rename="Size")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub size: Option<i64>,
 }
 
@@ -7266,21 +8113,34 @@ impl DescribeDBLogFilesListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBLogFilesMessage {
     #[doc="<p>The customer-assigned name of the DB instance that contains the log files you want to list.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
     #[doc="<p>Filters the available log files for files written since the specified date, in POSIX timestamp format with milliseconds.</p>"]
+    #[serde(rename="FileLastWritten")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub file_last_written: Option<i64>,
     #[doc="<p>Filters the available log files for files larger than the specified size.</p>"]
+    #[serde(rename="FileSize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub file_size: Option<i64>,
     #[doc="<p>Filters the available log files for log file names that contain the specified string.</p>"]
+    #[serde(rename="FilenameContains")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filename_contains: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The pagination token provided in the previous request. If this parameter is specified the response includes only records beyond the marker, up to MaxRecords.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified MaxRecords value, a pagination token called a marker is included in the response so that the remaining results can be retrieved.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -7326,11 +8186,15 @@ impl DescribeDBLogFilesMessageSerializer {
 }
 
 #[doc="<p> The response from a call to <a>DescribeDBLogFiles</a>. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBLogFilesResponse {
     #[doc="<p>The DB log files returned.</p>"]
+    #[serde(rename="DescribeDBLogFiles")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub describe_db_log_files: Option<Vec<DescribeDBLogFilesDetails>>,
     #[doc="<p>A pagination token that can be used in a subsequent DescribeDBLogFiles request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -7382,15 +8246,23 @@ impl DescribeDBLogFilesResponseDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBParameterGroupsMessage {
     #[doc="<p>The name of a specific DB parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_name: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <code>DescribeDBParameterGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -7425,17 +8297,26 @@ impl DescribeDBParameterGroupsMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBParametersMessage {
     #[doc="<p>The name of a specific DB parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBParameterGroupName")]
     pub db_parameter_group_name: String,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <code>DescribeDBParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The parameter types to return.</p> <p>Default: All parameter types returned</p> <p>Valid Values: <code>user | system | engine-default</code> </p>"]
+    #[serde(rename="Source")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source: Option<String>,
 }
 
@@ -7473,15 +8354,23 @@ impl DescribeDBParametersMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBSecurityGroupsMessage {
     #[doc="<p>The name of the DB security group to return details for.</p>"]
+    #[serde(rename="DBSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_group_name: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <code>DescribeDBSecurityGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -7517,9 +8406,10 @@ impl DescribeDBSecurityGroupsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBSnapshotAttributesMessage {
     #[doc="<p>The identifier for the DB snapshot to describe the attributes for.</p>"]
+    #[serde(rename="DBSnapshotIdentifier")]
     pub db_snapshot_identifier: String,
 }
 
@@ -7539,8 +8429,10 @@ impl DescribeDBSnapshotAttributesMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBSnapshotAttributesResult {
+    #[serde(rename="DBSnapshotAttributesResult")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot_attributes_result: Option<DBSnapshotAttributesResult>,
 }
 
@@ -7587,23 +8479,39 @@ impl DescribeDBSnapshotAttributesResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBSnapshotsMessage {
     #[doc="<p>The ID of the DB instance to retrieve the list of DB snapshots for. This parameter cannot be used in conjunction with <code>DBSnapshotIdentifier</code>. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBInstanceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_identifier: Option<String>,
     #[doc="<p> A specific DB snapshot identifier to describe. This parameter cannot be used in conjunction with <code>DBInstanceIdentifier</code>. This value is stored as a lowercase string. </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> <li> <p>If this identifier is for an automated snapshot, the <code>SnapshotType</code> parameter must also be specified.</p> </li> </ul>"]
+    #[serde(rename="DBSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot_identifier: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>Set this value to <code>true</code> to include manual DB snapshots that are public and can be copied or restored by any AWS account, otherwise set this value to <code>false</code>. The default is <code>false</code>.</p> <p>You can share a manual DB snapshot as public by using the <a>ModifyDBSnapshotAttribute</a> API.</p>"]
+    #[serde(rename="IncludePublic")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub include_public: Option<bool>,
     #[doc="<p>Set this value to <code>true</code> to include shared manual DB snapshots from other AWS accounts that this AWS account has been given permission to copy or restore, otherwise set this value to <code>false</code>. The default is <code>false</code>.</p> <p>You can give an AWS account permission to restore a manual DB snapshot from another AWS account by using the <a>ModifyDBSnapshotAttribute</a> API action.</p>"]
+    #[serde(rename="IncludeShared")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub include_shared: Option<bool>,
     #[doc="<p> An optional pagination token provided by a previous <code>DescribeDBSnapshots</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The type of snapshots to be returned. You can specify one of the following values:</p> <ul> <li> <p> <code>automated</code> - Return all DB snapshots that have been automatically taken by Amazon RDS for my AWS account.</p> </li> <li> <p> <code>manual</code> - Return all DB snapshots that have been taken by my AWS account.</p> </li> <li> <p> <code>shared</code> - Return all manual DB snapshots that have been shared to my AWS account.</p> </li> <li> <p> <code>public</code> - Return all DB snapshots that have been marked as public.</p> </li> </ul> <p>If you don't specify a <code>SnapshotType</code> value, then both automated and manual snapshots are returned. Shared and public DB snapshots are not included in the returned results by default. You can include shared snapshots with these results by setting the <code>IncludeShared</code> parameter to <code>true</code>. You can include public snapshots with these results by setting the <code>IncludePublic</code> parameter to <code>true</code>.</p> <p>The <code>IncludeShared</code> and <code>IncludePublic</code> parameters don't apply for <code>SnapshotType</code> values of <code>manual</code> or <code>automated</code>. The <code>IncludePublic</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>shared</code>. The <code>IncludeShared</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>public</code>.</p>"]
+    #[serde(rename="SnapshotType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_type: Option<String>,
 }
 
@@ -7655,15 +8563,23 @@ impl DescribeDBSnapshotsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDBSubnetGroupsMessage {
     #[doc="<p>The name of the DB subnet group to return details for.</p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous DescribeDBSubnetGroups request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -7699,15 +8615,22 @@ impl DescribeDBSubnetGroupsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEngineDefaultClusterParametersMessage {
     #[doc="<p>The name of the DB cluster parameter group family to return engine parameter information for.</p>"]
+    #[serde(rename="DBParameterGroupFamily")]
     pub db_parameter_group_family: String,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <code>DescribeEngineDefaultClusterParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -7742,8 +8665,10 @@ impl DescribeEngineDefaultClusterParametersMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEngineDefaultClusterParametersResult {
+    #[serde(rename="EngineDefaults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_defaults: Option<EngineDefaults>,
 }
 
@@ -7792,15 +8717,22 @@ impl DescribeEngineDefaultClusterParametersResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEngineDefaultParametersMessage {
     #[doc="<p>The name of the DB parameter group family.</p>"]
+    #[serde(rename="DBParameterGroupFamily")]
     pub db_parameter_group_family: String,
     #[doc="<p>Not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <code>DescribeEngineDefaultParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -7833,8 +8765,10 @@ impl DescribeEngineDefaultParametersMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEngineDefaultParametersResult {
+    #[serde(rename="EngineDefaults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_defaults: Option<EngineDefaults>,
 }
 
@@ -7883,11 +8817,15 @@ impl DescribeEngineDefaultParametersResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventCategoriesMessage {
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The type of source that will be generating the events.</p> <p>Valid values: db-instance | db-parameter-group | db-security-group | db-snapshot</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
 }
 
@@ -7915,15 +8853,23 @@ impl DescribeEventCategoriesMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventSubscriptionsMessage {
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous DescribeOrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The name of the RDS event notification subscription you want to describe.</p>"]
+    #[serde(rename="SubscriptionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subscription_name: Option<String>,
 }
 
@@ -7959,25 +8905,43 @@ impl DescribeEventSubscriptionsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsMessage {
     #[doc="<p>The number of minutes to retrieve events for.</p> <p>Default: 60</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p> The end of the time interval for which to retrieve events, specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: 2009-07-08T18:00Z</p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>A list of event categories that trigger notifications for a event notification subscription.</p>"]
+    #[serde(rename="EventCategories")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories: Option<Vec<String>>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous DescribeEvents request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The identifier of the event source for which events will be returned. If not specified, then all sources are included in the response.</p> <p>Constraints:</p> <ul> <li> <p>If SourceIdentifier is supplied, SourceType must also be provided.</p> </li> <li> <p>If the source type is <code>DBInstance</code>, then a <code>DBInstanceIdentifier</code> must be supplied.</p> </li> <li> <p>If the source type is <code>DBSecurityGroup</code>, a <code>DBSecurityGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is <code>DBParameterGroup</code>, a <code>DBParameterGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is <code>DBSnapshot</code>, a <code>DBSnapshotIdentifier</code> must be supplied.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>"]
+    #[serde(rename="SourceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_identifier: Option<String>,
     #[doc="<p>The event source to retrieve events for. If no value is specified, all events are returned.</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
     #[doc="<p> The beginning of the time interval to retrieve events for, specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: 2009-07-08T18:00Z</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
 }
 
@@ -8034,17 +8998,26 @@ impl DescribeEventsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeOptionGroupOptionsMessage {
     #[doc="<p>A required parameter. Options available for the given engine name will be described.</p>"]
+    #[serde(rename="EngineName")]
     pub engine_name: String,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>If specified, filters the results to include only options for the specified major engine version.</p>"]
+    #[serde(rename="MajorEngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub major_engine_version: Option<String>,
     #[doc="<p>An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -8082,19 +9055,31 @@ impl DescribeOptionGroupOptionsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeOptionGroupsMessage {
     #[doc="<p>Filters the list of option groups to only include groups associated with a specific database engine.</p>"]
+    #[serde(rename="EngineName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_name: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>Filters the list of option groups to only include groups associated with a specific database engine version. If specified, then EngineName must also be specified.</p>"]
+    #[serde(rename="MajorEngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub major_engine_version: Option<String>,
     #[doc="<p> An optional pagination token provided by a previous DescribeOptionGroups request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The name of the option group to describe. Cannot be supplied together with EngineName or MajorEngineVersion.</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
 }
 
@@ -8138,23 +9123,38 @@ impl DescribeOptionGroupsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeOrderableDBInstanceOptionsMessage {
     #[doc="<p>The DB instance class filter value. Specify this parameter to show only the available offerings matching the specified DB instance class.</p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p>The name of the engine to retrieve DB instance options for.</p>"]
+    #[serde(rename="Engine")]
     pub engine: String,
     #[doc="<p>The engine version filter value. Specify this parameter to show only the available offerings matching the specified engine version.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The license model filter value. Specify this parameter to show only the available offerings matching the specified license model.</p>"]
+    #[serde(rename="LicenseModel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_model: Option<String>,
     #[doc="<p> An optional pagination token provided by a previous DescribeOrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The VPC filter value. Specify this parameter to show only the available VPC or non-VPC offerings.</p>"]
+    #[serde(rename="Vpc")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc: Option<bool>,
 }
 
@@ -8206,15 +9206,23 @@ impl DescribeOrderableDBInstanceOptionsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePendingMaintenanceActionsMessage {
     #[doc="<p>A filter that specifies one or more resources to return pending maintenance actions for.</p> <p>Supported filters:</p> <ul> <li> <p> <code>db-cluster-id</code> - Accepts DB cluster identifiers and DB cluster Amazon Resource Names (ARNs). The results list will only include pending maintenance actions for the DB clusters identified by these ARNs.</p> </li> <li> <p> <code>db-instance-id</code> - Accepts DB instance identifiers and DB instance ARNs. The results list will only include pending maintenance actions for the DB instances identified by these ARNs.</p> </li> </ul>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <code>DescribePendingMaintenanceActions</code> request. If this parameter is specified, the response includes only records beyond the marker, up to a number of records specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The ARN of a resource to return pending maintenance actions for.</p>"]
+    #[serde(rename="ResourceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_identifier: Option<String>,
 }
 
@@ -8250,27 +9258,47 @@ impl DescribePendingMaintenanceActionsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedDBInstancesMessage {
     #[doc="<p>The DB instance class filter value. Specify this parameter to show only those reservations matching the specified DB instances class.</p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p>The duration filter value, specified in years or seconds. Specify this parameter to show only reservations for this duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more than the <code>MaxRecords</code> value is available, a pagination token called a marker is included in the response so that the following results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The Multi-AZ filter value. Specify this parameter to show only those reservations matching the specified Multi-AZ parameter.</p>"]
+    #[serde(rename="MultiAZ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az: Option<bool>,
     #[doc="<p>The offering type filter value. Specify this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid Values: <code>\"Partial Upfront\" | \"All Upfront\" | \"No Upfront\" </code> </p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The product description filter value. Specify this parameter to show only those reservations matching the specified product description.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The reserved DB instance identifier filter value. Specify this parameter to show only the reservation that matches the specified reservation ID.</p>"]
+    #[serde(rename="ReservedDBInstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_db_instance_id: Option<String>,
     #[doc="<p>The offering identifier filter value. Specify this parameter to show only purchased reservations matching the specified offering identifier.</p>"]
+    #[serde(rename="ReservedDBInstancesOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_db_instances_offering_id: Option<String>,
 }
 
@@ -8330,25 +9358,43 @@ impl DescribeReservedDBInstancesMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedDBInstancesOfferingsMessage {
     #[doc="<p>The DB instance class filter value. Specify this parameter to show only the available offerings matching the specified DB instance class.</p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p>Duration filter value, specified in years or seconds. Specify this parameter to show only reservations for this duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<String>,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p> The maximum number of records to include in the response. If more than the <code>MaxRecords</code> value is available, a pagination token called a marker is included in the response so that the following results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The Multi-AZ filter value. Specify this parameter to show only the available offerings matching the specified Multi-AZ parameter.</p>"]
+    #[serde(rename="MultiAZ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az: Option<bool>,
     #[doc="<p>The offering type filter value. Specify this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid Values: <code>\"Partial Upfront\" | \"All Upfront\" | \"No Upfront\" </code> </p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>Product description filter value. Specify this parameter to show only the available offerings matching the specified product description.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The offering identifier filter value. Specify this parameter to show only the available offering that matches the specified reservation identifier.</p> <p>Example: <code>438012d3-4052-4cc7-b2e3-8d3372e0e706</code> </p>"]
+    #[serde(rename="ReservedDBInstancesOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_db_instances_offering_id: Option<String>,
 }
 
@@ -8406,15 +9452,23 @@ impl DescribeReservedDBInstancesOfferingsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSourceRegionsMessage {
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p> An optional pagination token provided by a previous <a>DescribeSourceRegions</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The source AWS Region name. For example, <code>us-east-1</code>.</p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid AWS Region name.</p> </li> </ul>"]
+    #[serde(rename="RegionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub region_name: Option<String>,
 }
 
@@ -8450,15 +9504,23 @@ impl DescribeSourceRegionsMessageSerializer {
 }
 
 #[doc="<p>An Active Directory Domain membership record associated with the DB instance.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainMembership {
     #[doc="<p>The identifier of the Active Directory Domain.</p>"]
+    #[serde(rename="Domain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain: Option<String>,
     #[doc="<p>The fully qualified domain name of the Active Directory Domain.</p>"]
+    #[serde(rename="FQDN")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fqdn: Option<String>,
     #[doc="<p>The name of the IAM role to be used when making API calls to the Directory Service.</p>"]
+    #[serde(rename="IAMRoleName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_role_name: Option<String>,
     #[doc="<p>The status of the DB instance's Active Directory Domain membership, such as joined, pending-join, failed etc).</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -8572,13 +9634,19 @@ impl DoubleDeserializer {
     }
 }
 #[doc="<p>This data type is used as a response element to <a>DownloadDBLogFilePortion</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DownloadDBLogFilePortionDetails {
     #[doc="<p>Boolean value that if true, indicates there is more data to be downloaded.</p>"]
+    #[serde(rename="AdditionalDataPending")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub additional_data_pending: Option<bool>,
     #[doc="<p>Entries from the specified log file.</p>"]
+    #[serde(rename="LogFileData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub log_file_data: Option<String>,
     #[doc="<p>A pagination token that can be used in a subsequent DownloadDBLogFilePortion request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -8635,15 +9703,21 @@ impl DownloadDBLogFilePortionDetailsDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DownloadDBLogFilePortionMessage {
     #[doc="<p>The customer-assigned name of the DB instance that contains the log files you want to list.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
     #[doc="<p>The name of the log file to be downloaded.</p>"]
+    #[serde(rename="LogFileName")]
     pub log_file_name: String,
     #[doc="<p>The pagination token provided in the previous request or \"0\". If the Marker parameter is specified the response includes only records beyond the marker until the end of the file or up to NumberOfLines.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The number of lines to download. If the number of lines specified results in a file over 1 MB in size, the file will be truncated at 1 MB in size.</p> <p>If the NumberOfLines parameter is specified, then the block of lines returned can be from the beginning or the end of the log file, depending on the value of the Marker parameter.</p> <ul> <li> <p>If neither Marker or NumberOfLines are specified, the entire log file is returned up to a maximum of 10000 lines, starting with the most recent log entries first.</p> </li> <li> <p>If NumberOfLines is specified and Marker is not specified, then the most recent lines from the end of the log file are returned.</p> </li> <li> <p>If Marker is specified as \"0\", then the specified number of lines from the beginning of the log file are returned.</p> </li> <li> <p>You can download the log file in blocks of lines by specifying the size of the block using the NumberOfLines parameter, and by specifying a value of \"0\" for the Marker parameter in your first request. Include the Marker value returned in the response as the Marker value for the next request, continuing until the AdditionalDataPending response element returns false.</p> </li> </ul>"]
+    #[serde(rename="NumberOfLines")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub number_of_lines: Option<i64>,
 }
 
@@ -8674,15 +9748,23 @@ impl DownloadDBLogFilePortionMessageSerializer {
 }
 
 #[doc="<p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>AuthorizeDBSecurityGroupIngress</a> </p> </li> <li> <p> <a>DescribeDBSecurityGroups</a> </p> </li> <li> <p> <a>RevokeDBSecurityGroupIngress</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EC2SecurityGroup {
     #[doc="<p>Specifies the id of the EC2 security group.</p>"]
+    #[serde(rename="EC2SecurityGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_id: Option<String>,
     #[doc="<p>Specifies the name of the EC2 security group.</p>"]
+    #[serde(rename="EC2SecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_name: Option<String>,
     #[doc="<p> Specifies the AWS ID of the owner of the EC2 security group specified in the <code>EC2SecurityGroupName</code> field. </p>"]
+    #[serde(rename="EC2SecurityGroupOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_owner_id: Option<String>,
     #[doc="<p>Provides the status of the EC2 security group. Status can be \"authorizing\", \"authorized\", \"revoking\", and \"revoked\".</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -8786,13 +9868,19 @@ impl EC2SecurityGroupListDeserializer {
     }
 }
 #[doc="<p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>DescribeDBInstances</a> </p> </li> <li> <p> <a>DeleteDBInstance</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Endpoint {
     #[doc="<p>Specifies the DNS address of the DB instance.</p>"]
+    #[serde(rename="Address")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub address: Option<String>,
     #[doc="<p>Specifies the ID that Amazon Route 53 assigns when you create a hosted zone.</p>"]
+    #[serde(rename="HostedZoneId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hosted_zone_id: Option<String>,
     #[doc="<p>Specifies the port that the database engine is listening on.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
 }
 
@@ -8846,13 +9934,19 @@ impl EndpointDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeEngineDefaultParameters</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EngineDefaults {
     #[doc="<p>Specifies the name of the DB parameter group family that the engine default parameters apply to.</p>"]
+    #[serde(rename="DBParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_family: Option<String>,
     #[doc="<p> An optional pagination token provided by a previous EngineDefaults request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>Contains a list of engine default parameters.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
 }
 
@@ -8909,19 +10003,31 @@ impl EngineDefaultsDeserializer {
     }
 }
 #[doc="<p> This data type is used as a response element in the <a>DescribeEvents</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Event {
     #[doc="<p>Specifies the date and time of the event.</p>"]
+    #[serde(rename="Date")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date: Option<String>,
     #[doc="<p>Specifies the category for the event.</p>"]
+    #[serde(rename="EventCategories")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories: Option<Vec<String>>,
     #[doc="<p>Provides the text of this event.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) for the event.</p>"]
+    #[serde(rename="SourceArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_arn: Option<String>,
     #[doc="<p>Provides the identifier for the source of the event.</p>"]
+    #[serde(rename="SourceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_identifier: Option<String>,
     #[doc="<p>Specifies the source type for this event.</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
 }
 
@@ -9043,11 +10149,15 @@ impl EventCategoriesListSerializer {
 }
 
 #[doc="<p>Contains the results of a successful invocation of the <a>DescribeEventCategories</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventCategoriesMap {
     #[doc="<p>The event categories for the specified source type</p>"]
+    #[serde(rename="EventCategories")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories: Option<Vec<String>>,
     #[doc="<p>The source type that the returned categories belong to</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
 }
 
@@ -9140,9 +10250,11 @@ impl EventCategoriesMapListDeserializer {
     }
 }
 #[doc="<p>Data returned from the <b>DescribeEventCategories</b> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventCategoriesMessage {
     #[doc="<p>A list of EventCategoriesMap data types.</p>"]
+    #[serde(rename="EventCategoriesMapList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories_map_list: Option<Vec<EventCategoriesMap>>,
 }
 
@@ -9231,27 +10343,47 @@ impl EventListDeserializer {
     }
 }
 #[doc="<p>Contains the results of a successful invocation of the <a>DescribeEventSubscriptions</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventSubscription {
     #[doc="<p>The RDS event notification subscription Id.</p>"]
+    #[serde(rename="CustSubscriptionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cust_subscription_id: Option<String>,
     #[doc="<p>The AWS customer account associated with the RDS event notification subscription.</p>"]
+    #[serde(rename="CustomerAwsId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub customer_aws_id: Option<String>,
     #[doc="<p>A Boolean value indicating if the subscription is enabled. True indicates the subscription is enabled.</p>"]
+    #[serde(rename="Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled: Option<bool>,
     #[doc="<p>A list of event categories for the RDS event notification subscription.</p>"]
+    #[serde(rename="EventCategoriesList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories_list: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) for the event subscription.</p>"]
+    #[serde(rename="EventSubscriptionArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_subscription_arn: Option<String>,
     #[doc="<p>The topic ARN of the RDS event notification subscription.</p>"]
+    #[serde(rename="SnsTopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sns_topic_arn: Option<String>,
     #[doc="<p>A list of source IDs for the RDS event notification subscription.</p>"]
+    #[serde(rename="SourceIdsList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_ids_list: Option<Vec<String>>,
     #[doc="<p>The source type for the RDS event notification subscription.</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
     #[doc="<p>The status of the RDS event notification subscription.</p> <p>Constraints:</p> <p>Can be one of the following: creating | modifying | deleting | active | no-permission | topic-not-exist</p> <p>The status \"no-permission\" indicates that RDS no longer has permission to post to the SNS topic. The status \"topic-not-exist\" indicates that the topic was deleted after the subscription was created.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The time the RDS event notification subscription was created.</p>"]
+    #[serde(rename="SubscriptionCreationTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subscription_creation_time: Option<String>,
 }
 
@@ -9380,11 +10512,15 @@ impl EventSubscriptionsListDeserializer {
     }
 }
 #[doc="<p>Data returned by the <b>DescribeEventSubscriptions</b> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventSubscriptionsMessage {
     #[doc="<p>A list of EventSubscriptions data types.</p>"]
+    #[serde(rename="EventSubscriptionsList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_subscriptions_list: Option<Vec<EventSubscription>>,
     #[doc="<p> An optional pagination token provided by a previous DescribeOrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -9436,11 +10572,15 @@ impl EventSubscriptionsMessageDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeEvents</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventsMessage {
     #[doc="<p> A list of <a>Event</a> instances. </p>"]
+    #[serde(rename="Events")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<Event>>,
     #[doc="<p> An optional pagination token provided by a previous Events request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -9491,11 +10631,15 @@ impl EventsMessageDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailoverDBClusterMessage {
     #[doc="<p>A DB cluster identifier to force a failover for. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_identifier: Option<String>,
     #[doc="<p>The name of the instance to promote to the primary instance.</p> <p>You must specify the instance identifier for an Aurora Replica in the DB cluster. For example, <code>mydbcluster-replica1</code>.</p>"]
+    #[serde(rename="TargetDBInstanceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_db_instance_identifier: Option<String>,
 }
 
@@ -9521,8 +10665,10 @@ impl FailoverDBClusterMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailoverDBClusterResult {
+    #[serde(rename="DBCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster: Option<DBCluster>,
 }
 
@@ -9569,11 +10715,13 @@ impl FailoverDBClusterResultDeserializer {
     }
 }
 #[doc="<p>This type is not currently supported.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Filter {
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Values")]
     pub values: Vec<String>,
 }
 
@@ -9621,11 +10769,15 @@ impl FilterValueListSerializer {
 }
 
 #[doc="<p> This data type is used as a response element in the <a>DescribeDBSecurityGroups</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IPRange {
     #[doc="<p>Specifies the IP range.</p>"]
+    #[serde(rename="CIDRIP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidrip: Option<String>,
     #[doc="<p>Specifies the status of the IP range. Status can be \"authorizing\", \"authorized\", \"revoking\", and \"revoked\".</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -9757,11 +10909,14 @@ impl KeyListSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceMessage {
     #[doc="<p>This parameter is not currently supported.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<Filter>>,
     #[doc="<p>The Amazon RDS resource with tags to be listed. This value is an Amazon Resource Name (ARN). For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>"]
+    #[serde(rename="ResourceName")]
     pub resource_name: String,
 }
 
@@ -9801,31 +10956,54 @@ impl LongDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBClusterMessage {
     #[doc="<p>A value that specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the DB cluster. If this parameter is set to <code>false</code>, changes to the DB cluster are applied during the next maintenance window.</p> <p>The <code>ApplyImmediately</code> parameter only affects the <code>NewDBClusterIdentifier</code> and <code>MasterUserPassword</code> values. If you set the <code>ApplyImmediately</code> parameter value to false, then changes to the <code>NewDBClusterIdentifier</code> and <code>MasterUserPassword</code> values are applied during the next maintenance window. All other changes are applied immediately, regardless of the value of the <code>ApplyImmediately</code> parameter.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="ApplyImmediately")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub apply_immediately: Option<bool>,
     #[doc="<p>The number of days for which automated backups are retained. You must specify a minimum value of 1.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 1 to 35</p> </li> </ul>"]
+    #[serde(rename="BackupRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub backup_retention_period: Option<i64>,
     #[doc="<p>The DB cluster identifier for the cluster being modified. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must be the identifier for an existing DB cluster.</p> </li> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>"]
+    #[serde(rename="DBClusterIdentifier")]
     pub db_cluster_identifier: String,
     #[doc="<p>The name of the DB cluster parameter group to use for the DB cluster.</p>"]
+    #[serde(rename="DBClusterParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_group_name: Option<String>,
     #[doc="<p>A Boolean value that is true to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EnableIAMDatabaseAuthentication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_iam_database_authentication: Option<bool>,
     #[doc="<p>The new password for the master database user. This password can contain any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p>Constraints: Must contain from 8 to 41 characters.</p>"]
+    #[serde(rename="MasterUserPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_user_password: Option<String>,
     #[doc="<p>The new DB cluster identifier for the DB cluster when renaming a DB cluster. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-cluster2</code> </p>"]
+    #[serde(rename="NewDBClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_db_cluster_identifier: Option<String>,
     #[doc="<p>A value that indicates that the DB cluster should be associated with the specified option group. Changing this parameter does not result in an outage except in the following case, and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. If the parameter change results in an option group that enables OEM, this change can cause a brief (sub-second) period during which new connections are rejected but existing connections are not interrupted. </p> <p>Permanent options cannot be removed from an option group. The option group cannot be removed from a DB cluster once it is associated with a DB cluster.</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The port number on which the DB cluster accepts connections.</p> <p>Constraints: Value must be <code>1150-65535</code> </p> <p>Default: The same port as the original DB cluster.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The daily time range during which automated backups are created if automated backups are enabled, using the <code>BackupRetentionPeriod</code> parameter. </p> <p>Default: A 30-minute window selected at random from an 8-hour block of time per AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Times should be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>"]
+    #[serde(rename="PreferredBackupWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_backup_window: Option<String>,
     #[doc="<p>The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p> <p> Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p>Default: A 30-minute window selected at random from an 8-hour block of time per AWS Region, occurring on a random day of the week. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun</p> <p>Constraints: Minimum 30-minute window.</p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>A list of VPC security groups that the DB cluster will belong to.</p>"]
+    #[serde(rename="VpcSecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_ids: Option<Vec<String>>,
 }
 
@@ -9893,11 +11071,13 @@ impl ModifyDBClusterMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBClusterParameterGroupMessage {
     #[doc="<p>The name of the DB cluster parameter group to modify.</p>"]
+    #[serde(rename="DBClusterParameterGroupName")]
     pub db_cluster_parameter_group_name: String,
     #[doc="<p>A list of parameters in the DB cluster parameter group to modify.</p>"]
+    #[serde(rename="Parameters")]
     pub parameters: Vec<Parameter>,
 }
 
@@ -9920,8 +11100,10 @@ impl ModifyDBClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBClusterResult {
+    #[serde(rename="DBCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster: Option<DBCluster>,
 }
 
@@ -9968,15 +11150,21 @@ impl ModifyDBClusterResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBClusterSnapshotAttributeMessage {
     #[doc="<p>The name of the DB cluster snapshot attribute to modify.</p> <p>To manage authorization for other AWS accounts to copy or restore a manual DB cluster snapshot, set this value to <code>restore</code>.</p>"]
+    #[serde(rename="AttributeName")]
     pub attribute_name: String,
     #[doc="<p>The identifier for the DB cluster snapshot to modify the attributes for.</p>"]
+    #[serde(rename="DBClusterSnapshotIdentifier")]
     pub db_cluster_snapshot_identifier: String,
     #[doc="<p>A list of DB cluster snapshot attributes to add to the attribute specified by <code>AttributeName</code>.</p> <p>To authorize other AWS accounts to copy or restore a manual DB cluster snapshot, set this list to include one or more AWS account IDs, or <code>all</code> to make the manual DB cluster snapshot restorable by any AWS account. Do not add the <code>all</code> value for any manual DB cluster snapshots that contain private information that you don't want available to all AWS accounts.</p>"]
+    #[serde(rename="ValuesToAdd")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub values_to_add: Option<Vec<String>>,
     #[doc="<p>A list of DB cluster snapshot attributes to remove from the attribute specified by <code>AttributeName</code>.</p> <p>To remove authorization for other AWS accounts to copy or restore a manual DB cluster snapshot, set this list to include one or more AWS account identifiers, or <code>all</code> to remove authorization for any AWS account to copy or restore the DB cluster snapshot. If you specify <code>all</code>, an AWS account whose account ID is explicitly added to the <code>restore</code> attribute can still copy or restore a manual DB cluster snapshot.</p>"]
+    #[serde(rename="ValuesToRemove")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub values_to_remove: Option<Vec<String>>,
 }
 
@@ -10008,8 +11196,10 @@ impl ModifyDBClusterSnapshotAttributeMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBClusterSnapshotAttributeResult {
+    #[serde(rename="DBClusterSnapshotAttributesResult")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_snapshot_attributes_result: Option<DBClusterSnapshotAttributesResult>,
 }
 
@@ -10056,73 +11246,138 @@ impl ModifyDBClusterSnapshotAttributeResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBInstanceMessage {
     #[doc="<p> The new storage capacity of the RDS instance. Changing this setting does not result in an outage and the change is applied during the next maintenance window unless <code>ApplyImmediately</code> is set to <code>true</code> for this request. </p> <p> <b>MySQL</b> </p> <p>Default: Uses existing setting</p> <p>Valid Values: 5-6144</p> <p>Constraints: Value supplied must be at least 10% greater than the current value. Values that are not at least 10% greater than the existing value are rounded up so that they are 10% greater than the current value.</p> <p>Type: Integer</p> <p> <b>MariaDB</b> </p> <p>Default: Uses existing setting</p> <p>Valid Values: 5-6144</p> <p>Constraints: Value supplied must be at least 10% greater than the current value. Values that are not at least 10% greater than the existing value are rounded up so that they are 10% greater than the current value.</p> <p>Type: Integer</p> <p> <b>PostgreSQL</b> </p> <p>Default: Uses existing setting</p> <p>Valid Values: 5-6144</p> <p>Constraints: Value supplied must be at least 10% greater than the current value. Values that are not at least 10% greater than the existing value are rounded up so that they are 10% greater than the current value.</p> <p>Type: Integer</p> <p> <b>Oracle</b> </p> <p>Default: Uses existing setting</p> <p>Valid Values: 10-6144</p> <p>Constraints: Value supplied must be at least 10% greater than the current value. Values that are not at least 10% greater than the existing value are rounded up so that they are 10% greater than the current value.</p> <p> <b>SQL Server</b> </p> <p>Cannot be modified.</p> <p>If you choose to migrate your DB instance from using standard storage to using Provisioned IOPS, or from using Provisioned IOPS to using standard storage, the process can take time. The duration of the migration depends on several factors such as database load, storage size, storage type (standard or Provisioned IOPS), amount of IOPS provisioned (if any), and the number of prior scale storage operations. Typical migration times are under 24 hours, but the process can take up to several days in some cases. During the migration, the DB instance will be available for use, but might experience performance degradation. While the migration takes place, nightly backups for the instance will be suspended. No other Amazon RDS operations can take place for the instance, including modifying the instance, rebooting the instance, deleting the instance, creating a Read Replica for the instance, and creating a DB snapshot of the instance.</p>"]
+    #[serde(rename="AllocatedStorage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocated_storage: Option<i64>,
     #[doc="<p>Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible.</p> <p>Constraints: This parameter must be set to true when specifying a value for the EngineVersion parameter that is a different major version than the DB instance's current version.</p>"]
+    #[serde(rename="AllowMajorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_major_version_upgrade: Option<bool>,
     #[doc="<p>Specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the DB instance. </p> <p> If this parameter is set to <code>false</code>, changes to the DB instance are applied during the next maintenance window. Some parameter changes can cause an outage and will be applied on the next call to <a>RebootDBInstance</a>, or the next failure reboot. Review the table of parameters in <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html\">Modifying a DB Instance and Using the Apply Immediately Parameter</a> to see the impact that setting <code>ApplyImmediately</code> to <code>true</code> or <code>false</code> has for each modified parameter and to determine when the changes will be applied. </p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="ApplyImmediately")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub apply_immediately: Option<bool>,
     #[doc="<p> Indicates that minor version upgrades will be applied automatically to the DB instance during the maintenance window. Changing this parameter does not result in an outage except in the following case and the change is asynchronously applied as soon as possible. An outage will result if this parameter is set to <code>true</code> during the maintenance window, and a newer minor version is available, and RDS has enabled auto patching for that engine version. </p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p>The number of days to retain automated backups. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups.</p> <p>Changing this parameter can result in an outage if you change from 0 to a non-zero value or from a non-zero value to 0. These changes are applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. If you change the parameter from one non-zero value to another non-zero value, the change is asynchronously applied as soon as possible.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The retention period for automated backups is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p>Default: Uses existing setting</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 0 to 35</p> </li> <li> <p>Can be specified for a MySQL Read Replica only if the source is running MySQL 5.6</p> </li> <li> <p>Can be specified for a PostgreSQL Read Replica only if the source is running PostgreSQL 9.3.5</p> </li> <li> <p>Cannot be set to 0 if the DB instance is a source to Read Replicas</p> </li> </ul>"]
+    #[serde(rename="BackupRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub backup_retention_period: Option<i64>,
     #[doc="<p>Indicates the certificate that needs to be associated with the instance.</p>"]
+    #[serde(rename="CACertificateIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ca_certificate_identifier: Option<String>,
     #[doc="<p>True to copy all tags from the DB instance to snapshots of the DB instance; otherwise false. The default is false.</p>"]
+    #[serde(rename="CopyTagsToSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_tags_to_snapshot: Option<bool>,
     #[doc="<p> The new compute and memory capacity of the DB instance. To determine the instance classes that are available for a particular DB engine, use the <a>DescribeOrderableDBInstanceOptions</a> action. Note that not all instance classes are available in all regions for all DB engines. </p> <p> Passing a value for this setting causes an outage during the change and is applied during the next maintenance window, unless <code>ApplyImmediately</code> is specified as <code>true</code> for this request. </p> <p>Default: Uses existing setting</p> <p>Valid Values: <code>db.t1.micro | db.m1.small | db.m1.medium | db.m1.large | db.m1.xlarge | db.m2.xlarge | db.m2.2xlarge | db.m2.4xlarge | db.m3.medium | db.m3.large | db.m3.xlarge | db.m3.2xlarge | db.m4.large | db.m4.xlarge | db.m4.2xlarge | db.m4.4xlarge | db.m4.10xlarge | db.r3.large | db.r3.xlarge | db.r3.2xlarge | db.r3.4xlarge | db.r3.8xlarge | db.t2.micro | db.t2.small | db.t2.medium | db.t2.large</code> </p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p>The DB instance identifier. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must be the identifier for an existing DB instance</p> </li> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
     #[doc="<p>The name of the DB parameter group to apply to the DB instance. Changing this setting does not result in an outage. The parameter group name itself is changed immediately, but the actual parameter changes are not applied until you reboot the instance without failover. The db instance will NOT be rebooted automatically and the parameter changes will NOT be applied during the next maintenance window.</p> <p>Default: Uses existing setting</p> <p>Constraints: The DB parameter group must be in the same DB parameter group family as this DB instance.</p>"]
+    #[serde(rename="DBParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_parameter_group_name: Option<String>,
     #[doc="<p>The port number on which the database accepts connections.</p> <p>The value of the <code>DBPortNumber</code> parameter must not match any of the port values specified for options in the option group for the DB instance.</p> <p>Your database will restart when you change the <code>DBPortNumber</code> value regardless of the value of the <code>ApplyImmediately</code> parameter.</p> <p> <b>MySQL</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>MariaDB</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>PostgreSQL</b> </p> <p> Default: <code>5432</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>Oracle</b> </p> <p> Default: <code>1521</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>SQL Server</b> </p> <p> Default: <code>1433</code> </p> <p> Valid Values: <code>1150-65535</code> except for <code>1434</code>, <code>3389</code>, <code>47001</code>, <code>49152</code>, and <code>49152</code> through <code>49156</code>. </p> <p> <b>Amazon Aurora</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p>"]
+    #[serde(rename="DBPortNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_port_number: Option<i64>,
     #[doc="<p>A list of DB security groups to authorize on this DB instance. Changing this setting does not result in an outage and the change is asynchronously applied as soon as possible.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_groups: Option<Vec<String>>,
     #[doc="<p>The new DB subnet group for the DB instance. You can use this parameter to move your DB instance to a different VPC. If your DB instance is not in a VPC, you can also use this parameter to move your DB instance into a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html#USER_VPC.Non-VPC2VPC\">Updating the VPC for a DB Instance</a>. </p> <p>Changing the subnet group causes an outage during the change. The change is applied during the next maintenance window, unless you specify <code>true</code> for the <code>ApplyImmediately</code> parameter. </p> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, underscores, spaces, or hyphens.</p> <p>Example: <code>mySubnetGroup</code> </p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>The Active Directory Domain to move the instance to. Specify <code>none</code> to remove the instance from its current domain. The domain must be created prior to this operation. Currently only a Microsoft SQL Server instance can be created in a Active Directory Domain. </p>"]
+    #[serde(rename="Domain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain: Option<String>,
     #[doc="<p>The name of the IAM role to use when making API calls to the Directory Service.</p>"]
+    #[serde(rename="DomainIAMRoleName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain_iam_role_name: Option<String>,
     #[doc="<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts; otherwise false.</p> <p> You can enable IAM database authentication for the following database engines</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. Mapping AWS IAM accounts to database accounts is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p> <b>MySQL</b> </p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> </ul> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EnableIAMDatabaseAuthentication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_iam_database_authentication: Option<bool>,
     #[doc="<p> The version number of the database engine to upgrade to. Changing this parameter results in an outage and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. </p> <p>For major version upgrades, if a nondefault DB parameter group is currently in use, a new DB parameter group in the DB parameter group family for the new engine version must be specified. The new DB parameter group can be the default for that DB parameter group family.</p> <p>For a list of valid engine versions, see <a>CreateDBInstance</a>.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p> The new Provisioned IOPS (I/O operations per second) value for the RDS instance. Changing this setting does not result in an outage and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. </p> <p>Default: Uses existing setting</p> <p>Constraints: Value supplied must be at least 10% greater than the current value. Values that are not at least 10% greater than the existing value are rounded up so that they are 10% greater than the current value. If you are migrating from Provisioned IOPS to standard storage, set this value to 0. The DB instance will require a reboot for the change in storage type to take effect.</p> <p> <b>SQL Server</b> </p> <p>Setting the IOPS value for the SQL Server database engine is not supported.</p> <p>Type: Integer</p> <p>If you choose to migrate your DB instance from using standard storage to using Provisioned IOPS, or from using Provisioned IOPS to using standard storage, the process can take time. The duration of the migration depends on several factors such as database load, storage size, storage type (standard or Provisioned IOPS), amount of IOPS provisioned (if any), and the number of prior scale storage operations. Typical migration times are under 24 hours, but the process can take up to several days in some cases. During the migration, the DB instance will be available for use, but might experience performance degradation. While the migration takes place, nightly backups for the instance will be suspended. No other Amazon RDS operations can take place for the instance, including modifying the instance, rebooting the instance, deleting the instance, creating a Read Replica for the instance, and creating a DB snapshot of the instance.</p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>The license model for the DB instance.</p> <p>Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>"]
+    #[serde(rename="LicenseModel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_model: Option<String>,
     #[doc="<p>The new password for the master user. Can be any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p> Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible. Between the time of the request and the completion of the request, the <code>MasterUserPassword</code> element exists in the <code>PendingModifiedValues</code> element of the operation response. </p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The password for the master user is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p>Default: Uses existing setting</p> <p>Constraints: Must be 8 to 41 alphanumeric characters (MySQL, MariaDB, and Amazon Aurora), 8 to 30 alphanumeric characters (Oracle), or 8 to 128 alphanumeric characters (SQL Server).</p> <note> <p>Amazon RDS API actions never return the password, so this action provides a way to regain access to a primary instance user if the password is lost. This includes restoring privileges that might have been accidentally revoked.</p> </note>"]
+    #[serde(rename="MasterUserPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_user_password: Option<String>,
     #[doc="<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0.</p> <p>If <code>MonitoringRoleArn</code> is specified, then you must also set <code>MonitoringInterval</code> to a value other than 0.</p> <p>Valid Values: <code>0, 1, 5, 10, 15, 30, 60</code> </p>"]
+    #[serde(rename="MonitoringInterval")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring_interval: Option<i64>,
     #[doc="<p>The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. For example, <code>arn:aws:iam:123456789012:role/emaccess</code>. For information on creating a monitoring role, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html#USER_Monitoring.OS.IAMRole\">To create an IAM role for Amazon RDS Enhanced Monitoring</a>.</p> <p>If <code>MonitoringInterval</code> is set to a value other than 0, then you must supply a <code>MonitoringRoleArn</code> value.</p>"]
+    #[serde(rename="MonitoringRoleArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub monitoring_role_arn: Option<String>,
     #[doc="<p> Specifies if the DB instance is a Multi-AZ deployment. Changing this parameter does not result in an outage and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. </p> <p>Constraints: Cannot be specified if the DB instance is a Read Replica.</p>"]
+    #[serde(rename="MultiAZ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az: Option<bool>,
     #[doc="<p> The new DB instance identifier for the DB instance when renaming a DB instance. When you change the DB instance identifier, an instance reboot will occur immediately if you set <code>Apply Immediately</code> to true, or will occur during the next maintenance window if <code>Apply Immediately</code> to false. This value is stored as a lowercase string. </p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="NewDBInstanceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_db_instance_identifier: Option<String>,
     #[doc="<p> Indicates that the DB instance should be associated with the specified option group. Changing this parameter does not result in an outage except in the following case and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. If the parameter change results in an option group that enables OEM, this change can cause a brief (sub-second) period during which new connections are rejected but existing connections are not interrupted. </p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, cannot be removed from an option group, and that option group cannot be removed from a DB instance once it is associated with a DB instance</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p> The daily time range during which automated backups are created if automated backups are enabled, as determined by the <code>BackupRetentionPeriod</code> parameter. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible. </p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The daily time range for creating automated backups is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p>Constraints:</p> <ul> <li> <p>Must be in the format hh24:mi-hh24:mi</p> </li> <li> <p>Times should be in Universal Time Coordinated (UTC)</p> </li> <li> <p>Must not conflict with the preferred maintenance window</p> </li> <li> <p>Must be at least 30 minutes</p> </li> </ul>"]
+    #[serde(rename="PreferredBackupWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_backup_window: Option<String>,
     #[doc="<p>The weekly time range (in UTC) during which system maintenance can occur, which might result in an outage. Changing this parameter does not result in an outage, except in the following situation, and the change is asynchronously applied as soon as possible. If there are pending actions that cause a reboot, and the maintenance window is changed to include the current time, then changing this parameter will cause a reboot of the DB instance. If moving this window to the current time, there must be at least 30 minutes between the current time and end of the window to ensure pending changes are applied.</p> <p>Default: Uses existing setting</p> <p>Format: ddd:hh24:mi-ddd:hh24:mi</p> <p>Valid Days: Mon | Tue | Wed | Thu | Fri | Sat | Sun</p> <p>Constraints: Must be at least 30 minutes</p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p> <p>Default: 1</p> <p>Valid Values: 0 - 15</p>"]
+    #[serde(rename="PromotionTier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub promotion_tier: Option<i64>,
     #[doc="<p>Boolean value that indicates if the DB instance has a publicly resolvable DNS name. Set to <code>True</code> to make the DB instance Internet-facing with a publicly resolvable DNS name, which resolves to a public IP address. Set to <code>False</code> to make the DB instance internal with a DNS name that resolves to a private IP address. </p> <p> <code>PubliclyAccessible</code> only applies to DB instances in a VPC. The DB instance must be part of a public subnet and <code>PubliclyAccessible</code> must be true in order for it to be publicly accessible. </p> <p>Changes to the <code>PubliclyAccessible</code> parameter are applied immediately regardless of the value of the <code>ApplyImmediately</code> parameter.</p> <p>Default: false</p>"]
+    #[serde(rename="PubliclyAccessible")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub publicly_accessible: Option<bool>,
     #[doc="<p>Specifies the storage type to be associated with the DB instance.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified; otherwise <code>standard</code> </p>"]
+    #[serde(rename="StorageType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_type: Option<String>,
     #[doc="<p>The ARN from the Key Store with which to associate the instance for TDE encryption.</p>"]
+    #[serde(rename="TdeCredentialArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tde_credential_arn: Option<String>,
     #[doc="<p>The password for the given ARN from the Key Store in order to access the device.</p>"]
+    #[serde(rename="TdeCredentialPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tde_credential_password: Option<String>,
     #[doc="<p>A list of EC2 VPC security groups to authorize on this DB instance. This change is asynchronously applied as soon as possible.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The associated list of EC2 VPC security groups is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="VpcSecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_ids: Option<Vec<String>>,
 }
 
@@ -10276,8 +11531,10 @@ impl ModifyDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBInstanceResult {
+    #[serde(rename="DBInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance: Option<DBInstance>,
 }
 
@@ -10325,11 +11582,13 @@ impl ModifyDBInstanceResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBParameterGroupMessage {
     #[doc="<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be the name of an existing DB parameter group</p> </li> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBParameterGroupName")]
     pub db_parameter_group_name: String,
     #[doc="<p>An array of parameter names, values, and the apply method for the parameter update. At least one parameter name, value, and apply method must be supplied; subsequent arguments are optional. A maximum of 20 parameters can be modified in a single request.</p> <p>Valid Values (for the application method): <code>immediate | pending-reboot</code> </p> <note> <p>You can use the immediate value with dynamic parameters only. You can use the pending-reboot value for both dynamic and static parameters, and changes are applied when you reboot the DB instance without failover.</p> </note>"]
+    #[serde(rename="Parameters")]
     pub parameters: Vec<Parameter>,
 }
 
@@ -10353,15 +11612,21 @@ impl ModifyDBParameterGroupMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBSnapshotAttributeMessage {
     #[doc="<p>The name of the DB snapshot attribute to modify.</p> <p>To manage authorization for other AWS accounts to copy or restore a manual DB snapshot, set this value to <code>restore</code>.</p>"]
+    #[serde(rename="AttributeName")]
     pub attribute_name: String,
     #[doc="<p>The identifier for the DB snapshot to modify the attributes for.</p>"]
+    #[serde(rename="DBSnapshotIdentifier")]
     pub db_snapshot_identifier: String,
     #[doc="<p>A list of DB snapshot attributes to add to the attribute specified by <code>AttributeName</code>.</p> <p>To authorize other AWS accounts to copy or restore a manual snapshot, set this list to include one or more AWS account IDs, or <code>all</code> to make the manual DB snapshot restorable by any AWS account. Do not add the <code>all</code> value for any manual DB snapshots that contain private information that you don't want available to all AWS accounts.</p>"]
+    #[serde(rename="ValuesToAdd")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub values_to_add: Option<Vec<String>>,
     #[doc="<p>A list of DB snapshot attributes to remove from the attribute specified by <code>AttributeName</code>.</p> <p>To remove authorization for other AWS accounts to copy or restore a manual snapshot, set this list to include one or more AWS account identifiers, or <code>all</code> to remove authorization for any AWS account to copy or restore the DB snapshot. If you specify <code>all</code>, an AWS account whose account ID is explicitly added to the <code>restore</code> attribute can still copy or restore the manual DB snapshot.</p>"]
+    #[serde(rename="ValuesToRemove")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub values_to_remove: Option<Vec<String>>,
 }
 
@@ -10393,8 +11658,10 @@ impl ModifyDBSnapshotAttributeMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBSnapshotAttributeResult {
+    #[serde(rename="DBSnapshotAttributesResult")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot_attributes_result: Option<DBSnapshotAttributesResult>,
 }
 
@@ -10440,11 +11707,14 @@ impl ModifyDBSnapshotAttributeResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBSnapshotMessage {
     #[doc="<p>The identifier of the DB snapshot to modify.</p>"]
+    #[serde(rename="DBSnapshotIdentifier")]
     pub db_snapshot_identifier: String,
     #[doc="<p>The engine version to update the DB snapshot to. </p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
 }
 
@@ -10468,8 +11738,10 @@ impl ModifyDBSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBSnapshotResult {
+    #[serde(rename="DBSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot: Option<DBSnapshot>,
 }
 
@@ -10517,13 +11789,17 @@ impl ModifyDBSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBSubnetGroupMessage {
     #[doc="<p>The description for the DB subnet group.</p>"]
+    #[serde(rename="DBSubnetGroupDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_description: Option<String>,
     #[doc="<p>The name for the DB subnet group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>"]
+    #[serde(rename="DBSubnetGroupName")]
     pub db_subnet_group_name: String,
     #[doc="<p>The EC2 subnet IDs for the DB subnet group.</p>"]
+    #[serde(rename="SubnetIds")]
     pub subnet_ids: Vec<String>,
 }
 
@@ -10550,8 +11826,10 @@ impl ModifyDBSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDBSubnetGroupResult {
+    #[serde(rename="DBSubnetGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group: Option<DBSubnetGroup>,
 }
 
@@ -10599,17 +11877,26 @@ impl ModifyDBSubnetGroupResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyEventSubscriptionMessage {
     #[doc="<p> A Boolean value; set to <b>true</b> to activate the subscription. </p>"]
+    #[serde(rename="Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled: Option<bool>,
     #[doc="<p> A list of event categories for a SourceType that you want to subscribe to. You can see a list of the categories for a given SourceType in the <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html\">Events</a> topic in the Amazon RDS User Guide or by using the <b>DescribeEventCategories</b> action. </p>"]
+    #[serde(rename="EventCategories")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories: Option<Vec<String>>,
     #[doc="<p>The Amazon Resource Name (ARN) of the SNS topic created for event notification. The ARN is created by Amazon SNS when you create a topic and subscribe to it.</p>"]
+    #[serde(rename="SnsTopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sns_topic_arn: Option<String>,
     #[doc="<p>The type of source that will be generating the events. For example, if you want to be notified of events generated by a DB instance, you would set this parameter to db-instance. if this value is not specified, all events are returned.</p> <p>Valid values: db-instance | db-parameter-group | db-security-group | db-snapshot</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
     #[doc="<p>The name of the RDS event notification subscription.</p>"]
+    #[serde(rename="SubscriptionName")]
     pub subscription_name: String,
 }
 
@@ -10646,8 +11933,10 @@ impl ModifyEventSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyEventSubscriptionResult {
+    #[serde(rename="EventSubscription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_subscription: Option<EventSubscription>,
 }
 
@@ -10695,15 +11984,22 @@ impl ModifyEventSubscriptionResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyOptionGroupMessage {
     #[doc="<p>Indicates whether the changes should be applied immediately, or during the next maintenance window for each instance associated with the option group.</p>"]
+    #[serde(rename="ApplyImmediately")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub apply_immediately: Option<bool>,
     #[doc="<p>The name of the option group to be modified.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, cannot be removed from an option group, and that option group cannot be removed from a DB instance once it is associated with a DB instance</p>"]
+    #[serde(rename="OptionGroupName")]
     pub option_group_name: String,
     #[doc="<p>Options in this list are added to the option group or, if already present, the specified configuration is used to update the existing configuration.</p>"]
+    #[serde(rename="OptionsToInclude")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options_to_include: Option<Vec<OptionConfiguration>>,
     #[doc="<p>Options in this list are removed from the option group.</p>"]
+    #[serde(rename="OptionsToRemove")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options_to_remove: Option<Vec<String>>,
 }
 
@@ -10739,8 +12035,10 @@ impl ModifyOptionGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyOptionGroupResult {
+    #[serde(rename="OptionGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group: Option<OptionGroup>,
 }
 
@@ -10788,25 +12086,43 @@ impl ModifyOptionGroupResultDeserializer {
     }
 }
 #[doc="<p>Option details.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RDSOption {
     #[doc="<p>If the option requires access to a port, then this DB security group allows access to the port.</p>"]
+    #[serde(rename="DBSecurityGroupMemberships")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_group_memberships: Option<Vec<DBSecurityGroupMembership>>,
     #[doc="<p>The description of the option.</p>"]
+    #[serde(rename="OptionDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_description: Option<String>,
     #[doc="<p>The name of the option.</p>"]
+    #[serde(rename="OptionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_name: Option<String>,
     #[doc="<p>The option settings for this option.</p>"]
+    #[serde(rename="OptionSettings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_settings: Option<Vec<OptionSetting>>,
     #[doc="<p>The version of the option.</p>"]
+    #[serde(rename="OptionVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_version: Option<String>,
     #[doc="<p>Indicate if this option is permanent.</p>"]
+    #[serde(rename="Permanent")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub permanent: Option<bool>,
     #[doc="<p>Indicate if this option is persistent.</p>"]
+    #[serde(rename="Persistent")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub persistent: Option<bool>,
     #[doc="<p>If required, the port configured for this option to use.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>If the option requires access to a port, then this VPC security group allows access to the port.</p>"]
+    #[serde(rename="VpcSecurityGroupMemberships")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_memberships: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
@@ -10883,19 +12199,30 @@ impl RDSOptionDeserializer {
     }
 }
 #[doc="<p>A list of all available options</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionConfiguration {
     #[doc="<p>A list of DBSecurityGroupMemebrship name strings used for this option.</p>"]
+    #[serde(rename="DBSecurityGroupMemberships")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_group_memberships: Option<Vec<String>>,
     #[doc="<p>The configuration of options to include in a group.</p>"]
+    #[serde(rename="OptionName")]
     pub option_name: String,
     #[doc="<p>The option settings to include in an option group.</p>"]
+    #[serde(rename="OptionSettings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_settings: Option<Vec<OptionSetting>>,
     #[doc="<p>The version for the option.</p>"]
+    #[serde(rename="OptionVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_version: Option<String>,
     #[doc="<p>The optional port for the option.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>A list of VpcSecurityGroupMemebrship name strings used for this option.</p>"]
+    #[serde(rename="VpcSecurityGroupMemberships")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_memberships: Option<Vec<String>>,
 }
 
@@ -10955,23 +12282,39 @@ impl OptionConfigurationListSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionGroup {
     #[doc="<p>Indicates whether this option group can be applied to both VPC and non-VPC instances. The value <code>true</code> indicates the option group can be applied to both VPC and non-VPC instances. </p>"]
+    #[serde(rename="AllowsVpcAndNonVpcInstanceMemberships")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allows_vpc_and_non_vpc_instance_memberships: Option<bool>,
     #[doc="<p>Indicates the name of the engine that this option group can be applied to.</p>"]
+    #[serde(rename="EngineName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_name: Option<String>,
     #[doc="<p>Indicates the major engine version associated with this option group.</p>"]
+    #[serde(rename="MajorEngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub major_engine_version: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) for the option group.</p>"]
+    #[serde(rename="OptionGroupArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_arn: Option<String>,
     #[doc="<p>Provides a description of the option group.</p>"]
+    #[serde(rename="OptionGroupDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_description: Option<String>,
     #[doc="<p>Specifies the name of the option group.</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>Indicates what options are available in the option group.</p>"]
+    #[serde(rename="Options")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options: Option<Vec<RDSOption>>,
     #[doc="<p>If <b>AllowsVpcAndNonVpcInstanceMemberships</b> is <code>false</code>, this field is blank. If <b>AllowsVpcAndNonVpcInstanceMemberships</b> is <code>true</code> and this field is blank, then this option group can be applied to both VPC and non-VPC instances. If this field contains a value, then this option group can only be applied to instances that are in the VPC indicated by this field. </p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -11051,11 +12394,15 @@ impl OptionGroupDeserializer {
     }
 }
 #[doc="<p>Provides information on the option groups the DB instance is a member of.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionGroupMembership {
     #[doc="<p>The name of the option group that the instance belongs to.</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The status of the DB instance's option group membership. Valid values are: <code>in-sync</code>, <code>pending-apply</code>, <code>pending-removal</code>, <code>pending-maintenance-apply</code>, <code>pending-maintenance-removal</code>, <code>applying</code>, <code>removing</code>, and <code>failed</code>. </p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -11148,39 +12495,71 @@ impl OptionGroupMembershipListDeserializer {
     }
 }
 #[doc="<p>Available option.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionGroupOption {
     #[doc="<p>If the option requires a port, specifies the default port for the option.</p>"]
+    #[serde(rename="DefaultPort")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_port: Option<i64>,
     #[doc="<p>The description of the option.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The name of the engine that this option can be applied to.</p>"]
+    #[serde(rename="EngineName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_name: Option<String>,
     #[doc="<p>Indicates the major engine version that the option is available for.</p>"]
+    #[serde(rename="MajorEngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub major_engine_version: Option<String>,
     #[doc="<p>The minimum required engine version for the option to be applied.</p>"]
+    #[serde(rename="MinimumRequiredMinorEngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub minimum_required_minor_engine_version: Option<String>,
     #[doc="<p>The name of the option.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The option settings that are available (and the default value) for each option in an option group.</p>"]
+    #[serde(rename="OptionGroupOptionSettings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_option_settings: Option<Vec<OptionGroupOptionSetting>>,
     #[doc="<p>The versions that are available for the option.</p>"]
+    #[serde(rename="OptionGroupOptionVersions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_option_versions: Option<Vec<OptionVersion>>,
     #[doc="<p>The options that conflict with this option.</p>"]
+    #[serde(rename="OptionsConflictsWith")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options_conflicts_with: Option<Vec<String>>,
     #[doc="<p>The options that are prerequisites for this option.</p>"]
+    #[serde(rename="OptionsDependedOn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub options_depended_on: Option<Vec<String>>,
     #[doc="<p>Permanent options can never be removed from an option group. An option group containing a permanent option can't be removed from a DB instance.</p>"]
+    #[serde(rename="Permanent")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub permanent: Option<bool>,
     #[doc="<p>Persistent options can't be removed from an option group while DB instances are associated with the option group. If you disassociate all DB instances from the option group, your can remove the persistent option from the option group.</p>"]
+    #[serde(rename="Persistent")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub persistent: Option<bool>,
     #[doc="<p>Specifies whether the option requires a port.</p>"]
+    #[serde(rename="PortRequired")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port_required: Option<bool>,
     #[doc="<p>If true, you must enable the Auto Minor Version Upgrade setting for your DB instance before you can use this option. You can enable Auto Minor Version Upgrade when you first create your DB instance, or by modifying your DB instance later. </p>"]
+    #[serde(rename="RequiresAutoMinorEngineVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub requires_auto_minor_engine_version_upgrade: Option<bool>,
     #[doc="<p>If true, you can change the option to an earlier version of the option. This only applies to options that have different versions available. </p>"]
+    #[serde(rename="SupportsOptionVersionDowngrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub supports_option_version_downgrade: Option<bool>,
     #[doc="<p>If true, you can only use this option with a DB instance that is in a VPC. </p>"]
+    #[serde(rename="VpcOnly")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_only: Option<bool>,
 }
 
@@ -11291,19 +12670,31 @@ impl OptionGroupOptionDeserializer {
     }
 }
 #[doc="<p>Option group option settings are used to display settings available for each option with their default values and other information. These values are used with the DescribeOptionGroupOptions action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionGroupOptionSetting {
     #[doc="<p>Indicates the acceptable values for the option group option.</p>"]
+    #[serde(rename="AllowedValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allowed_values: Option<String>,
     #[doc="<p>The DB engine specific parameter type for the option group option.</p>"]
+    #[serde(rename="ApplyType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub apply_type: Option<String>,
     #[doc="<p>The default value for the option group option.</p>"]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>Boolean value where true indicates that this option group option can be changed from the default value.</p>"]
+    #[serde(rename="IsModifiable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_modifiable: Option<bool>,
     #[doc="<p>The description of the option group option.</p>"]
+    #[serde(rename="SettingDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub setting_description: Option<String>,
     #[doc="<p>The name of the option group option.</p>"]
+    #[serde(rename="SettingName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub setting_name: Option<String>,
 }
 
@@ -11495,10 +12886,14 @@ impl OptionGroupOptionsListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionGroupOptionsMessage {
     #[doc="<p>An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
+    #[serde(rename="OptionGroupOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_options: Option<Vec<OptionGroupOption>>,
 }
 
@@ -11550,11 +12945,15 @@ impl OptionGroupOptionsMessageDeserializer {
     }
 }
 #[doc="<p>List of option groups.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionGroups {
     #[doc="<p>An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>List of option groups.</p>"]
+    #[serde(rename="OptionGroupsList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_groups_list: Option<Vec<OptionGroup>>,
 }
 
@@ -11659,25 +13058,43 @@ impl OptionNamesListSerializer {
 }
 
 #[doc="<p>Option settings are the actual settings being applied or configured for that option. It is used when you modify an option group or describe option groups. For example, the NATIVE_NETWORK_ENCRYPTION option has a setting called SQLNET.ENCRYPTION_SERVER that can have several different values.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionSetting {
     #[doc="<p>The allowed values of the option setting.</p>"]
+    #[serde(rename="AllowedValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allowed_values: Option<String>,
     #[doc="<p>The DB engine specific parameter type.</p>"]
+    #[serde(rename="ApplyType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub apply_type: Option<String>,
     #[doc="<p>The data type of the option setting.</p>"]
+    #[serde(rename="DataType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub data_type: Option<String>,
     #[doc="<p>The default value of the option setting.</p>"]
+    #[serde(rename="DefaultValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_value: Option<String>,
     #[doc="<p>The description of the option setting.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>Indicates if the option setting is part of a collection.</p>"]
+    #[serde(rename="IsCollection")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_collection: Option<bool>,
     #[doc="<p>A Boolean value that, when true, indicates the option setting can be modified from the default.</p>"]
+    #[serde(rename="IsModifiable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_modifiable: Option<bool>,
     #[doc="<p>The name of the option that has settings that you can set.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The current value of the option setting.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -11858,11 +13275,15 @@ impl OptionSettingsListSerializer {
 }
 
 #[doc="<p>The version for an option. Option group option versions are returned by the <a>DescribeOptionGroupOptions</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptionVersion {
     #[doc="<p>True if the version is the default version of the option; otherwise, false.</p>"]
+    #[serde(rename="IsDefault")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_default: Option<bool>,
     #[doc="<p>The version of the option.</p>"]
+    #[serde(rename="Version")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version: Option<String>,
 }
 
@@ -12037,33 +13458,59 @@ impl OptionsListDeserializer {
     }
 }
 #[doc="<p>Contains a list of available options for a DB instance</p> <p> This data type is used as a response element in the <a>DescribeOrderableDBInstanceOptions</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OrderableDBInstanceOption {
     #[doc="<p>A list of Availability Zones for the orderable DB instance.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<AvailabilityZone>>,
     #[doc="<p>The DB instance class for the orderable DB instance.</p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p>The engine type of the orderable DB instance.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>The engine version of the orderable DB instance.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>The license model for the orderable DB instance.</p>"]
+    #[serde(rename="LicenseModel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_model: Option<String>,
     #[doc="<p>Indicates whether this orderable DB instance is multi-AZ capable.</p>"]
+    #[serde(rename="MultiAZCapable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az_capable: Option<bool>,
     #[doc="<p>Indicates whether this orderable DB instance can have a Read Replica.</p>"]
+    #[serde(rename="ReadReplicaCapable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub read_replica_capable: Option<bool>,
     #[doc="<p>Indicates the storage type for this orderable DB instance.</p>"]
+    #[serde(rename="StorageType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_type: Option<String>,
     #[doc="<p>Indicates whether the DB instance supports enhanced monitoring at intervals from 1 to 60 seconds.</p>"]
+    #[serde(rename="SupportsEnhancedMonitoring")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub supports_enhanced_monitoring: Option<bool>,
     #[doc="<p>Indicates whether this orderable DB instance supports IAM database authentication.</p>"]
+    #[serde(rename="SupportsIAMDatabaseAuthentication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub supports_iam_database_authentication: Option<bool>,
     #[doc="<p>Indicates whether this orderable DB instance supports provisioned IOPS.</p>"]
+    #[serde(rename="SupportsIops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub supports_iops: Option<bool>,
     #[doc="<p>Indicates whether this orderable DB instance supports encrypted storage.</p>"]
+    #[serde(rename="SupportsStorageEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub supports_storage_encryption: Option<bool>,
     #[doc="<p>Indicates whether this is a VPC orderable DB instance.</p>"]
+    #[serde(rename="Vpc")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc: Option<bool>,
 }
 
@@ -12205,11 +13652,15 @@ impl OrderableDBInstanceOptionsListDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeOrderableDBInstanceOptions</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OrderableDBInstanceOptionsMessage {
     #[doc="<p> An optional pagination token provided by a previous OrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>An <a>OrderableDBInstanceOption</a> structure containing information about orderable options for the DB instance.</p>"]
+    #[serde(rename="OrderableDBInstanceOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub orderable_db_instance_options: Option<Vec<OrderableDBInstanceOption>>,
 }
 
@@ -12260,27 +13711,47 @@ impl OrderableDBInstanceOptionsMessageDeserializer {
     }
 }
 #[doc="<p> This data type is used as a request parameter in the <a>ModifyDBParameterGroup</a> and <a>ResetDBParameterGroup</a> actions. </p> <p>This data type is used as a response element in the <a>DescribeEngineDefaultParameters</a> and <a>DescribeDBParameters</a> actions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Parameter {
     #[doc="<p>Specifies the valid range of values for the parameter.</p>"]
+    #[serde(rename="AllowedValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allowed_values: Option<String>,
     #[doc="<p>Indicates when to apply parameter updates.</p>"]
+    #[serde(rename="ApplyMethod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub apply_method: Option<String>,
     #[doc="<p>Specifies the engine specific parameters type.</p>"]
+    #[serde(rename="ApplyType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub apply_type: Option<String>,
     #[doc="<p>Specifies the valid data type for the parameter.</p>"]
+    #[serde(rename="DataType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub data_type: Option<String>,
     #[doc="<p>Provides a description of the parameter.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p> Indicates whether (<code>true</code>) or not (<code>false</code>) the parameter can be modified. Some parameters have security or operational implications that prevent them from being changed. </p>"]
+    #[serde(rename="IsModifiable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_modifiable: Option<bool>,
     #[doc="<p>The earliest engine version to which the parameter can apply.</p>"]
+    #[serde(rename="MinimumEngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub minimum_engine_version: Option<String>,
     #[doc="<p>Specifies the name of the parameter.</p>"]
+    #[serde(rename="ParameterName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_name: Option<String>,
     #[doc="<p>Specifies the value of the parameter.</p>"]
+    #[serde(rename="ParameterValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_value: Option<String>,
     #[doc="<p>Indicates the source of the parameter value.</p>"]
+    #[serde(rename="Source")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source: Option<String>,
 }
 
@@ -12473,19 +13944,31 @@ impl ParametersListSerializer {
 }
 
 #[doc="<p>Provides information about a pending maintenance action for a resource.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PendingMaintenanceAction {
     #[doc="<p>The type of pending maintenance action that is available for the resource.</p>"]
+    #[serde(rename="Action")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub action: Option<String>,
     #[doc="<p>The date of the maintenance window when the action will be applied. The maintenance action will be applied to the resource during its first maintenance window after this date. If this date is specified, any <code>next-maintenance</code> opt-in requests are ignored.</p>"]
+    #[serde(rename="AutoAppliedAfterDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_applied_after_date: Option<String>,
     #[doc="<p>The effective date when the pending maintenance action will be applied to the resource. This date takes into account opt-in requests received from the <a>ApplyPendingMaintenanceAction</a> API, the <code>AutoAppliedAfterDate</code>, and the <code>ForcedApplyDate</code>. This value is blank if an opt-in request has not been received and nothing has been specified as <code>AutoAppliedAfterDate</code> or <code>ForcedApplyDate</code>.</p>"]
+    #[serde(rename="CurrentApplyDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub current_apply_date: Option<String>,
     #[doc="<p>A description providing more detail about the maintenance action.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The date when the maintenance action will be automatically applied. The maintenance action will be applied to the resource on this date regardless of the maintenance window for the resource. If this date is specified, any <code>immediate</code> opt-in requests are ignored.</p>"]
+    #[serde(rename="ForcedApplyDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub forced_apply_date: Option<String>,
     #[doc="<p>Indicates the type of opt-in request that has been received for the resource.</p>"]
+    #[serde(rename="OptInStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub opt_in_status: Option<String>,
 }
 
@@ -12638,11 +14121,15 @@ impl PendingMaintenanceActionsDeserializer {
     }
 }
 #[doc="<p>Data returned from the <b>DescribePendingMaintenanceActions</b> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PendingMaintenanceActionsMessage {
     #[doc="<p> An optional pagination token provided by a previous <code>DescribePendingMaintenanceActions</code> request. If this parameter is specified, the response includes only records beyond the marker, up to a number of records specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of the pending maintenance actions for the resource.</p>"]
+    #[serde(rename="PendingMaintenanceActions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pending_maintenance_actions: Option<Vec<ResourcePendingMaintenanceActions>>,
 }
 
@@ -12693,33 +14180,59 @@ impl PendingMaintenanceActionsMessageDeserializer {
     }
 }
 #[doc="<p> This data type is used as a response element in the <a>ModifyDBInstance</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PendingModifiedValues {
     #[doc="<p> Contains the new <code>AllocatedStorage</code> size for the DB instance that will be applied or is in progress. </p>"]
+    #[serde(rename="AllocatedStorage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allocated_storage: Option<i64>,
     #[doc="<p>Specifies the pending number of days for which automated backups are retained.</p>"]
+    #[serde(rename="BackupRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub backup_retention_period: Option<i64>,
     #[doc="<p>Specifies the identifier of the CA certificate for the DB instance.</p>"]
+    #[serde(rename="CACertificateIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ca_certificate_identifier: Option<String>,
     #[doc="<p> Contains the new <code>DBInstanceClass</code> for the DB instance that will be applied or is in progress. </p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p> Contains the new <code>DBInstanceIdentifier</code> for the DB instance that will be applied or is in progress. </p>"]
+    #[serde(rename="DBInstanceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_identifier: Option<String>,
     #[doc="<p>The new DB subnet group for the DB instance. </p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>Indicates the database engine version.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>Specifies the new Provisioned IOPS value for the DB instance that will be applied or is being applied.</p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>The license model for the DB instance.</p> <p>Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>"]
+    #[serde(rename="LicenseModel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_model: Option<String>,
     #[doc="<p>Contains the pending or in-progress change of the master credentials for the DB instance.</p>"]
+    #[serde(rename="MasterUserPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_user_password: Option<String>,
     #[doc="<p>Indicates that the Single-AZ DB instance is to change to a Multi-AZ deployment.</p>"]
+    #[serde(rename="MultiAZ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az: Option<bool>,
     #[doc="<p>Specifies the pending port for the DB instance.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>Specifies the storage type to be associated with the DB instance.</p>"]
+    #[serde(rename="StorageType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_type: Option<String>,
 }
 
@@ -12822,9 +14335,10 @@ impl PendingModifiedValuesDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PromoteReadReplicaDBClusterMessage {
     #[doc="<p>The identifier of the DB cluster Read Replica to promote. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster-replica1</code> </p>"]
+    #[serde(rename="DBClusterIdentifier")]
     pub db_cluster_identifier: String,
 }
 
@@ -12844,8 +14358,10 @@ impl PromoteReadReplicaDBClusterMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PromoteReadReplicaDBClusterResult {
+    #[serde(rename="DBCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster: Option<DBCluster>,
 }
 
@@ -12893,13 +14409,18 @@ impl PromoteReadReplicaDBClusterResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PromoteReadReplicaMessage {
     #[doc="<p>The number of days to retain automated backups. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 0 to 8</p> </li> </ul>"]
+    #[serde(rename="BackupRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub backup_retention_period: Option<i64>,
     #[doc="<p>The DB instance identifier. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must be the identifier for an existing Read Replica DB instance</p> </li> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>mydbinstance</code> </p>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
     #[doc="<p> The daily time range during which automated backups are created if automated backups are enabled, using the <code>BackupRetentionPeriod</code> parameter. </p> <p> Default: A 30-minute window selected at random from an 8-hour block of time per AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Times should be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>"]
+    #[serde(rename="PreferredBackupWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_backup_window: Option<String>,
 }
 
@@ -12927,8 +14448,10 @@ impl PromoteReadReplicaMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PromoteReadReplicaResult {
+    #[serde(rename="DBInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance: Option<DBInstance>,
 }
 
@@ -12976,14 +14499,21 @@ impl PromoteReadReplicaResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseReservedDBInstancesOfferingMessage {
     #[doc="<p>The number of instances to reserve.</p> <p>Default: <code>1</code> </p>"]
+    #[serde(rename="DBInstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_count: Option<i64>,
     #[doc="<p>Customer-specified identifier to track this reservation.</p> <p>Example: myreservationID</p>"]
+    #[serde(rename="ReservedDBInstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_db_instance_id: Option<String>,
     #[doc="<p>The ID of the Reserved DB instance offering to purchase.</p> <p>Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706</p>"]
+    #[serde(rename="ReservedDBInstancesOfferingId")]
     pub reserved_db_instances_offering_id: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -13016,8 +14546,10 @@ impl PurchaseReservedDBInstancesOfferingMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseReservedDBInstancesOfferingResult {
+    #[serde(rename="ReservedDBInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_db_instance: Option<ReservedDBInstance>,
 }
 
@@ -13190,11 +14722,14 @@ impl ReadReplicaIdentifierListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootDBInstanceMessage {
     #[doc="<p>The DB instance identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
     #[doc="<p> When <code>true</code>, the reboot will be conducted through a MultiAZ failover. </p> <p>Constraint: You cannot specify <code>true</code> if the instance is not configured for MultiAZ.</p>"]
+    #[serde(rename="ForceFailover")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub force_failover: Option<bool>,
 }
 
@@ -13218,8 +14753,10 @@ impl RebootDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootDBInstanceResult {
+    #[serde(rename="DBInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance: Option<DBInstance>,
 }
 
@@ -13267,11 +14804,15 @@ impl RebootDBInstanceResultDeserializer {
     }
 }
 #[doc="<p> This data type is used as a response element in the <a>DescribeReservedDBInstances</a> and <a>DescribeReservedDBInstancesOfferings</a> actions. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecurringCharge {
     #[doc="<p>The amount of the recurring charge.</p>"]
+    #[serde(rename="RecurringChargeAmount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charge_amount: Option<f64>,
     #[doc="<p>The frequency of the recurring charge.</p>"]
+    #[serde(rename="RecurringChargeFrequency")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charge_frequency: Option<String>,
 }
 
@@ -13365,11 +14906,13 @@ impl RecurringChargeListDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveRoleFromDBClusterMessage {
     #[doc="<p>The name of the DB cluster to disassociate the IAM role from.</p>"]
+    #[serde(rename="DBClusterIdentifier")]
     pub db_cluster_identifier: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM role to disassociate from the Aurora DB cluster, for example <code>arn:aws:iam::123456789012:role/AuroraAccessRole</code>.</p>"]
+    #[serde(rename="RoleArn")]
     pub role_arn: String,
 }
 
@@ -13392,11 +14935,13 @@ impl RemoveRoleFromDBClusterMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveSourceIdentifierFromSubscriptionMessage {
     #[doc="<p> The source identifier to be removed from the subscription, such as the <b>DB instance identifier</b> for a DB instance or the name of a security group. </p>"]
+    #[serde(rename="SourceIdentifier")]
     pub source_identifier: String,
     #[doc="<p>The name of the RDS event notification subscription you want to remove a source identifier from.</p>"]
+    #[serde(rename="SubscriptionName")]
     pub subscription_name: String,
 }
 
@@ -13420,8 +14965,10 @@ impl RemoveSourceIdentifierFromSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveSourceIdentifierFromSubscriptionResult {
+    #[serde(rename="EventSubscription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_subscription: Option<EventSubscription>,
 }
 
@@ -13470,11 +15017,13 @@ impl RemoveSourceIdentifierFromSubscriptionResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceMessage {
     #[doc="<p>The Amazon RDS resource the tags will be removed from. This value is an Amazon Resource Name (ARN). For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>"]
+    #[serde(rename="ResourceName")]
     pub resource_name: String,
     #[doc="<p>The tag key (name) of the tag to be removed.</p>"]
+    #[serde(rename="TagKeys")]
     pub tag_keys: Vec<String>,
 }
 
@@ -13496,37 +15045,67 @@ impl RemoveTagsFromResourceMessageSerializer {
 }
 
 #[doc="<p> This data type is used as a response element in the <a>DescribeReservedDBInstances</a> and <a>PurchaseReservedDBInstancesOffering</a> actions. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedDBInstance {
     #[doc="<p>The currency code for the reserved DB instance.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The DB instance class for the reserved DB instance.</p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p>The number of reserved DB instances.</p>"]
+    #[serde(rename="DBInstanceCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_count: Option<i64>,
     #[doc="<p>The duration of the reservation in seconds.</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The fixed price charged for this reserved DB instance.</p>"]
+    #[serde(rename="FixedPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fixed_price: Option<f64>,
     #[doc="<p>Indicates if the reservation applies to Multi-AZ deployments.</p>"]
+    #[serde(rename="MultiAZ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az: Option<bool>,
     #[doc="<p>The offering type of this reserved DB instance.</p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The description of the reserved DB instance.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The recurring price charged to run this reserved DB instance.</p>"]
+    #[serde(rename="RecurringCharges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charges: Option<Vec<RecurringCharge>>,
     #[doc="<p>The Amazon Resource Name (ARN) for the reserved DB instance.</p>"]
+    #[serde(rename="ReservedDBInstanceArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_db_instance_arn: Option<String>,
     #[doc="<p>The unique identifier for the reservation.</p>"]
+    #[serde(rename="ReservedDBInstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_db_instance_id: Option<String>,
     #[doc="<p>The offering identifier.</p>"]
+    #[serde(rename="ReservedDBInstancesOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_db_instances_offering_id: Option<String>,
     #[doc="<p>The time the reservation started.</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
     #[doc="<p>The state of the reserved DB instance.</p>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The hourly price charged for this reserved DB instance.</p>"]
+    #[serde(rename="UsagePrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub usage_price: Option<f64>,
 }
 
@@ -13676,11 +15255,15 @@ impl ReservedDBInstanceListDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeReservedDBInstances</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedDBInstanceMessage {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of reserved DB instances.</p>"]
+    #[serde(rename="ReservedDBInstances")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_db_instances: Option<Vec<ReservedDBInstance>>,
 }
 
@@ -13732,27 +15315,47 @@ impl ReservedDBInstanceMessageDeserializer {
     }
 }
 #[doc="<p> This data type is used as a response element in the <a>DescribeReservedDBInstancesOfferings</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedDBInstancesOffering {
     #[doc="<p>The currency code for the reserved DB instance offering.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The DB instance class for the reserved DB instance.</p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p>The duration of the offering in seconds.</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The fixed price charged for this offering.</p>"]
+    #[serde(rename="FixedPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fixed_price: Option<f64>,
     #[doc="<p>Indicates if the offering applies to Multi-AZ deployments.</p>"]
+    #[serde(rename="MultiAZ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az: Option<bool>,
     #[doc="<p>The offering type.</p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The database engine used by the offering.</p>"]
+    #[serde(rename="ProductDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub product_description: Option<String>,
     #[doc="<p>The recurring price charged to run this reserved DB instance.</p>"]
+    #[serde(rename="RecurringCharges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charges: Option<Vec<RecurringCharge>>,
     #[doc="<p>The offering identifier.</p>"]
+    #[serde(rename="ReservedDBInstancesOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_db_instances_offering_id: Option<String>,
     #[doc="<p>The hourly price charged for this offering.</p>"]
+    #[serde(rename="UsagePrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub usage_price: Option<f64>,
 }
 
@@ -13881,11 +15484,15 @@ impl ReservedDBInstancesOfferingListDeserializer {
     }
 }
 #[doc="<p> Contains the result of a successful invocation of the <a>DescribeReservedDBInstancesOfferings</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedDBInstancesOfferingMessage {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of reserved DB instance offerings.</p>"]
+    #[serde(rename="ReservedDBInstancesOfferings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_db_instances_offerings: Option<Vec<ReservedDBInstancesOffering>>,
 }
 
@@ -13936,13 +15543,18 @@ impl ReservedDBInstancesOfferingMessageDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetDBClusterParameterGroupMessage {
     #[doc="<p>The name of the DB cluster parameter group to reset.</p>"]
+    #[serde(rename="DBClusterParameterGroupName")]
     pub db_cluster_parameter_group_name: String,
     #[doc="<p>A list of parameter names in the DB cluster parameter group to reset to the default values. You cannot use this parameter if the <code>ResetAllParameters</code> parameter is set to <code>true</code>.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p>A value that is set to <code>true</code> to reset all parameters in the DB cluster parameter group to their default values, and <code>false</code> otherwise. You cannot use this parameter if there is a list of parameter names specified for the <code>Parameters</code> parameter.</p>"]
+    #[serde(rename="ResetAllParameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reset_all_parameters: Option<bool>,
 }
 
@@ -13972,13 +15584,18 @@ impl ResetDBClusterParameterGroupMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetDBParameterGroupMessage {
     #[doc="<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBParameterGroupName")]
     pub db_parameter_group_name: String,
     #[doc="<p>To reset the entire DB parameter group, specify the <code>DBParameterGroup</code> name and <code>ResetAllParameters</code> parameters. To reset specific parameters, provide a list of the following: <code>ParameterName</code> and <code>ApplyMethod</code>. A maximum of 20 parameters can be modified in a single request.</p> <p> <b>MySQL</b> </p> <p>Valid Values (for Apply method): <code>immediate</code> | <code>pending-reboot</code> </p> <p>You can use the immediate value with dynamic parameters only. You can use the <code>pending-reboot</code> value for both dynamic and static parameters, and changes are applied when DB instance reboots.</p> <p> <b>MariaDB</b> </p> <p>Valid Values (for Apply method): <code>immediate</code> | <code>pending-reboot</code> </p> <p>You can use the immediate value with dynamic parameters only. You can use the <code>pending-reboot</code> value for both dynamic and static parameters, and changes are applied when DB instance reboots.</p> <p> <b>Oracle</b> </p> <p>Valid Values (for Apply method): <code>pending-reboot</code> </p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p> Specifies whether (<code>true</code>) or not (<code>false</code>) to reset all parameters in the DB parameter group to default values. </p> <p>Default: <code>true</code> </p>"]
+    #[serde(rename="ResetAllParameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reset_all_parameters: Option<bool>,
 }
 
@@ -14008,11 +15625,15 @@ impl ResetDBParameterGroupMessageSerializer {
 }
 
 #[doc="<p>Describes the pending maintenance actions for a resource.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourcePendingMaintenanceActions {
     #[doc="<p>A list that provides details about the pending maintenance actions for the resource.</p>"]
+    #[serde(rename="PendingMaintenanceActionDetails")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pending_maintenance_action_details: Option<Vec<PendingMaintenanceAction>>,
     #[doc="<p>The ARN of the resource that has pending maintenance actions.</p>"]
+    #[serde(rename="ResourceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_identifier: Option<String>,
 }
 
@@ -14063,56 +15684,98 @@ impl ResourcePendingMaintenanceActionsDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreDBClusterFromS3Message {
     #[doc="<p>A list of EC2 Availability Zones that instances in the restored DB cluster can be created in.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<String>>,
     #[doc="<p>The number of days for which automated backups of the restored DB cluster are retained. You must specify a minimum value of 1.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 1 to 35</p> </li> </ul>"]
+    #[serde(rename="BackupRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub backup_retention_period: Option<i64>,
     #[doc="<p>A value that indicates that the restored DB cluster should be associated with the specified CharacterSet.</p>"]
+    #[serde(rename="CharacterSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub character_set_name: Option<String>,
     #[doc="<p>The name of the DB cluster to create from the source data in the S3 bucket. This parameter is isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>"]
+    #[serde(rename="DBClusterIdentifier")]
     pub db_cluster_identifier: String,
     #[doc="<p>The name of the DB cluster parameter group to associate with the restored DB cluster. If this argument is omitted, <code>default.aurora5.6</code> will be used. </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBClusterParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster_parameter_group_name: Option<String>,
     #[doc="<p>A DB subnet group to associate with the restored DB cluster.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>The database name for the restored DB cluster.</p>"]
+    #[serde(rename="DatabaseName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub database_name: Option<String>,
     #[doc="<p>A Boolean value that is true to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EnableIAMDatabaseAuthentication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_iam_database_authentication: Option<bool>,
     #[doc="<p>The name of the database engine to be used for the restored DB cluster.</p> <p>Valid Values: <code>aurora</code> </p>"]
+    #[serde(rename="Engine")]
     pub engine: String,
     #[doc="<p>The version number of the database engine to use.</p> <p> <b>Aurora</b> </p> <p>Example: <code>5.6.10a</code> </p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>The KMS key identifier for an encrypted DB cluster.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are creating a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KM encryption key.</p> <p>If the <code>StorageEncrypted</code> parameter is true, and you do not specify a value for the <code>KmsKeyId</code> parameter, then Amazon RDS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS Region.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The password for the master database user. This password can contain any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p>Constraints: Must contain from 8 to 41 characters.</p>"]
+    #[serde(rename="MasterUserPassword")]
     pub master_user_password: String,
     #[doc="<p>The name of the master user for the restored DB cluster.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 16 alphanumeric characters.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul>"]
+    #[serde(rename="MasterUsername")]
     pub master_username: String,
     #[doc="<p>A value that indicates that the restored DB cluster should be associated with the specified option group.</p> <p>Permanent options cannot be removed from an option group. An option group cannot be removed from a DB cluster once it is associated with a DB cluster.</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The port number on which the instances in the restored DB cluster accept connections.</p> <p> Default: <code>3306</code> </p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The daily time range during which automated backups are created if automated backups are enabled using the <code>BackupRetentionPeriod</code> parameter. </p> <p>Default: A 30-minute window selected at random from an 8-hour block of time per AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Times should be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>"]
+    #[serde(rename="PreferredBackupWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_backup_window: Option<String>,
     #[doc="<p>The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p> <p> Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p>Default: A 30-minute window selected at random from an 8-hour block of time per AWS Region, occurring on a random day of the week. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun</p> <p>Constraints: Minimum 30-minute window.</p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>The name of the Amazon S3 bucket that contains the data used to create the Amazon Aurora DB cluster.</p>"]
+    #[serde(rename="S3BucketName")]
     pub s3_bucket_name: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that authorizes Amazon RDS to access the Amazon S3 bucket on your behalf.</p>"]
+    #[serde(rename="S3IngestionRoleArn")]
     pub s3_ingestion_role_arn: String,
     #[doc="<p>The prefix for all of the file names that contain the data used to create the Amazon Aurora DB cluster. If you do not specify a <b>SourceS3Prefix</b> value, then the Amazon Aurora DB cluster is created by using all of the files in the Amazon S3 bucket.</p>"]
+    #[serde(rename="S3Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_prefix: Option<String>,
     #[doc="<p>The identifier for the database engine that was backed up to create the files stored in the Amazon S3 bucket. </p> <p>Valid values: <code>mysql</code> </p>"]
+    #[serde(rename="SourceEngine")]
     pub source_engine: String,
     #[doc="<p>The version of the database that the backup files were created from.</p> <p>MySQL version 5.5 and 5.6 are supported. </p> <p>Example: <code>5.6.22</code> </p>"]
+    #[serde(rename="SourceEngineVersion")]
     pub source_engine_version: String,
     #[doc="<p>Specifies whether the restored DB cluster is encrypted.</p>"]
+    #[serde(rename="StorageEncrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_encrypted: Option<bool>,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>A list of EC2 VPC security groups to associate with the restored DB cluster.</p>"]
+    #[serde(rename="VpcSecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_ids: Option<Vec<String>>,
 }
 
@@ -14217,8 +15880,10 @@ impl RestoreDBClusterFromS3MessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreDBClusterFromS3Result {
+    #[serde(rename="DBCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster: Option<DBCluster>,
 }
 
@@ -14265,33 +15930,56 @@ impl RestoreDBClusterFromS3ResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreDBClusterFromSnapshotMessage {
     #[doc="<p>Provides the list of EC2 Availability Zones that instances in the restored DB cluster can be created in.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<String>>,
     #[doc="<p>The name of the DB cluster to create from the DB cluster snapshot. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-snapshot-id</code> </p>"]
+    #[serde(rename="DBClusterIdentifier")]
     pub db_cluster_identifier: String,
     #[doc="<p>The name of the DB subnet group to use for the new DB cluster.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>The database name for the restored DB cluster.</p>"]
+    #[serde(rename="DatabaseName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub database_name: Option<String>,
     #[doc="<p>A Boolean value that is true to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EnableIAMDatabaseAuthentication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_iam_database_authentication: Option<bool>,
     #[doc="<p>The database engine to use for the new DB cluster.</p> <p>Default: The same as source</p> <p>Constraint: Must be compatible with the engine of the source</p>"]
+    #[serde(rename="Engine")]
     pub engine: String,
     #[doc="<p>The version of the database engine to use for the new DB cluster.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>The KMS key identifier to use when restoring an encrypted DB cluster from a DB cluster snapshot.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are restoring a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KMS encryption key.</p> <p>If you do not specify a value for the <code>KmsKeyId</code> parameter, then the following will occur:</p> <ul> <li> <p>If the DB cluster snapshot is encrypted, then the restored DB cluster is encrypted using the KMS key that was used to encrypt the DB cluster snapshot.</p> </li> <li> <p>If the DB cluster snapshot is not encrypted, then the restored DB cluster is encrypted using the specified encryption key.</p> </li> </ul>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The name of the option group to use for the restored DB cluster.</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The port number on which the new DB cluster accepts connections.</p> <p>Constraints: Value must be <code>1150-65535</code> </p> <p>Default: The same port as the original DB cluster.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The identifier for the DB cluster snapshot to restore from.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="SnapshotIdentifier")]
     pub snapshot_identifier: String,
     #[doc="<p>The tags to be assigned to the restored DB cluster.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>A list of VPC security groups that the new DB cluster will belong to.</p>"]
+    #[serde(rename="VpcSecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_ids: Option<Vec<String>>,
 }
 
@@ -14358,8 +16046,10 @@ impl RestoreDBClusterFromSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreDBClusterFromSnapshotResult {
+    #[serde(rename="DBCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster: Option<DBCluster>,
 }
 
@@ -14407,30 +16097,52 @@ impl RestoreDBClusterFromSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreDBClusterToPointInTimeMessage {
     #[doc="<p>The name of the new DB cluster to be created.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="DBClusterIdentifier")]
     pub db_cluster_identifier: String,
     #[doc="<p>The DB subnet group name to use for the new DB cluster.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>A Boolean value that is true to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EnableIAMDatabaseAuthentication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_iam_database_authentication: Option<bool>,
     #[doc="<p>The KMS key identifier to use when restoring an encrypted DB cluster from an encrypted DB cluster.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are restoring a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KMS encryption key.</p> <p>You can restore to a new DB cluster and encrypt the new DB cluster with a KMS key that is different than the KMS key used to encrypt the source DB cluster. The new DB cluster will be encrypted with the KMS key identified by the <code>KmsKeyId</code> parameter.</p> <p>If you do not specify a value for the <code>KmsKeyId</code> parameter, then the following will occur:</p> <ul> <li> <p>If the DB cluster is encrypted, then the restored DB cluster is encrypted using the KMS key that was used to encrypt the source DB cluster.</p> </li> <li> <p>If the DB cluster is not encrypted, then the restored DB cluster is not encrypted.</p> </li> </ul> <p>If <code>DBClusterIdentifier</code> refers to a DB cluster that is not encrypted, then the restore request is rejected.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The name of the option group for the new DB cluster.</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The port number on which the new DB cluster accepts connections.</p> <p>Constraints: Value must be <code>1150-65535</code> </p> <p>Default: The same port as the original DB cluster.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The date and time to restore the DB cluster to.</p> <p>Valid Values: Value must be a time in Universal Coordinated Time (UTC) format</p> <p>Constraints:</p> <ul> <li> <p>Must be before the latest restorable time for the DB instance</p> </li> <li> <p>Must be specified if <code>UseLatestRestorableTime</code> parameter is not provided</p> </li> <li> <p>Cannot be specified if <code>UseLatestRestorableTime</code> parameter is true</p> </li> <li> <p>Cannot be specified if <code>RestoreType</code> parameter is <code>copy-on-write</code> </p> </li> </ul> <p>Example: <code>2015-03-07T23:45:00Z</code> </p>"]
+    #[serde(rename="RestoreToTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub restore_to_time: Option<String>,
     #[doc="<p>The type of restore to be performed. You can specify one of the following values:</p> <ul> <li> <p> <code>full-copy</code> - The new DB cluster is restored as a full copy of the source DB cluster.</p> </li> <li> <p> <code>copy-on-write</code> - The new DB cluster is restored as a clone of the source DB cluster.</p> </li> </ul> <p>Constraints: You cannot specify <code>copy-on-write</code> if the engine version of the source DB cluster is earlier than 1.11.</p> <p>If you don't specify a <code>RestoreType</code> value, then the new DB cluster is restored as a full copy of the source DB cluster.</p>"]
+    #[serde(rename="RestoreType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub restore_type: Option<String>,
     #[doc="<p>The identifier of the source DB cluster from which to restore.</p> <p>Constraints:</p> <ul> <li> <p>Must be the identifier of an existing database instance</p> </li> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="SourceDBClusterIdentifier")]
     pub source_db_cluster_identifier: String,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>A value that is set to <code>true</code> to restore the DB cluster to the latest restorable backup time, and <code>false</code> otherwise. </p> <p>Default: <code>false</code> </p> <p>Constraints: Cannot be specified if <code>RestoreToTime</code> parameter is provided.</p>"]
+    #[serde(rename="UseLatestRestorableTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub use_latest_restorable_time: Option<bool>,
     #[doc="<p>A list of VPC security groups that the new DB cluster belongs to.</p>"]
+    #[serde(rename="VpcSecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_ids: Option<Vec<String>>,
 }
 
@@ -14494,8 +16206,10 @@ impl RestoreDBClusterToPointInTimeMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreDBClusterToPointInTimeResult {
+    #[serde(rename="DBCluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_cluster: Option<DBCluster>,
 }
 
@@ -14543,50 +16257,92 @@ impl RestoreDBClusterToPointInTimeResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreDBInstanceFromDBSnapshotMessage {
     #[doc="<p>Indicates that minor version upgrades will be applied automatically to the DB instance during the maintenance window.</p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p>The EC2 Availability Zone that the database instance will be created in.</p> <p>Default: A random, system-chosen Availability Zone.</p> <p>Constraint: You cannot specify the AvailabilityZone parameter if the MultiAZ parameter is set to <code>true</code>.</p> <p>Example: <code>us-east-1a</code> </p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>True to copy all tags from the restored DB instance to snapshots of the DB instance; otherwise false. The default is false.</p>"]
+    #[serde(rename="CopyTagsToSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_tags_to_snapshot: Option<bool>,
     #[doc="<p>The compute and memory capacity of the Amazon RDS DB instance.</p> <p>Valid Values: <code>db.t1.micro | db.m1.small | db.m1.medium | db.m1.large | db.m1.xlarge | db.m2.2xlarge | db.m2.4xlarge | db.m3.medium | db.m3.large | db.m3.xlarge | db.m3.2xlarge | db.m4.large | db.m4.xlarge | db.m4.2xlarge | db.m4.4xlarge | db.m4.10xlarge | db.r3.large | db.r3.xlarge | db.r3.2xlarge | db.r3.4xlarge | db.r3.8xlarge | db.t2.micro | db.t2.small | db.t2.medium | db.t2.large</code> </p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p>Name of the DB instance to create from the DB snapshot. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-snapshot-id</code> </p>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
     #[doc="<p>The database name for the restored DB instance.</p> <note> <p>This parameter doesn't apply to the MySQL, PostgreSQL, or MariaDB engines.</p> </note>"]
+    #[serde(rename="DBName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_name: Option<String>,
     #[doc="<p>The identifier for the DB snapshot to restore from.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>If you are restoring from a shared manual DB snapshot, the <code>DBSnapshotIdentifier</code> must be the ARN of the shared DB snapshot.</p>"]
+    #[serde(rename="DBSnapshotIdentifier")]
     pub db_snapshot_identifier: String,
     #[doc="<p>The DB subnet group name to use for the new instance.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>Specify the Active Directory Domain to restore the instance in.</p>"]
+    #[serde(rename="Domain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain: Option<String>,
     #[doc="<p>Specify the name of the IAM role to be used when making API calls to the Directory Service.</p>"]
+    #[serde(rename="DomainIAMRoleName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain_iam_role_name: Option<String>,
     #[doc="<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts; otherwise false.</p> <p>You can enable IAM database authentication for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> <li> <p>Aurora 5.6 or higher.</p> </li> </ul> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EnableIAMDatabaseAuthentication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_iam_database_authentication: Option<bool>,
     #[doc="<p>The database engine to use for the new instance.</p> <p>Default: The same as source</p> <p>Constraint: Must be compatible with the engine of the source. You can restore a MariaDB 10.1 DB instance from a MySQL 5.6 snapshot.</p> <p> Valid Values: <code>MySQL</code> | <code>mariadb</code> | <code>oracle-se1</code> | <code>oracle-se</code> | <code>oracle-ee</code> | <code>sqlserver-ee</code> | <code>sqlserver-se</code> | <code>sqlserver-ex</code> | <code>sqlserver-web</code> | <code>postgres</code> | <code>aurora</code> </p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>Specifies the amount of provisioned IOPS for the DB instance, expressed in I/O operations per second. If this parameter is not specified, the IOPS value will be taken from the backup. If this parameter is set to 0, the new instance will be converted to a non-PIOPS instance, which will take additional time, though your DB instance will be available for connections before the conversion starts.</p> <p>Constraints: Must be an integer greater than 1000.</p> <p> <b>SQL Server</b> </p> <p>Setting the IOPS value for the SQL Server database engine is not supported.</p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>License model information for the restored DB instance.</p> <p>Default: Same as source.</p> <p> Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>"]
+    #[serde(rename="LicenseModel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_model: Option<String>,
     #[doc="<p>Specifies if the DB instance is a Multi-AZ deployment.</p> <p>Constraint: You cannot specify the AvailabilityZone parameter if the MultiAZ parameter is set to <code>true</code>.</p>"]
+    #[serde(rename="MultiAZ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az: Option<bool>,
     #[doc="<p>The name of the option group to be used for the restored DB instance.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, cannot be removed from an option group, and that option group cannot be removed from a DB instance once it is associated with a DB instance</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The port number on which the database accepts connections.</p> <p>Default: The same port as the original DB instance</p> <p>Constraints: Value must be <code>1150-65535</code> </p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b> true</p> </li> <li> <p> <b>VPC:</b> false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be private.</p>"]
+    #[serde(rename="PubliclyAccessible")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub publicly_accessible: Option<bool>,
     #[doc="<p>Specifies the storage type to be associated with the DB instance.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified; otherwise <code>standard</code> </p>"]
+    #[serde(rename="StorageType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_type: Option<String>,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The ARN from the Key Store with which to associate the instance for TDE encryption.</p>"]
+    #[serde(rename="TdeCredentialArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tde_credential_arn: Option<String>,
     #[doc="<p>The password for the given ARN from the Key Store in order to access the device.</p>"]
+    #[serde(rename="TdeCredentialPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tde_credential_password: Option<String>,
 }
 
@@ -14687,8 +16443,10 @@ impl RestoreDBInstanceFromDBSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreDBInstanceFromDBSnapshotResult {
+    #[serde(rename="DBInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance: Option<DBInstance>,
 }
 
@@ -14737,54 +16495,100 @@ impl RestoreDBInstanceFromDBSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreDBInstanceToPointInTimeMessage {
     #[doc="<p>Indicates that minor version upgrades will be applied automatically to the DB instance during the maintenance window.</p>"]
+    #[serde(rename="AutoMinorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_minor_version_upgrade: Option<bool>,
     #[doc="<p>The EC2 Availability Zone that the database instance will be created in.</p> <p>Default: A random, system-chosen Availability Zone.</p> <p>Constraint: You cannot specify the AvailabilityZone parameter if the MultiAZ parameter is set to true.</p> <p>Example: <code>us-east-1a</code> </p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>True to copy all tags from the restored DB instance to snapshots of the DB instance; otherwise false. The default is false.</p>"]
+    #[serde(rename="CopyTagsToSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_tags_to_snapshot: Option<bool>,
     #[doc="<p>The compute and memory capacity of the Amazon RDS DB instance.</p> <p>Valid Values: <code>db.t1.micro | db.m1.small | db.m1.medium | db.m1.large | db.m1.xlarge | db.m2.2xlarge | db.m2.4xlarge | db.m3.medium | db.m3.large | db.m3.xlarge | db.m3.2xlarge | db.m4.large | db.m4.xlarge | db.m4.2xlarge | db.m4.4xlarge | db.m4.10xlarge | db.r3.large | db.r3.xlarge | db.r3.2xlarge | db.r3.4xlarge | db.r3.8xlarge | db.t2.micro | db.t2.small | db.t2.medium | db.t2.large</code> </p> <p>Default: The same DBInstanceClass as the original DB instance.</p>"]
+    #[serde(rename="DBInstanceClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance_class: Option<String>,
     #[doc="<p>The database name for the restored DB instance.</p> <note> <p>This parameter is not used for the MySQL or MariaDB engines.</p> </note>"]
+    #[serde(rename="DBName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_name: Option<String>,
     #[doc="<p>The DB subnet group name to use for the new instance.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>"]
+    #[serde(rename="DBSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_subnet_group_name: Option<String>,
     #[doc="<p>Specify the Active Directory Domain to restore the instance in.</p>"]
+    #[serde(rename="Domain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain: Option<String>,
     #[doc="<p>Specify the name of the IAM role to be used when making API calls to the Directory Service.</p>"]
+    #[serde(rename="DomainIAMRoleName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain_iam_role_name: Option<String>,
     #[doc="<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts; otherwise false.</p> <p> You can enable IAM database authentication for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> <li> <p>Aurora 5.6 or higher.</p> </li> </ul> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="EnableIAMDatabaseAuthentication")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_iam_database_authentication: Option<bool>,
     #[doc="<p>The database engine to use for the new instance.</p> <p>Default: The same as source</p> <p>Constraint: Must be compatible with the engine of the source</p> <p> Valid Values: <code>MySQL</code> | <code>mariadb</code> | <code>oracle-se1</code> | <code>oracle-se</code> | <code>oracle-ee</code> | <code>sqlserver-ee</code> | <code>sqlserver-se</code> | <code>sqlserver-ex</code> | <code>sqlserver-web</code> | <code>postgres</code> | <code>aurora</code> </p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for the DB instance.</p> <p>Constraints: Must be an integer greater than 1000.</p> <p> <b>SQL Server</b> </p> <p>Setting the IOPS value for the SQL Server database engine is not supported.</p>"]
+    #[serde(rename="Iops")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iops: Option<i64>,
     #[doc="<p>License model information for the restored DB instance.</p> <p>Default: Same as source.</p> <p> Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>"]
+    #[serde(rename="LicenseModel")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub license_model: Option<String>,
     #[doc="<p>Specifies if the DB instance is a Multi-AZ deployment.</p> <p>Constraint: You cannot specify the AvailabilityZone parameter if the MultiAZ parameter is set to <code>true</code>.</p>"]
+    #[serde(rename="MultiAZ")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_az: Option<bool>,
     #[doc="<p>The name of the option group to be used for the restored DB instance.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, cannot be removed from an option group, and that option group cannot be removed from a DB instance once it is associated with a DB instance</p>"]
+    #[serde(rename="OptionGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub option_group_name: Option<String>,
     #[doc="<p>The port number on which the database accepts connections.</p> <p>Constraints: Value must be <code>1150-65535</code> </p> <p>Default: The same port as the original DB instance.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b>true</p> </li> <li> <p> <b>VPC:</b>false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be private.</p>"]
+    #[serde(rename="PubliclyAccessible")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub publicly_accessible: Option<bool>,
     #[doc="<p>The date and time to restore from.</p> <p>Valid Values: Value must be a time in Universal Coordinated Time (UTC) format</p> <p>Constraints:</p> <ul> <li> <p>Must be before the latest restorable time for the DB instance</p> </li> <li> <p>Cannot be specified if UseLatestRestorableTime parameter is true</p> </li> </ul> <p>Example: <code>2009-09-07T23:45:00Z</code> </p>"]
+    #[serde(rename="RestoreTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub restore_time: Option<String>,
     #[doc="<p>The identifier of the source DB instance from which to restore.</p> <p>Constraints:</p> <ul> <li> <p>Must be the identifier of an existing database instance</p> </li> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="SourceDBInstanceIdentifier")]
     pub source_db_instance_identifier: String,
     #[doc="<p>Specifies the storage type to be associated with the DB instance.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified; otherwise <code>standard</code> </p>"]
+    #[serde(rename="StorageType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_type: Option<String>,
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The name of the new database instance to be created.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="TargetDBInstanceIdentifier")]
     pub target_db_instance_identifier: String,
     #[doc="<p>The ARN from the Key Store with which to associate the instance for TDE encryption.</p>"]
+    #[serde(rename="TdeCredentialArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tde_credential_arn: Option<String>,
     #[doc="<p>The password for the given ARN from the Key Store in order to access the device.</p>"]
+    #[serde(rename="TdeCredentialPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tde_credential_password: Option<String>,
     #[doc="<p> Specifies whether (<code>true</code>) or not (<code>false</code>) the DB instance is restored from the latest backup time. </p> <p>Default: <code>false</code> </p> <p>Constraints: Cannot be specified if RestoreTime parameter is provided.</p>"]
+    #[serde(rename="UseLatestRestorableTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub use_latest_restorable_time: Option<bool>,
 }
 
@@ -14893,8 +16697,10 @@ impl RestoreDBInstanceToPointInTimeMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreDBInstanceToPointInTimeResult {
+    #[serde(rename="DBInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance: Option<DBInstance>,
 }
 
@@ -14943,17 +16749,26 @@ impl RestoreDBInstanceToPointInTimeResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevokeDBSecurityGroupIngressMessage {
     #[doc="<p> The IP range to revoke access from. Must be a valid CIDR range. If <code>CIDRIP</code> is specified, <code>EC2SecurityGroupName</code>, <code>EC2SecurityGroupId</code> and <code>EC2SecurityGroupOwnerId</code> cannot be provided. </p>"]
+    #[serde(rename="CIDRIP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidrip: Option<String>,
     #[doc="<p>The name of the DB security group to revoke ingress from.</p>"]
+    #[serde(rename="DBSecurityGroupName")]
     pub db_security_group_name: String,
     #[doc="<p> The id of the EC2 security group to revoke access from. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, EC2SecurityGroupOwnerId and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>"]
+    #[serde(rename="EC2SecurityGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_id: Option<String>,
     #[doc="<p> The name of the EC2 security group to revoke access from. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, EC2SecurityGroupOwnerId and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>"]
+    #[serde(rename="EC2SecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_name: Option<String>,
     #[doc="<p> The AWS Account Number of the owner of the EC2 security group specified in the <code>EC2SecurityGroupName</code> parameter. The AWS Access Key ID is not an acceptable value. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, EC2SecurityGroupOwnerId and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>"]
+    #[serde(rename="EC2SecurityGroupOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_owner_id: Option<String>,
 }
 
@@ -14989,8 +16804,10 @@ impl RevokeDBSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevokeDBSecurityGroupIngressResult {
+    #[serde(rename="DBSecurityGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_security_group: Option<DBSecurityGroup>,
 }
 
@@ -15092,13 +16909,19 @@ impl SourceIdsListSerializer {
 }
 
 #[doc="<p>Contains an AWS Region name as the result of a successful call to the <a>DescribeSourceRegions</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SourceRegion {
     #[doc="<p>The endpoint for the source AWS Region endpoint.</p>"]
+    #[serde(rename="Endpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoint: Option<String>,
     #[doc="<p>The name of the source AWS Region.</p>"]
+    #[serde(rename="RegionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub region_name: Option<String>,
     #[doc="<p>The status of the source AWS Region.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -15195,11 +17018,15 @@ impl SourceRegionListDeserializer {
     }
 }
 #[doc="<p>Contains the result of a successful invocation of the <a>DescribeSourceRegions</a> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SourceRegionMessage {
     #[doc="<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of SourceRegion instances that contains each source AWS Region that the current AWS Region can get a Read Replica or a DB snapshot from.</p>"]
+    #[serde(rename="SourceRegions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_regions: Option<Vec<SourceRegion>>,
 }
 
@@ -15264,9 +17091,10 @@ impl SourceTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartDBInstanceMessage {
     #[doc="<p> The user-supplied instance identifier. </p>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
 }
 
@@ -15286,8 +17114,10 @@ impl StartDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartDBInstanceResult {
+    #[serde(rename="DBInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance: Option<DBInstance>,
 }
 
@@ -15334,11 +17164,14 @@ impl StartDBInstanceResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopDBInstanceMessage {
     #[doc="<p> The user-supplied instance identifier. </p>"]
+    #[serde(rename="DBInstanceIdentifier")]
     pub db_instance_identifier: String,
     #[doc="<p> The user-supplied instance identifier of the DB Snapshot created immediately before the DB instance is stopped. </p>"]
+    #[serde(rename="DBSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_snapshot_identifier: Option<String>,
 }
 
@@ -15362,8 +17195,10 @@ impl StopDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopDBInstanceResult {
+    #[serde(rename="DBInstance")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_instance: Option<DBInstance>,
 }
 
@@ -15425,12 +17260,18 @@ impl StringDeserializer {
     }
 }
 #[doc="<p> This data type is used as a response element in the <a>DescribeDBSubnetGroups</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Subnet {
+    #[serde(rename="SubnetAvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_availability_zone: Option<AvailabilityZone>,
     #[doc="<p>Specifies the identifier of the subnet.</p>"]
+    #[serde(rename="SubnetIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_identifier: Option<String>,
     #[doc="<p>Specifies the status of the subnet.</p>"]
+    #[serde(rename="SubnetStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_status: Option<String>,
 }
 
@@ -15637,11 +17478,15 @@ impl TStampDeserializer {
     }
 }
 #[doc="<p>Metadata assigned to an Amazon RDS resource consisting of a key-value pair.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>A key is the required name of the tag. The string value can be from 1 to 128 Unicode characters in length and cannot be prefixed with \"aws:\" or \"rds:\". The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: \"^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=+\\\\-]*)$\").</p>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>A value is the optional value of the tag. The string value can be from 1 to 256 Unicode characters in length and cannot be prefixed with \"aws:\" or \"rds:\". The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: \"^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=+\\\\-]*)$\").</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -15765,9 +17610,11 @@ impl TagListSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagListMessage {
     #[doc="<p>List of tags returned by the ListTagsForResource operation.</p>"]
+    #[serde(rename="TagList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_list: Option<Vec<Tag>>,
 }
 
@@ -15814,9 +17661,11 @@ impl TagListMessageDeserializer {
     }
 }
 #[doc="<p>A time zone associated with a <a>DBInstance</a> or a <a>DBSnapshot</a>. This data type is an element in the response to the <a>DescribeDBInstances</a>, the <a>DescribeDBSnapshots</a>, and the <a>DescribeDBEngineVersions</a> actions. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Timezone {
     #[doc="<p>The name of the time zone.</p>"]
+    #[serde(rename="TimezoneName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timezone_name: Option<String>,
 }
 
@@ -15863,17 +17712,27 @@ impl TimezoneDeserializer {
     }
 }
 #[doc="<p>The version of the database engine that a DB instance can be upgraded to.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpgradeTarget {
     #[doc="<p>A value that indicates whether the target version will be applied to any source DB instances that have AutoMinorVersionUpgrade set to true.</p>"]
+    #[serde(rename="AutoUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_upgrade: Option<bool>,
     #[doc="<p>The version of the database engine that a DB instance can be upgraded to.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The name of the upgrade target database engine.</p>"]
+    #[serde(rename="Engine")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine: Option<String>,
     #[doc="<p>The version number of the upgrade target database engine.</p>"]
+    #[serde(rename="EngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub engine_version: Option<String>,
     #[doc="<p>A value that indicates whether a database engine will be upgraded to a major version.</p>"]
+    #[serde(rename="IsMajorVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_major_version_upgrade: Option<bool>,
 }
 
@@ -15991,11 +17850,15 @@ impl VpcSecurityGroupIdListSerializer {
 }
 
 #[doc="<p>This data type is used as a response element for queries on VPC security group membership.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcSecurityGroupMembership {
     #[doc="<p>The status of the VPC security group.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The name of the VPC security group.</p>"]
+    #[serde(rename="VpcSecurityGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_id: Option<String>,
 }
 

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -40,11 +40,15 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>Describes an AWS customer account authorized to restore a snapshot.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccountWithRestoreAccess {
     #[doc="<p>The identifier of an AWS support account authorized to restore a snapshot. For AWS support, the identifier is <code>amazon-redshift-support</code>. </p>"]
+    #[serde(rename="AccountAlias")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account_alias: Option<String>,
     #[doc="<p>The identifier of an AWS customer account authorized to restore a snapshot.</p>"]
+    #[serde(rename="AccountId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account_id: Option<String>,
 }
 
@@ -136,15 +140,22 @@ impl AccountsWithRestoreAccessListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthorizeClusterSecurityGroupIngressMessage {
     #[doc="<p>The IP range to be added the Amazon Redshift security group.</p>"]
+    #[serde(rename="CIDRIP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidrip: Option<String>,
     #[doc="<p>The name of the security group to which the ingress rule is added.</p>"]
+    #[serde(rename="ClusterSecurityGroupName")]
     pub cluster_security_group_name: String,
     #[doc="<p>The EC2 security group to be added the Amazon Redshift security group.</p>"]
+    #[serde(rename="EC2SecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_name: Option<String>,
     #[doc="<p>The AWS account number of the owner of the security group specified by the <i>EC2SecurityGroupName</i> parameter. The AWS Access Key ID is not an acceptable value. </p> <p>Example: <code>111122223333</code> </p>"]
+    #[serde(rename="EC2SecurityGroupOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_owner_id: Option<String>,
 }
 
@@ -178,8 +189,10 @@ impl AuthorizeClusterSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthorizeClusterSecurityGroupIngressResult {
+    #[serde(rename="ClusterSecurityGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_security_group: Option<ClusterSecurityGroup>,
 }
 
@@ -228,13 +241,17 @@ impl AuthorizeClusterSecurityGroupIngressResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthorizeSnapshotAccessMessage {
     #[doc="<p>The identifier of the AWS customer account authorized to restore the specified snapshot.</p> <p>To share a snapshot with AWS support, specify amazon-redshift-support.</p>"]
+    #[serde(rename="AccountWithRestoreAccess")]
     pub account_with_restore_access: String,
     #[doc="<p>The identifier of the cluster the snapshot was created from. This parameter is required if your IAM user has a policy containing a snapshot resource element that specifies anything other than * for the cluster name.</p>"]
+    #[serde(rename="SnapshotClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_cluster_identifier: Option<String>,
     #[doc="<p>The identifier of the snapshot the account is authorized to restore.</p>"]
+    #[serde(rename="SnapshotIdentifier")]
     pub snapshot_identifier: String,
 }
 
@@ -260,8 +277,10 @@ impl AuthorizeSnapshotAccessMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AuthorizeSnapshotAccessResult {
+    #[serde(rename="Snapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot: Option<Snapshot>,
 }
 
@@ -308,9 +327,11 @@ impl AuthorizeSnapshotAccessResultDeserializer {
     }
 }
 #[doc="<p>Describes an availability zone.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AvailabilityZone {
     #[doc="<p>The name of the availability zone.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -426,73 +447,139 @@ impl BooleanOptionalDeserializer {
     }
 }
 #[doc="<p>Describes a cluster.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Cluster {
     #[doc="<p>A Boolean value that, if <code>true</code>, indicates that major version upgrades will be applied automatically to the cluster during the maintenance window. </p>"]
+    #[serde(rename="AllowVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_version_upgrade: Option<bool>,
     #[doc="<p>The number of days that automatic cluster snapshots are retained.</p>"]
+    #[serde(rename="AutomatedSnapshotRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub automated_snapshot_retention_period: Option<i64>,
     #[doc="<p>The name of the Availability Zone in which the cluster is located.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The date and time that the cluster was created.</p>"]
+    #[serde(rename="ClusterCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_create_time: Option<String>,
     #[doc="<p>The unique identifier of the cluster.</p>"]
+    #[serde(rename="ClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_identifier: Option<String>,
     #[doc="<p>The nodes in the cluster.</p>"]
+    #[serde(rename="ClusterNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_nodes: Option<Vec<ClusterNode>>,
     #[doc="<p>The list of cluster parameter groups that are associated with this cluster. Each parameter group in the list is returned with its status.</p>"]
+    #[serde(rename="ClusterParameterGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_parameter_groups: Option<Vec<ClusterParameterGroupStatus>>,
     #[doc="<p>The public key for the cluster.</p>"]
+    #[serde(rename="ClusterPublicKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_public_key: Option<String>,
     #[doc="<p>The specific revision number of the database in the cluster.</p>"]
+    #[serde(rename="ClusterRevisionNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_revision_number: Option<String>,
     #[doc="<p>A list of cluster security group that are associated with the cluster. Each security group is represented by an element that contains <code>ClusterSecurityGroup.Name</code> and <code>ClusterSecurityGroup.Status</code> subelements. </p> <p>Cluster security groups are used when the cluster is not created in an Amazon Virtual Private Cloud (VPC). Clusters that are created in a VPC use VPC security groups, which are listed by the <b>VpcSecurityGroups</b> parameter. </p>"]
+    #[serde(rename="ClusterSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_security_groups: Option<Vec<ClusterSecurityGroupMembership>>,
     #[doc="<p>A value that returns the destination region and retention period that are configured for cross-region snapshot copy.</p>"]
+    #[serde(rename="ClusterSnapshotCopyStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_snapshot_copy_status: Option<ClusterSnapshotCopyStatus>,
     #[doc="<p> The current state of the cluster. Possible values are the following:</p> <ul> <li> <p> <code>available</code> </p> </li> <li> <p> <code>creating</code> </p> </li> <li> <p> <code>deleting</code> </p> </li> <li> <p> <code>final-snapshot</code> </p> </li> <li> <p> <code>hardware-failure</code> </p> </li> <li> <p> <code>incompatible-hsm</code> </p> </li> <li> <p> <code>incompatible-network</code> </p> </li> <li> <p> <code>incompatible-parameters</code> </p> </li> <li> <p> <code>incompatible-restore</code> </p> </li> <li> <p> <code>modifying</code> </p> </li> <li> <p> <code>rebooting</code> </p> </li> <li> <p> <code>renaming</code> </p> </li> <li> <p> <code>resizing</code> </p> </li> <li> <p> <code>rotating-keys</code> </p> </li> <li> <p> <code>storage-full</code> </p> </li> <li> <p> <code>updating-hsm</code> </p> </li> </ul>"]
+    #[serde(rename="ClusterStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_status: Option<String>,
     #[doc="<p>The name of the subnet group that is associated with the cluster. This parameter is valid only when the cluster is in a VPC.</p>"]
+    #[serde(rename="ClusterSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_subnet_group_name: Option<String>,
     #[doc="<p>The version ID of the Amazon Redshift engine that is running on the cluster.</p>"]
+    #[serde(rename="ClusterVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_version: Option<String>,
     #[doc="<p>The name of the initial database that was created when the cluster was created. This same name is returned for the life of the cluster. If an initial database was not specified, a database named <code>dev</code>dev was created by default. </p>"]
+    #[serde(rename="DBName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_name: Option<String>,
     #[doc="<p>The status of the elastic IP (EIP) address.</p>"]
+    #[serde(rename="ElasticIpStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_ip_status: Option<ElasticIpStatus>,
     #[doc="<p>A Boolean value that, if <code>true</code>, indicates that data in the cluster is encrypted at rest.</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>The connection endpoint.</p>"]
+    #[serde(rename="Endpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoint: Option<Endpoint>,
     #[doc="<p>An option that specifies whether to create the cluster with enhanced VPC routing enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in the Amazon Redshift Cluster Management Guide.</p> <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p> <p>Default: false</p>"]
+    #[serde(rename="EnhancedVpcRouting")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enhanced_vpc_routing: Option<bool>,
     #[doc="<p>A value that reports whether the Amazon Redshift cluster has finished applying any hardware security module (HSM) settings changes specified in a modify cluster command.</p> <p>Values: active, applying</p>"]
+    #[serde(rename="HsmStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_status: Option<HsmStatus>,
     #[doc="<p>A list of AWS Identity and Access Management (IAM) roles that can be used by the cluster to access other AWS services.</p>"]
+    #[serde(rename="IamRoles")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_roles: Option<Vec<ClusterIamRole>>,
     #[doc="<p>The AWS Key Management Service (AWS KMS) key ID of the encryption key used to encrypt data in the cluster.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The master user name for the cluster. This name is used to connect to the database that is specified in the <b>DBName</b> parameter. </p>"]
+    #[serde(rename="MasterUsername")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_username: Option<String>,
     #[doc="<p>The status of a modify operation, if any, initiated for the cluster.</p>"]
+    #[serde(rename="ModifyStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub modify_status: Option<String>,
     #[doc="<p>The node type for the nodes in the cluster.</p>"]
+    #[serde(rename="NodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_type: Option<String>,
     #[doc="<p>The number of compute nodes in the cluster.</p>"]
+    #[serde(rename="NumberOfNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub number_of_nodes: Option<i64>,
     #[doc="<p>A value that, if present, indicates that changes to the cluster are pending. Specific pending changes are identified by subelements.</p>"]
+    #[serde(rename="PendingModifiedValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub pending_modified_values: Option<PendingModifiedValues>,
     #[doc="<p>The weekly time range, in Universal Coordinated Time (UTC), during which system maintenance can occur.</p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>A Boolean value that, if <code>true</code>, indicates that the cluster can be accessed from a public network.</p>"]
+    #[serde(rename="PubliclyAccessible")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub publicly_accessible: Option<bool>,
     #[doc="<p>A value that describes the status of a cluster restore action. This parameter returns null if the cluster was not created by restoring a snapshot.</p>"]
+    #[serde(rename="RestoreStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub restore_status: Option<RestoreStatus>,
     #[doc="<p>The list of tags for the cluster.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The identifier of the VPC the cluster is in, if the cluster is in a VPC.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
     #[doc="<p>A list of Amazon Virtual Private Cloud (Amazon VPC) security groups that are associated with the cluster. This parameter is returned only if the cluster is in a VPC.</p>"]
+    #[serde(rename="VpcSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_groups: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
@@ -681,13 +768,19 @@ impl ClusterDeserializer {
     }
 }
 #[doc="<p>Temporary credentials with authorization to log in to an Amazon Redshift database. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterCredentials {
     #[doc="<p>A temporary password that authorizes the user name returned by <code>DbUser</code> to log on to the database <code>DbName</code>. </p>"]
+    #[serde(rename="DbPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_password: Option<String>,
     #[doc="<p>A database user name that is authorized to log on to the database <code>DbName</code> using the password <code>DbPassword</code>. If the <code>DbGroups</code> parameter is specifed, <code>DbUser</code> is added to the listed groups for the current session. The user name is prefixed with <code>IAM:</code> for an existing user name or <code>IAMA:</code> if the user was auto-created. </p>"]
+    #[serde(rename="DbUser")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_user: Option<String>,
     #[doc="<p>The date and time <code>DbPassword</code> expires.</p>"]
+    #[serde(rename="Expiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expiration: Option<String>,
 }
 
@@ -743,11 +836,15 @@ impl ClusterCredentialsDeserializer {
     }
 }
 #[doc="<p>An AWS Identity and Access Management (IAM) role that can be used by the associated Amazon Redshift cluster to access other AWS services.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterIamRole {
     #[doc="<p>A value that describes the status of the IAM role's association with an Amazon Redshift cluster.</p> <p>The following are possible statuses and descriptions.</p> <ul> <li> <p> <code>in-sync</code>: The role is available for use by the cluster.</p> </li> <li> <p> <code>adding</code>: The role is in the process of being associated with the cluster.</p> </li> <li> <p> <code>removing</code>: The role is in the process of being disassociated with the cluster.</p> </li> </ul>"]
+    #[serde(rename="ApplyStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub apply_status: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the IAM role, for example, <code>arn:aws:iam::123456789012:role/RedshiftCopyUnload</code>. </p>"]
+    #[serde(rename="IamRoleArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_role_arn: Option<String>,
 }
 
@@ -881,13 +978,19 @@ impl ClusterListDeserializer {
     }
 }
 #[doc="<p>The identifier of a node in a cluster.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterNode {
     #[doc="<p>Whether the node is a leader node or a compute node.</p>"]
+    #[serde(rename="NodeRole")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_role: Option<String>,
     #[doc="<p>The private IP address of a node within a cluster.</p>"]
+    #[serde(rename="PrivateIPAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_ip_address: Option<String>,
     #[doc="<p>The public IP address of a node within a cluster.</p>"]
+    #[serde(rename="PublicIPAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub public_ip_address: Option<String>,
 }
 
@@ -985,15 +1088,23 @@ impl ClusterNodesListDeserializer {
     }
 }
 #[doc="<p>Describes a parameter group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterParameterGroup {
     #[doc="<p>The description of the parameter group.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The name of the cluster parameter group family that this cluster parameter group is compatible with.</p>"]
+    #[serde(rename="ParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_group_family: Option<String>,
     #[doc="<p>The name of the cluster parameter group.</p>"]
+    #[serde(rename="ParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_group_name: Option<String>,
     #[doc="<p>The list of tags for the cluster parameter group.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -1053,11 +1164,15 @@ impl ClusterParameterGroupDeserializer {
     }
 }
 #[doc="<p>Contains the output from the <a>DescribeClusterParameters</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterParameterGroupDetails {
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of <a>Parameter</a> instances. Each instance lists the parameters of one cluster parameter group. </p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
 }
 
@@ -1109,11 +1224,15 @@ impl ClusterParameterGroupDetailsDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterParameterGroupNameMessage {
     #[doc="<p>The name of the cluster parameter group.</p>"]
+    #[serde(rename="ParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_group_name: Option<String>,
     #[doc="<p>The status of the parameter group. For example, if you made a change to a parameter group name-value pair, then the change could be pending a reboot of an associated cluster.</p>"]
+    #[serde(rename="ParameterGroupStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_group_status: Option<String>,
 }
 
@@ -1167,13 +1286,19 @@ impl ClusterParameterGroupNameMessageDeserializer {
     }
 }
 #[doc="<p>Describes the status of a parameter group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterParameterGroupStatus {
     #[doc="<p>The list of parameter statuses.</p> <p> For more information about parameters and parameter groups, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html\">Amazon Redshift Parameter Groups</a> in the <i>Amazon Redshift Cluster Management Guide</i>.</p>"]
+    #[serde(rename="ClusterParameterStatusList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_parameter_status_list: Option<Vec<ClusterParameterStatus>>,
     #[doc="<p>The status of parameter updates.</p>"]
+    #[serde(rename="ParameterApplyStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_apply_status: Option<String>,
     #[doc="<p>The name of the cluster parameter group.</p>"]
+    #[serde(rename="ParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_group_name: Option<String>,
 }
 
@@ -1271,11 +1396,15 @@ impl ClusterParameterGroupStatusListDeserializer {
     }
 }
 #[doc="<p>Contains the output from the <a>DescribeClusterParameterGroups</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterParameterGroupsMessage {
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of <a>ClusterParameterGroup</a> instances. Each instance describes one cluster parameter group. </p>"]
+    #[serde(rename="ParameterGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_groups: Option<Vec<ClusterParameterGroup>>,
 }
 
@@ -1327,13 +1456,19 @@ impl ClusterParameterGroupsMessageDeserializer {
     }
 }
 #[doc="<p>Describes the status of a parameter group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterParameterStatus {
     #[doc="<p>The error that prevented the parameter from being applied to the database.</p>"]
+    #[serde(rename="ParameterApplyErrorDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_apply_error_description: Option<String>,
     #[doc="<p>The status of the parameter that indicates whether the parameter is in sync with the database, waiting for a cluster reboot, or encountered an error when being applied.</p> <p>The following are possible statuses and descriptions.</p> <ul> <li> <p> <code>in-sync</code>: The parameter value is in sync with the database.</p> </li> <li> <p> <code>pending-reboot</code>: The parameter value will be applied after the cluster reboots.</p> </li> <li> <p> <code>applying</code>: The parameter value is being applied to the database.</p> </li> <li> <p> <code>invalid-parameter</code>: Cannot apply the parameter value because it has an invalid value or syntax.</p> </li> <li> <p> <code>apply-deferred</code>: The parameter contains static property changes. The changes are deferred until the cluster reboots.</p> </li> <li> <p> <code>apply-error</code>: Cannot connect to the cluster. The parameter change will be applied after the cluster reboots.</p> </li> <li> <p> <code>unknown-error</code>: Cannot apply the parameter change right now. The change will be applied after the cluster reboots.</p> </li> </ul>"]
+    #[serde(rename="ParameterApplyStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_apply_status: Option<String>,
     #[doc="<p>The name of the parameter.</p>"]
+    #[serde(rename="ParameterName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_name: Option<String>,
 }
 
@@ -1432,17 +1567,27 @@ impl ClusterParameterStatusListDeserializer {
     }
 }
 #[doc="<p>Describes a security group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterSecurityGroup {
     #[doc="<p>The name of the cluster security group to which the operation was applied.</p>"]
+    #[serde(rename="ClusterSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_security_group_name: Option<String>,
     #[doc="<p>A description of the security group.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>A list of EC2 security groups that are permitted to access clusters associated with this cluster security group.</p>"]
+    #[serde(rename="EC2SecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_groups: Option<Vec<EC2SecurityGroup>>,
     #[doc="<p>A list of IP ranges (CIDR blocks) that are permitted to access clusters associated with this cluster security group.</p>"]
+    #[serde(rename="IPRanges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_ranges: Option<Vec<IPRange>>,
     #[doc="<p>The list of tags for the cluster security group.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -1506,11 +1651,15 @@ impl ClusterSecurityGroupDeserializer {
     }
 }
 #[doc="<p>Describes a cluster security group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterSecurityGroupMembership {
     #[doc="<p>The name of the cluster security group.</p>"]
+    #[serde(rename="ClusterSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_security_group_name: Option<String>,
     #[doc="<p>The status of the cluster security group.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -1604,11 +1753,15 @@ impl ClusterSecurityGroupMembershipListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterSecurityGroupMessage {
     #[doc="<p>A list of <a>ClusterSecurityGroup</a> instances. </p>"]
+    #[serde(rename="ClusterSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_security_groups: Option<Vec<ClusterSecurityGroup>>,
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -1713,13 +1866,19 @@ impl ClusterSecurityGroupsDeserializer {
     }
 }
 #[doc="<p>Returns the destination region and retention period that are configured for cross-region snapshot copy.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterSnapshotCopyStatus {
     #[doc="<p>The destination region that snapshots are automatically copied to when cross-region snapshot copy is enabled.</p>"]
+    #[serde(rename="DestinationRegion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destination_region: Option<String>,
     #[doc="<p>The number of days that automated snapshots are retained in the destination region after they are copied from a source region.</p>"]
+    #[serde(rename="RetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub retention_period: Option<i64>,
     #[doc="<p>The name of the snapshot copy grant.</p>"]
+    #[serde(rename="SnapshotCopyGrantName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_copy_grant_name: Option<String>,
 }
 
@@ -1776,19 +1935,31 @@ impl ClusterSnapshotCopyStatusDeserializer {
     }
 }
 #[doc="<p>Describes a subnet group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterSubnetGroup {
     #[doc="<p>The name of the cluster subnet group.</p>"]
+    #[serde(rename="ClusterSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_subnet_group_name: Option<String>,
     #[doc="<p>The description of the cluster subnet group.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The status of the cluster subnet group. Possible values are <code>Complete</code>, <code>Incomplete</code> and <code>Invalid</code>. </p>"]
+    #[serde(rename="SubnetGroupStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_group_status: Option<String>,
     #[doc="<p>A list of the VPC <a>Subnet</a> elements. </p>"]
+    #[serde(rename="Subnets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnets: Option<Vec<Subnet>>,
     #[doc="<p>The list of tags for the cluster subnet group.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The VPC ID of the cluster subnet group.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -1856,11 +2027,15 @@ impl ClusterSubnetGroupDeserializer {
     }
 }
 #[doc="<p>Contains the output from the <a>DescribeClusterSubnetGroups</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterSubnetGroupMessage {
     #[doc="<p>A list of <a>ClusterSubnetGroup</a> instances. </p>"]
+    #[serde(rename="ClusterSubnetGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_subnet_groups: Option<Vec<ClusterSubnetGroup>>,
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -1953,13 +2128,19 @@ impl ClusterSubnetGroupsDeserializer {
     }
 }
 #[doc="<p>Describes a cluster version, including the parameter group family and description of the version.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterVersion {
     #[doc="<p>The name of the cluster parameter group family for the cluster.</p>"]
+    #[serde(rename="ClusterParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_parameter_group_family: Option<String>,
     #[doc="<p>The version number used by the cluster.</p>"]
+    #[serde(rename="ClusterVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_version: Option<String>,
     #[doc="<p>The description of the cluster version.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
 }
 
@@ -2058,11 +2239,15 @@ impl ClusterVersionListDeserializer {
     }
 }
 #[doc="<p>Contains the output from the <a>DescribeClusterVersions</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterVersionsMessage {
     #[doc="<p>A list of <code>Version</code> elements. </p>"]
+    #[serde(rename="ClusterVersions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_versions: Option<Vec<ClusterVersion>>,
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -2114,11 +2299,15 @@ impl ClusterVersionsMessageDeserializer {
     }
 }
 #[doc="<p>Contains the output from the <a>DescribeClusters</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClustersMessage {
     #[doc="<p>A list of <code>Cluster</code> objects, where each object describes one cluster. </p>"]
+    #[serde(rename="Clusters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub clusters: Option<Vec<Cluster>>,
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -2169,13 +2358,17 @@ impl ClustersMessageDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyClusterSnapshotMessage {
     #[doc="<p>The identifier of the cluster the source snapshot was created from. This parameter is required if your IAM user has a policy containing a snapshot resource element that specifies anything other than * for the cluster name.</p> <p>Constraints:</p> <ul> <li> <p>Must be the identifier for a valid cluster.</p> </li> </ul>"]
+    #[serde(rename="SourceSnapshotClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_snapshot_cluster_identifier: Option<String>,
     #[doc="<p>The identifier for the source snapshot.</p> <p>Constraints:</p> <ul> <li> <p>Must be the identifier for a valid automated snapshot whose state is <code>available</code>.</p> </li> </ul>"]
+    #[serde(rename="SourceSnapshotIdentifier")]
     pub source_snapshot_identifier: String,
     #[doc="<p>The identifier given to the new manual snapshot.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank.</p> </li> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> <li> <p>Must be unique for the AWS account that is making the request.</p> </li> </ul>"]
+    #[serde(rename="TargetSnapshotIdentifier")]
     pub target_snapshot_identifier: String,
 }
 
@@ -2201,8 +2394,10 @@ impl CopyClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CopyClusterSnapshotResult {
+    #[serde(rename="Snapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot: Option<Snapshot>,
 }
 
@@ -2249,61 +2444,111 @@ impl CopyClusterSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterMessage {
     #[doc="<p>Reserved.</p>"]
+    #[serde(rename="AdditionalInfo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub additional_info: Option<String>,
     #[doc="<p>If <code>true</code>, major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster.</p> <p>When a new major version of the Amazon Redshift engine is released, you can request that the service automatically apply upgrades during the maintenance window to the Amazon Redshift engine that is running on your cluster.</p> <p>Default: <code>true</code> </p>"]
+    #[serde(rename="AllowVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_version_upgrade: Option<bool>,
     #[doc="<p>The number of days that automated snapshots are retained. If the value is 0, automated snapshots are disabled. Even if automated snapshots are disabled, you can still create manual snapshots when you want with <a>CreateClusterSnapshot</a>. </p> <p>Default: <code>1</code> </p> <p>Constraints: Must be a value from 0 to 35.</p>"]
+    #[serde(rename="AutomatedSnapshotRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub automated_snapshot_retention_period: Option<i64>,
     #[doc="<p>The EC2 Availability Zone (AZ) in which you want Amazon Redshift to provision the cluster. For example, if you have several EC2 instances running in a specific Availability Zone, then you might want the cluster to be provisioned in the same zone in order to decrease network latency.</p> <p>Default: A random, system-chosen Availability Zone in the region that is specified by the endpoint.</p> <p>Example: <code>us-east-1d</code> </p> <p>Constraint: The specified Availability Zone must be in the same region as the current endpoint.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>A unique identifier for the cluster. You use this identifier to refer to the cluster for any subsequent cluster operations such as deleting or modifying. The identifier also appears in the Amazon Redshift console.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>Alphabetic characters must be lowercase.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> <li> <p>Must be unique for all clusters within an AWS account.</p> </li> </ul> <p>Example: <code>myexamplecluster</code> </p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
     #[doc="<p>The name of the parameter group to be associated with this cluster.</p> <p>Default: The default Amazon Redshift cluster parameter group. For information about the default parameter group, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html\">Working with Amazon Redshift Parameter Groups</a> </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>"]
+    #[serde(rename="ClusterParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_parameter_group_name: Option<String>,
     #[doc="<p>A list of security groups to be associated with this cluster.</p> <p>Default: The default cluster security group for Amazon Redshift.</p>"]
+    #[serde(rename="ClusterSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_security_groups: Option<Vec<String>>,
     #[doc="<p>The name of a cluster subnet group to be associated with this cluster.</p> <p>If this parameter is not provided the resulting cluster will be deployed outside virtual private cloud (VPC).</p>"]
+    #[serde(rename="ClusterSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_subnet_group_name: Option<String>,
     #[doc="<p>The type of the cluster. When cluster type is specified as</p> <ul> <li> <p> <code>single-node</code>, the <b>NumberOfNodes</b> parameter is not required.</p> </li> <li> <p> <code>multi-node</code>, the <b>NumberOfNodes</b> parameter is required.</p> </li> </ul> <p>Valid Values: <code>multi-node</code> | <code>single-node</code> </p> <p>Default: <code>multi-node</code> </p>"]
+    #[serde(rename="ClusterType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_type: Option<String>,
     #[doc="<p>The version of the Amazon Redshift engine software that you want to deploy on the cluster.</p> <p>The version selected runs on all the nodes in the cluster.</p> <p>Constraints: Only version 1.0 is currently available.</p> <p>Example: <code>1.0</code> </p>"]
+    #[serde(rename="ClusterVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_version: Option<String>,
     #[doc="<p>The name of the first database to be created when the cluster is created.</p> <p>To create additional databases after the cluster is created, connect to the cluster with a SQL client and use SQL commands to create a database. For more information, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/t_creating_database.html\">Create a Database</a> in the Amazon Redshift Database Developer Guide. </p> <p>Default: <code>dev</code> </p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 64 alphanumeric characters.</p> </li> <li> <p>Must contain only lowercase letters.</p> </li> <li> <p>Cannot be a word that is reserved by the service. A list of reserved words can be found in <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html\">Reserved Words</a> in the Amazon Redshift Database Developer Guide. </p> </li> </ul>"]
+    #[serde(rename="DBName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_name: Option<String>,
     #[doc="<p>The Elastic IP (EIP) address for the cluster.</p> <p>Constraints: The cluster must be provisioned in EC2-VPC and publicly-accessible through an Internet gateway. For more information about provisioning clusters in EC2-VPC, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#cluster-platforms\">Supported Platforms to Launch Your Cluster</a> in the Amazon Redshift Cluster Management Guide.</p>"]
+    #[serde(rename="ElasticIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_ip: Option<String>,
     #[doc="<p>If <code>true</code>, the data in the cluster is encrypted at rest. </p> <p>Default: false</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>An option that specifies whether to create the cluster with enhanced VPC routing enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in the Amazon Redshift Cluster Management Guide.</p> <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p> <p>Default: false</p>"]
+    #[serde(rename="EnhancedVpcRouting")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enhanced_vpc_routing: Option<bool>,
     #[doc="<p>Specifies the name of the HSM client certificate the Amazon Redshift cluster uses to retrieve the data encryption keys stored in an HSM.</p>"]
+    #[serde(rename="HsmClientCertificateIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_client_certificate_identifier: Option<String>,
     #[doc="<p>Specifies the name of the HSM configuration that contains the information the Amazon Redshift cluster can use to retrieve and store keys in an HSM.</p>"]
+    #[serde(rename="HsmConfigurationIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_configuration_identifier: Option<String>,
     #[doc="<p>A list of AWS Identity and Access Management (IAM) roles that can be used by the cluster to access other AWS services. You must supply the IAM roles in their Amazon Resource Name (ARN) format. You can supply up to 10 IAM roles in a single request.</p> <p>A cluster can have up to 10 IAM roles associated with it at any time.</p>"]
+    #[serde(rename="IamRoles")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_roles: Option<Vec<String>>,
     #[doc="<p>The AWS Key Management Service (KMS) key ID of the encryption key that you want to use to encrypt data in the cluster.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The password associated with the master user account for the cluster that is being created.</p> <p>Constraints:</p> <ul> <li> <p>Must be between 8 and 64 characters in length.</p> </li> <li> <p>Must contain at least one uppercase letter.</p> </li> <li> <p>Must contain at least one lowercase letter.</p> </li> <li> <p>Must contain one number.</p> </li> <li> <p>Can be any printable ASCII character (ASCII code 33 to 126) except ' (single quote), \" (double quote), \\, /, @, or space.</p> </li> </ul>"]
+    #[serde(rename="MasterUserPassword")]
     pub master_user_password: String,
     #[doc="<p>The user name associated with the master user account for the cluster that is being created.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 - 128 alphanumeric characters.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word. A list of reserved words can be found in <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html\">Reserved Words</a> in the Amazon Redshift Database Developer Guide. </p> </li> </ul>"]
+    #[serde(rename="MasterUsername")]
     pub master_username: String,
     #[doc="<p>The node type to be provisioned for the cluster. For information about node types, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#how-many-nodes\"> Working with Clusters</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p> <p>Valid Values: <code>ds1.xlarge</code> | <code>ds1.8xlarge</code> | <code>ds2.xlarge</code> | <code>ds2.8xlarge</code> | <code>dc1.large</code> | <code>dc1.8xlarge</code>. </p>"]
+    #[serde(rename="NodeType")]
     pub node_type: String,
     #[doc="<p>The number of compute nodes in the cluster. This parameter is required when the <b>ClusterType</b> parameter is specified as <code>multi-node</code>. </p> <p>For information about determining how many nodes you need, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#how-many-nodes\"> Working with Clusters</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p> <p>If you don't specify this parameter, you get a single-node cluster. When requesting a multi-node cluster, you must specify the number of nodes that you want in the cluster.</p> <p>Default: <code>1</code> </p> <p>Constraints: Value must be at least 1 and no more than 100.</p>"]
+    #[serde(rename="NumberOfNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub number_of_nodes: Option<i64>,
     #[doc="<p>The port number on which the cluster accepts incoming connections.</p> <p>The cluster is accessible only via the JDBC and ODBC connection strings. Part of the connection string requires the port on which the cluster will listen for incoming connections.</p> <p>Default: <code>5439</code> </p> <p>Valid Values: <code>1150-65535</code> </p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The weekly time range (in UTC) during which automated cluster maintenance can occur.</p> <p> Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p> Default: A 30-minute window selected at random from an 8-hour block of time per region, occurring on a random day of the week. For more information about the time blocks for each region, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#rs-maintenance-windows\">Maintenance Windows</a> in Amazon Redshift Cluster Management Guide.</p> <p>Valid Days: Mon | Tue | Wed | Thu | Fri | Sat | Sun</p> <p>Constraints: Minimum 30-minute window.</p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>If <code>true</code>, the cluster can be accessed from a public network. </p>"]
+    #[serde(rename="PubliclyAccessible")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub publicly_accessible: Option<bool>,
     #[doc="<p>A list of tag instances.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster.</p> <p>Default: The default VPC security group is associated with the cluster.</p>"]
+    #[serde(rename="VpcSecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_ids: Option<Vec<String>>,
 }
 
@@ -2428,15 +2673,20 @@ impl CreateClusterMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterParameterGroupMessage {
     #[doc="<p>A description of the parameter group.</p>"]
+    #[serde(rename="Description")]
     pub description: String,
     #[doc="<p>The Amazon Redshift engine version to which the cluster parameter group applies. The cluster engine version determines the set of parameters.</p> <p>To get a list of valid parameter group family names, you can call <a>DescribeClusterParameterGroups</a>. By default, Amazon Redshift returns a list of all the parameter groups that are owned by your AWS account, including the default parameter groups for each Amazon Redshift engine version. The parameter group family names associated with the default parameter groups provide you the valid values. For example, a valid family name is \"redshift-1.0\". </p>"]
+    #[serde(rename="ParameterGroupFamily")]
     pub parameter_group_family: String,
     #[doc="<p>The name of the cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> <li> <p>Must be unique withing your AWS account.</p> </li> </ul> <note> <p>This value is stored as a lower-case string.</p> </note>"]
+    #[serde(rename="ParameterGroupName")]
     pub parameter_group_name: String,
     #[doc="<p>A list of tag instances.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2463,8 +2713,10 @@ impl CreateClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterParameterGroupResult {
+    #[serde(rename="ClusterParameterGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_parameter_group: Option<ClusterParameterGroup>,
 }
 
@@ -2512,8 +2764,10 @@ impl CreateClusterParameterGroupResultDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterResult {
+    #[serde(rename="Cluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster: Option<Cluster>,
 }
 
@@ -2560,13 +2814,17 @@ impl CreateClusterResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterSecurityGroupMessage {
     #[doc="<p>The name for the security group. Amazon Redshift stores the value as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain no more than 255 alphanumeric characters or hyphens.</p> </li> <li> <p>Must not be \"Default\".</p> </li> <li> <p>Must be unique for all security groups that are created by your AWS account.</p> </li> </ul> <p>Example: <code>examplesecuritygroup</code> </p>"]
+    #[serde(rename="ClusterSecurityGroupName")]
     pub cluster_security_group_name: String,
     #[doc="<p>A description for the security group.</p>"]
+    #[serde(rename="Description")]
     pub description: String,
     #[doc="<p>A list of tag instances.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2591,8 +2849,10 @@ impl CreateClusterSecurityGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterSecurityGroupResult {
+    #[serde(rename="ClusterSecurityGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_security_group: Option<ClusterSecurityGroup>,
 }
 
@@ -2641,13 +2901,17 @@ impl CreateClusterSecurityGroupResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterSnapshotMessage {
     #[doc="<p>The cluster identifier for which you want a snapshot.</p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
     #[doc="<p>A unique identifier for the snapshot that you are requesting. This identifier must be unique for all snapshots within the AWS account.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-snapshot-id</code> </p>"]
+    #[serde(rename="SnapshotIdentifier")]
     pub snapshot_identifier: String,
     #[doc="<p>A list of tag instances.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2672,8 +2936,10 @@ impl CreateClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterSnapshotResult {
+    #[serde(rename="Snapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot: Option<Snapshot>,
 }
 
@@ -2720,15 +2986,20 @@ impl CreateClusterSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterSubnetGroupMessage {
     #[doc="<p>The name for the subnet group. Amazon Redshift stores the value as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain no more than 255 alphanumeric characters or hyphens.</p> </li> <li> <p>Must not be \"Default\".</p> </li> <li> <p>Must be unique for all subnet groups that are created by your AWS account.</p> </li> </ul> <p>Example: <code>examplesubnetgroup</code> </p>"]
+    #[serde(rename="ClusterSubnetGroupName")]
     pub cluster_subnet_group_name: String,
     #[doc="<p>A description for the subnet group.</p>"]
+    #[serde(rename="Description")]
     pub description: String,
     #[doc="<p>An array of VPC subnet IDs. A maximum of 20 subnets can be modified in a single request.</p>"]
+    #[serde(rename="SubnetIds")]
     pub subnet_ids: Vec<String>,
     #[doc="<p>A list of tag instances.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2756,8 +3027,10 @@ impl CreateClusterSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterSubnetGroupResult {
+    #[serde(rename="ClusterSubnetGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_subnet_group: Option<ClusterSubnetGroup>,
 }
 
@@ -2805,23 +3078,37 @@ impl CreateClusterSubnetGroupResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEventSubscriptionMessage {
     #[doc="<p>A Boolean value; set to <code>true</code> to activate the subscription, set to <code>false</code> to create the subscription but not active it. </p>"]
+    #[serde(rename="Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled: Option<bool>,
     #[doc="<p>Specifies the Amazon Redshift event categories to be published by the event notification subscription.</p> <p>Values: Configuration, Management, Monitoring, Security</p>"]
+    #[serde(rename="EventCategories")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories: Option<Vec<String>>,
     #[doc="<p>Specifies the Amazon Redshift event severity to be published by the event notification subscription.</p> <p>Values: ERROR, INFO</p>"]
+    #[serde(rename="Severity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub severity: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic used to transmit the event notifications. The ARN is created by Amazon SNS when you create a topic and subscribe to it.</p>"]
+    #[serde(rename="SnsTopicArn")]
     pub sns_topic_arn: String,
     #[doc="<p>A list of one or more identifiers of Amazon Redshift source objects. All of the objects must be of the same type as was specified in the source type parameter. The event subscription will return only events generated by the specified objects. If not specified, then events are returned for all objects within the source type specified.</p> <p>Example: my-cluster-1, my-cluster-2</p> <p>Example: my-snapshot-20131010</p>"]
+    #[serde(rename="SourceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_ids: Option<Vec<String>>,
     #[doc="<p>The type of source that will be generating the events. For example, if you want to be notified of events generated by a cluster, you would set this parameter to cluster. If this value is not specified, events are returned for all Amazon Redshift objects in your AWS account. You must specify a source type in order to specify source IDs.</p> <p>Valid values: cluster, cluster-parameter-group, cluster-security-group, and cluster-snapshot.</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
     #[doc="<p>The name of the event subscription to be created.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank.</p> </li> <li> <p>Must contain from 1 to 255 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>"]
+    #[serde(rename="SubscriptionName")]
     pub subscription_name: String,
     #[doc="<p>A list of tag instances.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2868,8 +3155,10 @@ impl CreateEventSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEventSubscriptionResult {
+    #[serde(rename="EventSubscription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_subscription: Option<EventSubscription>,
 }
 
@@ -2917,11 +3206,14 @@ impl CreateEventSubscriptionResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHsmClientCertificateMessage {
     #[doc="<p>The identifier to be assigned to the new HSM client certificate that the cluster will use to connect to the HSM to use the database encryption keys.</p>"]
+    #[serde(rename="HsmClientCertificateIdentifier")]
     pub hsm_client_certificate_identifier: String,
     #[doc="<p>A list of tag instances.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -2944,8 +3236,10 @@ impl CreateHsmClientCertificateMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHsmClientCertificateResult {
+    #[serde(rename="HsmClientCertificate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_client_certificate: Option<HsmClientCertificate>,
 }
 
@@ -2994,21 +3288,29 @@ impl CreateHsmClientCertificateResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHsmConfigurationMessage {
     #[doc="<p>A text description of the HSM configuration to be created.</p>"]
+    #[serde(rename="Description")]
     pub description: String,
     #[doc="<p>The identifier to be assigned to the new Amazon Redshift HSM configuration.</p>"]
+    #[serde(rename="HsmConfigurationIdentifier")]
     pub hsm_configuration_identifier: String,
     #[doc="<p>The IP address that the Amazon Redshift cluster must use to access the HSM.</p>"]
+    #[serde(rename="HsmIpAddress")]
     pub hsm_ip_address: String,
     #[doc="<p>The name of the partition in the HSM where the Amazon Redshift clusters will store their database encryption keys.</p>"]
+    #[serde(rename="HsmPartitionName")]
     pub hsm_partition_name: String,
     #[doc="<p>The password required to access the HSM partition.</p>"]
+    #[serde(rename="HsmPartitionPassword")]
     pub hsm_partition_password: String,
     #[doc="<p>The HSMs public certificate file. When using Cloud HSM, the file name is server.pem.</p>"]
+    #[serde(rename="HsmServerPublicCertificate")]
     pub hsm_server_public_certificate: String,
     #[doc="<p>A list of tag instances.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -3041,8 +3343,10 @@ impl CreateHsmConfigurationMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateHsmConfigurationResult {
+    #[serde(rename="HsmConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_configuration: Option<HsmConfiguration>,
 }
 
@@ -3090,13 +3394,18 @@ impl CreateHsmConfigurationResultDeserializer {
     }
 }
 #[doc="<p>The result of the <code>CreateSnapshotCopyGrant</code> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSnapshotCopyGrantMessage {
     #[doc="<p>The unique identifier of the customer master key (CMK) to which to grant Amazon Redshift permission. If no key is specified, the default key is used.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The name of the snapshot copy grant. This name must be unique in the region for the AWS account.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>Alphabetic characters must be lowercase.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> <li> <p>Must be unique for all clusters within an AWS account.</p> </li> </ul>"]
+    #[serde(rename="SnapshotCopyGrantName")]
     pub snapshot_copy_grant_name: String,
     #[doc="<p>A list of tag instances.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -3123,8 +3432,10 @@ impl CreateSnapshotCopyGrantMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSnapshotCopyGrantResult {
+    #[serde(rename="SnapshotCopyGrant")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_copy_grant: Option<SnapshotCopyGrant>,
 }
 
@@ -3172,11 +3483,13 @@ impl CreateSnapshotCopyGrantResultDeserializer {
     }
 }
 #[doc="<p>Contains the output from the <code>CreateTags</code> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTagsMessage {
     #[doc="<p>The Amazon Resource Name (ARN) to which you want to add the tag or tags. For example, <code>arn:aws:redshift:us-east-1:123456789:cluster:t1</code>. </p>"]
+    #[serde(rename="ResourceName")]
     pub resource_name: String,
     #[doc="<p>One or more name/value pairs to add as tags to the specified resource. Each tag name is passed in with the parameter <code>Key</code> and the corresponding value is passed in with the parameter <code>Value</code>. The <code>Key</code> and <code>Value</code> parameters are separated by a comma (,). Separate multiple tags with a space. For example, <code>--tags \"Key\"=\"owner\",\"Value\"=\"admin\" \"Key\"=\"environment\",\"Value\"=\"test\" \"Key\"=\"version\",\"Value\"=\"1.0\"</code>. </p>"]
+    #[serde(rename="Tags")]
     pub tags: Vec<Tag>,
 }
 
@@ -3210,13 +3523,19 @@ impl DbGroupListSerializer {
 }
 
 #[doc="<p>Describes the default cluster parameters for a parameter group family.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DefaultClusterParameters {
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The name of the cluster parameter group family to which the engine default parameters apply.</p>"]
+    #[serde(rename="ParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_group_family: Option<String>,
     #[doc="<p>The list of cluster default parameters.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
 }
 
@@ -3273,13 +3592,18 @@ impl DefaultClusterParametersDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterMessage {
     #[doc="<p>The identifier of the cluster to be deleted.</p> <p>Constraints:</p> <ul> <li> <p>Must contain lowercase characters.</p> </li> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
     #[doc="<p>The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, <i>SkipFinalClusterSnapshot</i> must be <code>false</code>. </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>"]
+    #[serde(rename="FinalClusterSnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub final_cluster_snapshot_identifier: Option<String>,
     #[doc="<p>Determines whether a final snapshot of the cluster is created before Amazon Redshift deletes the cluster. If <code>true</code>, a final cluster snapshot is not created. If <code>false</code>, a final cluster snapshot is created before the cluster is deleted. </p> <note> <p>The <i>FinalClusterSnapshotIdentifier</i> parameter must be specified if <i>SkipFinalClusterSnapshot</i> is <code>false</code>.</p> </note> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="SkipFinalClusterSnapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub skip_final_cluster_snapshot: Option<bool>,
 }
 
@@ -3308,9 +3632,10 @@ impl DeleteClusterMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterParameterGroupMessage {
     #[doc="<p>The name of the parameter group to be deleted.</p> <p>Constraints:</p> <ul> <li> <p>Must be the name of an existing cluster parameter group.</p> </li> <li> <p>Cannot delete a default cluster parameter group.</p> </li> </ul>"]
+    #[serde(rename="ParameterGroupName")]
     pub parameter_group_name: String,
 }
 
@@ -3330,8 +3655,10 @@ impl DeleteClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterResult {
+    #[serde(rename="Cluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster: Option<Cluster>,
 }
 
@@ -3378,9 +3705,10 @@ impl DeleteClusterResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterSecurityGroupMessage {
     #[doc="<p>The name of the cluster security group to be deleted.</p>"]
+    #[serde(rename="ClusterSecurityGroupName")]
     pub cluster_security_group_name: String,
 }
 
@@ -3401,11 +3729,14 @@ impl DeleteClusterSecurityGroupMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterSnapshotMessage {
     #[doc="<p>The unique identifier of the cluster the snapshot was created from. This parameter is required if your IAM user has a policy containing a snapshot resource element that specifies anything other than * for the cluster name.</p> <p>Constraints: Must be the name of valid cluster.</p>"]
+    #[serde(rename="SnapshotClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_cluster_identifier: Option<String>,
     #[doc="<p>The unique identifier of the manual snapshot to be deleted.</p> <p>Constraints: Must be the name of an existing snapshot that is in the <code>available</code> state.</p>"]
+    #[serde(rename="SnapshotIdentifier")]
     pub snapshot_identifier: String,
 }
 
@@ -3429,8 +3760,10 @@ impl DeleteClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterSnapshotResult {
+    #[serde(rename="Snapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot: Option<Snapshot>,
 }
 
@@ -3477,9 +3810,10 @@ impl DeleteClusterSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteClusterSubnetGroupMessage {
     #[doc="<p>The name of the cluster subnet group name to be deleted.</p>"]
+    #[serde(rename="ClusterSubnetGroupName")]
     pub cluster_subnet_group_name: String,
 }
 
@@ -3500,9 +3834,10 @@ impl DeleteClusterSubnetGroupMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEventSubscriptionMessage {
     #[doc="<p>The name of the Amazon Redshift event notification subscription to be deleted.</p>"]
+    #[serde(rename="SubscriptionName")]
     pub subscription_name: String,
 }
 
@@ -3523,9 +3858,10 @@ impl DeleteEventSubscriptionMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteHsmClientCertificateMessage {
     #[doc="<p>The identifier of the HSM client certificate to be deleted.</p>"]
+    #[serde(rename="HsmClientCertificateIdentifier")]
     pub hsm_client_certificate_identifier: String,
 }
 
@@ -3546,9 +3882,10 @@ impl DeleteHsmClientCertificateMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteHsmConfigurationMessage {
     #[doc="<p>The identifier of the Amazon Redshift HSM configuration to be deleted.</p>"]
+    #[serde(rename="HsmConfigurationIdentifier")]
     pub hsm_configuration_identifier: String,
 }
 
@@ -3569,9 +3906,10 @@ impl DeleteHsmConfigurationMessageSerializer {
 }
 
 #[doc="<p>The result of the <code>DeleteSnapshotCopyGrant</code> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSnapshotCopyGrantMessage {
     #[doc="<p>The name of the snapshot copy grant to delete.</p>"]
+    #[serde(rename="SnapshotCopyGrantName")]
     pub snapshot_copy_grant_name: String,
 }
 
@@ -3592,11 +3930,13 @@ impl DeleteSnapshotCopyGrantMessageSerializer {
 }
 
 #[doc="<p>Contains the output from the <code>DeleteTags</code> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsMessage {
     #[doc="<p>The Amazon Resource Name (ARN) from which you want to remove the tag or tags. For example, <code>arn:aws:redshift:us-east-1:123456789:cluster:t1</code>. </p>"]
+    #[serde(rename="ResourceName")]
     pub resource_name: String,
     #[doc="<p>The tag key that you want to delete.</p>"]
+    #[serde(rename="TagKeys")]
     pub tag_keys: Vec<String>,
 }
 
@@ -3618,17 +3958,27 @@ impl DeleteTagsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClusterParameterGroupsMessage {
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeClusterParameterGroups</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The name of a specific parameter group for which to return details. By default, details about all parameter groups and the default parameter group are returned.</p>"]
+    #[serde(rename="ParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_group_name: Option<String>,
     #[doc="<p>A tag key or keys for which you want to return all matching cluster parameter groups that are associated with the specified key or keys. For example, suppose that you have parameter groups that are tagged with keys called <code>owner</code> and <code>environment</code>. If you specify both of these tag keys in the request, Amazon Redshift returns a response with the parameter groups that have either or both of these tag keys associated with them.</p>"]
+    #[serde(rename="TagKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_keys: Option<Vec<String>>,
     #[doc="<p>A tag value or values for which you want to return all matching cluster parameter groups that are associated with the specified tag value or values. For example, suppose that you have parameter groups that are tagged with values called <code>admin</code> and <code>test</code>. If you specify both of these tag values in the request, Amazon Redshift returns a response with the parameter groups that have either or both of these tag values associated with them.</p>"]
+    #[serde(rename="TagValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_values: Option<Vec<String>>,
 }
 
@@ -3669,15 +4019,22 @@ impl DescribeClusterParameterGroupsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClusterParametersMessage {
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeClusterParameters</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The name of a cluster parameter group for which to return details.</p>"]
+    #[serde(rename="ParameterGroupName")]
     pub parameter_group_name: String,
     #[doc="<p>The parameter types to return. Specify <code>user</code> to show parameters that are different form the default. Similarly, specify <code>engine-default</code> to show parameters that are the same as the default parameter group. </p> <p>Default: All parameter types returned.</p> <p>Valid Values: <code>user</code> | <code>engine-default</code> </p>"]
+    #[serde(rename="Source")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source: Option<String>,
 }
 
@@ -3710,17 +4067,27 @@ impl DescribeClusterParametersMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClusterSecurityGroupsMessage {
     #[doc="<p>The name of a cluster security group for which you are requesting details. You can specify either the <b>Marker</b> parameter or a <b>ClusterSecurityGroupName</b> parameter, but not both. </p> <p> Example: <code>securitygroup1</code> </p>"]
+    #[serde(rename="ClusterSecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_security_group_name: Option<String>,
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeClusterSecurityGroups</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p> <p>Constraints: You can specify either the <b>ClusterSecurityGroupName</b> parameter or the <b>Marker</b> parameter, but not both. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>A tag key or keys for which you want to return all matching cluster security groups that are associated with the specified key or keys. For example, suppose that you have security groups that are tagged with keys called <code>owner</code> and <code>environment</code>. If you specify both of these tag keys in the request, Amazon Redshift returns a response with the security groups that have either or both of these tag keys associated with them.</p>"]
+    #[serde(rename="TagKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_keys: Option<Vec<String>>,
     #[doc="<p>A tag value or values for which you want to return all matching cluster security groups that are associated with the specified tag value or values. For example, suppose that you have security groups that are tagged with values called <code>admin</code> and <code>test</code>. If you specify both of these tag values in the request, Amazon Redshift returns a response with the security groups that have either or both of these tag values associated with them.</p>"]
+    #[serde(rename="TagValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_values: Option<Vec<String>>,
 }
 
@@ -3761,27 +4128,47 @@ impl DescribeClusterSecurityGroupsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClusterSnapshotsMessage {
     #[doc="<p>The identifier of the cluster for which information about snapshots is requested.</p>"]
+    #[serde(rename="ClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_identifier: Option<String>,
     #[doc="<p>A time value that requests only snapshots created at or before the specified time. The time value is specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: <code>2012-07-16T18:00:00Z</code> </p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeClusterSnapshots</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The AWS customer account used to create or copy the snapshot. Use this field to filter the results to snapshots owned by a particular account. To describe snapshots you own, either specify your AWS customer account, or do not specify the parameter.</p>"]
+    #[serde(rename="OwnerAccount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_account: Option<String>,
     #[doc="<p>The snapshot identifier of the snapshot about which to return information.</p>"]
+    #[serde(rename="SnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_identifier: Option<String>,
     #[doc="<p>The type of snapshots for which you are requesting information. By default, snapshots of all types are returned.</p> <p>Valid Values: <code>automated</code> | <code>manual</code> </p>"]
+    #[serde(rename="SnapshotType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_type: Option<String>,
     #[doc="<p>A value that requests only snapshots created at or after the specified time. The time value is specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: <code>2012-07-16T18:00:00Z</code> </p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
     #[doc="<p>A tag key or keys for which you want to return all matching cluster snapshots that are associated with the specified key or keys. For example, suppose that you have snapshots that are tagged with keys called <code>owner</code> and <code>environment</code>. If you specify both of these tag keys in the request, Amazon Redshift returns a response with the snapshots that have either or both of these tag keys associated with them.</p>"]
+    #[serde(rename="TagKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_keys: Option<Vec<String>>,
     #[doc="<p>A tag value or values for which you want to return all matching cluster snapshots that are associated with the specified tag value or values. For example, suppose that you have snapshots that are tagged with values called <code>admin</code> and <code>test</code>. If you specify both of these tag values in the request, Amazon Redshift returns a response with the snapshots that have either or both of these tag values associated with them.</p>"]
+    #[serde(rename="TagValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_values: Option<Vec<String>>,
 }
 
@@ -3842,17 +4229,27 @@ impl DescribeClusterSnapshotsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClusterSubnetGroupsMessage {
     #[doc="<p>The name of the cluster subnet group for which information is requested.</p>"]
+    #[serde(rename="ClusterSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_subnet_group_name: Option<String>,
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeClusterSubnetGroups</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>A tag key or keys for which you want to return all matching cluster subnet groups that are associated with the specified key or keys. For example, suppose that you have subnet groups that are tagged with keys called <code>owner</code> and <code>environment</code>. If you specify both of these tag keys in the request, Amazon Redshift returns a response with the subnet groups that have either or both of these tag keys associated with them.</p>"]
+    #[serde(rename="TagKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_keys: Option<Vec<String>>,
     #[doc="<p>A tag value or values for which you want to return all matching cluster subnet groups that are associated with the specified tag value or values. For example, suppose that you have subnet groups that are tagged with values called <code>admin</code> and <code>test</code>. If you specify both of these tag values in the request, Amazon Redshift returns a response with the subnet groups that have either or both of these tag values associated with them.</p>"]
+    #[serde(rename="TagValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_values: Option<Vec<String>>,
 }
 
@@ -3893,15 +4290,23 @@ impl DescribeClusterSubnetGroupsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClusterVersionsMessage {
     #[doc="<p>The name of a specific cluster parameter group family to return details for.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="ClusterParameterGroupFamily")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_parameter_group_family: Option<String>,
     #[doc="<p>The specific cluster version to return.</p> <p>Example: <code>1.0</code> </p>"]
+    #[serde(rename="ClusterVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_version: Option<String>,
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeClusterVersions</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
 }
 
@@ -3936,17 +4341,27 @@ impl DescribeClusterVersionsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClustersMessage {
     #[doc="<p>The unique identifier of a cluster whose properties you are requesting. This parameter is case sensitive.</p> <p>The default is that all clusters defined for an account are returned.</p>"]
+    #[serde(rename="ClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_identifier: Option<String>,
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeClusters</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p> <p>Constraints: You can specify either the <b>ClusterIdentifier</b> parameter or the <b>Marker</b> parameter, but not both. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>A tag key or keys for which you want to return all matching clusters that are associated with the specified key or keys. For example, suppose that you have clusters that are tagged with keys called <code>owner</code> and <code>environment</code>. If you specify both of these tag keys in the request, Amazon Redshift returns a response with the clusters that have either or both of these tag keys associated with them.</p>"]
+    #[serde(rename="TagKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_keys: Option<Vec<String>>,
     #[doc="<p>A tag value or values for which you want to return all matching clusters that are associated with the specified tag value or values. For example, suppose that you have clusters that are tagged with values called <code>admin</code> and <code>test</code>. If you specify both of these tag values in the request, Amazon Redshift returns a response with the clusters that have either or both of these tag values associated with them.</p>"]
+    #[serde(rename="TagValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_values: Option<Vec<String>>,
 }
 
@@ -3987,13 +4402,18 @@ impl DescribeClustersMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDefaultClusterParametersMessage {
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeDefaultClusterParameters</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The name of the cluster parameter group family.</p>"]
+    #[serde(rename="ParameterGroupFamily")]
     pub parameter_group_family: String,
 }
 
@@ -4021,8 +4441,10 @@ impl DescribeDefaultClusterParametersMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDefaultClusterParametersResult {
+    #[serde(rename="DefaultClusterParameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub default_cluster_parameters: Option<DefaultClusterParameters>,
 }
 
@@ -4069,9 +4491,11 @@ impl DescribeDefaultClusterParametersResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventCategoriesMessage {
     #[doc="<p>The source type, such as cluster or parameter group, to which the described event categories apply.</p> <p>Valid values: cluster, cluster-snapshot, cluster-parameter-group, and cluster-security-group.</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
 }
 
@@ -4094,13 +4518,19 @@ impl DescribeEventCategoriesMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventSubscriptionsMessage {
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeEventSubscriptions</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The name of the Amazon Redshift event notification subscription to be described.</p>"]
+    #[serde(rename="SubscriptionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subscription_name: Option<String>,
 }
 
@@ -4131,21 +4561,35 @@ impl DescribeEventSubscriptionsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEventsMessage {
     #[doc="<p>The number of minutes prior to the time of the request for which to retrieve events. For example, if the request is sent at 18:00 and you specify a duration of 60, then only events which have occurred after 17:00 will be returned.</p> <p>Default: <code>60</code> </p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The end of the time interval for which to retrieve events, specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: <code>2009-07-08T18:00Z</code> </p>"]
+    #[serde(rename="EndTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub end_time: Option<String>,
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeEvents</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The identifier of the event source for which events will be returned. If this parameter is not specified, then all sources are included in the response.</p> <p>Constraints:</p> <p>If <i>SourceIdentifier</i> is supplied, <i>SourceType</i> must also be provided.</p> <ul> <li> <p>Specify a cluster identifier when <i>SourceType</i> is <code>cluster</code>.</p> </li> <li> <p>Specify a cluster security group name when <i>SourceType</i> is <code>cluster-security-group</code>.</p> </li> <li> <p>Specify a cluster parameter group name when <i>SourceType</i> is <code>cluster-parameter-group</code>.</p> </li> <li> <p>Specify a cluster snapshot identifier when <i>SourceType</i> is <code>cluster-snapshot</code>.</p> </li> </ul>"]
+    #[serde(rename="SourceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_identifier: Option<String>,
     #[doc="<p>The event source to retrieve events for. If no value is specified, all events are returned.</p> <p>Constraints:</p> <p>If <i>SourceType</i> is supplied, <i>SourceIdentifier</i> must also be provided.</p> <ul> <li> <p>Specify <code>cluster</code> when <i>SourceIdentifier</i> is a cluster identifier.</p> </li> <li> <p>Specify <code>cluster-security-group</code> when <i>SourceIdentifier</i> is a cluster security group name.</p> </li> <li> <p>Specify <code>cluster-parameter-group</code> when <i>SourceIdentifier</i> is a cluster parameter group name.</p> </li> <li> <p>Specify <code>cluster-snapshot</code> when <i>SourceIdentifier</i> is a cluster snapshot identifier.</p> </li> </ul>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
     #[doc="<p>The beginning of the time interval to retrieve events for, specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: <code>2009-07-08T18:00Z</code> </p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
 }
 
@@ -4192,17 +4636,27 @@ impl DescribeEventsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHsmClientCertificatesMessage {
     #[doc="<p>The identifier of a specific HSM client certificate for which you want information. If no identifier is specified, information is returned for all HSM client certificates owned by your AWS customer account.</p>"]
+    #[serde(rename="HsmClientCertificateIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_client_certificate_identifier: Option<String>,
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeHsmClientCertificates</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>A tag key or keys for which you want to return all matching HSM client certificates that are associated with the specified key or keys. For example, suppose that you have HSM client certificates that are tagged with keys called <code>owner</code> and <code>environment</code>. If you specify both of these tag keys in the request, Amazon Redshift returns a response with the HSM client certificates that have either or both of these tag keys associated with them.</p>"]
+    #[serde(rename="TagKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_keys: Option<Vec<String>>,
     #[doc="<p>A tag value or values for which you want to return all matching HSM client certificates that are associated with the specified tag value or values. For example, suppose that you have HSM client certificates that are tagged with values called <code>admin</code> and <code>test</code>. If you specify both of these tag values in the request, Amazon Redshift returns a response with the HSM client certificates that have either or both of these tag values associated with them.</p>"]
+    #[serde(rename="TagValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_values: Option<Vec<String>>,
 }
 
@@ -4243,17 +4697,27 @@ impl DescribeHsmClientCertificatesMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeHsmConfigurationsMessage {
     #[doc="<p>The identifier of a specific Amazon Redshift HSM configuration to be described. If no identifier is specified, information is returned for all HSM configurations owned by your AWS customer account.</p>"]
+    #[serde(rename="HsmConfigurationIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_configuration_identifier: Option<String>,
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeHsmConfigurations</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>A tag key or keys for which you want to return all matching HSM configurations that are associated with the specified key or keys. For example, suppose that you have HSM configurations that are tagged with keys called <code>owner</code> and <code>environment</code>. If you specify both of these tag keys in the request, Amazon Redshift returns a response with the HSM configurations that have either or both of these tag keys associated with them.</p>"]
+    #[serde(rename="TagKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_keys: Option<Vec<String>>,
     #[doc="<p>A tag value or values for which you want to return all matching HSM configurations that are associated with the specified tag value or values. For example, suppose that you have HSM configurations that are tagged with values called <code>admin</code> and <code>test</code>. If you specify both of these tag values in the request, Amazon Redshift returns a response with the HSM configurations that have either or both of these tag values associated with them.</p>"]
+    #[serde(rename="TagValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_values: Option<Vec<String>>,
 }
 
@@ -4294,9 +4758,10 @@ impl DescribeHsmConfigurationsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeLoggingStatusMessage {
     #[doc="<p>The identifier of the cluster from which to get the logging status.</p> <p>Example: <code>examplecluster</code> </p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
 }
 
@@ -4317,15 +4782,23 @@ impl DescribeLoggingStatusMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeOrderableClusterOptionsMessage {
     #[doc="<p>The version filter value. Specify this parameter to show only the available offerings matching the specified version.</p> <p>Default: All versions.</p> <p>Constraints: Must be one of the version returned from <a>DescribeClusterVersions</a>.</p>"]
+    #[serde(rename="ClusterVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_version: Option<String>,
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeOrderableClusterOptions</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The node type filter value. Specify this parameter to show only the available offerings matching the specified node type.</p>"]
+    #[serde(rename="NodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_type: Option<String>,
 }
 
@@ -4360,13 +4833,19 @@ impl DescribeOrderableClusterOptionsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedNodeOfferingsMessage {
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeReservedNodeOfferings</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The unique identifier for the offering.</p>"]
+    #[serde(rename="ReservedNodeOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_node_offering_id: Option<String>,
 }
 
@@ -4397,13 +4876,19 @@ impl DescribeReservedNodeOfferingsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReservedNodesMessage {
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeReservedNodes</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>Identifier for the node reservation.</p>"]
+    #[serde(rename="ReservedNodeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_node_id: Option<String>,
 }
 
@@ -4434,9 +4919,10 @@ impl DescribeReservedNodesMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeResizeMessage {
     #[doc="<p>The unique identifier of a cluster whose resize progress you are requesting. This parameter is case-sensitive.</p> <p>By default, resize operations for all clusters defined for an AWS account are returned.</p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
 }
 
@@ -4457,17 +4943,27 @@ impl DescribeResizeMessageSerializer {
 }
 
 #[doc="<p>The result of the <code>DescribeSnapshotCopyGrants</code> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSnapshotCopyGrantsMessage {
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <code>DescribeSnapshotCopyGrant</code> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p> <p>Constraints: You can specify either the <b>SnapshotCopyGrantName</b> parameter or the <b>Marker</b> parameter, but not both. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned marker value. </p> <p>Default: <code>100</code> </p> <p>Constraints: minimum 20, maximum 100.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The name of the snapshot copy grant.</p>"]
+    #[serde(rename="SnapshotCopyGrantName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_copy_grant_name: Option<String>,
     #[doc="<p>A tag key or keys for which you want to return all matching resources that are associated with the specified key or keys. For example, suppose that you have resources tagged with keys called <code>owner</code> and <code>environment</code>. If you specify both of these tag keys in the request, Amazon Redshift returns a response with all resources that have either or both of these tag keys associated with them.</p>"]
+    #[serde(rename="TagKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_keys: Option<Vec<String>>,
     #[doc="<p>A tag value or values for which you want to return all matching resources that are associated with the specified value or values. For example, suppose that you have resources tagged with values called <code>admin</code> and <code>test</code>. If you specify both of these tag values in the request, Amazon Redshift returns a response with all resources that have either or both of these tag values associated with them.</p>"]
+    #[serde(rename="TagValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_values: Option<Vec<String>>,
 }
 
@@ -4508,15 +5004,23 @@ impl DescribeSnapshotCopyGrantsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTableRestoreStatusMessage {
     #[doc="<p>The Amazon Redshift cluster that the table is being restored to.</p>"]
+    #[serde(rename="ClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_identifier: Option<String>,
     #[doc="<p>An optional pagination token provided by a previous <code>DescribeTableRestoreStatus</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by the <code>MaxRecords</code> parameter.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved.</p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The identifier of the table restore request to return status for. If you don't specify a <code>TableRestoreRequestId</code> value, then <code>DescribeTableRestoreStatus</code> returns the status of all in-progress table restore requests.</p>"]
+    #[serde(rename="TableRestoreRequestId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub table_restore_request_id: Option<String>,
 }
 
@@ -4551,19 +5055,31 @@ impl DescribeTableRestoreStatusMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsMessage {
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>marker</code> parameter and retrying the command. If the <code>marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number or response records to return in each call. If the number of remaining response records exceeds the specified <code>MaxRecords</code> value, a value is returned in a <code>marker</code> field of the response. You can retrieve the next set of records by retrying the command with the returned <code>marker</code> value. </p>"]
+    #[serde(rename="MaxRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_records: Option<i64>,
     #[doc="<p>The Amazon Resource Name (ARN) for which you want to describe the tag or tags. For example, <code>arn:aws:redshift:us-east-1:123456789:cluster:t1</code>. </p>"]
+    #[serde(rename="ResourceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_name: Option<String>,
     #[doc="<p>The type of resource with which you want to view tags. Valid resource types are: </p> <ul> <li> <p>Cluster</p> </li> <li> <p>CIDR/IP</p> </li> <li> <p>EC2 security group</p> </li> <li> <p>Snapshot</p> </li> <li> <p>Cluster security group</p> </li> <li> <p>Subnet group</p> </li> <li> <p>HSM connection</p> </li> <li> <p>HSM certificate</p> </li> <li> <p>Parameter group</p> </li> <li> <p>Snapshot copy grant</p> </li> </ul> <p>For more information about Amazon Redshift resource types and constructing ARNs, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/constructing-redshift-arn.html\">Constructing an Amazon Redshift Amazon Resource Name (ARN)</a> in the Amazon Redshift Cluster Management Guide. </p>"]
+    #[serde(rename="ResourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
     #[doc="<p>A tag key or keys for which you want to return all matching resources that are associated with the specified key or keys. For example, suppose that you have resources tagged with keys called <code>owner</code> and <code>environment</code>. If you specify both of these tag keys in the request, Amazon Redshift returns a response with all resources that have either or both of these tag keys associated with them.</p>"]
+    #[serde(rename="TagKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_keys: Option<Vec<String>>,
     #[doc="<p>A tag value or values for which you want to return all matching resources that are associated with the specified value or values. For example, suppose that you have resources tagged with values called <code>admin</code> and <code>test</code>. If you specify both of these tag values in the request, Amazon Redshift returns a response with all resources that have either or both of these tag values associated with them.</p>"]
+    #[serde(rename="TagValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_values: Option<Vec<String>>,
 }
 
@@ -4608,9 +5124,10 @@ impl DescribeTagsMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableLoggingMessage {
     #[doc="<p>The identifier of the cluster on which logging is to be stopped.</p> <p>Example: <code>examplecluster</code> </p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
 }
 
@@ -4631,9 +5148,10 @@ impl DisableLoggingMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableSnapshotCopyMessage {
     #[doc="<p>The unique identifier of the source cluster that you want to disable copying of snapshots to a destination region.</p> <p>Constraints: Must be the valid name of an existing cluster that has cross-region snapshot copy enabled.</p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
 }
 
@@ -4653,8 +5171,10 @@ impl DisableSnapshotCopyMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableSnapshotCopyResult {
+    #[serde(rename="Cluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster: Option<Cluster>,
 }
 
@@ -4729,15 +5249,23 @@ impl DoubleOptionalDeserializer {
     }
 }
 #[doc="<p>Describes an Amazon EC2 security group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EC2SecurityGroup {
     #[doc="<p>The name of the EC2 Security Group.</p>"]
+    #[serde(rename="EC2SecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_name: Option<String>,
     #[doc="<p>The AWS ID of the owner of the EC2 security group specified in the <code>EC2SecurityGroupName</code> field. </p>"]
+    #[serde(rename="EC2SecurityGroupOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_owner_id: Option<String>,
     #[doc="<p>The status of the EC2 security group.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The list of tags for the EC2 security group.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -4839,11 +5367,15 @@ impl EC2SecurityGroupListDeserializer {
     }
 }
 #[doc="<p>Describes the status of the elastic IP (EIP) address.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ElasticIpStatus {
     #[doc="<p>The elastic IP (EIP) address for the cluster.</p>"]
+    #[serde(rename="ElasticIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_ip: Option<String>,
     #[doc="<p>The status of the elastic IP (EIP) address.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -4894,13 +5426,17 @@ impl ElasticIpStatusDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableLoggingMessage {
     #[doc="<p>The name of an existing S3 bucket where the log files are to be stored.</p> <p>Constraints:</p> <ul> <li> <p>Must be in the same region as the cluster</p> </li> <li> <p>The cluster must have read bucket and put object permissions</p> </li> </ul>"]
+    #[serde(rename="BucketName")]
     pub bucket_name: String,
     #[doc="<p>The identifier of the cluster on which logging is to be started.</p> <p>Example: <code>examplecluster</code> </p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
     #[doc="<p>The prefix applied to the log file names.</p> <p>Constraints:</p> <ul> <li> <p>Cannot exceed 512 characters</p> </li> <li> <p>Cannot contain spaces( ), double quotes (\"), single quotes ('), a backslash (\\), or control characters. The hexadecimal codes for invalid characters are: </p> <ul> <li> <p>x00 to x20</p> </li> <li> <p>x22</p> </li> <li> <p>x27</p> </li> <li> <p>x5c</p> </li> <li> <p>x7f or larger</p> </li> </ul> </li> </ul>"]
+    #[serde(rename="S3KeyPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_key_prefix: Option<String>,
 }
 
@@ -4927,15 +5463,21 @@ impl EnableLoggingMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableSnapshotCopyMessage {
     #[doc="<p>The unique identifier of the source cluster to copy snapshots from.</p> <p>Constraints: Must be the valid name of an existing cluster that does not already have cross-region snapshot copy enabled.</p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
     #[doc="<p>The destination region that you want to copy snapshots to.</p> <p>Constraints: Must be the name of a valid region. For more information, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html#redshift_region\">Regions and Endpoints</a> in the Amazon Web Services General Reference. </p>"]
+    #[serde(rename="DestinationRegion")]
     pub destination_region: String,
     #[doc="<p>The number of days to retain automated snapshots in the destination region after they are copied from the source region.</p> <p>Default: 7.</p> <p>Constraints: Must be at least 1 and no more than 35.</p>"]
+    #[serde(rename="RetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub retention_period: Option<i64>,
     #[doc="<p>The name of the snapshot copy grant to use when snapshots of an AWS KMS-encrypted cluster are copied to the destination region.</p>"]
+    #[serde(rename="SnapshotCopyGrantName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_copy_grant_name: Option<String>,
 }
 
@@ -4965,8 +5507,10 @@ impl EnableSnapshotCopyMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableSnapshotCopyResult {
+    #[serde(rename="Cluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster: Option<Cluster>,
 }
 
@@ -5013,11 +5557,15 @@ impl EnableSnapshotCopyResultDeserializer {
     }
 }
 #[doc="<p>Describes a connection endpoint.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Endpoint {
     #[doc="<p>The DNS address of the Cluster.</p>"]
+    #[serde(rename="Address")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub address: Option<String>,
     #[doc="<p>The port that the database engine is listening on.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
 }
 
@@ -5067,21 +5615,35 @@ impl EndpointDeserializer {
     }
 }
 #[doc="<p>Describes an event.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Event {
     #[doc="<p>The date and time of the event.</p>"]
+    #[serde(rename="Date")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date: Option<String>,
     #[doc="<p>A list of the event categories.</p> <p>Values: Configuration, Management, Monitoring, Security</p>"]
+    #[serde(rename="EventCategories")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories: Option<Vec<String>>,
     #[doc="<p>The identifier of the event.</p>"]
+    #[serde(rename="EventId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_id: Option<String>,
     #[doc="<p>The text of this event.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
     #[doc="<p>The severity of the event.</p> <p>Values: ERROR, INFO</p>"]
+    #[serde(rename="Severity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub severity: Option<String>,
     #[doc="<p>The identifier for the source of the event.</p>"]
+    #[serde(rename="SourceIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_identifier: Option<String>,
     #[doc="<p>The source type for this event.</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
 }
 
@@ -5207,11 +5769,15 @@ impl EventCategoriesListSerializer {
 }
 
 #[doc="<p>Describes event categories.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventCategoriesMap {
     #[doc="<p>The events in the event category.</p>"]
+    #[serde(rename="Events")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<EventInfoMap>>,
     #[doc="<p>The source type, such as cluster or cluster-snapshot, that the returned categories belong to.</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
 }
 
@@ -5304,9 +5870,11 @@ impl EventCategoriesMapListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventCategoriesMessage {
     #[doc="<p>A list of event categories descriptions.</p>"]
+    #[serde(rename="EventCategoriesMapList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories_map_list: Option<Vec<EventCategoriesMap>>,
 }
 
@@ -5354,15 +5922,23 @@ impl EventCategoriesMessageDeserializer {
     }
 }
 #[doc="<p>Describes event information.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventInfoMap {
     #[doc="<p>The category of an Amazon Redshift event.</p>"]
+    #[serde(rename="EventCategories")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories: Option<Vec<String>>,
     #[doc="<p>The description of an Amazon Redshift event.</p>"]
+    #[serde(rename="EventDescription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_description: Option<String>,
     #[doc="<p>The identifier of an Amazon Redshift event.</p>"]
+    #[serde(rename="EventId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_id: Option<String>,
     #[doc="<p>The severity of the event.</p> <p>Values: ERROR, INFO</p>"]
+    #[serde(rename="Severity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub severity: Option<String>,
 }
 
@@ -5506,29 +6082,51 @@ impl EventListDeserializer {
     }
 }
 #[doc="<p>Describes event subscriptions.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventSubscription {
     #[doc="<p>The name of the Amazon Redshift event notification subscription.</p>"]
+    #[serde(rename="CustSubscriptionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cust_subscription_id: Option<String>,
     #[doc="<p>The AWS customer account associated with the Amazon Redshift event notification subscription.</p>"]
+    #[serde(rename="CustomerAwsId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub customer_aws_id: Option<String>,
     #[doc="<p>A Boolean value indicating whether the subscription is enabled. <code>true</code> indicates the subscription is enabled.</p>"]
+    #[serde(rename="Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled: Option<bool>,
     #[doc="<p>The list of Amazon Redshift event categories specified in the event notification subscription.</p> <p>Values: Configuration, Management, Monitoring, Security</p>"]
+    #[serde(rename="EventCategoriesList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories_list: Option<Vec<String>>,
     #[doc="<p>The event severity specified in the Amazon Redshift event notification subscription.</p> <p>Values: ERROR, INFO</p>"]
+    #[serde(rename="Severity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub severity: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic used by the event notification subscription.</p>"]
+    #[serde(rename="SnsTopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sns_topic_arn: Option<String>,
     #[doc="<p>A list of the sources that publish events to the Amazon Redshift event notification subscription.</p>"]
+    #[serde(rename="SourceIdsList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_ids_list: Option<Vec<String>>,
     #[doc="<p>The source type of the events returned the Amazon Redshift event notification, such as cluster, or cluster-snapshot.</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
     #[doc="<p>The status of the Amazon Redshift event notification subscription.</p> <p>Constraints:</p> <ul> <li> <p>Can be one of the following: active | no-permission | topic-not-exist</p> </li> <li> <p>The status \"no-permission\" indicates that Amazon Redshift no longer has permission to post to the Amazon SNS topic. The status \"topic-not-exist\" indicates that the topic was deleted after the subscription was created.</p> </li> </ul>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The date and time the Amazon Redshift event notification subscription was created.</p>"]
+    #[serde(rename="SubscriptionCreationTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subscription_creation_time: Option<String>,
     #[doc="<p>The list of tags for the event subscription.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -5659,11 +6257,15 @@ impl EventSubscriptionsListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventSubscriptionsMessage {
     #[doc="<p>A list of event subscriptions.</p>"]
+    #[serde(rename="EventSubscriptionsList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_subscriptions_list: Option<Vec<EventSubscription>>,
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5715,11 +6317,15 @@ impl EventSubscriptionsMessageDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventsMessage {
     #[doc="<p>A list of <code>Event</code> instances. </p>"]
+    #[serde(rename="Events")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<Event>>,
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5770,19 +6376,29 @@ impl EventsMessageDeserializer {
     }
 }
 #[doc="<p>The request parameters to get cluster credentials.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetClusterCredentialsMessage {
     #[doc="<p>Create a database user with the name specified for <code>DbUser</code> if one does not exist.</p>"]
+    #[serde(rename="AutoCreate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub auto_create: Option<bool>,
     #[doc="<p>The unique identifier of the cluster that contains the database for which your are requesting credentials. This parameter is case sensitive.</p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
     #[doc="<p>A list of the names of existing database groups that <code>DbUser</code> will join for the current session. If not specified, the new user is added only to PUBLIC.</p>"]
+    #[serde(rename="DbGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_groups: Option<Vec<String>>,
     #[doc="<p>The name of a database that <code>DbUser</code> is authorized to log on to. If <code>DbName</code> is not specified, <code>DbUser</code> can log in to any existing database.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 64 alphanumeric characters or hyphens</p> </li> <li> <p>Must contain only lowercase letters.</p> </li> <li> <p>Cannot be a reserved word. A list of reserved words can be found in <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html\">Reserved Words</a> in the Amazon Redshift Database Developer Guide.</p> </li> </ul>"]
+    #[serde(rename="DbName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_name: Option<String>,
     #[doc="<p>The name of a database user. If a user name matching <code>DbUser</code> exists in the database, the temporary user credentials have the same permissions as the existing user. If <code>DbUser</code> doesn't exist in the database and <code>Autocreate</code> is <code>True</code>, a new user is created using the value for <code>DbUser</code> with PUBLIC permissions. If a database user matching the value for <code>DbUser</code> doesn't exist and <code>Autocreate</code> is <code>False</code>, then the command succeeds but the connection attempt will fail because the user doesn't exist in the database.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/http:/docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html\">CREATE USER</a> in the Amazon Redshift Database Developer Guide. </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 128 alphanumeric characters or hyphens</p> </li> <li> <p>Must contain only lowercase letters.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Must not contain a colon ( : ) or slash ( / ). </p> </li> <li> <p>Cannot be a reserved word. A list of reserved words can be found in <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html\">Reserved Words</a> in the Amazon Redshift Database Developer Guide.</p> </li> </ul>"]
+    #[serde(rename="DbUser")]
     pub db_user: String,
     #[doc="<p>The number of seconds until the returned temporary password expires.</p> <p>Constraint: minimum 900, maximum 3600.</p> <p>Default: 900</p>"]
+    #[serde(rename="DurationSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration_seconds: Option<i64>,
 }
 
@@ -5822,13 +6438,19 @@ impl GetClusterCredentialsMessageSerializer {
 }
 
 #[doc="<p>Returns information about an HSM client certificate. The certificate is stored in a secure Hardware Storage Module (HSM), and used by the Amazon Redshift cluster to encrypt data files.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HsmClientCertificate {
     #[doc="<p>The identifier of the HSM client certificate.</p>"]
+    #[serde(rename="HsmClientCertificateIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_client_certificate_identifier: Option<String>,
     #[doc="<p>The public key that the Amazon Redshift cluster will use to connect to the HSM. You must register the public key in the HSM.</p>"]
+    #[serde(rename="HsmClientCertificatePublicKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_client_certificate_public_key: Option<String>,
     #[doc="<p>The list of tags for the HSM client certificate.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -5925,11 +6547,15 @@ impl HsmClientCertificateListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HsmClientCertificateMessage {
     #[doc="<p>A list of the identifiers for one or more HSM client certificates used by Amazon Redshift clusters to store and retrieve database encryption keys in an HSM.</p>"]
+    #[serde(rename="HsmClientCertificates")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_client_certificates: Option<Vec<HsmClientCertificate>>,
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -5979,17 +6605,27 @@ impl HsmClientCertificateMessageDeserializer {
     }
 }
 #[doc="<p>Returns information about an HSM configuration, which is an object that describes to Amazon Redshift clusters the information they require to connect to an HSM where they can store database encryption keys.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HsmConfiguration {
     #[doc="<p>A text description of the HSM configuration.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>The name of the Amazon Redshift HSM configuration.</p>"]
+    #[serde(rename="HsmConfigurationIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_configuration_identifier: Option<String>,
     #[doc="<p>The IP address that the Amazon Redshift cluster must use to access the HSM.</p>"]
+    #[serde(rename="HsmIpAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_ip_address: Option<String>,
     #[doc="<p>The name of the partition in the HSM where the Amazon Redshift clusters will store their database encryption keys.</p>"]
+    #[serde(rename="HsmPartitionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_partition_name: Option<String>,
     #[doc="<p>The list of tags for the HSM configuration.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -6095,11 +6731,15 @@ impl HsmConfigurationListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HsmConfigurationMessage {
     #[doc="<p>A list of <code>HsmConfiguration</code> objects.</p>"]
+    #[serde(rename="HsmConfigurations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_configurations: Option<Vec<HsmConfiguration>>,
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
 }
 
@@ -6151,13 +6791,19 @@ impl HsmConfigurationMessageDeserializer {
     }
 }
 #[doc="<p>Describes the status of changes to HSM settings.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HsmStatus {
     #[doc="<p>Specifies the name of the HSM client certificate the Amazon Redshift cluster uses to retrieve the data encryption keys stored in an HSM.</p>"]
+    #[serde(rename="HsmClientCertificateIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_client_certificate_identifier: Option<String>,
     #[doc="<p>Specifies the name of the HSM configuration that contains the information the Amazon Redshift cluster can use to retrieve and store keys in an HSM.</p>"]
+    #[serde(rename="HsmConfigurationIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_configuration_identifier: Option<String>,
     #[doc="<p>Reports whether the Amazon Redshift cluster has finished applying any HSM settings changes specified in a modify cluster command.</p> <p>Values: active, applying</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -6214,13 +6860,19 @@ impl HsmStatusDeserializer {
     }
 }
 #[doc="<p>Describes an IP range used in a security group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IPRange {
     #[doc="<p>The IP range in Classless Inter-Domain Routing (CIDR) notation.</p>"]
+    #[serde(rename="CIDRIP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidrip: Option<String>,
     #[doc="<p>The status of the IP range, for example, \"authorized\".</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The list of tags for the IP range.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -6478,19 +7130,31 @@ impl IntegerOptionalDeserializer {
     }
 }
 #[doc="<p>Describes the status of logging for a cluster.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LoggingStatus {
     #[doc="<p>The name of the S3 bucket where the log files are stored.</p>"]
+    #[serde(rename="BucketName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bucket_name: Option<String>,
     #[doc="<p>The message indicating that logs failed to be delivered.</p>"]
+    #[serde(rename="LastFailureMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_failure_message: Option<String>,
     #[doc="<p>The last time when logs failed to be delivered.</p>"]
+    #[serde(rename="LastFailureTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_failure_time: Option<String>,
     #[doc="<p>The last time that logs were delivered.</p>"]
+    #[serde(rename="LastSuccessfulDeliveryTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_successful_delivery_time: Option<String>,
     #[doc="<p> <code>true</code> if logging is on, <code>false</code> if logging is off.</p>"]
+    #[serde(rename="LoggingEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub logging_enabled: Option<bool>,
     #[doc="<p>The prefix applied to the log file names.</p>"]
+    #[serde(rename="S3KeyPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_key_prefix: Option<String>,
 }
 
@@ -6589,13 +7253,18 @@ impl LongOptionalDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyClusterIamRolesMessage {
     #[doc="<p>Zero or more IAM roles to associate with the cluster. The roles must be in their Amazon Resource Name (ARN) format. You can associate up to 10 IAM roles with a single cluster in a single request.</p>"]
+    #[serde(rename="AddIamRoles")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub add_iam_roles: Option<Vec<String>>,
     #[doc="<p>The unique identifier of the cluster for which you want to associate or disassociate IAM roles.</p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
     #[doc="<p>Zero or more IAM roles in ARN format to disassociate from the cluster. You can disassociate up to 10 IAM roles from a single cluster in a single request.</p>"]
+    #[serde(rename="RemoveIamRoles")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub remove_iam_roles: Option<Vec<String>>,
 }
 
@@ -6625,8 +7294,10 @@ impl ModifyClusterIamRolesMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyClusterIamRolesResult {
+    #[serde(rename="Cluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster: Option<Cluster>,
 }
 
@@ -6673,43 +7344,78 @@ impl ModifyClusterIamRolesResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyClusterMessage {
     #[doc="<p>If <code>true</code>, major version upgrades will be applied automatically to the cluster during the maintenance window. </p> <p>Default: <code>false</code> </p>"]
+    #[serde(rename="AllowVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_version_upgrade: Option<bool>,
     #[doc="<p>The number of days that automated snapshots are retained. If the value is 0, automated snapshots are disabled. Even if automated snapshots are disabled, you can still create manual snapshots when you want with <a>CreateClusterSnapshot</a>. </p> <p>If you decrease the automated snapshot retention period from its current value, existing automated snapshots that fall outside of the new retention period will be immediately deleted.</p> <p>Default: Uses existing setting.</p> <p>Constraints: Must be a value from 0 to 35.</p>"]
+    #[serde(rename="AutomatedSnapshotRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub automated_snapshot_retention_period: Option<i64>,
     #[doc="<p>The unique identifier of the cluster to be modified.</p> <p>Example: <code>examplecluster</code> </p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
     #[doc="<p>The name of the cluster parameter group to apply to this cluster. This change is applied only after the cluster is rebooted. To reboot a cluster use <a>RebootCluster</a>. </p> <p>Default: Uses existing setting.</p> <p>Constraints: The cluster parameter group must be in the same parameter group family that matches the cluster version.</p>"]
+    #[serde(rename="ClusterParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_parameter_group_name: Option<String>,
     #[doc="<p>A list of cluster security groups to be authorized on this cluster. This change is asynchronously applied as soon as possible.</p> <p>Security groups currently associated with the cluster, and not in the list of groups to apply, will be revoked from the cluster.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>"]
+    #[serde(rename="ClusterSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_security_groups: Option<Vec<String>>,
     #[doc="<p>The new cluster type.</p> <p>When you submit your cluster resize request, your existing cluster goes into a read-only mode. After Amazon Redshift provisions a new cluster based on your resize requirements, there will be outage for a period while the old cluster is deleted and your connection is switched to the new cluster. You can use <a>DescribeResize</a> to track the progress of the resize request. </p> <p>Valid Values: <code> multi-node | single-node </code> </p>"]
+    #[serde(rename="ClusterType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_type: Option<String>,
     #[doc="<p>The new version number of the Amazon Redshift engine to upgrade to.</p> <p>For major version upgrades, if a non-default cluster parameter group is currently in use, a new cluster parameter group in the cluster parameter group family for the new version must be specified. The new cluster parameter group can be the default for that cluster parameter group family. For more information about parameters and parameter groups, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html\">Amazon Redshift Parameter Groups</a> in the <i>Amazon Redshift Cluster Management Guide</i>.</p> <p>Example: <code>1.0</code> </p>"]
+    #[serde(rename="ClusterVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_version: Option<String>,
     #[doc="<p>The Elastic IP (EIP) address for the cluster.</p> <p>Constraints: The cluster must be provisioned in EC2-VPC and publicly-accessible through an Internet gateway. For more information about provisioning clusters in EC2-VPC, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#cluster-platforms\">Supported Platforms to Launch Your Cluster</a> in the Amazon Redshift Cluster Management Guide.</p>"]
+    #[serde(rename="ElasticIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_ip: Option<String>,
     #[doc="<p>An option that specifies whether to create the cluster with enhanced VPC routing enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in the Amazon Redshift Cluster Management Guide.</p> <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p> <p>Default: false</p>"]
+    #[serde(rename="EnhancedVpcRouting")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enhanced_vpc_routing: Option<bool>,
     #[doc="<p>Specifies the name of the HSM client certificate the Amazon Redshift cluster uses to retrieve the data encryption keys stored in an HSM.</p>"]
+    #[serde(rename="HsmClientCertificateIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_client_certificate_identifier: Option<String>,
     #[doc="<p>Specifies the name of the HSM configuration that contains the information the Amazon Redshift cluster can use to retrieve and store keys in an HSM.</p>"]
+    #[serde(rename="HsmConfigurationIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_configuration_identifier: Option<String>,
     #[doc="<p>The new password for the cluster master user. This change is asynchronously applied as soon as possible. Between the time of the request and the completion of the request, the <code>MasterUserPassword</code> element exists in the <code>PendingModifiedValues</code> element of the operation response. </p> <note> <p>Operations never return the password, so this operation provides a way to regain access to the master user account for a cluster if the password is lost.</p> </note> <p>Default: Uses existing setting.</p> <p>Constraints:</p> <ul> <li> <p>Must be between 8 and 64 characters in length.</p> </li> <li> <p>Must contain at least one uppercase letter.</p> </li> <li> <p>Must contain at least one lowercase letter.</p> </li> <li> <p>Must contain one number.</p> </li> <li> <p>Can be any printable ASCII character (ASCII code 33 to 126) except ' (single quote), \" (double quote), \\, /, @, or space.</p> </li> </ul>"]
+    #[serde(rename="MasterUserPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_user_password: Option<String>,
     #[doc="<p>The new identifier for the cluster.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>Alphabetic characters must be lowercase.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> <li> <p>Must be unique for all clusters within an AWS account.</p> </li> </ul> <p>Example: <code>examplecluster</code> </p>"]
+    #[serde(rename="NewClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_cluster_identifier: Option<String>,
     #[doc="<p>The new node type of the cluster. If you specify a new node type, you must also specify the number of nodes parameter.</p> <p>When you submit your request to resize a cluster, Amazon Redshift sets access permissions for the cluster to read-only. After Amazon Redshift provisions a new cluster according to your resize requirements, there will be a temporary outage while the old cluster is deleted and your connection is switched to the new cluster. When the new connection is complete, the original access permissions for the cluster are restored. You can use <a>DescribeResize</a> to track the progress of the resize request. </p> <p>Valid Values: <code> ds1.xlarge</code> | <code>ds1.8xlarge</code> | <code> ds2.xlarge</code> | <code>ds2.8xlarge</code> | <code>dc1.large</code> | <code>dc1.8xlarge</code>.</p>"]
+    #[serde(rename="NodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_type: Option<String>,
     #[doc="<p>The new number of nodes of the cluster. If you specify a new number of nodes, you must also specify the node type parameter.</p> <p>When you submit your request to resize a cluster, Amazon Redshift sets access permissions for the cluster to read-only. After Amazon Redshift provisions a new cluster according to your resize requirements, there will be a temporary outage while the old cluster is deleted and your connection is switched to the new cluster. When the new connection is complete, the original access permissions for the cluster are restored. You can use <a>DescribeResize</a> to track the progress of the resize request. </p> <p>Valid Values: Integer greater than <code>0</code>.</p>"]
+    #[serde(rename="NumberOfNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub number_of_nodes: Option<i64>,
     #[doc="<p>The weekly time range (in UTC) during which system maintenance can occur, if necessary. If system maintenance is necessary during the window, it may result in an outage.</p> <p>This maintenance window change is made immediately. If the new maintenance window indicates the current time, there must be at least 120 minutes between the current time and end of the window in order to ensure that pending changes are applied.</p> <p>Default: Uses existing setting.</p> <p>Format: ddd:hh24:mi-ddd:hh24:mi, for example <code>wed:07:30-wed:08:00</code>.</p> <p>Valid Days: Mon | Tue | Wed | Thu | Fri | Sat | Sun</p> <p>Constraints: Must be at least 30 minutes.</p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>If <code>true</code>, the cluster can be accessed from a public network. Only clusters in VPCs can be set to be publicly available.</p>"]
+    #[serde(rename="PubliclyAccessible")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub publicly_accessible: Option<bool>,
     #[doc="<p>A list of virtual private cloud (VPC) security groups to be associated with the cluster.</p>"]
+    #[serde(rename="VpcSecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_ids: Option<Vec<String>>,
 }
 
@@ -6804,11 +7510,13 @@ impl ModifyClusterMessageSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyClusterParameterGroupMessage {
     #[doc="<p>The name of the parameter group to be modified.</p>"]
+    #[serde(rename="ParameterGroupName")]
     pub parameter_group_name: String,
     #[doc="<p>An array of parameters to be modified. A maximum of 20 parameters can be modified in a single request.</p> <p>For each parameter to be modified, you must supply at least the parameter name and parameter value; other name-value pairs of the parameter are optional.</p> <p>For the workload management (WLM) configuration, you must supply all the name-value pairs in the wlm_json_configuration parameter.</p>"]
+    #[serde(rename="Parameters")]
     pub parameters: Vec<Parameter>,
 }
 
@@ -6831,8 +7539,10 @@ impl ModifyClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyClusterResult {
+    #[serde(rename="Cluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster: Option<Cluster>,
 }
 
@@ -6879,13 +7589,17 @@ impl ModifyClusterResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyClusterSubnetGroupMessage {
     #[doc="<p>The name of the subnet group to be modified.</p>"]
+    #[serde(rename="ClusterSubnetGroupName")]
     pub cluster_subnet_group_name: String,
     #[doc="<p>A text description of the subnet group to be modified.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>An array of VPC subnet IDs. A maximum of 20 subnets can be modified in a single request.</p>"]
+    #[serde(rename="SubnetIds")]
     pub subnet_ids: Vec<String>,
 }
 
@@ -6912,8 +7626,10 @@ impl ModifyClusterSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyClusterSubnetGroupResult {
+    #[serde(rename="ClusterSubnetGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_subnet_group: Option<ClusterSubnetGroup>,
 }
 
@@ -6961,21 +7677,34 @@ impl ModifyClusterSubnetGroupResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyEventSubscriptionMessage {
     #[doc="<p>A Boolean value indicating if the subscription is enabled. <code>true</code> indicates the subscription is enabled </p>"]
+    #[serde(rename="Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled: Option<bool>,
     #[doc="<p>Specifies the Amazon Redshift event categories to be published by the event notification subscription.</p> <p>Values: Configuration, Management, Monitoring, Security</p>"]
+    #[serde(rename="EventCategories")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_categories: Option<Vec<String>>,
     #[doc="<p>Specifies the Amazon Redshift event severity to be published by the event notification subscription.</p> <p>Values: ERROR, INFO</p>"]
+    #[serde(rename="Severity")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub severity: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the SNS topic to be used by the event notification subscription.</p>"]
+    #[serde(rename="SnsTopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sns_topic_arn: Option<String>,
     #[doc="<p>A list of one or more identifiers of Amazon Redshift source objects. All of the objects must be of the same type as was specified in the source type parameter. The event subscription will return only events generated by the specified objects. If not specified, then events are returned for all objects within the source type specified.</p> <p>Example: my-cluster-1, my-cluster-2</p> <p>Example: my-snapshot-20131010</p>"]
+    #[serde(rename="SourceIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_ids: Option<Vec<String>>,
     #[doc="<p>The type of source that will be generating the events. For example, if you want to be notified of events generated by a cluster, you would set this parameter to cluster. If this value is not specified, events are returned for all Amazon Redshift objects in your AWS account. You must specify a source type in order to specify source IDs.</p> <p>Valid values: cluster, cluster-parameter-group, cluster-security-group, and cluster-snapshot.</p>"]
+    #[serde(rename="SourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_type: Option<String>,
     #[doc="<p>The name of the modified Amazon Redshift event notification subscription.</p>"]
+    #[serde(rename="SubscriptionName")]
     pub subscription_name: String,
 }
 
@@ -7021,8 +7750,10 @@ impl ModifyEventSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyEventSubscriptionResult {
+    #[serde(rename="EventSubscription")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_subscription: Option<EventSubscription>,
 }
 
@@ -7070,11 +7801,13 @@ impl ModifyEventSubscriptionResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifySnapshotCopyRetentionPeriodMessage {
     #[doc="<p>The unique identifier of the cluster for which you want to change the retention period for automated snapshots that are copied to a destination region.</p> <p>Constraints: Must be the valid name of an existing cluster that has cross-region snapshot copy enabled.</p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
     #[doc="<p>The number of days to retain automated snapshots in the destination region after they are copied from the source region.</p> <p>If you decrease the retention period for automated snapshots that are copied to a destination region, Amazon Redshift will delete any existing automated snapshots that were copied to the destination region and that fall outside of the new retention period.</p> <p>Constraints: Must be at least 1 and no more than 35.</p>"]
+    #[serde(rename="RetentionPeriod")]
     pub retention_period: i64,
 }
 
@@ -7096,8 +7829,10 @@ impl ModifySnapshotCopyRetentionPeriodMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifySnapshotCopyRetentionPeriodResult {
+    #[serde(rename="Cluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster: Option<Cluster>,
 }
 
@@ -7145,15 +7880,23 @@ impl ModifySnapshotCopyRetentionPeriodResultDeserializer {
     }
 }
 #[doc="<p>Describes an orderable cluster option.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OrderableClusterOption {
     #[doc="<p>A list of availability zones for the orderable cluster.</p>"]
+    #[serde(rename="AvailabilityZones")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zones: Option<Vec<AvailabilityZone>>,
     #[doc="<p>The cluster type, for example <code>multi-node</code>. </p>"]
+    #[serde(rename="ClusterType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_type: Option<String>,
     #[doc="<p>The version of the orderable cluster.</p>"]
+    #[serde(rename="ClusterVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_version: Option<String>,
     #[doc="<p>The node type for the orderable cluster.</p>"]
+    #[serde(rename="NodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_type: Option<String>,
 }
 
@@ -7255,11 +7998,15 @@ impl OrderableClusterOptionsListDeserializer {
     }
 }
 #[doc="<p>Contains the output from the <a>DescribeOrderableClusterOptions</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OrderableClusterOptionsMessage {
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>An <code>OrderableClusterOption</code> structure containing information about orderable options for the cluster.</p>"]
+    #[serde(rename="OrderableClusterOptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub orderable_cluster_options: Option<Vec<OrderableClusterOption>>,
 }
 
@@ -7309,25 +8056,43 @@ impl OrderableClusterOptionsMessageDeserializer {
     }
 }
 #[doc="<p>Describes a parameter in a cluster parameter group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Parameter {
     #[doc="<p>The valid range of values for the parameter.</p>"]
+    #[serde(rename="AllowedValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allowed_values: Option<String>,
     #[doc="<p>Specifies how to apply the WLM configuration parameter. Some properties can be applied dynamically, while other properties require that any associated clusters be rebooted for the configuration changes to be applied. For more information about parameters and parameter groups, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html\">Amazon Redshift Parameter Groups</a> in the <i>Amazon Redshift Cluster Management Guide</i>.</p>"]
+    #[serde(rename="ApplyType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub apply_type: Option<String>,
     #[doc="<p>The data type of the parameter.</p>"]
+    #[serde(rename="DataType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub data_type: Option<String>,
     #[doc="<p>A description of the parameter.</p>"]
+    #[serde(rename="Description")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub description: Option<String>,
     #[doc="<p>If <code>true</code>, the parameter can be modified. Some parameters have security or operational implications that prevent them from being changed. </p>"]
+    #[serde(rename="IsModifiable")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_modifiable: Option<bool>,
     #[doc="<p>The earliest engine version to which the parameter can apply.</p>"]
+    #[serde(rename="MinimumEngineVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub minimum_engine_version: Option<String>,
     #[doc="<p>The name of the parameter.</p>"]
+    #[serde(rename="ParameterName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_name: Option<String>,
     #[doc="<p>The value of the parameter.</p>"]
+    #[serde(rename="ParameterValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameter_value: Option<String>,
     #[doc="<p>The source of the parameter value, such as \"engine-default\" or \"user\".</p>"]
+    #[serde(rename="Source")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source: Option<String>,
 }
 
@@ -7567,25 +8332,43 @@ impl ParametersListSerializer {
 }
 
 #[doc="<p>Describes cluster attributes that are in a pending state. A change to one or more the attributes was requested and is in progress or will be applied.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PendingModifiedValues {
     #[doc="<p>The pending or in-progress change of the automated snapshot retention period.</p>"]
+    #[serde(rename="AutomatedSnapshotRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub automated_snapshot_retention_period: Option<i64>,
     #[doc="<p>The pending or in-progress change of the new identifier for the cluster.</p>"]
+    #[serde(rename="ClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_identifier: Option<String>,
     #[doc="<p>The pending or in-progress change of the cluster type.</p>"]
+    #[serde(rename="ClusterType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_type: Option<String>,
     #[doc="<p>The pending or in-progress change of the service version.</p>"]
+    #[serde(rename="ClusterVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_version: Option<String>,
     #[doc="<p>An option that specifies whether to create the cluster with enhanced VPC routing enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in the Amazon Redshift Cluster Management Guide.</p> <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p> <p>Default: false</p>"]
+    #[serde(rename="EnhancedVpcRouting")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enhanced_vpc_routing: Option<bool>,
     #[doc="<p>The pending or in-progress change of the master user password for the cluster.</p>"]
+    #[serde(rename="MasterUserPassword")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_user_password: Option<String>,
     #[doc="<p>The pending or in-progress change of the cluster's node type.</p>"]
+    #[serde(rename="NodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_type: Option<String>,
     #[doc="<p>The pending or in-progress change of the number of nodes in the cluster.</p>"]
+    #[serde(rename="NumberOfNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub number_of_nodes: Option<i64>,
     #[doc="<p>The pending or in-progress change of the ability to connect to the cluster from the public network.</p>"]
+    #[serde(rename="PubliclyAccessible")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub publicly_accessible: Option<bool>,
 }
 
@@ -7671,11 +8454,14 @@ impl PendingModifiedValuesDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseReservedNodeOfferingMessage {
     #[doc="<p>The number of reserved nodes that you want to purchase.</p> <p>Default: <code>1</code> </p>"]
+    #[serde(rename="NodeCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_count: Option<i64>,
     #[doc="<p>The unique identifier of the reserved node offering you want to purchase.</p>"]
+    #[serde(rename="ReservedNodeOfferingId")]
     pub reserved_node_offering_id: String,
 }
 
@@ -7699,8 +8485,10 @@ impl PurchaseReservedNodeOfferingMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurchaseReservedNodeOfferingResult {
+    #[serde(rename="ReservedNode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_node: Option<ReservedNode>,
 }
 
@@ -7749,9 +8537,10 @@ impl PurchaseReservedNodeOfferingResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootClusterMessage {
     #[doc="<p>The cluster identifier.</p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
 }
 
@@ -7771,8 +8560,10 @@ impl RebootClusterMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootClusterResult {
+    #[serde(rename="Cluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster: Option<Cluster>,
 }
 
@@ -7819,11 +8610,15 @@ impl RebootClusterResultDeserializer {
     }
 }
 #[doc="<p>Describes a recurring charge.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecurringCharge {
     #[doc="<p>The amount charged per the period of time specified by the recurring charge frequency.</p>"]
+    #[serde(rename="RecurringChargeAmount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charge_amount: Option<f64>,
     #[doc="<p>The frequency at which the recurring charge amount is applied.</p>"]
+    #[serde(rename="RecurringChargeFrequency")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charge_frequency: Option<String>,
 }
 
@@ -7918,31 +8713,55 @@ impl RecurringChargeListDeserializer {
     }
 }
 #[doc="<p>Describes a reserved node. You can call the <a>DescribeReservedNodeOfferings</a> API to obtain the available reserved node offerings. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedNode {
     #[doc="<p>The currency code for the reserved cluster.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The duration of the node reservation in seconds.</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The fixed cost Amazon Redshift charges you for this reserved node.</p>"]
+    #[serde(rename="FixedPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fixed_price: Option<f64>,
     #[doc="<p>The number of reserved compute nodes.</p>"]
+    #[serde(rename="NodeCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_count: Option<i64>,
     #[doc="<p>The node type of the reserved node.</p>"]
+    #[serde(rename="NodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_type: Option<String>,
     #[doc="<p>The anticipated utilization of the reserved node, as defined in the reserved node offering.</p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The recurring charges for the reserved node.</p>"]
+    #[serde(rename="RecurringCharges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charges: Option<Vec<RecurringCharge>>,
     #[doc="<p>The unique identifier for the reservation.</p>"]
+    #[serde(rename="ReservedNodeId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_node_id: Option<String>,
     #[doc="<p>The identifier for the reserved node offering.</p>"]
+    #[serde(rename="ReservedNodeOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_node_offering_id: Option<String>,
     #[doc="<p>The time the reservation started. You purchase a reserved node offering for a duration. This is the start time of that duration.</p>"]
+    #[serde(rename="StartTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_time: Option<String>,
     #[doc="<p>The state of the reserved compute node.</p> <p>Possible Values:</p> <ul> <li> <p>pending-payment-This reserved node has recently been purchased, and the sale has been approved, but payment has not yet been confirmed.</p> </li> <li> <p>active-This reserved node is owned by the caller and is available for use.</p> </li> <li> <p>payment-failed-Payment failed for the purchase attempt.</p> </li> </ul>"]
+    #[serde(rename="State")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub state: Option<String>,
     #[doc="<p>The hourly rate Amazon Redshift charges you for this reserved node.</p>"]
+    #[serde(rename="UsagePrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub usage_price: Option<f64>,
 }
 
@@ -8077,23 +8896,39 @@ impl ReservedNodeListDeserializer {
     }
 }
 #[doc="<p>Describes a reserved node offering.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedNodeOffering {
     #[doc="<p>The currency code for the compute nodes offering.</p>"]
+    #[serde(rename="CurrencyCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub currency_code: Option<String>,
     #[doc="<p>The duration, in seconds, for which the offering will reserve the node.</p>"]
+    #[serde(rename="Duration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration: Option<i64>,
     #[doc="<p>The upfront fixed charge you will pay to purchase the specific reserved node offering.</p>"]
+    #[serde(rename="FixedPrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fixed_price: Option<f64>,
     #[doc="<p>The node type offered by the reserved node offering.</p>"]
+    #[serde(rename="NodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_type: Option<String>,
     #[doc="<p>The anticipated utilization of the reserved node, as defined in the reserved node offering.</p>"]
+    #[serde(rename="OfferingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub offering_type: Option<String>,
     #[doc="<p>The charge to your account regardless of whether you are creating any clusters using the node offering. Recurring charges are only in effect for heavy-utilization reserved nodes.</p>"]
+    #[serde(rename="RecurringCharges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recurring_charges: Option<Vec<RecurringCharge>>,
     #[doc="<p>The offering identifier.</p>"]
+    #[serde(rename="ReservedNodeOfferingId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_node_offering_id: Option<String>,
     #[doc="<p>The rate you are charged for each hour the cluster that is using the offering is running.</p>"]
+    #[serde(rename="UsagePrice")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub usage_price: Option<f64>,
 }
 
@@ -8211,11 +9046,15 @@ impl ReservedNodeOfferingListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedNodeOfferingsMessage {
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of <code>ReservedNodeOffering</code> objects.</p>"]
+    #[serde(rename="ReservedNodeOfferings")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_node_offerings: Option<Vec<ReservedNodeOffering>>,
 }
 
@@ -8265,11 +9104,15 @@ impl ReservedNodeOfferingsMessageDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReservedNodesMessage {
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The list of <code>ReservedNode</code> objects.</p>"]
+    #[serde(rename="ReservedNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reserved_nodes: Option<Vec<ReservedNode>>,
 }
 
@@ -8321,13 +9164,18 @@ impl ReservedNodesMessageDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetClusterParameterGroupMessage {
     #[doc="<p>The name of the cluster parameter group to be reset.</p>"]
+    #[serde(rename="ParameterGroupName")]
     pub parameter_group_name: String,
     #[doc="<p>An array of names of parameters to be reset. If <i>ResetAllParameters</i> option is not used, then at least one parameter name must be supplied. </p> <p>Constraints: A maximum of 20 parameters can be reset in a single request.</p>"]
+    #[serde(rename="Parameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
     #[doc="<p>If <code>true</code>, all parameters in the specified parameter group will be reset to their default values. </p> <p>Default: <code>true</code> </p>"]
+    #[serde(rename="ResetAllParameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reset_all_parameters: Option<bool>,
 }
 
@@ -8357,31 +9205,55 @@ impl ResetClusterParameterGroupMessageSerializer {
 }
 
 #[doc="<p>Describes the result of a cluster resize operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResizeProgressMessage {
     #[doc="<p>The average rate of the resize operation over the last few minutes, measured in megabytes per second. After the resize operation completes, this value shows the average rate of the entire resize operation.</p>"]
+    #[serde(rename="AvgResizeRateInMegaBytesPerSecond")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub avg_resize_rate_in_mega_bytes_per_second: Option<f64>,
     #[doc="<p>The amount of seconds that have elapsed since the resize operation began. After the resize operation completes, this value shows the total actual time, in seconds, for the resize operation.</p>"]
+    #[serde(rename="ElapsedTimeInSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elapsed_time_in_seconds: Option<i64>,
     #[doc="<p>The estimated time remaining, in seconds, until the resize operation is complete. This value is calculated based on the average resize rate and the estimated amount of data remaining to be processed. Once the resize operation is complete, this value will be 0.</p>"]
+    #[serde(rename="EstimatedTimeToCompletionInSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub estimated_time_to_completion_in_seconds: Option<i64>,
     #[doc="<p>The names of tables that have been completely imported .</p> <p>Valid Values: List of table names.</p>"]
+    #[serde(rename="ImportTablesCompleted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_tables_completed: Option<Vec<String>>,
     #[doc="<p>The names of tables that are being currently imported.</p> <p>Valid Values: List of table names.</p>"]
+    #[serde(rename="ImportTablesInProgress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_tables_in_progress: Option<Vec<String>>,
     #[doc="<p>The names of tables that have not been yet imported.</p> <p>Valid Values: List of table names</p>"]
+    #[serde(rename="ImportTablesNotStarted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub import_tables_not_started: Option<Vec<String>>,
     #[doc="<p>While the resize operation is in progress, this value shows the current amount of data, in megabytes, that has been processed so far. When the resize operation is complete, this value shows the total amount of data, in megabytes, on the cluster, which may be more or less than TotalResizeDataInMegaBytes (the estimated total amount of data before resize).</p>"]
+    #[serde(rename="ProgressInMegaBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress_in_mega_bytes: Option<i64>,
     #[doc="<p>The status of the resize operation.</p> <p>Valid Values: <code>NONE</code> | <code>IN_PROGRESS</code> | <code>FAILED</code> | <code>SUCCEEDED</code> </p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The cluster type after the resize operation is complete.</p> <p>Valid Values: <code>multi-node</code> | <code>single-node</code> </p>"]
+    #[serde(rename="TargetClusterType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_cluster_type: Option<String>,
     #[doc="<p>The node type that the cluster will have after the resize operation is complete.</p>"]
+    #[serde(rename="TargetNodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_node_type: Option<String>,
     #[doc="<p>The number of nodes that the cluster will have after the resize operation is complete.</p>"]
+    #[serde(rename="TargetNumberOfNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_number_of_nodes: Option<i64>,
     #[doc="<p>The estimated total amount of data, in megabytes, on the cluster before the resize operation began.</p>"]
+    #[serde(rename="TotalResizeDataInMegaBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub total_resize_data_in_mega_bytes: Option<i64>,
 }
 
@@ -8524,51 +9396,93 @@ impl RestorableNodeTypeListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreFromClusterSnapshotMessage {
     #[doc="<p>Reserved.</p>"]
+    #[serde(rename="AdditionalInfo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub additional_info: Option<String>,
     #[doc="<p>If <code>true</code>, major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster. </p> <p>Default: <code>true</code> </p>"]
+    #[serde(rename="AllowVersionUpgrade")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allow_version_upgrade: Option<bool>,
     #[doc="<p>The number of days that automated snapshots are retained. If the value is 0, automated snapshots are disabled. Even if automated snapshots are disabled, you can still create manual snapshots when you want with <a>CreateClusterSnapshot</a>. </p> <p>Default: The value selected for the cluster from which the snapshot was taken.</p> <p>Constraints: Must be a value from 0 to 35.</p>"]
+    #[serde(rename="AutomatedSnapshotRetentionPeriod")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub automated_snapshot_retention_period: Option<i64>,
     #[doc="<p>The Amazon EC2 Availability Zone in which to restore the cluster.</p> <p>Default: A random, system-chosen Availability Zone.</p> <p>Example: <code>us-east-1a</code> </p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The identifier of the cluster that will be created from restoring the snapshot.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>Alphabetic characters must be lowercase.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> <li> <p>Must be unique for all clusters within an AWS account.</p> </li> </ul>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
     #[doc="<p>The name of the parameter group to be associated with this cluster.</p> <p>Default: The default Amazon Redshift cluster parameter group. For information about the default parameter group, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html\">Working with Amazon Redshift Parameter Groups</a>.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>"]
+    #[serde(rename="ClusterParameterGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_parameter_group_name: Option<String>,
     #[doc="<p>A list of security groups to be associated with this cluster.</p> <p>Default: The default cluster security group for Amazon Redshift.</p> <p>Cluster security groups only apply to clusters outside of VPCs.</p>"]
+    #[serde(rename="ClusterSecurityGroups")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_security_groups: Option<Vec<String>>,
     #[doc="<p>The name of the subnet group where you want to cluster restored.</p> <p>A snapshot of cluster in VPC can be restored only in VPC. Therefore, you must provide subnet group name where you want the cluster restored.</p>"]
+    #[serde(rename="ClusterSubnetGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_subnet_group_name: Option<String>,
     #[doc="<p>The elastic IP (EIP) address for the cluster.</p>"]
+    #[serde(rename="ElasticIp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elastic_ip: Option<String>,
     #[doc="<p>An option that specifies whether to create the cluster with enhanced VPC routing enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in the Amazon Redshift Cluster Management Guide.</p> <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p> <p>Default: false</p>"]
+    #[serde(rename="EnhancedVpcRouting")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enhanced_vpc_routing: Option<bool>,
     #[doc="<p>Specifies the name of the HSM client certificate the Amazon Redshift cluster uses to retrieve the data encryption keys stored in an HSM.</p>"]
+    #[serde(rename="HsmClientCertificateIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_client_certificate_identifier: Option<String>,
     #[doc="<p>Specifies the name of the HSM configuration that contains the information the Amazon Redshift cluster can use to retrieve and store keys in an HSM.</p>"]
+    #[serde(rename="HsmConfigurationIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hsm_configuration_identifier: Option<String>,
     #[doc="<p>A list of AWS Identity and Access Management (IAM) roles that can be used by the cluster to access other AWS services. You must supply the IAM roles in their Amazon Resource Name (ARN) format. You can supply up to 10 IAM roles in a single request.</p> <p>A cluster can have up to 10 IAM roles associated at any time.</p>"]
+    #[serde(rename="IamRoles")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub iam_roles: Option<Vec<String>>,
     #[doc="<p>The AWS Key Management Service (KMS) key ID of the encryption key that you want to use to encrypt data in the cluster that you restore from a shared snapshot.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The node type that the restored cluster will be provisioned with.</p> <p>Default: The node type of the cluster from which the snapshot was taken. You can modify this if you are using any DS node type. In that case, you can choose to restore into another DS node type of the same size. For example, you can restore ds1.8xlarge into ds2.8xlarge, or ds2.xlarge into ds1.xlarge. If you have a DC instance type, you must restore into that same instance type and size. In other words, you can only restore a dc1.large instance type into another dc1.large instance type. For more information about node types, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#rs-about-clusters-and-nodes\"> About Clusters and Nodes</a> in the <i>Amazon Redshift Cluster Management Guide</i> </p>"]
+    #[serde(rename="NodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_type: Option<String>,
     #[doc="<p>The AWS customer account used to create or copy the snapshot. Required if you are restoring a snapshot you do not own, optional if you own the snapshot.</p>"]
+    #[serde(rename="OwnerAccount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_account: Option<String>,
     #[doc="<p>The port number on which the cluster accepts connections.</p> <p>Default: The same port as the original cluster.</p> <p>Constraints: Must be between <code>1115</code> and <code>65535</code>.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The weekly time range (in UTC) during which automated cluster maintenance can occur.</p> <p> Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p> Default: The value selected for the cluster from which the snapshot was taken. For more information about the time blocks for each region, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#rs-maintenance-windows\">Maintenance Windows</a> in Amazon Redshift Cluster Management Guide. </p> <p>Valid Days: Mon | Tue | Wed | Thu | Fri | Sat | Sun</p> <p>Constraints: Minimum 30-minute window.</p>"]
+    #[serde(rename="PreferredMaintenanceWindow")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub preferred_maintenance_window: Option<String>,
     #[doc="<p>If <code>true</code>, the cluster can be accessed from a public network. </p>"]
+    #[serde(rename="PubliclyAccessible")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub publicly_accessible: Option<bool>,
     #[doc="<p>The name of the cluster the source snapshot was created from. This parameter is required if your IAM user has a policy containing a snapshot resource element that specifies anything other than * for the cluster name.</p>"]
+    #[serde(rename="SnapshotClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_cluster_identifier: Option<String>,
     #[doc="<p>The name of the snapshot from which to create the new cluster. This parameter isn't case sensitive.</p> <p>Example: <code>my-snapshot-id</code> </p>"]
+    #[serde(rename="SnapshotIdentifier")]
     pub snapshot_identifier: String,
     #[doc="<p>A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster.</p> <p>Default: The default VPC security group is associated with the cluster.</p> <p>VPC security groups only apply to clusters in VPCs.</p>"]
+    #[serde(rename="VpcSecurityGroupIds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_ids: Option<Vec<String>>,
 }
 
@@ -8677,8 +9591,10 @@ impl RestoreFromClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreFromClusterSnapshotResult {
+    #[serde(rename="Cluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster: Option<Cluster>,
 }
 
@@ -8726,19 +9642,31 @@ impl RestoreFromClusterSnapshotResultDeserializer {
     }
 }
 #[doc="<p>Describes the status of a cluster restore action. Returns null if the cluster was not created by restoring a snapshot.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreStatus {
     #[doc="<p>The number of megabytes per second being transferred from the backup storage. Returns the average rate for a completed backup.</p>"]
+    #[serde(rename="CurrentRestoreRateInMegaBytesPerSecond")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub current_restore_rate_in_mega_bytes_per_second: Option<f64>,
     #[doc="<p>The amount of time an in-progress restore has been running, or the amount of time it took a completed restore to finish.</p>"]
+    #[serde(rename="ElapsedTimeInSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elapsed_time_in_seconds: Option<i64>,
     #[doc="<p>The estimate of the time remaining before the restore will complete. Returns 0 for a completed restore.</p>"]
+    #[serde(rename="EstimatedTimeToCompletionInSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub estimated_time_to_completion_in_seconds: Option<i64>,
     #[doc="<p>The number of megabytes that have been transferred from snapshot storage.</p>"]
+    #[serde(rename="ProgressInMegaBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress_in_mega_bytes: Option<i64>,
     #[doc="<p>The size of the set of snapshot data used to restore the cluster.</p>"]
+    #[serde(rename="SnapshotSizeInMegaBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_size_in_mega_bytes: Option<i64>,
     #[doc="<p>The status of the restore action. Returns starting, restoring, completed, or failed.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -8810,23 +9738,34 @@ impl RestoreStatusDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreTableFromClusterSnapshotMessage {
     #[doc="<p>The identifier of the Amazon Redshift cluster to restore the table to.</p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
     #[doc="<p>The name of the table to create as a result of the current request.</p>"]
+    #[serde(rename="NewTableName")]
     pub new_table_name: String,
     #[doc="<p>The identifier of the snapshot to restore the table from. This snapshot must have been created from the Amazon Redshift cluster specified by the <code>ClusterIdentifier</code> parameter.</p>"]
+    #[serde(rename="SnapshotIdentifier")]
     pub snapshot_identifier: String,
     #[doc="<p>The name of the source database that contains the table to restore from.</p>"]
+    #[serde(rename="SourceDatabaseName")]
     pub source_database_name: String,
     #[doc="<p>The name of the source schema that contains the table to restore from. If you do not specify a <code>SourceSchemaName</code> value, the default is <code>public</code>.</p>"]
+    #[serde(rename="SourceSchemaName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_schema_name: Option<String>,
     #[doc="<p>The name of the source table to restore from.</p>"]
+    #[serde(rename="SourceTableName")]
     pub source_table_name: String,
     #[doc="<p>The name of the database to restore the table to.</p>"]
+    #[serde(rename="TargetDatabaseName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_database_name: Option<String>,
     #[doc="<p>The name of the schema to restore the table to.</p>"]
+    #[serde(rename="TargetSchemaName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_schema_name: Option<String>,
 }
 
@@ -8866,8 +9805,10 @@ impl RestoreTableFromClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RestoreTableFromClusterSnapshotResult {
+    #[serde(rename="TableRestoreStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub table_restore_status: Option<TableRestoreStatus>,
 }
 
@@ -8916,15 +9857,22 @@ impl RestoreTableFromClusterSnapshotResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevokeClusterSecurityGroupIngressMessage {
     #[doc="<p>The IP range for which to revoke access. This range must be a valid Classless Inter-Domain Routing (CIDR) block of IP addresses. If <code>CIDRIP</code> is specified, <code>EC2SecurityGroupName</code> and <code>EC2SecurityGroupOwnerId</code> cannot be provided. </p>"]
+    #[serde(rename="CIDRIP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cidrip: Option<String>,
     #[doc="<p>The name of the security Group from which to revoke the ingress rule.</p>"]
+    #[serde(rename="ClusterSecurityGroupName")]
     pub cluster_security_group_name: String,
     #[doc="<p>The name of the EC2 Security Group whose access is to be revoked. If <code>EC2SecurityGroupName</code> is specified, <code>EC2SecurityGroupOwnerId</code> must also be provided and <code>CIDRIP</code> cannot be provided. </p>"]
+    #[serde(rename="EC2SecurityGroupName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_name: Option<String>,
     #[doc="<p>The AWS account number of the owner of the security group specified in the <code>EC2SecurityGroupName</code> parameter. The AWS access key ID is not an acceptable value. If <code>EC2SecurityGroupOwnerId</code> is specified, <code>EC2SecurityGroupName</code> must also be provided. and <code>CIDRIP</code> cannot be provided. </p> <p>Example: <code>111122223333</code> </p>"]
+    #[serde(rename="EC2SecurityGroupOwnerId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ec2_security_group_owner_id: Option<String>,
 }
 
@@ -8956,8 +9904,10 @@ impl RevokeClusterSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevokeClusterSecurityGroupIngressResult {
+    #[serde(rename="ClusterSecurityGroup")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_security_group: Option<ClusterSecurityGroup>,
 }
 
@@ -9006,13 +9956,17 @@ impl RevokeClusterSecurityGroupIngressResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevokeSnapshotAccessMessage {
     #[doc="<p>The identifier of the AWS customer account that can no longer restore the specified snapshot.</p>"]
+    #[serde(rename="AccountWithRestoreAccess")]
     pub account_with_restore_access: String,
     #[doc="<p>The identifier of the cluster the snapshot was created from. This parameter is required if your IAM user has a policy containing a snapshot resource element that specifies anything other than * for the cluster name.</p>"]
+    #[serde(rename="SnapshotClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_cluster_identifier: Option<String>,
     #[doc="<p>The identifier of the snapshot that the account can no longer access.</p>"]
+    #[serde(rename="SnapshotIdentifier")]
     pub snapshot_identifier: String,
 }
 
@@ -9038,8 +9992,10 @@ impl RevokeSnapshotAccessMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RevokeSnapshotAccessResult {
+    #[serde(rename="Snapshot")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot: Option<Snapshot>,
 }
 
@@ -9086,9 +10042,10 @@ impl RevokeSnapshotAccessResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RotateEncryptionKeyMessage {
     #[doc="<p>The unique identifier of the cluster that you want to rotate the encryption keys for.</p> <p>Constraints: Must be the name of valid cluster that has encryption enabled.</p>"]
+    #[serde(rename="ClusterIdentifier")]
     pub cluster_identifier: String,
 }
 
@@ -9108,8 +10065,10 @@ impl RotateEncryptionKeyMessageSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RotateEncryptionKeyResult {
+    #[serde(rename="Cluster")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster: Option<Cluster>,
 }
 
@@ -9170,65 +10129,123 @@ impl SensitiveStringDeserializer {
     }
 }
 #[doc="<p>Describes a snapshot.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Snapshot {
     #[doc="<p>A list of the AWS customer accounts authorized to restore the snapshot. Returns <code>null</code> if no accounts are authorized. Visible only to the snapshot owner. </p>"]
+    #[serde(rename="AccountsWithRestoreAccess")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub accounts_with_restore_access: Option<Vec<AccountWithRestoreAccess>>,
     #[doc="<p>The size of the incremental backup.</p>"]
+    #[serde(rename="ActualIncrementalBackupSizeInMegaBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub actual_incremental_backup_size_in_mega_bytes: Option<f64>,
     #[doc="<p>The Availability Zone in which the cluster was created.</p>"]
+    #[serde(rename="AvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub availability_zone: Option<String>,
     #[doc="<p>The number of megabytes that have been transferred to the snapshot backup.</p>"]
+    #[serde(rename="BackupProgressInMegaBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub backup_progress_in_mega_bytes: Option<f64>,
     #[doc="<p>The time (UTC) when the cluster was originally created.</p>"]
+    #[serde(rename="ClusterCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_create_time: Option<String>,
     #[doc="<p>The identifier of the cluster for which the snapshot was taken.</p>"]
+    #[serde(rename="ClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_identifier: Option<String>,
     #[doc="<p>The version ID of the Amazon Redshift engine that is running on the cluster.</p>"]
+    #[serde(rename="ClusterVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_version: Option<String>,
     #[doc="<p>The number of megabytes per second being transferred to the snapshot backup. Returns <code>0</code> for a completed backup. </p>"]
+    #[serde(rename="CurrentBackupRateInMegaBytesPerSecond")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub current_backup_rate_in_mega_bytes_per_second: Option<f64>,
     #[doc="<p>The name of the database that was created when the cluster was created.</p>"]
+    #[serde(rename="DBName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub db_name: Option<String>,
     #[doc="<p>The amount of time an in-progress snapshot backup has been running, or the amount of time it took a completed backup to finish.</p>"]
+    #[serde(rename="ElapsedTimeInSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub elapsed_time_in_seconds: Option<i64>,
     #[doc="<p>If <code>true</code>, the data in the snapshot is encrypted at rest.</p>"]
+    #[serde(rename="Encrypted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted: Option<bool>,
     #[doc="<p>A boolean that indicates whether the snapshot data is encrypted using the HSM keys of the source cluster. <code>true</code> indicates that the data is encrypted using HSM keys.</p>"]
+    #[serde(rename="EncryptedWithHSM")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encrypted_with_hsm: Option<bool>,
     #[doc="<p>An option that specifies whether to create the cluster with enhanced VPC routing enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in the Amazon Redshift Cluster Management Guide.</p> <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p> <p>Default: false</p>"]
+    #[serde(rename="EnhancedVpcRouting")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enhanced_vpc_routing: Option<bool>,
     #[doc="<p>The estimate of the time remaining before the snapshot backup will complete. Returns <code>0</code> for a completed backup. </p>"]
+    #[serde(rename="EstimatedSecondsToCompletion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub estimated_seconds_to_completion: Option<i64>,
     #[doc="<p>The AWS Key Management Service (KMS) key ID of the encryption key that was used to encrypt data in the cluster from which the snapshot was taken.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The master user name for the cluster.</p>"]
+    #[serde(rename="MasterUsername")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub master_username: Option<String>,
     #[doc="<p>The node type of the nodes in the cluster.</p>"]
+    #[serde(rename="NodeType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub node_type: Option<String>,
     #[doc="<p>The number of nodes in the cluster.</p>"]
+    #[serde(rename="NumberOfNodes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub number_of_nodes: Option<i64>,
     #[doc="<p>For manual snapshots, the AWS customer account used to create or copy the snapshot. For automatic snapshots, the owner of the cluster. The owner can perform all snapshot actions, such as sharing a manual snapshot.</p>"]
+    #[serde(rename="OwnerAccount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner_account: Option<String>,
     #[doc="<p>The port that the cluster is listening on.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>The list of node types that this cluster snapshot is able to restore into.</p>"]
+    #[serde(rename="RestorableNodeTypes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub restorable_node_types: Option<Vec<String>>,
     #[doc="<p>The time (UTC) when Amazon Redshift began the snapshot. A snapshot contains a copy of the cluster data as of this exact time.</p>"]
+    #[serde(rename="SnapshotCreateTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_create_time: Option<String>,
     #[doc="<p>The snapshot identifier that is provided in the request.</p>"]
+    #[serde(rename="SnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_identifier: Option<String>,
     #[doc="<p>The snapshot type. Snapshots created using <a>CreateClusterSnapshot</a> and <a>CopyClusterSnapshot</a> will be of type \"manual\". </p>"]
+    #[serde(rename="SnapshotType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_type: Option<String>,
     #[doc="<p>The source region from which the snapshot was copied.</p>"]
+    #[serde(rename="SourceRegion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_region: Option<String>,
     #[doc="<p>The snapshot status. The value of the status depends on the API operation used. </p> <ul> <li> <p> <a>CreateClusterSnapshot</a> and <a>CopyClusterSnapshot</a> returns status as \"creating\". </p> </li> <li> <p> <a>DescribeClusterSnapshots</a> returns status as \"creating\", \"available\", \"final snapshot\", or \"failed\".</p> </li> <li> <p> <a>DeleteClusterSnapshot</a> returns status as \"deleted\".</p> </li> </ul>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The list of tags for the cluster snapshot.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
     #[doc="<p>The size of the complete set of backup data that would be used to restore the cluster.</p>"]
+    #[serde(rename="TotalBackupSizeInMegaBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub total_backup_size_in_mega_bytes: Option<f64>,
     #[doc="<p>The VPC identifier of the cluster if the snapshot is from a cluster in a VPC. Otherwise, this field is not in the output.</p>"]
+    #[serde(rename="VpcId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
 }
 
@@ -9401,13 +10418,19 @@ impl SnapshotDeserializer {
     }
 }
 #[doc="<p>The snapshot copy grant that grants Amazon Redshift permission to encrypt copied snapshots with the specified customer master key (CMK) from AWS KMS in the destination region.</p> <p> For more information about managing snapshot copy grants, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-db-encryption.html\">Amazon Redshift Database Encryption</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SnapshotCopyGrant {
     #[doc="<p>The unique identifier of the customer master key (CMK) in AWS KMS to which Amazon Redshift is granted permission.</p>"]
+    #[serde(rename="KmsKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_id: Option<String>,
     #[doc="<p>The name of the snapshot copy grant.</p>"]
+    #[serde(rename="SnapshotCopyGrantName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_copy_grant_name: Option<String>,
     #[doc="<p>A list of tag instances.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -9503,11 +10526,15 @@ impl SnapshotCopyGrantListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SnapshotCopyGrantMessage {
     #[doc="<p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <code>DescribeSnapshotCopyGrant</code> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p> <p>Constraints: You can specify either the <b>SnapshotCopyGrantName</b> parameter or the <b>Marker</b> parameter, but not both. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The list of <code>SnapshotCopyGrant</code> objects.</p>"]
+    #[serde(rename="SnapshotCopyGrants")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_copy_grants: Option<Vec<SnapshotCopyGrant>>,
 }
 
@@ -9600,11 +10627,15 @@ impl SnapshotListDeserializer {
     }
 }
 #[doc="<p>Contains the output from the <a>DescribeClusterSnapshots</a> action. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SnapshotMessage {
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of <a>Snapshot</a> instances. </p>"]
+    #[serde(rename="Snapshots")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshots: Option<Vec<Snapshot>>,
 }
 
@@ -9737,12 +10768,18 @@ impl StringDeserializer {
     }
 }
 #[doc="<p>Describes a subnet.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Subnet {
+    #[serde(rename="SubnetAvailabilityZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_availability_zone: Option<AvailabilityZone>,
     #[doc="<p>The identifier of the subnet.</p>"]
+    #[serde(rename="SubnetIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_identifier: Option<String>,
     #[doc="<p>The status of the subnet.</p>"]
+    #[serde(rename="SubnetStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subnet_status: Option<String>,
 }
 
@@ -9866,35 +10903,63 @@ impl TStampDeserializer {
     }
 }
 #[doc="<p>Describes the status of a <a>RestoreTableFromClusterSnapshot</a> operation.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TableRestoreStatus {
     #[doc="<p>The identifier of the Amazon Redshift cluster that the table is being restored to.</p>"]
+    #[serde(rename="ClusterIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cluster_identifier: Option<String>,
     #[doc="<p>A description of the status of the table restore request. Status values include <code>SUCCEEDED</code>, <code>FAILED</code>, <code>CANCELED</code>, <code>PENDING</code>, <code>IN_PROGRESS</code>.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
     #[doc="<p>The name of the table to create as a result of the table restore request.</p>"]
+    #[serde(rename="NewTableName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub new_table_name: Option<String>,
     #[doc="<p>The amount of data restored to the new table so far, in megabytes (MB).</p>"]
+    #[serde(rename="ProgressInMegaBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub progress_in_mega_bytes: Option<i64>,
     #[doc="<p>The time that the table restore request was made, in Universal Coordinated Time (UTC).</p>"]
+    #[serde(rename="RequestTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_time: Option<String>,
     #[doc="<p>The identifier of the snapshot that the table is being restored from.</p>"]
+    #[serde(rename="SnapshotIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub snapshot_identifier: Option<String>,
     #[doc="<p>The name of the source database that contains the table being restored.</p>"]
+    #[serde(rename="SourceDatabaseName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_database_name: Option<String>,
     #[doc="<p>The name of the source schema that contains the table being restored.</p>"]
+    #[serde(rename="SourceSchemaName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_schema_name: Option<String>,
     #[doc="<p>The name of the source table being restored.</p>"]
+    #[serde(rename="SourceTableName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_table_name: Option<String>,
     #[doc="<p>A value that describes the current state of the table restore request.</p> <p>Valid Values: <code>SUCCEEDED</code>, <code>FAILED</code>, <code>CANCELED</code>, <code>PENDING</code>, <code>IN_PROGRESS</code> </p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The unique identifier for the table restore request.</p>"]
+    #[serde(rename="TableRestoreRequestId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub table_restore_request_id: Option<String>,
     #[doc="<p>The name of the database to restore the table to.</p>"]
+    #[serde(rename="TargetDatabaseName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_database_name: Option<String>,
     #[doc="<p>The name of the schema to restore the table to.</p>"]
+    #[serde(rename="TargetSchemaName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_schema_name: Option<String>,
     #[doc="<p>The total amount of data to restore to the new table, in megabytes (MB).</p>"]
+    #[serde(rename="TotalDataInMegaBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub total_data_in_mega_bytes: Option<i64>,
 }
 
@@ -10045,11 +11110,15 @@ impl TableRestoreStatusListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TableRestoreStatusMessage {
     #[doc="<p>A pagination token that can be used in a subsequent <a>DescribeTableRestoreStatus</a> request.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of status details for one or more table restore requests.</p>"]
+    #[serde(rename="TableRestoreStatusDetails")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub table_restore_status_details: Option<Vec<TableRestoreStatus>>,
 }
 
@@ -10115,11 +11184,15 @@ impl TableRestoreStatusTypeDeserializer {
     }
 }
 #[doc="<p>A tag consisting of a name/value pair for a resource.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>The key, or name, for the resource tag.</p>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>The value for the resource tag.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -10267,13 +11340,19 @@ impl TagValueListSerializer {
 }
 
 #[doc="<p>A tag and its associated resource.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TaggedResource {
     #[doc="<p>The Amazon Resource Name (ARN) with which the tag is associated. For example, <code>arn:aws:redshift:us-east-1:123456789:cluster:t1</code>.</p>"]
+    #[serde(rename="ResourceName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_name: Option<String>,
     #[doc="<p>The type of resource with which the tag is associated. Valid resource types are: </p> <ul> <li> <p>Cluster</p> </li> <li> <p>CIDR/IP</p> </li> <li> <p>EC2 security group</p> </li> <li> <p>Snapshot</p> </li> <li> <p>Cluster security group</p> </li> <li> <p>Subnet group</p> </li> <li> <p>HSM connection</p> </li> <li> <p>HSM certificate</p> </li> <li> <p>Parameter group</p> </li> </ul> <p>For more information about Amazon Redshift resource types and constructing ARNs, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/constructing-redshift-arn.html\">Constructing an Amazon Redshift Amazon Resource Name (ARN)</a> in the Amazon Redshift Cluster Management Guide. </p>"]
+    #[serde(rename="ResourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
     #[doc="<p>The tag for the resource.</p>"]
+    #[serde(rename="Tag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag: Option<Tag>,
 }
 
@@ -10369,11 +11448,15 @@ impl TaggedResourceListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TaggedResourceListMessage {
     #[doc="<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>A list of tags with their associated resources.</p>"]
+    #[serde(rename="TaggedResources")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tagged_resources: Option<Vec<TaggedResource>>,
 }
 
@@ -10437,11 +11520,15 @@ impl VpcSecurityGroupIdListSerializer {
 }
 
 #[doc="<p>Describes the members of a VPC security group.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VpcSecurityGroupMembership {
     #[doc="<p>The status of the VPC security group.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
     #[doc="<p>The identifier of the VPC security group.</p>"]
+    #[serde(rename="VpcSecurityGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_security_group_id: Option<String>,
 }
 

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Structure containing the estimated age range, in years, for a face.</p> <p>Rekognition estimates an age-range for faces detected in the input image. Estimated age ranges can overlap; a face of a 5 year old may have an estimated range of 4-6 whilst the face of a 6 year old may have an estimated range of 4-8.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AgeRange {
     #[doc="<p>The highest estimated age.</p>"]
     #[serde(rename="High")]
@@ -42,7 +42,7 @@ pub struct AgeRange {
 }
 
 #[doc="<p>Indicates whether or not the face has a beard, and the confidence level in the determination.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Beard {
     #[doc="<p>Level of confidence in the determination.</p>"]
     #[serde(rename="Confidence")]
@@ -55,7 +55,7 @@ pub struct Beard {
 }
 
 #[doc="<p>Identifies the bounding box around the object or face. The <code>left</code> (x-coordinate) and <code>top</code> (y-coordinate) are coordinates representing the top and left sides of the bounding box. Note that the upper-left corner of the image is the origin (0,0). </p> <p>The <code>top</code> and <code>left</code> values returned are ratios of the overall image size. For example, if the input image is 700x200 pixels, and the top-left coordinate of the bounding box is 350x50 pixels, the API returns a <code>left</code> value of 0.5 (350/700) and a <code>top</code> value of 0.25 (50/200).</p> <p> The <code>width</code> and <code>height</code> values represent the dimensions of the bounding box as a ratio of the overall image dimension. For example, if the input image is 700x200 pixels, and the bounding box width is 70 pixels, the width returned is 0.1. </p> <note> <p> The bounding box coordinates can have negative values. For example, if Amazon Rekognition is able to detect a face that is at the image edge and is only partially visible, the service can return coordinates that are outside the image bounds and, depending on the image edge, you might get negative values or values greater than 1 for the <code>left</code> or <code>top</code> values. </p> </note>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BoundingBox {
     #[doc="<p>Height of the bounding box as a ratio of the overall image height.</p>"]
     #[serde(rename="Height")]
@@ -76,7 +76,7 @@ pub struct BoundingBox {
 }
 
 #[doc="<p>Provides information about a celebrity recognized by the operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Celebrity {
     #[doc="<p>Provides information about the celebrity's face, such as its location on the image.</p>"]
     #[serde(rename="Face")]
@@ -101,7 +101,7 @@ pub struct Celebrity {
 }
 
 #[doc="<p>Provides information about a face in a target image that matches the source image face analysed by <code>CompareFaces</code>. The <code>Face</code> property contains the bounding box of the face in the target image. The <code>Similarity</code> property is the confidence that the source image face matches the face in the bounding box.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompareFacesMatch {
     #[doc="<p>Provides face metadata (bounding box and confidence that the bounding box actually contains a face).</p>"]
     #[serde(rename="Face")]
@@ -113,7 +113,7 @@ pub struct CompareFacesMatch {
     pub similarity: Option<f32>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompareFacesRequest {
     #[doc="<p>The minimum level of confidence in the face matches that a match must meet to be included in the <code>FaceMatches</code> array.</p>"]
     #[serde(rename="SimilarityThreshold")]
@@ -127,7 +127,7 @@ pub struct CompareFacesRequest {
     pub target_image: Image,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompareFacesResponse {
     #[doc="<p>An array of faces in the target image that match the source image face. Each <code>CompareFacesMatch</code> object provides the bounding box, the confidence level that the bounding box contains a face, and the similarity score for the face in the bounding box and the face in the source image.</p>"]
     #[serde(rename="FaceMatches")]
@@ -152,7 +152,7 @@ pub struct CompareFacesResponse {
 }
 
 #[doc="<p>Provides face metadata for target image faces that are analysed by <code>CompareFaces</code> and <code>RecognizeCelebrities</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComparedFace {
     #[doc="<p>Bounding box of the face.</p>"]
     #[serde(rename="BoundingBox")]
@@ -177,7 +177,7 @@ pub struct ComparedFace {
 }
 
 #[doc="<p>Type that describes the face Amazon Rekognition chose to compare with the faces in the target. This contains a bounding box for the selected face and confidence level that the bounding box contains a face. Note that Amazon Rekognition selects the largest face in the source image for this comparison. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComparedSourceImageFace {
     #[doc="<p>Bounding box of the face.</p>"]
     #[serde(rename="BoundingBox")]
@@ -189,14 +189,14 @@ pub struct ComparedSourceImageFace {
     pub confidence: Option<f32>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCollectionRequest {
     #[doc="<p>ID for the collection that you are creating.</p>"]
     #[serde(rename="CollectionId")]
     pub collection_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCollectionResponse {
     #[doc="<p>Amazon Resource Name (ARN) of the collection. You can use this to manage permissions on your resources. </p>"]
     #[serde(rename="CollectionArn")]
@@ -208,14 +208,14 @@ pub struct CreateCollectionResponse {
     pub status_code: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCollectionRequest {
     #[doc="<p>ID of the collection to delete.</p>"]
     #[serde(rename="CollectionId")]
     pub collection_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCollectionResponse {
     #[doc="<p>HTTP status code that indicates the result of the operation.</p>"]
     #[serde(rename="StatusCode")]
@@ -223,7 +223,7 @@ pub struct DeleteCollectionResponse {
     pub status_code: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFacesRequest {
     #[doc="<p>Collection from which to remove the specific faces.</p>"]
     #[serde(rename="CollectionId")]
@@ -233,7 +233,7 @@ pub struct DeleteFacesRequest {
     pub face_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFacesResponse {
     #[doc="<p>An array of strings (face IDs) of the faces that were deleted.</p>"]
     #[serde(rename="DeletedFaces")]
@@ -241,7 +241,7 @@ pub struct DeleteFacesResponse {
     pub deleted_faces: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetectFacesRequest {
     #[doc="<p>An array of facial attributes you want to be returned. This can be the default list of attributes or all attributes. If you don't specify a value for <code>Attributes</code> or if you specify <code>[\"DEFAULT\"]</code>, the API returns the following subset of facial attributes: <code>BoundingBox</code>, <code>Confidence</code>, <code>Pose</code>, <code>Quality</code> and <code>Landmarks</code>. If you provide <code>[\"ALL\"]</code>, all facial attributes are returned but the operation will take longer to complete.</p> <p>If you provide both, <code>[\"ALL\", \"DEFAULT\"]</code>, the service uses a logical AND operator to determine which attributes to return (in this case, all attributes). </p>"]
     #[serde(rename="Attributes")]
@@ -252,7 +252,7 @@ pub struct DetectFacesRequest {
     pub image: Image,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetectFacesResponse {
     #[doc="<p>Details of each face found in the image. </p>"]
     #[serde(rename="FaceDetails")]
@@ -264,7 +264,7 @@ pub struct DetectFacesResponse {
     pub orientation_correction: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetectLabelsRequest {
     #[doc="<p>The input image. You can provide a blob of image bytes or an S3 object.</p>"]
     #[serde(rename="Image")]
@@ -279,7 +279,7 @@ pub struct DetectLabelsRequest {
     pub min_confidence: Option<f32>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetectLabelsResponse {
     #[doc="<p>An array of labels for the real-world objects detected. </p>"]
     #[serde(rename="Labels")]
@@ -291,7 +291,7 @@ pub struct DetectLabelsResponse {
     pub orientation_correction: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetectModerationLabelsRequest {
     #[doc="<p>The input image as bytes or an S3 object.</p>"]
     #[serde(rename="Image")]
@@ -302,7 +302,7 @@ pub struct DetectModerationLabelsRequest {
     pub min_confidence: Option<f32>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DetectModerationLabelsResponse {
     #[doc="<p>An array of labels for explicit or suggestive adult content found in the image. The list includes the top-level label and each child label detected in the image. This is useful for filtering specific categories of content. </p>"]
     #[serde(rename="ModerationLabels")]
@@ -311,7 +311,7 @@ pub struct DetectModerationLabelsResponse {
 }
 
 #[doc="<p>The emotions detected on the face, and the confidence level in the determination. For example, HAPPY, SAD, and ANGRY.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Emotion {
     #[doc="<p>Level of confidence in the determination.</p>"]
     #[serde(rename="Confidence")]
@@ -324,7 +324,7 @@ pub struct Emotion {
 }
 
 #[doc="<p>Indicates whether or not the eyes on the face are open, and the confidence level in the determination.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EyeOpen {
     #[doc="<p>Level of confidence in the determination.</p>"]
     #[serde(rename="Confidence")]
@@ -337,7 +337,7 @@ pub struct EyeOpen {
 }
 
 #[doc="<p>Indicates whether or not the face is wearing eye glasses, and the confidence level in the determination.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Eyeglasses {
     #[doc="<p>Level of confidence in the determination.</p>"]
     #[serde(rename="Confidence")]
@@ -350,7 +350,7 @@ pub struct Eyeglasses {
 }
 
 #[doc="<p>Describes the face properties such as the bounding box, face ID, image ID of the input image, and external image ID that you assigned. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Face {
     #[doc="<p>Bounding box of the face.</p>"]
     #[serde(rename="BoundingBox")]
@@ -375,7 +375,7 @@ pub struct Face {
 }
 
 #[doc="<p>Structure containing attributes of the face that the algorithm detected.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FaceDetail {
     #[doc="<p>The estimated age range, in years, for the face. Low represents the lowest estimated age and High represents the highest estimated age.</p>"]
     #[serde(rename="AgeRange")]
@@ -440,7 +440,7 @@ pub struct FaceDetail {
 }
 
 #[doc="<p>Provides face metadata. In addition, it also provides the confidence in the match of this face with the input face.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FaceMatch {
     #[doc="<p>Describes the face properties such as the bounding box, face ID, image ID of the source image, and external image ID that you assigned.</p>"]
     #[serde(rename="Face")]
@@ -453,7 +453,7 @@ pub struct FaceMatch {
 }
 
 #[doc="<p>Object containing both the face metadata (stored in the back-end database) and facial attributes that are detected but aren't stored in the database.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FaceRecord {
     #[doc="<p>Describes the face properties such as the bounding box, face ID, image ID of the input image, and external image ID that you assigned. </p>"]
     #[serde(rename="Face")]
@@ -466,7 +466,7 @@ pub struct FaceRecord {
 }
 
 #[doc="<p>Gender of the face and the confidence level in the determination.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Gender {
     #[doc="<p>Level of confidence in the determination.</p>"]
     #[serde(rename="Confidence")]
@@ -478,14 +478,14 @@ pub struct Gender {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCelebrityInfoRequest {
     #[doc="<p>The ID for the celebrity. You get the celebrity ID from a call to the operation, which recognizes celebrities in an image. </p>"]
     #[serde(rename="Id")]
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCelebrityInfoResponse {
     #[doc="<p>The name of the celebrity.</p>"]
     #[serde(rename="Name")]
@@ -498,7 +498,7 @@ pub struct GetCelebrityInfoResponse {
 }
 
 #[doc="<p>Provides the input image either as bytes or an S3 object.</p> <p>You pass image bytes to a Rekognition API operation by using the <code>Bytes</code> property. For example, you would use the <code>Bytes</code> property to pass an image loaded from a local file system. Image bytes passed by using the <code>Bytes</code> property must be base64-encoded. Your code may not need to encode image bytes if you are using an AWS SDK to call Rekognition API operations. For more information, see <a>example4</a>.</p> <p> You pass images stored in an S3 bucket to a Rekognition API operation by using the <code>S3Object</code> property. Images stored in an S3 bucket do not need to be base64-encoded.</p> <p>The region for the S3 bucket containing the S3 object must match the region you use for Amazon Rekognition operations.</p> <p>If you use the Amazon CLI to call Amazon Rekognition operations, passing image bytes using the Bytes property is not supported. You must first upload the image to an Amazon S3 bucket and then call the operation using the S3Object property.</p> <p>For Amazon Rekognition to process an S3 object, the user must have permission to access the S3 object. For more information, see <a>manage-access-resource-policies</a>. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Image {
     #[doc="<p>Blob of image bytes up to 5 MBs.</p>"]
     #[serde(rename="Bytes")]
@@ -515,7 +515,7 @@ pub struct Image {
 }
 
 #[doc="<p>Identifies face image brightness and sharpness. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImageQuality {
     #[doc="<p>Value representing brightness of the face. The service returns a value between 0 and 100 (inclusive). A higher value indicates a brighter face image.</p>"]
     #[serde(rename="Brightness")]
@@ -527,7 +527,7 @@ pub struct ImageQuality {
     pub sharpness: Option<f32>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IndexFacesRequest {
     #[doc="<p>The ID of an existing collection to which you want to add the faces that are detected in the input images.</p>"]
     #[serde(rename="CollectionId")]
@@ -545,7 +545,7 @@ pub struct IndexFacesRequest {
     pub image: Image,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IndexFacesResponse {
     #[doc="<p>An array of faces detected and added to the collection. For more information, see <a>howitworks-index-faces</a>. </p>"]
     #[serde(rename="FaceRecords")]
@@ -558,7 +558,7 @@ pub struct IndexFacesResponse {
 }
 
 #[doc="<p>Structure containing details about the detected label, including name, and level of confidence.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Label {
     #[doc="<p>Level of confidence.</p>"]
     #[serde(rename="Confidence")]
@@ -571,7 +571,7 @@ pub struct Label {
 }
 
 #[doc="<p>Indicates the location of the landmark on the face.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Landmark {
     #[doc="<p>Type of the landmark.</p>"]
     #[serde(rename="Type")]
@@ -587,7 +587,7 @@ pub struct Landmark {
     pub y: Option<f32>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCollectionsRequest {
     #[doc="<p>Maximum number of collection IDs to return.</p>"]
     #[serde(rename="MaxResults")]
@@ -599,7 +599,7 @@ pub struct ListCollectionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCollectionsResponse {
     #[doc="<p>An array of collection IDs.</p>"]
     #[serde(rename="CollectionIds")]
@@ -611,7 +611,7 @@ pub struct ListCollectionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFacesRequest {
     #[doc="<p>ID of the collection from which to list the faces.</p>"]
     #[serde(rename="CollectionId")]
@@ -626,7 +626,7 @@ pub struct ListFacesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFacesResponse {
     #[doc="<p>An array of <code>Face</code> objects. </p>"]
     #[serde(rename="Faces")]
@@ -639,7 +639,7 @@ pub struct ListFacesResponse {
 }
 
 #[doc="<p>Provides information about a single type of moderated content found in an image. Each type of moderated content has a label within a hierarchical taxonomy. For more information, see <a>image-moderation</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModerationLabel {
     #[doc="<p>Specifies the confidence that Amazon Rekognition has that the label has been correctly identified.</p> <p>If you don't specify the <code>MinConfidence</code> parameter in the call to <code>DetectModerationLabels</code>, the operation returns labels with a confidence value greater than or equal to 50 percent.</p>"]
     #[serde(rename="Confidence")]
@@ -656,7 +656,7 @@ pub struct ModerationLabel {
 }
 
 #[doc="<p>Indicates whether or not the mouth on the face is open, and the confidence level in the determination.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MouthOpen {
     #[doc="<p>Level of confidence in the determination.</p>"]
     #[serde(rename="Confidence")]
@@ -669,7 +669,7 @@ pub struct MouthOpen {
 }
 
 #[doc="<p>Indicates whether or not the face has a mustache, and the confidence level in the determination.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Mustache {
     #[doc="<p>Level of confidence in the determination.</p>"]
     #[serde(rename="Confidence")]
@@ -682,7 +682,7 @@ pub struct Mustache {
 }
 
 #[doc="<p>Indicates the pose of the face as determined by its pitch, roll, and yaw.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Pose {
     #[doc="<p>Value representing the face rotation on the pitch axis.</p>"]
     #[serde(rename="Pitch")]
@@ -698,14 +698,14 @@ pub struct Pose {
     pub yaw: Option<f32>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecognizeCelebritiesRequest {
     #[doc="<p>The input image to use for celebrity recognition.</p>"]
     #[serde(rename="Image")]
     pub image: Image,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecognizeCelebritiesResponse {
     #[doc="<p>Details about each celebrity found in the image. Amazon Rekognition can detect a maximum of 15 celebrities in an image.</p>"]
     #[serde(rename="CelebrityFaces")]
@@ -722,7 +722,7 @@ pub struct RecognizeCelebritiesResponse {
 }
 
 #[doc="<p>Provides the S3 bucket name and object name.</p> <p>The region for the S3 bucket containing the S3 object must match the region you use for Amazon Rekognition operations.</p> <p>For Amazon Rekognition to process an S3 object, the user must have permission to access the S3 object. For more information, see <a>manage-access-resource-policies</a>. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3Object {
     #[doc="<p>Name of the S3 bucket.</p>"]
     #[serde(rename="Bucket")]
@@ -738,7 +738,7 @@ pub struct S3Object {
     pub version: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchFacesByImageRequest {
     #[doc="<p>ID of the collection to search.</p>"]
     #[serde(rename="CollectionId")]
@@ -756,7 +756,7 @@ pub struct SearchFacesByImageRequest {
     pub max_faces: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchFacesByImageResponse {
     #[doc="<p>An array of faces that match the input face, along with the confidence in the match.</p>"]
     #[serde(rename="FaceMatches")]
@@ -772,7 +772,7 @@ pub struct SearchFacesByImageResponse {
     pub searched_face_confidence: Option<f32>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchFacesRequest {
     #[doc="<p>ID of the collection the face belongs to.</p>"]
     #[serde(rename="CollectionId")]
@@ -790,7 +790,7 @@ pub struct SearchFacesRequest {
     pub max_faces: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchFacesResponse {
     #[doc="<p>An array of faces that matched the input face, along with the confidence in the match.</p>"]
     #[serde(rename="FaceMatches")]
@@ -803,7 +803,7 @@ pub struct SearchFacesResponse {
 }
 
 #[doc="<p>Indicates whether or not the face is smiling, and the confidence level in the determination.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Smile {
     #[doc="<p>Level of confidence in the determination.</p>"]
     #[serde(rename="Confidence")]
@@ -816,7 +816,7 @@ pub struct Smile {
 }
 
 #[doc="<p>Indicates whether or not the face is wearing sunglasses, and the confidence level in the determination.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Sunglasses {
     #[doc="<p>Level of confidence in the determination.</p>"]
     #[serde(rename="Confidence")]

--- a/rusoto/services/resourcegroupstaggingapi/src/generated.rs
+++ b/rusoto/services/resourcegroupstaggingapi/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Details of the common errors that all actions return.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailureInfo {
     #[doc="<p>The code of the common error. Valid values include <code>InternalServiceException</code>, <code>InvalidParameterException</code>, and any valid error code returned by the AWS service that hosts the resource that you want to tag.</p>"]
     #[serde(rename="ErrorCode")]
@@ -45,7 +45,7 @@ pub struct FailureInfo {
     pub status_code: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetResourcesInput {
     #[doc="<p>A string that indicates that additional data is available. Leave this value empty for your initial request. If the response includes a <code>PaginationToken</code>, use that string for this value to request an additional page of data.</p>"]
     #[serde(rename="PaginationToken")]
@@ -69,7 +69,7 @@ pub struct GetResourcesInput {
     pub tags_per_page: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetResourcesOutput {
     #[doc="<p>A string that indicates that the response contains more data than can be returned in a single response. To receive additional data, specify this string for the <code>PaginationToken</code> value in a subsequent request.</p>"]
     #[serde(rename="PaginationToken")]
@@ -81,7 +81,7 @@ pub struct GetResourcesOutput {
     pub resource_tag_mapping_list: Option<Vec<ResourceTagMapping>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTagKeysInput {
     #[doc="<p>A string that indicates that additional data is available. Leave this value empty for your initial request. If the response includes a PaginationToken, use that string for this value to request an additional page of data.</p>"]
     #[serde(rename="PaginationToken")]
@@ -89,7 +89,7 @@ pub struct GetTagKeysInput {
     pub pagination_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTagKeysOutput {
     #[doc="<p>A string that indicates that the response contains more data than can be returned in a single response. To receive additional data, specify this string for the <code>PaginationToken</code> value in a subsequent request.</p>"]
     #[serde(rename="PaginationToken")]
@@ -101,7 +101,7 @@ pub struct GetTagKeysOutput {
     pub tag_keys: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTagValuesInput {
     #[doc="<p>The key for which you want to list all existing values in the specified region for the AWS account.</p>"]
     #[serde(rename="Key")]
@@ -112,7 +112,7 @@ pub struct GetTagValuesInput {
     pub pagination_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTagValuesOutput {
     #[doc="<p>A string that indicates that the response contains more data than can be returned in a single response. To receive additional data, specify this string for the <code>PaginationToken</code> value in a subsequent request.</p>"]
     #[serde(rename="PaginationToken")]
@@ -125,7 +125,7 @@ pub struct GetTagValuesOutput {
 }
 
 #[doc="<p>A list of resource ARNs and the tags (keys and values) that are associated with each.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceTagMapping {
     #[doc="<p>An array of resource ARN(s).</p>"]
     #[serde(rename="ResourceARN")]
@@ -138,7 +138,7 @@ pub struct ResourceTagMapping {
 }
 
 #[doc="<p>The metadata that you apply to AWS resources to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-basics\">Tag Basics</a> in the <i>Amazon EC2 User Guide for Linux Instances</i>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.</p>"]
     #[serde(rename="Key")]
@@ -149,7 +149,7 @@ pub struct Tag {
 }
 
 #[doc="<p>A list of tags (keys and values) that are used to specify the associated resources.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagFilter {
     #[doc="<p>One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.</p>"]
     #[serde(rename="Key")]
@@ -161,7 +161,7 @@ pub struct TagFilter {
     pub values: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourcesInput {
     #[doc="<p>A list of ARNs. An ARN (Amazon Resource Name) uniquely identifies a resource. You can specify a minimum of 1 and a maximum of 20 ARNs (resources) to tag. An ARN can be set to a maximum of 1600 characters. For more information, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
     #[serde(rename="ResourceARNList")]
@@ -171,7 +171,7 @@ pub struct TagResourcesInput {
     pub tags: ::std::collections::HashMap<String, String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagResourcesOutput {
     #[doc="<p>Details of resources that could not be tagged. An error code, status code, and error message are returned for each failed item.</p>"]
     #[serde(rename="FailedResourcesMap")]
@@ -179,7 +179,7 @@ pub struct TagResourcesOutput {
     pub failed_resources_map: Option<::std::collections::HashMap<String, FailureInfo>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourcesInput {
     #[doc="<p>A list of ARNs. An ARN (Amazon Resource Name) uniquely identifies a resource. You can specify a minimum of 1 and a maximum of 20 ARNs (resources) to untag. An ARN can be set to a maximum of 1600 characters. For more information, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>"]
     #[serde(rename="ResourceARNList")]
@@ -189,7 +189,7 @@ pub struct UntagResourcesInput {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UntagResourcesOutput {
     #[doc="<p>Details of resources that could not be untagged. An error code, status code, and error message are returned for each failed item.</p>"]
     #[serde(rename="FailedResourcesMap")]

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -43,11 +43,13 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>A complex type that identifies the CloudWatch alarm that you want Amazon Route 53 health checkers to use to determine whether this health check is healthy.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AlarmIdentifier {
     #[doc="<p>The name of the CloudWatch alarm that you want Amazon Route 53 health checkers to use to determine whether this health check is healthy.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>A complex type that identifies the CloudWatch alarm that you want Amazon Route 53 health checkers to use to determine whether this health check is healthy.</p> <p>For the current list of CloudWatch regions, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html#cw_region\">Amazon CloudWatch</a> in the <i>AWS Regions and Endpoints</i> chapter of the <i>Amazon Web Services General Reference</i>.</p>"]
+    #[serde(rename="Region")]
     pub region: String,
 }
 
@@ -185,13 +187,16 @@ impl AliasHealthEnabledSerializer {
 }
 
 #[doc="<p> <i>Alias resource record sets only:</i> Information about the CloudFront distribution, Elastic Beanstalk environment, ELB load balancer, Amazon S3 bucket, or Amazon Route 53 resource record set that you're redirecting queries to. An Elastic Beanstalk environment must have a regionalized subdomain.</p> <p>When creating resource record sets for a private hosted zone, note the following:</p> <ul> <li> <p>Resource record sets can't be created for CloudFront distributions in a private hosted zone.</p> </li> <li> <p>Creating geolocation alias resource record sets or latency alias resource record sets in a private hosted zone is unsupported.</p> </li> <li> <p>For information about creating failover resource record sets in a private hosted zone, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html\">Configuring Failover in a Private Hosted Zone</a>.</p> </li> </ul>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AliasTarget {
     #[doc="<p> <i>Alias resource record sets only:</i> The value that you specify depends on where you want to route queries:</p> <dl> <dt>CloudFront distribution</dt> <dd> <p>Specify the domain name that CloudFront assigned when you created your distribution.</p> <p>Your CloudFront distribution must include an alternate domain name that matches the name of the resource record set. For example, if the name of the resource record set is <i>acme.example.com</i>, your CloudFront distribution must include <i>acme.example.com</i> as one of the alternate domain names. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html\">Using Alternate Domain Names (CNAMEs)</a> in the <i>Amazon CloudFront Developer Guide</i>.</p> </dd> <dt>Elastic Beanstalk environment</dt> <dd> <p>Specify the <code>CNAME</code> attribute for the environment. (The environment must have a regionalized domain name.) You can use the following methods to get the value of the CNAME attribute:</p> <ul> <li> <p> <i>AWS Management Console</i>: For information about how to get the value by using the console, see <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customdomains.html\">Using Custom Domains with AWS Elastic Beanstalk</a> in the <i>AWS Elastic Beanstalk Developer Guide</i>.</p> </li> <li> <p> <i>Elastic Beanstalk API</i>: Use the <code>DescribeEnvironments</code> action to get the value of the <code>CNAME</code> attribute. For more information, see <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_DescribeEnvironments.html\">DescribeEnvironments</a> in the <i>AWS Elastic Beanstalk API Reference</i>.</p> </li> <li> <p> <i>AWS CLI</i>: Use the <code>describe-environments</code> command to get the value of the <code>CNAME</code> attribute. For more information, see <a href=\"http://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/describe-environments.html\">describe-environments</a> in the <i>AWS Command Line Interface Reference</i>.</p> </li> </ul> </dd> <dt>ELB load balancer</dt> <dd> <p>Specify the DNS name that is associated with the load balancer. Get the DNS name by using the AWS Management Console, the ELB API, or the AWS CLI. </p> <ul> <li> <p> <b>AWS Management Console</b>: Go to the EC2 page, choose <b>Load Balancers</b> in the navigation pane, choose the load balancer, choose the <b>Description</b> tab, and get the value of the <b>DNS name</b> field. (If you're routing traffic to a Classic Load Balancer, get the value that begins with <b>dualstack</b>.) </p> </li> <li> <p> <b>Elastic Load Balancing API</b>: Use <code>DescribeLoadBalancers</code> to get the value of <code>DNSName</code>. For more information, see the applicable guide:</p> <ul> <li> <p>Classic Load Balancer: <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html\">DescribeLoadBalancers</a> </p> </li> <li> <p>Application Load Balancer: <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html\">DescribeLoadBalancers</a> </p> </li> </ul> </li> <li> <p> <b>AWS CLI</b>: Use <code> <a href=\"http://docs.aws.amazon.com/cli/latest/reference/elb/describe-load-balancers.html\">describe-load-balancers</a> </code> to get the value of <code>DNSName</code>.</p> </li> </ul> </dd> <dt>Amazon S3 bucket that is configured as a static website</dt> <dd> <p>Specify the domain name of the Amazon S3 website endpoint in which you created the bucket, for example, <code>s3-website-us-east-2.amazonaws.com</code>. For more information about valid values, see the table <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region\">Amazon Simple Storage Service (S3) Website Endpoints</a> in the <i>Amazon Web Services General Reference</i>. For more information about using S3 buckets for websites, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/getting-started.html\">Getting Started with Amazon Route 53</a> in the <i>Amazon Route 53 Developer Guide.</i> </p> </dd> <dt>Another Amazon Route 53 resource record set</dt> <dd> <p>Specify the value of the <code>Name</code> element for a resource record set in the current hosted zone.</p> </dd> </dl>"]
+    #[serde(rename="DNSName")]
     pub dns_name: String,
     #[doc="<p> <i>Applies only to alias, failover alias, geolocation alias, latency alias, and weighted alias resource record sets:</i> When <code>EvaluateTargetHealth</code> is <code>true</code>, an alias resource record set inherits the health of the referenced AWS resource, such as an ELB load balancer, or the referenced resource record set.</p> <p>Note the following:</p> <ul> <li> <p>You can't set <code>EvaluateTargetHealth</code> to <code>true</code> when the alias target is a CloudFront distribution.</p> </li> <li> <p>If the AWS resource that you specify in <code>AliasTarget</code> is a resource record set or a group of resource record sets (for example, a group of weighted resource record sets), but it is not another alias resource record set, we recommend that you associate a health check with all of the resource record sets in the alias target. For more information, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-complex-configs.html#dns-failover-complex-configs-hc-omitting\">What Happens When You Omit Health Checks?</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> </li> <li> <p>If you specify an Elastic Beanstalk environment in <code>HostedZoneId</code> and <code>DNSName</code>, and if the environment contains an ELB load balancer, Elastic Load Balancing routes queries only to the healthy Amazon EC2 instances that are registered with the load balancer. (An environment automatically contains an ELB load balancer if it includes more than one EC2 instance.) If you set <code>EvaluateTargetHealth</code> to <code>true</code> and either no EC2 instances are healthy or the load balancer itself is unhealthy, Amazon Route 53 routes queries to other available resources that are healthy, if any.</p> <p>If the environment contains a single EC2 instance, there are no special requirements.</p> </li> <li> <p>If you specify an ELB load balancer in <code> <a>AliasTarget</a> </code>, ELB routes queries only to the healthy EC2 instances that are registered with the load balancer. If no EC2 instances are healthy or if the load balancer itself is unhealthy, and if <code>EvaluateTargetHealth</code> is true for the corresponding alias resource record set, Amazon Route 53 routes queries to other resources. When you create a load balancer, you configure settings for ELB health checks; they're not Amazon Route 53 health checks, but they perform a similar function. Do not create Amazon Route 53 health checks for the EC2 instances that you register with an ELB load balancer.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-complex-configs.html\">How Health Checks Work in More Complex Amazon Route 53 Configurations</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> </li> <li> <p>We recommend that you set <code>EvaluateTargetHealth</code> to true only when you have enough idle capacity to handle the failure of one or more endpoints.</p> </li> </ul> <p>For more information and examples, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html\">Amazon Route 53 Health Checks and DNS Failover</a> in the <i>Amazon Route 53 Developer Guide</i>.</p>"]
+    #[serde(rename="EvaluateTargetHealth")]
     pub evaluate_target_health: bool,
     #[doc="<p> <i>Alias resource records sets only</i>: The value used depends on where you want to route traffic:</p> <dl> <dt>CloudFront distribution</dt> <dd> <p>Specify <code>Z2FDTNDATAQYW2</code>.</p> <note> <p>Alias resource record sets for CloudFront can't be created in a private zone.</p> </note> </dd> <dt>Elastic Beanstalk environment</dt> <dd> <p>Specify the hosted zone ID for the region in which you created the environment. The environment must have a regionalized subdomain. For a list of regions and the corresponding hosted zone IDs, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html#elasticbeanstalk_region\">AWS Elastic Beanstalk</a> in the \"AWS Regions and Endpoints\" chapter of the <i>Amazon Web Services General Reference</i>.</p> </dd> <dt>ELB load balancer</dt> <dd> <p>Specify the value of the hosted zone ID for the load balancer. Use the following methods to get the hosted zone ID:</p> <ul> <li> <p> <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region\">Elastic Load Balancing</a> table in the \"AWS Regions and Endpoints\" chapter of the <i>Amazon Web Services General Reference</i>: Use the value in the \"Amazon Route 53 Hosted Zone ID\" column that corresponds with the region that you created your load balancer in.</p> </li> <li> <p> <b>AWS Management Console</b>: Go to the Amazon EC2 page, click <b>Load Balancers</b> in the navigation pane, select the load balancer, and get the value of the <b>Hosted zone</b> field on the <b>Description</b> tab.</p> </li> <li> <p> <b>Elastic Load Balancing API</b>: Use <code>DescribeLoadBalancers</code> to get the value of <code>CanonicalHostedZoneNameId</code>. For more information, see the applicable guide:</p> <ul> <li> <p>Classic Load Balancer: <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html\">DescribeLoadBalancers</a> </p> </li> <li> <p>Application Load Balancer: <a href=\"http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html\">DescribeLoadBalancers</a> </p> </li> </ul> </li> <li> <p> <b>AWS CLI</b>: Use <code> <a href=\"http://docs.aws.amazon.com/cli/latest/reference/elb/describe-load-balancers.html\">describe-load-balancers</a> </code> to get the value of <code>CanonicalHostedZoneNameID</code>.</p> </li> </ul> </dd> <dt>An Amazon S3 bucket configured as a static website</dt> <dd> <p>Specify the hosted zone ID for the region that you created the bucket in. For more information about valid values, see the <a href=\"http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region\">Amazon Simple Storage Service Website Endpoints</a> table in the \"AWS Regions and Endpoints\" chapter of the <i>Amazon Web Services General Reference</i>.</p> </dd> <dt>Another Amazon Route 53 resource record set in your hosted zone</dt> <dd> <p>Specify the hosted zone ID of your hosted zone. (An alias resource record set can't reference a resource record set in a different hosted zone.)</p> </dd> </dl>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
 }
 
@@ -296,13 +301,17 @@ impl AssociateVPCCommentSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the request to associate a VPC with a private hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AssociateVPCWithHostedZoneRequest {
     #[doc="<p> <i>Optional:</i> A comment about the association request.</p>"]
+    #[serde(rename="Comment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub comment: Option<String>,
     #[doc="<p>The ID of the private hosted zone that you want to associate an Amazon VPC with.</p> <p>Note that you can't associate a VPC with a hosted zone that doesn't have an existing VPC association.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p>A complex type that contains information about the VPC that you want to associate with a private hosted zone.</p>"]
+    #[serde(rename="VPC")]
     pub vpc: VPC,
 }
 
@@ -326,9 +335,10 @@ impl AssociateVPCWithHostedZoneRequestSerializer {
     }
 }
 #[doc="<p>A complex type that contains the response information for the <code>AssociateVPCWithHostedZone</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AssociateVPCWithHostedZoneResponse {
     #[doc="<p>A complex type that describes the changes made to your hosted zone.</p>"]
+    #[serde(rename="ChangeInfo")]
     pub change_info: ChangeInfo,
 }
 
@@ -376,11 +386,13 @@ impl AssociateVPCWithHostedZoneResponseDeserializer {
     }
 }
 #[doc="<p>The information for each resource record set that you want to change.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Change {
     #[doc="<p>The action to perform:</p> <ul> <li> <p> <code>CREATE</code>: Creates a resource record set that has the specified values.</p> </li> <li> <p> <code>DELETE</code>: Deletes a existing resource record set.</p> <important> <p>To delete the resource record set that is associated with a traffic policy instance, use <code> <a>DeleteTrafficPolicyInstance</a> </code>. Amazon Route 53 will delete the resource record set automatically. If you delete the resource record set by using <code>ChangeResourceRecordSets</code>, Amazon Route 53 doesn't automatically delete the traffic policy instance, and you'll continue to be charged for it even though it's no longer in use. </p> </important> </li> <li> <p> <code>UPSERT</code>: If a resource record set doesn't already exist, Amazon Route 53 creates it. If a resource record set does exist, Amazon Route 53 updates it with the values in the request.</p> </li> </ul> <p>The values that you need to include in the request depend on the type of resource record set that you're creating, deleting, or updating:</p> <p> <b>Basic resource record sets (excluding alias, failover, geolocation, latency, and weighted resource record sets)</b> </p> <ul> <li> <p> <code>Name</code> </p> </li> <li> <p> <code>Type</code> </p> </li> <li> <p> <code>TTL</code> </p> </li> </ul> <p> <b>Failover, geolocation, latency, or weighted resource record sets (excluding alias resource record sets)</b> </p> <ul> <li> <p> <code>Name</code> </p> </li> <li> <p> <code>Type</code> </p> </li> <li> <p> <code>TTL</code> </p> </li> <li> <p> <code>SetIdentifier</code> </p> </li> </ul> <p> <b>Alias resource record sets (including failover alias, geolocation alias, latency alias, and weighted alias resource record sets)</b> </p> <ul> <li> <p> <code>Name</code> </p> </li> <li> <p> <code>Type</code> </p> </li> <li> <p> <code>AliasTarget</code> (includes <code>DNSName</code>, <code>EvaluateTargetHealth</code>, and <code>HostedZoneId</code>)</p> </li> <li> <p> <code>SetIdentifier</code> (for failover, geolocation, latency, and weighted resource record sets)</p> </li> </ul>"]
+    #[serde(rename="Action")]
     pub action: String,
     #[doc="<p>Information about the resource record set to create, delete, or update.</p>"]
+    #[serde(rename="ResourceRecordSet")]
     pub resource_record_set: ResourceRecordSet,
 }
 
@@ -426,11 +438,14 @@ impl ChangeActionSerializer {
 }
 
 #[doc="<p>The information for a change request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ChangeBatch {
     #[doc="<p>Information about the changes to make to the record sets.</p>"]
+    #[serde(rename="Changes")]
     pub changes: Vec<Change>,
     #[doc="<p> <i>Optional:</i> Any comments you want to include about a change batch request.</p>"]
+    #[serde(rename="Comment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub comment: Option<String>,
 }
 
@@ -457,15 +472,20 @@ impl ChangeBatchSerializer {
 }
 
 #[doc="<p>A complex type that describes change information about changes made to your hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ChangeInfo {
     #[doc="<p>A complex type that describes change information about changes made to your hosted zone.</p> <p>This element contains an ID that you use when performing a <a>GetChange</a> action to get detailed information about the change.</p>"]
+    #[serde(rename="Comment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub comment: Option<String>,
     #[doc="<p>The ID of the request.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The current state of the request. <code>PENDING</code> indicates that this request has not yet been applied to all Amazon Route 53 DNS servers.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
     #[doc="<p>The date and time that the change request was submitted in <a href=\"https://en.wikipedia.org/wiki/ISO_8601\">ISO 8601 format</a> and Coordinated Universal Time (UTC). For example, the value <code>2017-03-27T17:48:16.751Z</code> represents March 27, 2017 at 17:48:16.751 UTC.</p>"]
+    #[serde(rename="SubmittedAt")]
     pub submitted_at: String,
 }
 
@@ -524,11 +544,13 @@ impl ChangeInfoDeserializer {
     }
 }
 #[doc="<p>A complex type that contains change information for the resource record set.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ChangeResourceRecordSetsRequest {
     #[doc="<p>A complex type that contains an optional comment and the <code>Changes</code> element.</p>"]
+    #[serde(rename="ChangeBatch")]
     pub change_batch: ChangeBatch,
     #[doc="<p>The ID of the hosted zone that contains the resource record sets that you want to change.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
 }
 
@@ -549,9 +571,10 @@ impl ChangeResourceRecordSetsRequestSerializer {
     }
 }
 #[doc="<p>A complex type containing the response for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ChangeResourceRecordSetsResponse {
     #[doc="<p>A complex type that contains information about changes made to your hosted zone.</p> <p>This element contains an ID that you use when performing a <a>GetChange</a> action to get detailed information about the change.</p>"]
+    #[serde(rename="ChangeInfo")]
     pub change_info: ChangeInfo,
 }
 
@@ -613,15 +636,21 @@ impl ChangeStatusDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the tags that you want to add, edit, or delete.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ChangeTagsForResourceRequest {
     #[doc="<p>A complex type that contains a list of the tags that you want to add to the specified health check or hosted zone and/or the tags that you want to edit <code>Value</code> for.</p> <p>You can add a maximum of 10 tags to a health check or a hosted zone.</p>"]
+    #[serde(rename="AddTags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub add_tags: Option<Vec<Tag>>,
     #[doc="<p>A complex type that contains a list of the tags that you want to delete from the specified health check or hosted zone. You can specify up to 10 keys.</p>"]
+    #[serde(rename="RemoveTagKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub remove_tag_keys: Option<Vec<String>>,
     #[doc="<p>The ID of the resource for which you want to add, change, or delete tags.</p>"]
+    #[serde(rename="ResourceId")]
     pub resource_id: String,
     #[doc="<p>The type of the resource.</p> <ul> <li> <p>The resource type for health checks is <code>healthcheck</code>.</p> </li> <li> <p>The resource type for hosted zones is <code>hostedzone</code>.</p> </li> </ul>"]
+    #[serde(rename="ResourceType")]
     pub resource_type: String,
 }
 
@@ -647,7 +676,7 @@ impl ChangeTagsForResourceRequestSerializer {
     }
 }
 #[doc="<p>Empty response for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ChangeTagsForResourceResponse;
 
 struct ChangeTagsForResourceResponseDeserializer;
@@ -788,23 +817,32 @@ impl ChildHealthCheckListSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the CloudWatch alarm that Amazon Route 53 is monitoring for this health check.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CloudWatchAlarmConfiguration {
     #[doc="<p>For the metric that the CloudWatch alarm is associated with, the arithmetic operation that is used for the comparison.</p>"]
+    #[serde(rename="ComparisonOperator")]
     pub comparison_operator: String,
     #[doc="<p>For the metric that the CloudWatch alarm is associated with, a complex type that contains information about the dimensions for the metric. For information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html\">Amazon CloudWatch Namespaces, Dimensions, and Metrics Reference</a> in the <i>Amazon CloudWatch User Guide</i>.</p>"]
+    #[serde(rename="Dimensions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dimensions: Option<Vec<Dimension>>,
     #[doc="<p>For the metric that the CloudWatch alarm is associated with, the number of periods that the metric is compared to the threshold.</p>"]
+    #[serde(rename="EvaluationPeriods")]
     pub evaluation_periods: i64,
     #[doc="<p>The name of the CloudWatch metric that the alarm is associated with.</p>"]
+    #[serde(rename="MetricName")]
     pub metric_name: String,
     #[doc="<p>The namespace of the metric that the alarm is associated with. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html\">Amazon CloudWatch Namespaces, Dimensions, and Metrics Reference</a> in the <i>Amazon CloudWatch User Guide</i>.</p>"]
+    #[serde(rename="Namespace")]
     pub namespace: String,
     #[doc="<p>For the metric that the CloudWatch alarm is associated with, the duration of one evaluation period in seconds.</p>"]
+    #[serde(rename="Period")]
     pub period: i64,
     #[doc="<p>For the metric that the CloudWatch alarm is associated with, the statistic that is applied to the metric.</p>"]
+    #[serde(rename="Statistic")]
     pub statistic: String,
     #[doc="<p>For the metric that the CloudWatch alarm is associated with, the value the metric is compared with.</p>"]
+    #[serde(rename="Threshold")]
     pub threshold: f64,
 }
 
@@ -927,11 +965,13 @@ impl ComparisonOperatorDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the health check request information.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateHealthCheckRequest {
     #[doc="<p>A unique string that identifies the request and that allows you to retry a failed <code>CreateHealthCheck</code> request without the risk of creating two identical health checks:</p> <ul> <li> <p>If you send a <code>CreateHealthCheck</code> request with the same <code>CallerReference</code> and settings as a previous request, and if the health check doesn't exist, Amazon Route 53 creates the health check. If the health check does exist, Amazon Route 53 returns the settings for the existing health check.</p> </li> <li> <p>If you send a <code>CreateHealthCheck</code> request with the same <code>CallerReference</code> as a deleted health check, regardless of the settings, Amazon Route 53 returns a <code>HealthCheckAlreadyExists</code> error.</p> </li> <li> <p>If you send a <code>CreateHealthCheck</code> request with the same <code>CallerReference</code> as an existing health check but with different settings, Amazon Route 53 returns a <code>HealthCheckAlreadyExists</code> error.</p> </li> <li> <p>If you send a <code>CreateHealthCheck</code> request with a unique <code>CallerReference</code> but settings identical to an existing health check, Amazon Route 53 creates the health check.</p> </li> </ul>"]
+    #[serde(rename="CallerReference")]
     pub caller_reference: String,
     #[doc="<p>A complex type that contains the response to a <code>CreateHealthCheck</code> request. </p>"]
+    #[serde(rename="HealthCheckConfig")]
     pub health_check_config: HealthCheckConfig,
 }
 
@@ -957,11 +997,13 @@ impl CreateHealthCheckRequestSerializer {
     }
 }
 #[doc="<p>A complex type containing the response information for the new health check.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateHealthCheckResponse {
     #[doc="<p>A complex type that contains identifying information about the health check.</p>"]
+    #[serde(rename="HealthCheck")]
     pub health_check: HealthCheck,
     #[doc="<p>The unique URL representing the new health check.</p>"]
+    #[serde(rename="Location")]
     pub location: String,
 }
 
@@ -1008,17 +1050,25 @@ impl CreateHealthCheckResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the request to create a hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateHostedZoneRequest {
     #[doc="<p>A unique string that identifies the request and that allows failed <code>CreateHostedZone</code> requests to be retried without the risk of executing the operation twice. You must use a unique <code>CallerReference</code> string every time you submit a <code>CreateHostedZone</code> request. <code>CallerReference</code> can be any unique string, for example, a date/time stamp.</p>"]
+    #[serde(rename="CallerReference")]
     pub caller_reference: String,
     #[doc="<p>If you want to associate a reusable delegation set with this hosted zone, the ID that Amazon Route 53 assigned to the reusable delegation set when you created it. For more information about reusable delegation sets, see <a>CreateReusableDelegationSet</a>.</p>"]
+    #[serde(rename="DelegationSetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delegation_set_id: Option<String>,
     #[doc="<p>(Optional) A complex type that contains the following optional values:</p> <ul> <li> <p>For public and private hosted zones, an optional comment</p> </li> <li> <p>For private hosted zones, an optional <code>PrivateZone</code> element</p> </li> </ul> <p>If you don't specify a comment or the <code>PrivateZone</code> element, omit <code>HostedZoneConfig</code> and the other elements.</p>"]
+    #[serde(rename="HostedZoneConfig")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hosted_zone_config: Option<HostedZoneConfig>,
     #[doc="<p>The name of the domain. For resource record types that include a domain name, specify a fully qualified domain name, for example, <i>www.example.com</i>. The trailing dot is optional; Amazon Route 53 assumes that the domain name is fully qualified. This means that Amazon Route 53 treats <i>www.example.com</i> (without a trailing dot) and <i>www.example.com.</i> (with a trailing dot) as identical.</p> <p>If you're creating a public hosted zone, this is the name you have registered with your DNS registrar. If your domain name is registered with a registrar other than Amazon Route 53, change the name servers for your domain to the set of <code>NameServers</code> that <code>CreateHostedZone</code> returns in <code>DelegationSet</code>.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>(Private hosted zones only) A complex type that contains information about the Amazon VPC that you're associating with this hosted zone.</p> <p>You can specify only one Amazon VPC when you create a private hosted zone. To associate additional Amazon VPCs with the hosted zone, use <a>AssociateVPCWithHostedZone</a> after you create a hosted zone.</p>"]
+    #[serde(rename="VPC")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc: Option<VPC>,
 }
 
@@ -1049,17 +1099,23 @@ impl CreateHostedZoneRequestSerializer {
     }
 }
 #[doc="<p>A complex type containing the response information for the hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateHostedZoneResponse {
     #[doc="<p>A complex type that contains information about the <code>CreateHostedZone</code> request.</p>"]
+    #[serde(rename="ChangeInfo")]
     pub change_info: ChangeInfo,
     #[doc="<p>A complex type that describes the name servers for this hosted zone.</p>"]
+    #[serde(rename="DelegationSet")]
     pub delegation_set: DelegationSet,
     #[doc="<p>A complex type that contains general information about the hosted zone.</p>"]
+    #[serde(rename="HostedZone")]
     pub hosted_zone: HostedZone,
     #[doc="<p>The unique URL representing the new hosted zone.</p>"]
+    #[serde(rename="Location")]
     pub location: String,
     #[doc="<p>A complex type that contains information about an Amazon VPC that you associated with this hosted zone.</p>"]
+    #[serde(rename="VPC")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc: Option<VPC>,
 }
 
@@ -1117,11 +1173,14 @@ impl CreateHostedZoneResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateReusableDelegationSetRequest {
     #[doc="<p>A unique string that identifies the request, and that allows you to retry failed <code>CreateReusableDelegationSet</code> requests without the risk of executing the operation twice. You must use a unique <code>CallerReference</code> string every time you submit a <code>CreateReusableDelegationSet</code> request. <code>CallerReference</code> can be any unique string, for example a date/time stamp.</p>"]
+    #[serde(rename="CallerReference")]
     pub caller_reference: String,
     #[doc="<p>If you want to mark the delegation set for an existing hosted zone as reusable, the ID for that hosted zone.</p>"]
+    #[serde(rename="HostedZoneId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hosted_zone_id: Option<String>,
 }
 
@@ -1144,11 +1203,13 @@ impl CreateReusableDelegationSetRequestSerializer {
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateReusableDelegationSetResponse {
     #[doc="<p>A complex type that contains name server information.</p>"]
+    #[serde(rename="DelegationSet")]
     pub delegation_set: DelegationSet,
     #[doc="<p>The unique URL representing the new reusable delegation set.</p>"]
+    #[serde(rename="Location")]
     pub location: String,
 }
 
@@ -1197,17 +1258,22 @@ impl CreateReusableDelegationSetResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the resource record sets that you want to create based on a specified traffic policy.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateTrafficPolicyInstanceRequest {
     #[doc="<p>The ID of the hosted zone in which you want Amazon Route 53 to create resource record sets by using the configuration in a traffic policy.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p>The domain name (such as example.com) or subdomain name (such as www.example.com) for which Amazon Route 53 responds to DNS queries by using the resource record sets that Amazon Route 53 creates for this traffic policy instance.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>(Optional) The TTL that you want Amazon Route 53 to assign to all of the resource record sets that it creates in the specified hosted zone.</p>"]
+    #[serde(rename="TTL")]
     pub ttl: i64,
     #[doc="<p>The ID of the traffic policy that you want to use to create resource record sets in the specified hosted zone.</p>"]
+    #[serde(rename="TrafficPolicyId")]
     pub traffic_policy_id: String,
     #[doc="<p>The version of the traffic policy that you want to use to create resource record sets in the specified hosted zone.</p>"]
+    #[serde(rename="TrafficPolicyVersion")]
     pub traffic_policy_version: i64,
 }
 
@@ -1236,11 +1302,13 @@ impl CreateTrafficPolicyInstanceRequestSerializer {
     }
 }
 #[doc="<p>A complex type that contains the response information for the <code>CreateTrafficPolicyInstance</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateTrafficPolicyInstanceResponse {
     #[doc="<p>A unique URL that represents a new traffic policy instance.</p>"]
+    #[serde(rename="Location")]
     pub location: String,
     #[doc="<p>A complex type that contains settings for the new traffic policy instance.</p>"]
+    #[serde(rename="TrafficPolicyInstance")]
     pub traffic_policy_instance: TrafficPolicyInstance,
 }
 
@@ -1289,13 +1357,17 @@ impl CreateTrafficPolicyInstanceResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the traffic policy that you want to create.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateTrafficPolicyRequest {
     #[doc="<p>(Optional) Any comments that you want to include about the traffic policy.</p>"]
+    #[serde(rename="Comment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub comment: Option<String>,
     #[doc="<p>The definition of this traffic policy in JSON format. For more information, see <a href=\"http://docs.aws.amazon.com/Route53/latest/APIReference/api-policies-traffic-policy-document-format.html\">Traffic Policy Document Format</a>.</p>"]
+    #[serde(rename="Document")]
     pub document: String,
     #[doc="<p>The name of the traffic policy.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
 }
 
@@ -1320,11 +1392,13 @@ impl CreateTrafficPolicyRequestSerializer {
     }
 }
 #[doc="<p>A complex type that contains the response information for the <code>CreateTrafficPolicy</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateTrafficPolicyResponse {
     #[doc="<p>A unique URL that represents a new traffic policy.</p>"]
+    #[serde(rename="Location")]
     pub location: String,
     #[doc="<p>A complex type that contains settings for the new traffic policy.</p>"]
+    #[serde(rename="TrafficPolicy")]
     pub traffic_policy: TrafficPolicy,
 }
 
@@ -1372,13 +1446,17 @@ impl CreateTrafficPolicyResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the traffic policy that you want to create a new version for.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateTrafficPolicyVersionRequest {
     #[doc="<p>The comment that you specified in the <code>CreateTrafficPolicyVersion</code> request, if any.</p>"]
+    #[serde(rename="Comment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub comment: Option<String>,
     #[doc="<p>The definition of this version of the traffic policy, in JSON format. You specified the JSON in the <code>CreateTrafficPolicyVersion</code> request. For more information about the JSON format, see <a>CreateTrafficPolicy</a>.</p>"]
+    #[serde(rename="Document")]
     pub document: String,
     #[doc="<p>The ID of the traffic policy for which you want to create a new version.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
@@ -1402,11 +1480,13 @@ impl CreateTrafficPolicyVersionRequestSerializer {
     }
 }
 #[doc="<p>A complex type that contains the response information for the <code>CreateTrafficPolicyVersion</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateTrafficPolicyVersionResponse {
     #[doc="<p>A unique URL that represents a new traffic policy version.</p>"]
+    #[serde(rename="Location")]
     pub location: String,
     #[doc="<p>A complex type that contains settings for the new version of the traffic policy.</p>"]
+    #[serde(rename="TrafficPolicy")]
     pub traffic_policy: TrafficPolicy,
 }
 
@@ -1455,11 +1535,13 @@ impl CreateTrafficPolicyVersionResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the request to authorize associating a VPC with your private hosted zone. Authorization is only required when a private hosted zone and a VPC were created by using different accounts.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateVPCAssociationAuthorizationRequest {
     #[doc="<p>The ID of the private hosted zone that you want to authorize associating a VPC with.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p>A complex type that contains the VPC ID and region for the VPC that you want to authorize associating with your hosted zone.</p>"]
+    #[serde(rename="VPC")]
     pub vpc: VPC,
 }
 
@@ -1480,11 +1562,13 @@ impl CreateVPCAssociationAuthorizationRequestSerializer {
     }
 }
 #[doc="<p>A complex type that contains the response information from a <code>CreateVPCAssociationAuthorization</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateVPCAssociationAuthorizationResponse {
     #[doc="<p>The ID of the hosted zone that you authorized associating a VPC with.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p>The VPC that you authorized associating with a hosted zone.</p>"]
+    #[serde(rename="VPC")]
     pub vpc: VPC,
 }
 
@@ -1581,13 +1665,18 @@ impl DNSRCodeDeserializer {
     }
 }
 #[doc="<p>A complex type that lists the name servers in a delegation set, as well as the <code>CallerReference</code> and the <code>ID</code> for the delegation set.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DelegationSet {
     #[doc="<p>The value that you specified for <code>CallerReference</code> when you created the reusable delegation set.</p>"]
+    #[serde(rename="CallerReference")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub caller_reference: Option<String>,
     #[doc="<p>The ID that Amazon Route 53 assigns to a reusable delegation set.</p>"]
+    #[serde(rename="Id")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
     #[doc="<p>A complex type that contains a list of the authoritative name servers for a hosted zone or for a reusable delegation set.</p>"]
+    #[serde(rename="NameServers")]
     pub name_servers: Vec<String>,
 }
 
@@ -1726,14 +1815,15 @@ impl DelegationSetsDeserializer {
     }
 }
 #[doc="<p>This action deletes a health check.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteHealthCheckRequest {
     #[doc="<p>The ID of the health check that you want to delete.</p>"]
+    #[serde(rename="HealthCheckId")]
     pub health_check_id: String,
 }
 
 #[doc="<p>An empty element.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteHealthCheckResponse;
 
 struct DeleteHealthCheckResponseDeserializer;
@@ -1753,16 +1843,18 @@ impl DeleteHealthCheckResponseDeserializer {
     }
 }
 #[doc="<p>A request to delete a hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteHostedZoneRequest {
     #[doc="<p>The ID of the hosted zone you want to delete.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>A complex type that contains the response to a <code>DeleteHostedZone</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteHostedZoneResponse {
     #[doc="<p>A complex type that contains the ID, the status, and the date and time of a request to delete a hosted zone.</p>"]
+    #[serde(rename="ChangeInfo")]
     pub change_info: ChangeInfo,
 }
 
@@ -1809,14 +1901,15 @@ impl DeleteHostedZoneResponseDeserializer {
     }
 }
 #[doc="<p>A request to delete a reusable delegation set.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteReusableDelegationSetRequest {
     #[doc="<p>The ID of the reusable delegation set that you want to delete.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>An empty element.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteReusableDelegationSetResponse;
 
 struct DeleteReusableDelegationSetResponseDeserializer;
@@ -1837,14 +1930,15 @@ impl DeleteReusableDelegationSetResponseDeserializer {
     }
 }
 #[doc="<p>A request to delete a specified traffic policy instance.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteTrafficPolicyInstanceRequest {
     #[doc="<p>The ID of the traffic policy instance that you want to delete. </p> <important> <p>When you delete a traffic policy instance, Amazon Route 53 also deletes all of the resource record sets that were created when you created the traffic policy instance.</p> </important>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>An empty element.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteTrafficPolicyInstanceResponse;
 
 struct DeleteTrafficPolicyInstanceResponseDeserializer;
@@ -1865,16 +1959,18 @@ impl DeleteTrafficPolicyInstanceResponseDeserializer {
     }
 }
 #[doc="<p>A request to delete a specified traffic policy version.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteTrafficPolicyRequest {
     #[doc="<p>The ID of the traffic policy that you want to delete.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The version number of the traffic policy that you want to delete.</p>"]
+    #[serde(rename="Version")]
     pub version: i64,
 }
 
 #[doc="<p>An empty element.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteTrafficPolicyResponse;
 
 struct DeleteTrafficPolicyResponseDeserializer;
@@ -1894,11 +1990,13 @@ impl DeleteTrafficPolicyResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the request to remove authorization to associate a VPC that was created by one AWS account with a hosted zone that was created with a different AWS account. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteVPCAssociationAuthorizationRequest {
     #[doc="<p>When removing authorization to associate a VPC that was created by one AWS account with a hosted zone that was created with a different AWS account, the ID of the hosted zone.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p>When removing authorization to associate a VPC that was created by one AWS account with a hosted zone that was created with a different AWS account, a complex type that includes the ID and region of the VPC.</p>"]
+    #[serde(rename="VPC")]
     pub vpc: VPC,
 }
 
@@ -1919,7 +2017,7 @@ impl DeleteVPCAssociationAuthorizationRequestSerializer {
     }
 }
 #[doc="<p>Empty response for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteVPCAssociationAuthorizationResponse;
 
 struct DeleteVPCAssociationAuthorizationResponseDeserializer;
@@ -1940,11 +2038,13 @@ impl DeleteVPCAssociationAuthorizationResponseDeserializer {
     }
 }
 #[doc="<p>For the metric that the CloudWatch alarm is associated with, a complex type that contains information about one dimension.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Dimension {
     #[doc="<p>For the metric that the CloudWatch alarm is associated with, the name of one dimension.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>For the metric that the CloudWatch alarm is associated with, the value of one dimension.</p>"]
+    #[serde(rename="Value")]
     pub value: String,
 }
 
@@ -2067,13 +2167,17 @@ impl DisassociateVPCCommentSerializer {
 }
 
 #[doc="<p>A complex type that contains information about the VPC that you want to disassociate from a specified private hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DisassociateVPCFromHostedZoneRequest {
     #[doc="<p> <i>Optional:</i> A comment about the disassociation request.</p>"]
+    #[serde(rename="Comment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub comment: Option<String>,
     #[doc="<p>The ID of the private hosted zone that you want to disassociate a VPC from.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p>A complex type that contains information about the VPC that you're disassociating from the specified hosted zone.</p>"]
+    #[serde(rename="VPC")]
     pub vpc: VPC,
 }
 
@@ -2097,9 +2201,10 @@ impl DisassociateVPCFromHostedZoneRequestSerializer {
     }
 }
 #[doc="<p>A complex type that contains the response information for the disassociate request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DisassociateVPCFromHostedZoneResponse {
     #[doc="<p>A complex type that describes the changes made to the specified private hosted zone.</p>"]
+    #[serde(rename="ChangeInfo")]
     pub change_info: ChangeInfo,
 }
 
@@ -2257,13 +2362,19 @@ impl FullyQualifiedDomainNameSerializer {
 }
 
 #[doc="<p>A complex type that contains information about a geo location.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GeoLocation {
     #[doc="<p>The two-letter code for the continent.</p> <p>Valid values: <code>AF</code> | <code>AN</code> | <code>AS</code> | <code>EU</code> | <code>OC</code> | <code>NA</code> | <code>SA</code> </p> <p>Constraint: Specifying <code>ContinentCode</code> with either <code>CountryCode</code> or <code>SubdivisionCode</code> returns an <code>InvalidInput</code> error.</p>"]
+    #[serde(rename="ContinentCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continent_code: Option<String>,
     #[doc="<p>The two-letter code for the country.</p>"]
+    #[serde(rename="CountryCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub country_code: Option<String>,
     #[doc="<p>The code for the subdivision, for example, a state in the United States or a province in Canada.</p>"]
+    #[serde(rename="SubdivisionCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subdivision_code: Option<String>,
 }
 
@@ -2442,19 +2553,31 @@ impl GeoLocationCountryNameDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the codes and full continent, country, and subdivision names for the specified <code>geolocation</code> code.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GeoLocationDetails {
     #[doc="<p>The two-letter code for the continent.</p>"]
+    #[serde(rename="ContinentCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continent_code: Option<String>,
     #[doc="<p>The full name of the continent.</p>"]
+    #[serde(rename="ContinentName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continent_name: Option<String>,
     #[doc="<p>The two-letter code for the country.</p>"]
+    #[serde(rename="CountryCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub country_code: Option<String>,
     #[doc="<p>The name of the country.</p>"]
+    #[serde(rename="CountryName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub country_name: Option<String>,
     #[doc="<p>The code for the subdivision, for example, a state in the United States or a province in Canada.</p>"]
+    #[serde(rename="SubdivisionCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subdivision_code: Option<String>,
     #[doc="<p>The full name of the subdivision, for example, a state in the United States or a province in Canada.</p>"]
+    #[serde(rename="SubdivisionName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subdivision_name: Option<String>,
 }
 
@@ -2606,16 +2729,18 @@ impl GeoLocationSubdivisionNameDeserializer {
     }
 }
 #[doc="<p>The input for a GetChange request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetChangeRequest {
     #[doc="<p>The ID of the change batch request. The value that you specify here is the value that <code>ChangeResourceRecordSets</code> returned in the <code>Id</code> element when you submitted the request.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>A complex type that contains the <code>ChangeInfo</code> element.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetChangeResponse {
     #[doc="<p>A complex type that contains information about the specified change batch.</p>"]
+    #[serde(rename="ChangeInfo")]
     pub change_info: ChangeInfo,
 }
 
@@ -2661,11 +2786,12 @@ impl GetChangeResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetCheckerIpRangesRequest;
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetCheckerIpRangesResponse {
+    #[serde(rename="CheckerIpRanges")]
     pub checker_ip_ranges: Vec<String>,
 }
 
@@ -2713,20 +2839,27 @@ impl GetCheckerIpRangesResponseDeserializer {
     }
 }
 #[doc="<p>A request for information about whether a specified geographic location is supported for Amazon Route 53 geolocation resource record sets.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetGeoLocationRequest {
     #[doc="<p>Amazon Route 53 supports the following continent codes:</p> <ul> <li> <p> <b>AF</b>: Africa</p> </li> <li> <p> <b>AN</b>: Antarctica</p> </li> <li> <p> <b>AS</b>: Asia</p> </li> <li> <p> <b>EU</b>: Europe</p> </li> <li> <p> <b>OC</b>: Oceania</p> </li> <li> <p> <b>NA</b>: North America</p> </li> <li> <p> <b>SA</b>: South America</p> </li> </ul>"]
+    #[serde(rename="ContinentCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continent_code: Option<String>,
     #[doc="<p>Amazon Route 53 uses the two-letter country codes that are specified in <a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">ISO standard 3166-1 alpha-2</a>.</p>"]
+    #[serde(rename="CountryCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub country_code: Option<String>,
     #[doc="<p>Amazon Route 53 uses the one- to three-letter subdivision codes that are specified in <a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">ISO standard 3166-1 alpha-2</a>. Amazon Route 53 doesn't support subdivision codes for all countries. If you specify <code>SubdivisionCode</code>, you must also specify <code>CountryCode</code>. </p>"]
+    #[serde(rename="SubdivisionCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subdivision_code: Option<String>,
 }
 
 #[doc="<p>A complex type that contains the response information for the specified geolocation code.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetGeoLocationResponse {
     #[doc="<p>A complex type that contains the codes and full continent, country, and subdivision names for the specified geolocation code.</p>"]
+    #[serde(rename="GeoLocationDetails")]
     pub geo_location_details: GeoLocationDetails,
 }
 
@@ -2774,13 +2907,14 @@ impl GetGeoLocationResponseDeserializer {
     }
 }
 #[doc="<p>A request for the number of health checks that are associated with the current AWS account.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHealthCheckCountRequest;
 
 #[doc="<p>A complex type that contains the response to a <code>GetHealthCheckCount</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHealthCheckCountResponse {
     #[doc="<p>The number of health checks associated with the current AWS account.</p>"]
+    #[serde(rename="HealthCheckCount")]
     pub health_check_count: i64,
 }
 
@@ -2828,16 +2962,18 @@ impl GetHealthCheckCountResponseDeserializer {
     }
 }
 #[doc="<p>A request for the reason that a health check failed most recently.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHealthCheckLastFailureReasonRequest {
     #[doc="<p>The ID for the health check for which you want the last failure reason. When you created the health check, <code>CreateHealthCheck</code> returned the ID in the response, in the <code>HealthCheckId</code> element.</p>"]
+    #[serde(rename="HealthCheckId")]
     pub health_check_id: String,
 }
 
 #[doc="<p>A complex type that contains the response to a <code>GetHealthCheckLastFailureReason</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHealthCheckLastFailureReasonResponse {
     #[doc="<p>A list that contains one <code>Observation</code> element for each Amazon Route 53 health checker that is reporting a last failure reason. </p>"]
+    #[serde(rename="HealthCheckObservations")]
     pub health_check_observations: Vec<HealthCheckObservation>,
 }
 
@@ -2886,16 +3022,18 @@ impl GetHealthCheckLastFailureReasonResponseDeserializer {
     }
 }
 #[doc="<p>A request to get information about a specified health check. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHealthCheckRequest {
     #[doc="<p>The identifier that Amazon Route 53 assigned to the health check when you created it. When you add or update a resource record set, you use this value to specify which health check to use. The value can be up to 64 characters long.</p>"]
+    #[serde(rename="HealthCheckId")]
     pub health_check_id: String,
 }
 
 #[doc="<p>A complex type that contains the response to a <code>GetHealthCheck</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHealthCheckResponse {
     #[doc="<p>A complex type that contains information about one health check that is associated with the current AWS account.</p>"]
+    #[serde(rename="HealthCheck")]
     pub health_check: HealthCheck,
 }
 
@@ -2942,16 +3080,18 @@ impl GetHealthCheckResponseDeserializer {
     }
 }
 #[doc="<p>A request to get the status for a health check.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHealthCheckStatusRequest {
     #[doc="<p>The ID for the health check that you want the current status for. When you created the health check, <code>CreateHealthCheck</code> returned the ID in the response, in the <code>HealthCheckId</code> element.</p> <note> <p>If you want to check the status of a calculated health check, you must use the Amazon Route 53 console or the CloudWatch console. You can't use <code>GetHealthCheckStatus</code> to get the status of a calculated health check.</p> </note>"]
+    #[serde(rename="HealthCheckId")]
     pub health_check_id: String,
 }
 
 #[doc="<p>A complex type that contains the response to a <code>GetHealthCheck</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHealthCheckStatusResponse {
     #[doc="<p>A list that contains one <code>HealthCheckObservation</code> element for each Amazon Route 53 health checker that is reporting a status about the health check endpoint.</p>"]
+    #[serde(rename="HealthCheckObservations")]
     pub health_check_observations: Vec<HealthCheckObservation>,
 }
 
@@ -2999,13 +3139,14 @@ impl GetHealthCheckStatusResponseDeserializer {
     }
 }
 #[doc="<p>A request to retrieve a count of all the hosted zones that are associated with the current AWS account.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHostedZoneCountRequest;
 
 #[doc="<p>A complex type that contains the response to a <code>GetHostedZoneCount</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHostedZoneCountResponse {
     #[doc="<p>The total number of public and private hosted zones that are associated with the current AWS account.</p>"]
+    #[serde(rename="HostedZoneCount")]
     pub hosted_zone_count: i64,
 }
 
@@ -3053,20 +3194,26 @@ impl GetHostedZoneCountResponseDeserializer {
     }
 }
 #[doc="<p>A request to get information about a specified hosted zone. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHostedZoneRequest {
     #[doc="<p>The ID of the hosted zone that you want to get information about.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>A complex type that contain the response to a <code>GetHostedZone</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetHostedZoneResponse {
     #[doc="<p>A complex type that lists the Amazon Route 53 name servers for the specified hosted zone.</p>"]
+    #[serde(rename="DelegationSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delegation_set: Option<DelegationSet>,
     #[doc="<p>A complex type that contains general information about the specified hosted zone.</p>"]
+    #[serde(rename="HostedZone")]
     pub hosted_zone: HostedZone,
     #[doc="<p>A complex type that contains information about the VPCs that are associated with the specified hosted zone.</p>"]
+    #[serde(rename="VPCs")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vp_cs: Option<Vec<VPC>>,
 }
 
@@ -3121,16 +3268,18 @@ impl GetHostedZoneResponseDeserializer {
     }
 }
 #[doc="<p>A request to get information about a specified reusable delegation set.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetReusableDelegationSetRequest {
     #[doc="<p>The ID of the reusable delegation set that you want to get a list of name servers for.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>A complex type that contains the response to the <code>GetReusableDelegationSet</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetReusableDelegationSetResponse {
     #[doc="<p>A complex type that contains information about the reusable delegation set.</p>"]
+    #[serde(rename="DelegationSet")]
     pub delegation_set: DelegationSet,
 }
 
@@ -3179,13 +3328,14 @@ impl GetReusableDelegationSetResponseDeserializer {
     }
 }
 #[doc="<p>Request to get the number of traffic policy instances that are associated with the current AWS account.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetTrafficPolicyInstanceCountRequest;
 
 #[doc="<p>A complex type that contains information about the resource record sets that Amazon Route 53 created based on a specified traffic policy.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetTrafficPolicyInstanceCountResponse {
     #[doc="<p>The number of traffic policy instances that are associated with the current AWS account.</p>"]
+    #[serde(rename="TrafficPolicyInstanceCount")]
     pub traffic_policy_instance_count: i64,
 }
 
@@ -3234,16 +3384,18 @@ impl GetTrafficPolicyInstanceCountResponseDeserializer {
     }
 }
 #[doc="<p>Gets information about a specified traffic policy instance.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetTrafficPolicyInstanceRequest {
     #[doc="<p>The ID of the traffic policy instance that you want to get information about.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
 #[doc="<p>A complex type that contains information about the resource record sets that Amazon Route 53 created based on a specified traffic policy.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetTrafficPolicyInstanceResponse {
     #[doc="<p>A complex type that contains settings for the traffic policy instance.</p>"]
+    #[serde(rename="TrafficPolicyInstance")]
     pub traffic_policy_instance: TrafficPolicyInstance,
 }
 
@@ -3292,18 +3444,21 @@ impl GetTrafficPolicyInstanceResponseDeserializer {
     }
 }
 #[doc="<p>Gets information about a specific traffic policy version.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetTrafficPolicyRequest {
     #[doc="<p>The ID of the traffic policy that you want to get information about.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The version number of the traffic policy that you want to get information about.</p>"]
+    #[serde(rename="Version")]
     pub version: i64,
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetTrafficPolicyResponse {
     #[doc="<p>A complex type that contains settings for the specified traffic policy.</p>"]
+    #[serde(rename="TrafficPolicy")]
     pub traffic_policy: TrafficPolicy,
 }
 
@@ -3351,17 +3506,23 @@ impl GetTrafficPolicyResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about one health check that is associated with the current AWS account.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct HealthCheck {
     #[doc="<p>A unique string that you specified when you created the health check.</p>"]
+    #[serde(rename="CallerReference")]
     pub caller_reference: String,
     #[doc="<p>A complex type that contains information about the CloudWatch alarm that Amazon Route 53 is monitoring for this health check.</p>"]
+    #[serde(rename="CloudWatchAlarmConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cloud_watch_alarm_configuration: Option<CloudWatchAlarmConfiguration>,
     #[doc="<p>A complex type that contains detailed information about one health check.</p>"]
+    #[serde(rename="HealthCheckConfig")]
     pub health_check_config: HealthCheckConfig,
     #[doc="<p>The version of the health check. You can optionally pass this value in a call to <code>UpdateHealthCheck</code> to prevent overwriting another change to the health check.</p>"]
+    #[serde(rename="HealthCheckVersion")]
     pub health_check_version: i64,
     #[doc="<p>The identifier that Amazon Route 53assigned to the health check when you created it. When you add or update a resource record set, you use this value to specify which health check to use. The value can be up to 64 characters long. </p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
@@ -3425,39 +3586,70 @@ impl HealthCheckDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the health check.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct HealthCheckConfig {
     #[doc="<p>A complex type that identifies the CloudWatch alarm that you want Amazon Route 53 health checkers to use to determine whether this health check is healthy.</p>"]
+    #[serde(rename="AlarmIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_identifier: Option<AlarmIdentifier>,
     #[doc="<p>(CALCULATED Health Checks Only) A complex type that contains one <code>ChildHealthCheck</code> element for each health check that you want to associate with a <code>CALCULATED</code> health check.</p>"]
+    #[serde(rename="ChildHealthChecks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub child_health_checks: Option<Vec<String>>,
     #[doc="<p>Specify whether you want Amazon Route 53 to send the value of <code>FullyQualifiedDomainName</code> to the endpoint in the <code>client_hello</code> message during TLS negotiation. This allows the endpoint to respond to <code>HTTPS</code> health check requests with the applicable SSL/TLS certificate.</p> <p>Some endpoints require that <code>HTTPS</code> requests include the host name in the <code>client_hello</code> message. If you don't enable SNI, the status of the health check will be <code>SSL alert handshake_failure</code>. A health check can also have that status for other reasons. If SNI is enabled and you're still getting the error, check the SSL/TLS configuration on your endpoint and confirm that your certificate is valid.</p> <p>The SSL/TLS certificate on your endpoint includes a domain name in the <code>Common Name</code> field and possibly several more in the <code>Subject Alternative Names</code> field. One of the domain names in the certificate should match the value that you specify for <code>FullyQualifiedDomainName</code>. If the endpoint responds to the <code>client_hello</code> message with a certificate that does not include the domain name that you specified in <code>FullyQualifiedDomainName</code>, a health checker will retry the handshake. In the second attempt, the health checker will omit <code>FullyQualifiedDomainName</code> from the <code>client_hello</code> message.</p>"]
+    #[serde(rename="EnableSNI")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_sni: Option<bool>,
     #[doc="<p>The number of consecutive health checks that an endpoint must pass or fail for Amazon Route 53 to change the current status of the endpoint from unhealthy to healthy or vice versa. For more information, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html\">How Amazon Route 53 Determines Whether an Endpoint Is Healthy</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> <p>If you don't specify a value for <code>FailureThreshold</code>, the default value is three health checks.</p>"]
+    #[serde(rename="FailureThreshold")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub failure_threshold: Option<i64>,
     #[doc="<p>Amazon Route 53 behavior depends on whether you specify a value for <code>IPAddress</code>.</p> <p> <b>If you specify a value for</b> <code>IPAddress</code>:</p> <p>Amazon Route 53 sends health check requests to the specified IPv4 or IPv6 address and passes the value of <code>FullyQualifiedDomainName</code> in the <code>Host</code> header for all health checks except TCP health checks. This is typically the fully qualified DNS name of the endpoint on which you want Amazon Route 53 to perform health checks.</p> <p>When Amazon Route 53 checks the health of an endpoint, here is how it constructs the <code>Host</code> header:</p> <ul> <li> <p>If you specify a value of <code>80</code> for <code>Port</code> and <code>HTTP</code> or <code>HTTP_STR_MATCH</code> for <code>Type</code>, Amazon Route 53 passes the value of <code>FullyQualifiedDomainName</code> to the endpoint in the Host header. </p> </li> <li> <p>If you specify a value of <code>443</code> for <code>Port</code> and <code>HTTPS</code> or <code>HTTPS_STR_MATCH</code> for <code>Type</code>, Amazon Route 53 passes the value of <code>FullyQualifiedDomainName</code> to the endpoint in the <code>Host</code> header.</p> </li> <li> <p>If you specify another value for <code>Port</code> and any value except <code>TCP</code> for <code>Type</code>, Amazon Route 53 passes <code>FullyQualifiedDomainName:Port</code> to the endpoint in the <code>Host</code> header.</p> </li> </ul> <p>If you don't specify a value for <code>FullyQualifiedDomainName</code>, Amazon Route 53 substitutes the value of <code>IPAddress</code> in the <code>Host</code> header in each of the preceding cases.</p> <p> <b>If you don't specify a value for <code>IPAddress</code> </b>:</p> <p>Amazon Route 53 sends a DNS request to the domain that you specify for <code>FullyQualifiedDomainName</code> at the interval that you specify for <code>RequestInterval</code>. Using an IPv4 address that DNS returns, Amazon Route 53 then checks the health of the endpoint.</p> <note> <p>If you don't specify a value for <code>IPAddress</code>, Amazon Route 53 uses only IPv4 to send health checks to the endpoint. If there's no resource record set with a type of A for the name that you specify for <code>FullyQualifiedDomainName</code>, the health check fails with a \"DNS resolution failed\" error.</p> </note> <p>If you want to check the health of weighted, latency, or failover resource record sets and you choose to specify the endpoint only by <code>FullyQualifiedDomainName</code>, we recommend that you create a separate health check for each endpoint. For example, create a health check for each HTTP server that is serving content for www.example.com. For the value of <code>FullyQualifiedDomainName</code>, specify the domain name of the server (such as us-east-2-www.example.com), not the name of the resource record sets (www.example.com).</p> <important> <p>In this configuration, if you create a health check for which the value of <code>FullyQualifiedDomainName</code> matches the name of the resource record sets and you then associate the health check with those resource record sets, health check results will be unpredictable.</p> </important> <p>In addition, if the value that you specify for <code>Type</code> is <code>HTTP</code>, <code>HTTPS</code>, <code>HTTP_STR_MATCH</code>, or <code>HTTPS_STR_MATCH</code>, Amazon Route 53 passes the value of <code>FullyQualifiedDomainName</code> in the <code>Host</code> header, as it does when you specify a value for <code>IPAddress</code>. If the value of <code>Type</code> is <code>TCP</code>, Amazon Route 53 doesn't pass a <code>Host</code> header.</p>"]
+    #[serde(rename="FullyQualifiedDomainName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fully_qualified_domain_name: Option<String>,
     #[doc="<p>The number of child health checks that are associated with a <code>CALCULATED</code> health that Amazon Route 53 must consider healthy for the <code>CALCULATED</code> health check to be considered healthy. To specify the child health checks that you want to associate with a <code>CALCULATED</code> health check, use the <a>HealthCheckConfig$ChildHealthChecks</a> and <a>HealthCheckConfig$ChildHealthChecks</a> elements.</p> <p>Note the following:</p> <ul> <li> <p>If you specify a number greater than the number of child health checks, Amazon Route 53 always considers this health check to be unhealthy.</p> </li> <li> <p>If you specify <code>0</code>, Amazon Route 53 always considers this health check to be healthy.</p> </li> </ul>"]
+    #[serde(rename="HealthThreshold")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_threshold: Option<i64>,
     #[doc="<p>The IPv4 or IPv6 IP address of the endpoint that you want Amazon Route 53 to perform health checks on. If you don't specify a value for <code>IPAddress</code>, Amazon Route 53 sends a DNS request to resolve the domain name that you specify in <code>FullyQualifiedDomainName</code> at the interval that you specify in <code>RequestInterval</code>. Using an IP address returned by DNS, Amazon Route 53 then checks the health of the endpoint.</p> <p>Use one of the following formats for the value of <code>IPAddress</code>: </p> <ul> <li> <p> <b>IPv4 address</b>: four values between 0 and 255, separated by periods (.), for example, <code>192.0.2.44</code>.</p> </li> <li> <p> <b>IPv6 address</b>: eight groups of four hexadecimal values, separated by colons (:), for example, <code>2001:0db8:85a3:0000:0000:abcd:0001:2345</code>. You can also shorten IPv6 addresses as described in RFC 5952, for example, <code>2001:db8:85a3::abcd:1:2345</code>.</p> </li> </ul> <p>If the endpoint is an EC2 instance, we recommend that you create an Elastic IP address, associate it with your EC2 instance, and specify the Elastic IP address for <code>IPAddress</code>. This ensures that the IP address of your instance will never change.</p> <p>For more information, see <a>HealthCheckConfig$FullyQualifiedDomainName</a>.</p> <p>Constraints: Amazon Route 53 can't check the health of endpoints for which the IP address is in local, private, non-routable, or multicast ranges. For more information about IP addresses for which you can't create health checks, see the following documents:</p> <ul> <li> <p> <a href=\"https://tools.ietf.org/html/rfc5735\">RFC 5735, Special Use IPv4 Addresses</a> </p> </li> <li> <p> <a href=\"https://tools.ietf.org/html/rfc6598\">RFC 6598, IANA-Reserved IPv4 Prefix for Shared Address Space</a> </p> </li> <li> <p> <a href=\"https://tools.ietf.org/html/rfc5156\">RFC 5156, Special-Use IPv6 Addresses</a> </p> </li> </ul> <p>When the value of <code>Type</code> is <code>CALCULATED</code> or <code>CLOUDWATCH_METRIC</code>, omit <code>IPAddress</code>.</p>"]
+    #[serde(rename="IPAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_address: Option<String>,
     #[doc="<p>When CloudWatch has insufficient data about the metric to determine the alarm state, the status that you want Amazon Route 53 to assign to the health check:</p> <ul> <li> <p> <code>Healthy</code>: Amazon Route 53 considers the health check to be healthy.</p> </li> <li> <p> <code>Unhealthy</code>: Amazon Route 53 considers the health check to be unhealthy.</p> </li> <li> <p> <code>LastKnownStatus</code>: Amazon Route 53 uses the status of the health check from the last time that CloudWatch had sufficient data to determine the alarm state. For new health checks that have no last known status, the default status for the health check is healthy.</p> </li> </ul>"]
+    #[serde(rename="InsufficientDataHealthStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub insufficient_data_health_status: Option<String>,
     #[doc="<p>Specify whether you want Amazon Route 53 to invert the status of a health check, for example, to consider a health check unhealthy when it otherwise would be considered healthy.</p>"]
+    #[serde(rename="Inverted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub inverted: Option<bool>,
     #[doc="<p>Specify whether you want Amazon Route 53 to measure the latency between health checkers in multiple AWS regions and your endpoint, and to display CloudWatch latency graphs on the <b>Health Checks</b> page in the Amazon Route 53 console.</p> <important> <p>You can't change the value of <code>MeasureLatency</code> after you create a health check.</p> </important>"]
+    #[serde(rename="MeasureLatency")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub measure_latency: Option<bool>,
     #[doc="<p>The port on the endpoint on which you want Amazon Route 53 to perform health checks. Specify a value for <code>Port</code> only when you specify a value for <code>IPAddress</code>.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>A complex type that contains one <code>Region</code> element for each region from which you want Amazon Route 53 health checkers to check the specified endpoint.</p> <p>If you don't specify any regions, Amazon Route 53 health checkers automatically performs checks from all of the regions that are listed under <b>Valid Values</b>.</p> <p>If you update a health check to remove a region that has been performing health checks, Amazon Route 53 will briefly continue to perform checks from that region to ensure that some health checkers are always checking the endpoint (for example, if you replace three regions with four different regions). </p>"]
+    #[serde(rename="Regions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub regions: Option<Vec<String>>,
     #[doc="<p>The number of seconds between the time that Amazon Route 53 gets a response from your endpoint and the time that it sends the next health check request. Each Amazon Route 53 health checker makes requests at this interval.</p> <important> <p>You can't change the value of <code>RequestInterval</code> after you create a health check.</p> </important> <p>If you don't specify a value for <code>RequestInterval</code>, the default value is <code>30</code> seconds.</p>"]
+    #[serde(rename="RequestInterval")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_interval: Option<i64>,
     #[doc="<p>The path, if any, that you want Amazon Route 53 to request when performing health checks. The path can be any value for which your endpoint will return an HTTP status code of 2xx or 3xx when the endpoint is healthy, for example, the file /docs/route53-health-check.html. </p>"]
+    #[serde(rename="ResourcePath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_path: Option<String>,
     #[doc="<p>If the value of Type is <code>HTTP_STR_MATCH</code> or <code>HTTP_STR_MATCH</code>, the string that you want Amazon Route 53 to search for in the response body from the specified resource. If the string appears in the response body, Amazon Route 53 considers the resource healthy.</p> <p>Amazon Route 53 considers case when searching for <code>SearchString</code> in the response body. </p>"]
+    #[serde(rename="SearchString")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_string: Option<String>,
     #[doc="<p>The type of health check that you want to create, which indicates how Amazon Route 53 determines whether an endpoint is healthy.</p> <important> <p>You can't change the value of <code>Type</code> after you create a health check.</p> </important> <p>You can create the following types of health checks:</p> <ul> <li> <p> <b>HTTP</b>: Amazon Route 53 tries to establish a TCP connection. If successful, Amazon Route 53 submits an HTTP request and waits for an HTTP status code of 200 or greater and less than 400.</p> </li> <li> <p> <b>HTTPS</b>: Amazon Route 53 tries to establish a TCP connection. If successful, Amazon Route 53 submits an HTTPS request and waits for an HTTP status code of 200 or greater and less than 400.</p> <important> <p>If you specify <code>HTTPS</code> for the value of <code>Type</code>, the endpoint must support TLS v1.0 or later.</p> </important> </li> <li> <p> <b>HTTP_STR_MATCH</b>: Amazon Route 53 tries to establish a TCP connection. If successful, Amazon Route 53 submits an HTTP request and searches the first 5,120 bytes of the response body for the string that you specify in <code>SearchString</code>.</p> </li> <li> <p> <b>HTTPS_STR_MATCH</b>: Amazon Route 53 tries to establish a TCP connection. If successful, Amazon Route 53 submits an <code>HTTPS</code> request and searches the first 5,120 bytes of the response body for the string that you specify in <code>SearchString</code>.</p> </li> <li> <p> <b>TCP</b>: Amazon Route 53 tries to establish a TCP connection.</p> </li> <li> <p> <b>CLOUDWATCH_METRIC</b>: The health check is associated with a CloudWatch alarm. If the state of the alarm is <code>OK</code>, the health check is considered healthy. If the state is <code>ALARM</code>, the health check is considered unhealthy. If CloudWatch doesn't have sufficient data to determine whether the state is <code>OK</code> or <code>ALARM</code>, the health check status depends on the setting for <code>InsufficientDataHealthStatus</code>: <code>Healthy</code>, <code>Unhealthy</code>, or <code>LastKnownStatus</code>. </p> </li> <li> <p> <b>CALCULATED</b>: For health checks that monitor the status of other health checks, Amazon Route 53 adds up the number of health checks that Amazon Route 53 health checkers consider to be healthy and compares that number with the value of <code>HealthThreshold</code>. </p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html\">How Amazon Route 53 Determines Whether an Endpoint Is Healthy</a> in the <i>Amazon Route 53 Developer Guide</i>.</p>"]
+    #[serde(rename="Type")]
     pub type_: String,
 }
 
@@ -3747,13 +3939,19 @@ impl HealthCheckNonceSerializer {
 }
 
 #[doc="<p>A complex type that contains the last failure reason as reported by one Amazon Route 53 health checker.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct HealthCheckObservation {
     #[doc="<p>The IP address of the Amazon Route 53 health checker that provided the failure reason in <code>StatusReport</code>.</p>"]
+    #[serde(rename="IPAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_address: Option<String>,
     #[doc="<p>The region of the Amazon Route 53 health checker that provided the status in <code>StatusReport</code>.</p>"]
+    #[serde(rename="Region")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub region: Option<String>,
     #[doc="<p>A complex type that contains the last failure reason as reported by one Amazon Route 53 health checker and the time of the failed health check.</p>"]
+    #[serde(rename="StatusReport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_report: Option<StatusReport>,
 }
 
@@ -4080,17 +4278,24 @@ impl HealthThresholdSerializer {
 }
 
 #[doc="<p>A complex type that contains general information about the hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct HostedZone {
     #[doc="<p>The value that you specified for <code>CallerReference</code> when you created the hosted zone.</p>"]
+    #[serde(rename="CallerReference")]
     pub caller_reference: String,
     #[doc="<p>A complex type that includes the <code>Comment</code> and <code>PrivateZone</code> elements. If you omitted the <code>HostedZoneConfig</code> and <code>Comment</code> elements from the request, the <code>Config</code> and <code>Comment</code> elements don't appear in the response.</p>"]
+    #[serde(rename="Config")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub config: Option<HostedZoneConfig>,
     #[doc="<p>The ID that Amazon Route 53 assigned to the hosted zone when you created it.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The name of the domain. For public hosted zones, this is the name that you have registered with your DNS registrar.</p> <p>For information about how to specify characters other than <code>a-z</code>, <code>0-9</code>, and <code>-</code> (hyphen) and how to specify internationalized domain names, see <a>CreateHostedZone</a>.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The number of resource record sets in the hosted zone.</p>"]
+    #[serde(rename="ResourceRecordSetCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_record_set_count: Option<i64>,
 }
 
@@ -4153,11 +4358,15 @@ impl HostedZoneDeserializer {
     }
 }
 #[doc="<p>A complex type that contains an optional comment about your hosted zone. If you don't want to specify a comment, omit both the <code>HostedZoneConfig</code> and <code>Comment</code> elements.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct HostedZoneConfig {
     #[doc="<p>Any comments that you want to include about the hosted zone.</p>"]
+    #[serde(rename="Comment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub comment: Option<String>,
     #[doc="<p>A value that indicates whether this is a private hosted zone.</p>"]
+    #[serde(rename="PrivateZone")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub private_zone: Option<bool>,
 }
 
@@ -4448,32 +4657,49 @@ impl IsPrivateZoneSerializer {
 }
 
 #[doc="<p>A request to get a list of geographic locations that Amazon Route 53 supports for geolocation resource record sets. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListGeoLocationsRequest {
     #[doc="<p>(Optional) The maximum number of geolocations to be included in the response body for this request. If more than <code>MaxItems</code> geolocations remain to be listed, then the value of the <code>IsTruncated</code> element in the response is <code>true</code>.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
     #[doc="<p>The code for the continent with which you want to start listing locations that Amazon Route 53 supports for geolocation. If Amazon Route 53 has already returned a page or more of results, if <code>IsTruncated</code> is true, and if <code>NextContinentCode</code> from the previous response has a value, enter that value in <code>StartContinentCode</code> to return the next page of results.</p> <p>Include <code>StartContinentCode</code> only if you want to list continents. Don't include <code>StartContinentCode</code> when you're listing countries or countries with their subdivisions.</p>"]
+    #[serde(rename="StartContinentCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_continent_code: Option<String>,
     #[doc="<p>The code for the country with which you want to start listing locations that Amazon Route 53 supports for geolocation. If Amazon Route 53 has already returned a page or more of results, if <code>IsTruncated</code> is <code>true</code>, and if <code>NextCountryCode</code> from the previous response has a value, enter that value in <code>StartCountryCode</code> to return the next page of results.</p> <p>Amazon Route 53 uses the two-letter country codes that are specified in <a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">ISO standard 3166-1 alpha-2</a>.</p>"]
+    #[serde(rename="StartCountryCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_country_code: Option<String>,
     #[doc="<p>The code for the subdivision (for example, state or province) with which you want to start listing locations that Amazon Route 53 supports for geolocation. If Amazon Route 53 has already returned a page or more of results, if <code>IsTruncated</code> is <code>true</code>, and if <code>NextSubdivisionCode</code> from the previous response has a value, enter that value in <code>StartSubdivisionCode</code> to return the next page of results.</p> <p>To list subdivisions of a country, you must include both <code>StartCountryCode</code> and <code>StartSubdivisionCode</code>.</p>"]
+    #[serde(rename="StartSubdivisionCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_subdivision_code: Option<String>,
 }
 
 #[doc="<p>A complex type containing the response information for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListGeoLocationsResponse {
     #[doc="<p>A complex type that contains one <code>GeoLocationDetails</code> element for each location that Amazon Route 53 supports for geolocation.</p>"]
+    #[serde(rename="GeoLocationDetailsList")]
     pub geo_location_details_list: Vec<GeoLocationDetails>,
     #[doc="<p>A value that indicates whether more locations remain to be listed after the last location in this response. If so, the value of <code>IsTruncated</code> is <code>true</code>. To get more values, submit another request and include the values of <code>NextContinentCode</code>, <code>NextCountryCode</code>, and <code>NextSubdivisionCode</code> in the <code>StartContinentCode</code>, <code>StartCountryCode</code>, and <code>StartSubdivisionCode</code>, as applicable.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>The value that you specified for <code>MaxItems</code> in the request.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: String,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, you can make a follow-up request to display more locations. Enter the value of <code>NextContinentCode</code> in the <code>StartContinentCode</code> parameter in another <code>ListGeoLocations</code> request.</p>"]
+    #[serde(rename="NextContinentCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_continent_code: Option<String>,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, you can make a follow-up request to display more locations. Enter the value of <code>NextCountryCode</code> in the <code>StartCountryCode</code> parameter in another <code>ListGeoLocations</code> request.</p>"]
+    #[serde(rename="NextCountryCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_country_code: Option<String>,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, you can make a follow-up request to display more locations. Enter the value of <code>NextSubdivisionCode</code> in the <code>StartSubdivisionCode</code> parameter in another <code>ListGeoLocations</code> request.</p>"]
+    #[serde(rename="NextSubdivisionCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_subdivision_code: Option<String>,
 }
 
@@ -4540,26 +4766,36 @@ impl ListGeoLocationsResponseDeserializer {
     }
 }
 #[doc="<p>A request to retrieve a list of the health checks that are associated with the current AWS account.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListHealthChecksRequest {
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more health checks. To get another group, submit another <code>ListHealthChecks</code> request. </p> <p>For the value of <code>marker</code>, specify the value of <code>NextMarker</code> from the previous response, which is the ID of the first health check that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more health checks to get.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The maximum number of health checks that you want <code>ListHealthChecks</code> to return in response to the current request. Amazon Route 53 returns a maximum of 100 items. If you set <code>MaxItems</code> to a value greater than 100, Amazon Route 53 returns only the first 100 health checks. </p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
 }
 
 #[doc="<p>A complex type that contains the response to a <code>ListHealthChecks</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListHealthChecksResponse {
     #[doc="<p>A complex type that contains one <code>HealthCheck</code> element for each health check that is associated with the current AWS account.</p>"]
+    #[serde(rename="HealthChecks")]
     pub health_checks: Vec<HealthCheck>,
     #[doc="<p>A flag that indicates whether there are more health checks to be listed. If the response was truncated, you can get the next group of health checks by submitting another <code>ListHealthChecks</code> request and specifying the value of <code>NextMarker</code> in the <code>marker</code> parameter.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>For the second and subsequent calls to <code>ListHealthChecks</code>, <code>Marker</code> is the value that you specified for the <code>marker</code> parameter in the previous request.</p>"]
+    #[serde(rename="Marker")]
     pub marker: String,
     #[doc="<p>The value that you specified for the <code>maxitems</code> parameter in the call to <code>ListHealthChecks</code> that produced the current response.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: String,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, the value of <code>NextMarker</code> identifies the first health check that Amazon Route 53 returns if you submit another <code>ListHealthChecks</code> request and specify the value of <code>NextMarker</code> in the <code>marker</code> parameter.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
 }
 
@@ -4622,32 +4858,49 @@ impl ListHealthChecksResponseDeserializer {
     }
 }
 #[doc="<p>Retrieves a list of the public and private hosted zones that are associated with the current AWS account in ASCII order by domain name. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListHostedZonesByNameRequest {
     #[doc="<p>(Optional) For your first request to <code>ListHostedZonesByName</code>, include the <code>dnsname</code> parameter only if you want to specify the name of the first hosted zone in the response. If you don't include the <code>dnsname</code> parameter, Amazon Route 53 returns all of the hosted zones that were created by the current AWS account, in ASCII order. For subsequent requests, include both <code>dnsname</code> and <code>hostedzoneid</code> parameters. For <code>dnsname</code>, specify the value of <code>NextDNSName</code> from the previous response.</p>"]
+    #[serde(rename="DNSName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dns_name: Option<String>,
     #[doc="<p>(Optional) For your first request to <code>ListHostedZonesByName</code>, do not include the <code>hostedzoneid</code> parameter.</p> <p>If you have more hosted zones than the value of <code>maxitems</code>, <code>ListHostedZonesByName</code> returns only the first <code>maxitems</code> hosted zones. To get the next group of <code>maxitems</code> hosted zones, submit another request to <code>ListHostedZonesByName</code> and include both <code>dnsname</code> and <code>hostedzoneid</code> parameters. For the value of <code>hostedzoneid</code>, specify the value of the <code>NextHostedZoneId</code> element from the previous response.</p>"]
+    #[serde(rename="HostedZoneId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hosted_zone_id: Option<String>,
     #[doc="<p>The maximum number of hosted zones to be included in the response body for this request. If you have more than <code>maxitems</code> hosted zones, then the value of the <code>IsTruncated</code> element in the response is true, and the values of <code>NextDNSName</code> and <code>NextHostedZoneId</code> specify the first hosted zone in the next group of <code>maxitems</code> hosted zones. </p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListHostedZonesByNameResponse {
     #[doc="<p>For the second and subsequent calls to <code>ListHostedZonesByName</code>, <code>DNSName</code> is the value that you specified for the <code>dnsname</code> parameter in the request that produced the current response.</p>"]
+    #[serde(rename="DNSName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dns_name: Option<String>,
     #[doc="<p>The ID that Amazon Route 53 assigned to the hosted zone when you created it.</p>"]
+    #[serde(rename="HostedZoneId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hosted_zone_id: Option<String>,
     #[doc="<p>A complex type that contains general information about the hosted zone.</p>"]
+    #[serde(rename="HostedZones")]
     pub hosted_zones: Vec<HostedZone>,
     #[doc="<p>A flag that indicates whether there are more hosted zones to be listed. If the response was truncated, you can get the next group of <code>maxitems</code> hosted zones by calling <code>ListHostedZonesByName</code> again and specifying the values of <code>NextDNSName</code> and <code>NextHostedZoneId</code> elements in the <code>dnsname</code> and <code>hostedzoneid</code> parameters.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>The value that you specified for the <code>maxitems</code> parameter in the call to <code>ListHostedZonesByName</code> that produced the current response.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: String,
     #[doc="<p>If <code>IsTruncated</code> is true, the value of <code>NextDNSName</code> is the name of the first hosted zone in the next group of <code>maxitems</code> hosted zones. Call <code>ListHostedZonesByName</code> again and specify the value of <code>NextDNSName</code> and <code>NextHostedZoneId</code> in the <code>dnsname</code> and <code>hostedzoneid</code> parameters, respectively.</p> <p>This element is present only if <code>IsTruncated</code> is <code>true</code>.</p>"]
+    #[serde(rename="NextDNSName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_dns_name: Option<String>,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, the value of <code>NextHostedZoneId</code> identifies the first hosted zone in the next group of <code>maxitems</code> hosted zones. Call <code>ListHostedZonesByName</code> again and specify the value of <code>NextDNSName</code> and <code>NextHostedZoneId</code> in the <code>dnsname</code> and <code>hostedzoneid</code> parameters, respectively.</p> <p>This element is present only if <code>IsTruncated</code> is <code>true</code>.</p>"]
+    #[serde(rename="NextHostedZoneId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_hosted_zone_id: Option<String>,
 }
 
@@ -4720,27 +4973,39 @@ impl ListHostedZonesByNameResponseDeserializer {
     }
 }
 #[doc="<p>A request to retrieve a list of the public and private hosted zones that are associated with the current AWS account.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListHostedZonesRequest {
     #[doc="<p>If you're using reusable delegation sets and you want to list all of the hosted zones that are associated with a reusable delegation set, specify the ID of that reusable delegation set. </p>"]
+    #[serde(rename="DelegationSetId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delegation_set_id: Option<String>,
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more hosted zones. To get more hosted zones, submit another <code>ListHostedZones</code> request. </p> <p>For the value of <code>marker</code>, specify the value of <code>NextMarker</code> from the previous response, which is the ID of the first hosted zone that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more hosted zones to get.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>(Optional) The maximum number of hosted zones that you want Amazon Route 53 to return. If you have more than <code>maxitems</code> hosted zones, the value of <code>IsTruncated</code> in the response is <code>true</code>, and the value of <code>NextMarker</code> is the hosted zone ID of the first hosted zone that Amazon Route 53 will return if you submit another request.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListHostedZonesResponse {
     #[doc="<p>A complex type that contains general information about the hosted zone.</p>"]
+    #[serde(rename="HostedZones")]
     pub hosted_zones: Vec<HostedZone>,
     #[doc="<p>A flag indicating whether there are more hosted zones to be listed. If the response was truncated, you can get more hosted zones by submitting another <code>ListHostedZones</code> request and specifying the value of <code>NextMarker</code> in the <code>marker</code> parameter.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>For the second and subsequent calls to <code>ListHostedZones</code>, <code>Marker</code> is the value that you specified for the <code>marker</code> parameter in the request that produced the current response.</p>"]
+    #[serde(rename="Marker")]
     pub marker: String,
     #[doc="<p>The value that you specified for the <code>maxitems</code> parameter in the call to <code>ListHostedZones</code> that produced the current response.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: String,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, the value of <code>NextMarker</code> identifies the first hosted zone in the next group of hosted zones. Submit another <code>ListHostedZones</code> request, and specify the value of <code>NextMarker</code> from the response in the <code>marker</code> parameter.</p> <p>This element is present only if <code>IsTruncated</code> is <code>true</code>.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
 }
 
@@ -4803,34 +5068,52 @@ impl ListHostedZonesResponseDeserializer {
     }
 }
 #[doc="<p>A request for the resource record sets that are associated with a specified hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListResourceRecordSetsRequest {
     #[doc="<p>The ID of the hosted zone that contains the resource record sets that you want to list.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p>(Optional) The maximum number of resource records sets to include in the response body for this request. If the response includes more than <code>maxitems</code> resource record sets, the value of the <code>IsTruncated</code> element in the response is <code>true</code>, and the values of the <code>NextRecordName</code> and <code>NextRecordType</code> elements in the response identify the first resource record set in the next group of <code>maxitems</code> resource record sets.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
     #[doc="<p> <i>Weighted resource record sets only:</i> If results were truncated for a given DNS name and type, specify the value of <code>NextRecordIdentifier</code> from the previous response to get the next resource record set that has the current DNS name and type.</p>"]
+    #[serde(rename="StartRecordIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_record_identifier: Option<String>,
     #[doc="<p>The first name in the lexicographic ordering of resource record sets that you want to list.</p>"]
+    #[serde(rename="StartRecordName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_record_name: Option<String>,
     #[doc="<p>The type of resource record set to begin the record listing from.</p> <p>Valid values for basic resource record sets: <code>A</code> | <code>AAAA</code> | <code>CAA</code> | <code>CNAME</code> | <code>MX</code> | <code>NAPTR</code> | <code>NS</code> | <code>PTR</code> | <code>SOA</code> | <code>SPF</code> | <code>SRV</code> | <code>TXT</code> </p> <p>Values for weighted, latency, geo, and failover resource record sets: <code>A</code> | <code>AAAA</code> | <code>CAA</code> | <code>CNAME</code> | <code>MX</code> | <code>NAPTR</code> | <code>PTR</code> | <code>SPF</code> | <code>SRV</code> | <code>TXT</code> </p> <p>Values for alias resource record sets: </p> <ul> <li> <p> <b>CloudFront distribution</b>: A or AAAA</p> </li> <li> <p> <b>Elastic Beanstalk environment that has a regionalized subdomain</b>: A</p> </li> <li> <p> <b>ELB load balancer</b>: A | AAAA</p> </li> <li> <p> <b>Amazon S3 bucket</b>: A</p> </li> <li> <p> <b>Another resource record set in this hosted zone:</b> The type of the resource record set that the alias references.</p> </li> </ul> <p>Constraint: Specifying <code>type</code> without specifying <code>name</code> returns an <code>InvalidInput</code> error.</p>"]
+    #[serde(rename="StartRecordType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_record_type: Option<String>,
 }
 
 #[doc="<p>A complex type that contains list information for the resource record set.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListResourceRecordSetsResponse {
     #[doc="<p>A flag that indicates whether more resource record sets remain to be listed. If your results were truncated, you can make a follow-up pagination request by using the <code>NextRecordName</code> element.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>The maximum number of records you requested.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: String,
     #[doc="<p> <i>Weighted, latency, geolocation, and failover resource record sets only</i>: If results were truncated for a given DNS name and type, the value of <code>SetIdentifier</code> for the next resource record set that has the current DNS name and type.</p>"]
+    #[serde(rename="NextRecordIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_record_identifier: Option<String>,
     #[doc="<p>If the results were truncated, the name of the next record in the list.</p> <p>This element is present only if <code>IsTruncated</code> is true. </p>"]
+    #[serde(rename="NextRecordName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_record_name: Option<String>,
     #[doc="<p>If the results were truncated, the type of the next record in the list.</p> <p>This element is present only if <code>IsTruncated</code> is true. </p>"]
+    #[serde(rename="NextRecordType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_record_type: Option<String>,
     #[doc="<p>Information about multiple resource record sets.</p>"]
+    #[serde(rename="ResourceRecordSets")]
     pub resource_record_sets: Vec<ResourceRecordSet>,
 }
 
@@ -4899,26 +5182,36 @@ impl ListResourceRecordSetsResponseDeserializer {
     }
 }
 #[doc="<p>A request to get a list of the reusable delegation sets that are associated with the current AWS account.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListReusableDelegationSetsRequest {
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more reusable delegation sets. To get another group, submit another <code>ListReusableDelegationSets</code> request. </p> <p>For the value of <code>marker</code>, specify the value of <code>NextMarker</code> from the previous response, which is the ID of the first reusable delegation set that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more reusable delegation sets to get.</p>"]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="<p>The number of reusable delegation sets that you want Amazon Route 53 to return in the response to this request. If you specify a value greater than 100, Amazon Route 53 returns only the first 100 reusable delegation sets.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
 }
 
 #[doc="<p>A complex type that contains information about the reusable delegation sets that are associated with the current AWS account.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListReusableDelegationSetsResponse {
     #[doc="<p>A complex type that contains one <code>DelegationSet</code> element for each reusable delegation set that was created by the current AWS account.</p>"]
+    #[serde(rename="DelegationSets")]
     pub delegation_sets: Vec<DelegationSet>,
     #[doc="<p>A flag that indicates whether there are more reusable delegation sets to be listed.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>For the second and subsequent calls to <code>ListReusableDelegationSets</code>, <code>Marker</code> is the value that you specified for the <code>marker</code> parameter in the request that produced the current response.</p>"]
+    #[serde(rename="Marker")]
     pub marker: String,
     #[doc="<p>The value that you specified for the <code>maxitems</code> parameter in the call to <code>ListReusableDelegationSets</code> that produced the current response.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: String,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, the value of <code>NextMarker</code> identifies the next reusable delegation set that Amazon Route 53 will return if you submit another <code>ListReusableDelegationSets</code> request and specify the value of <code>NextMarker</code> in the <code>marker</code> parameter.</p>"]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
 }
 
@@ -4983,18 +5276,21 @@ impl ListReusableDelegationSetsResponseDeserializer {
     }
 }
 #[doc="<p>A complex type containing information about a request for a list of the tags that are associated with an individual resource.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTagsForResourceRequest {
     #[doc="<p>The ID of the resource for which you want to retrieve tags.</p>"]
+    #[serde(rename="ResourceId")]
     pub resource_id: String,
     #[doc="<p>The type of the resource.</p> <ul> <li> <p>The resource type for health checks is <code>healthcheck</code>.</p> </li> <li> <p>The resource type for hosted zones is <code>hostedzone</code>.</p> </li> </ul>"]
+    #[serde(rename="ResourceType")]
     pub resource_type: String,
 }
 
 #[doc="<p>A complex type that contains information about the health checks or hosted zones for which you want to list tags.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTagsForResourceResponse {
     #[doc="<p>A <code>ResourceTagSet</code> containing tags associated with the specified resource.</p>"]
+    #[serde(rename="ResourceTagSet")]
     pub resource_tag_set: ResourceTagSet,
 }
 
@@ -5042,11 +5338,13 @@ impl ListTagsForResourceResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the health checks or hosted zones for which you want to list tags.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTagsForResourcesRequest {
     #[doc="<p>A complex type that contains the ResourceId element for each resource for which you want to get a list of tags.</p>"]
+    #[serde(rename="ResourceIds")]
     pub resource_ids: Vec<String>,
     #[doc="<p>The type of the resources.</p> <ul> <li> <p>The resource type for health checks is <code>healthcheck</code>.</p> </li> <li> <p>The resource type for hosted zones is <code>hostedzone</code>.</p> </li> </ul>"]
+    #[serde(rename="ResourceType")]
     pub resource_type: String,
 }
 
@@ -5067,9 +5365,10 @@ impl ListTagsForResourcesRequestSerializer {
     }
 }
 #[doc="<p>A complex type containing tags for the specified resources.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTagsForResourcesResponse {
     #[doc="<p>A list of <code>ResourceTagSet</code>s containing tags associated with the specified resources.</p>"]
+    #[serde(rename="ResourceTagSets")]
     pub resource_tag_sets: Vec<ResourceTagSet>,
 }
 
@@ -5117,24 +5416,32 @@ impl ListTagsForResourcesResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the information about the request to list the traffic policies that are associated with the current AWS account.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTrafficPoliciesRequest {
     #[doc="<p>(Optional) The maximum number of traffic policies that you want Amazon Route 53 to return in response to this request. If you have more than <code>MaxItems</code> traffic policies, the value of <code>IsTruncated</code> in the response is <code>true</code>, and the value of <code>TrafficPolicyIdMarker</code> is the ID of the first traffic policy that Amazon Route 53 will return if you submit another request.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
     #[doc="<p>(Conditional) For your first request to <code>ListTrafficPolicies</code>, don't include the <code>TrafficPolicyIdMarker</code> parameter.</p> <p>If you have more traffic policies than the value of <code>MaxItems</code>, <code>ListTrafficPolicies</code> returns only the first <code>MaxItems</code> traffic policies. To get the next group of policies, submit another request to <code>ListTrafficPolicies</code>. For the value of <code>TrafficPolicyIdMarker</code>, specify the value of <code>TrafficPolicyIdMarker</code> that was returned in the previous response.</p>"]
+    #[serde(rename="TrafficPolicyIdMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_id_marker: Option<String>,
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTrafficPoliciesResponse {
     #[doc="<p>A flag that indicates whether there are more traffic policies to be listed. If the response was truncated, you can get the next group of traffic policies by submitting another <code>ListTrafficPolicies</code> request and specifying the value of <code>TrafficPolicyIdMarker</code> in the <code>TrafficPolicyIdMarker</code> request parameter.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>The value that you specified for the <code>MaxItems</code> parameter in the <code>ListTrafficPolicies</code> request that produced the current response.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: String,
     #[doc="<p>If the value of <code>IsTruncated</code> is <code>true</code>, <code>TrafficPolicyIdMarker</code> is the ID of the first traffic policy in the next group of <code>MaxItems</code> traffic policies.</p>"]
+    #[serde(rename="TrafficPolicyIdMarker")]
     pub traffic_policy_id_marker: String,
     #[doc="<p>A list that contains one <code>TrafficPolicySummary</code> element for each traffic policy that was created by the current AWS account.</p>"]
+    #[serde(rename="TrafficPolicySummaries")]
     pub traffic_policy_summaries: Vec<TrafficPolicySummary>,
 }
 
@@ -5195,30 +5502,44 @@ impl ListTrafficPoliciesResponseDeserializer {
     }
 }
 #[doc="<p>A request for the traffic policy instances that you created in a specified hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTrafficPolicyInstancesByHostedZoneRequest {
     #[doc="<p>The ID of the hosted zone that you want to list traffic policy instances for.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p>The maximum number of traffic policy instances to be included in the response body for this request. If you have more than <code>MaxItems</code> traffic policy instances, the value of the <code>IsTruncated</code> element in the response is <code>true</code>, and the values of <code>HostedZoneIdMarker</code>, <code>TrafficPolicyInstanceNameMarker</code>, and <code>TrafficPolicyInstanceTypeMarker</code> represent the first traffic policy instance that Amazon Route 53 will return if you submit another request.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response is true, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstances</code> request. For the value of <code>trafficpolicyinstancename</code>, specify the value of <code>TrafficPolicyInstanceNameMarker</code> from the previous response, which is the name of the first traffic policy instance in the next group of traffic policy instances.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>"]
+    #[serde(rename="TrafficPolicyInstanceNameMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_name_marker: Option<String>,
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response is true, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstances</code> request. For the value of <code>trafficpolicyinstancetype</code>, specify the value of <code>TrafficPolicyInstanceTypeMarker</code> from the previous response, which is the type of the first traffic policy instance in the next group of traffic policy instances.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>"]
+    #[serde(rename="TrafficPolicyInstanceTypeMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_type_marker: Option<String>,
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTrafficPolicyInstancesByHostedZoneResponse {
     #[doc="<p>A flag that indicates whether there are more traffic policy instances to be listed. If the response was truncated, you can get the next group of traffic policy instances by submitting another <code>ListTrafficPolicyInstancesByHostedZone</code> request and specifying the values of <code>HostedZoneIdMarker</code>, <code>TrafficPolicyInstanceNameMarker</code>, and <code>TrafficPolicyInstanceTypeMarker</code> in the corresponding request parameters.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>The value that you specified for the <code>MaxItems</code> parameter in the <code>ListTrafficPolicyInstancesByHostedZone</code> request that produced the current response.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: String,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, <code>TrafficPolicyInstanceNameMarker</code> is the name of the first traffic policy instance in the next group of traffic policy instances.</p>"]
+    #[serde(rename="TrafficPolicyInstanceNameMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_name_marker: Option<String>,
     #[doc="<p>If <code>IsTruncated</code> is true, <code>TrafficPolicyInstanceTypeMarker</code> is the DNS type of the resource record sets that are associated with the first traffic policy instance in the next group of traffic policy instances.</p>"]
+    #[serde(rename="TrafficPolicyInstanceTypeMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_type_marker: Option<String>,
     #[doc="<p>A list that contains one <code>TrafficPolicyInstance</code> element for each traffic policy instance that matches the elements in the request. </p>"]
+    #[serde(rename="TrafficPolicyInstances")]
     pub traffic_policy_instances: Vec<TrafficPolicyInstance>,
 }
 
@@ -5285,36 +5606,55 @@ impl ListTrafficPolicyInstancesByHostedZoneResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the information about the request to list your traffic policy instances.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTrafficPolicyInstancesByPolicyRequest {
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstancesByPolicy</code> request. </p> <p>For the value of <code>hostedzoneid</code>, specify the value of <code>HostedZoneIdMarker</code> from the previous response, which is the hosted zone ID of the first traffic policy instance that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>"]
+    #[serde(rename="HostedZoneIdMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hosted_zone_id_marker: Option<String>,
     #[doc="<p>The maximum number of traffic policy instances to be included in the response body for this request. If you have more than <code>MaxItems</code> traffic policy instances, the value of the <code>IsTruncated</code> element in the response is <code>true</code>, and the values of <code>HostedZoneIdMarker</code>, <code>TrafficPolicyInstanceNameMarker</code>, and <code>TrafficPolicyInstanceTypeMarker</code> represent the first traffic policy instance that Amazon Route 53 will return if you submit another request.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
     #[doc="<p>The ID of the traffic policy for which you want to list traffic policy instances.</p>"]
+    #[serde(rename="TrafficPolicyId")]
     pub traffic_policy_id: String,
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstancesByPolicy</code> request.</p> <p>For the value of <code>trafficpolicyinstancename</code>, specify the value of <code>TrafficPolicyInstanceNameMarker</code> from the previous response, which is the name of the first traffic policy instance that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>"]
+    #[serde(rename="TrafficPolicyInstanceNameMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_name_marker: Option<String>,
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstancesByPolicy</code> request.</p> <p>For the value of <code>trafficpolicyinstancetype</code>, specify the value of <code>TrafficPolicyInstanceTypeMarker</code> from the previous response, which is the name of the first traffic policy instance that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>"]
+    #[serde(rename="TrafficPolicyInstanceTypeMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_type_marker: Option<String>,
     #[doc="<p>The version of the traffic policy for which you want to list traffic policy instances. The version must be associated with the traffic policy that is specified by <code>TrafficPolicyId</code>.</p>"]
+    #[serde(rename="TrafficPolicyVersion")]
     pub traffic_policy_version: i64,
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTrafficPolicyInstancesByPolicyResponse {
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, <code>HostedZoneIdMarker</code> is the ID of the hosted zone of the first traffic policy instance in the next group of traffic policy instances.</p>"]
+    #[serde(rename="HostedZoneIdMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hosted_zone_id_marker: Option<String>,
     #[doc="<p>A flag that indicates whether there are more traffic policy instances to be listed. If the response was truncated, you can get the next group of traffic policy instances by calling <code>ListTrafficPolicyInstancesByPolicy</code> again and specifying the values of the <code>HostedZoneIdMarker</code>, <code>TrafficPolicyInstanceNameMarker</code>, and <code>TrafficPolicyInstanceTypeMarker</code> elements in the corresponding request parameters.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>The value that you specified for the <code>MaxItems</code> parameter in the call to <code>ListTrafficPolicyInstancesByPolicy</code> that produced the current response.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: String,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, <code>TrafficPolicyInstanceNameMarker</code> is the name of the first traffic policy instance in the next group of <code>MaxItems</code> traffic policy instances.</p>"]
+    #[serde(rename="TrafficPolicyInstanceNameMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_name_marker: Option<String>,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, <code>TrafficPolicyInstanceTypeMarker</code> is the DNS type of the resource record sets that are associated with the first traffic policy instance in the next group of <code>MaxItems</code> traffic policy instances.</p>"]
+    #[serde(rename="TrafficPolicyInstanceTypeMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_type_marker: Option<String>,
     #[doc="<p>A list that contains one <code>TrafficPolicyInstance</code> element for each traffic policy instance that matches the elements in the request.</p>"]
+    #[serde(rename="TrafficPolicyInstances")]
     pub traffic_policy_instances: Vec<TrafficPolicyInstance>,
 }
 
@@ -5386,32 +5726,49 @@ impl ListTrafficPolicyInstancesByPolicyResponseDeserializer {
     }
 }
 #[doc="<p>A request to get information about the traffic policy instances that you created by using the current AWS account.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTrafficPolicyInstancesRequest {
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstances</code> request. For the value of <code>HostedZoneId</code>, specify the value of <code>HostedZoneIdMarker</code> from the previous response, which is the hosted zone ID of the first traffic policy instance in the next group of traffic policy instances.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>"]
+    #[serde(rename="HostedZoneIdMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hosted_zone_id_marker: Option<String>,
     #[doc="<p>The maximum number of traffic policy instances that you want Amazon Route 53 to return in response to a <code>ListTrafficPolicyInstances</code> request. If you have more than <code>MaxItems</code> traffic policy instances, the value of the <code>IsTruncated</code> element in the response is <code>true</code>, and the values of <code>HostedZoneIdMarker</code>, <code>TrafficPolicyInstanceNameMarker</code>, and <code>TrafficPolicyInstanceTypeMarker</code> represent the first traffic policy instance in the next group of <code>MaxItems</code> traffic policy instances.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstances</code> request. For the value of <code>trafficpolicyinstancename</code>, specify the value of <code>TrafficPolicyInstanceNameMarker</code> from the previous response, which is the name of the first traffic policy instance in the next group of traffic policy instances.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>"]
+    #[serde(rename="TrafficPolicyInstanceNameMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_name_marker: Option<String>,
     #[doc="<p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstances</code> request. For the value of <code>trafficpolicyinstancetype</code>, specify the value of <code>TrafficPolicyInstanceTypeMarker</code> from the previous response, which is the type of the first traffic policy instance in the next group of traffic policy instances.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>"]
+    #[serde(rename="TrafficPolicyInstanceTypeMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_type_marker: Option<String>,
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTrafficPolicyInstancesResponse {
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, <code>HostedZoneIdMarker</code> is the ID of the hosted zone of the first traffic policy instance that Amazon Route 53 will return if you submit another <code>ListTrafficPolicyInstances</code> request. </p>"]
+    #[serde(rename="HostedZoneIdMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub hosted_zone_id_marker: Option<String>,
     #[doc="<p>A flag that indicates whether there are more traffic policy instances to be listed. If the response was truncated, you can get more traffic policy instances by calling <code>ListTrafficPolicyInstances</code> again and specifying the values of the <code>HostedZoneIdMarker</code>, <code>TrafficPolicyInstanceNameMarker</code>, and <code>TrafficPolicyInstanceTypeMarker</code> in the corresponding request parameters.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>The value that you specified for the <code>MaxItems</code> parameter in the call to <code>ListTrafficPolicyInstances</code> that produced the current response.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: String,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, <code>TrafficPolicyInstanceNameMarker</code> is the name of the first traffic policy instance that Amazon Route 53 will return if you submit another <code>ListTrafficPolicyInstances</code> request. </p>"]
+    #[serde(rename="TrafficPolicyInstanceNameMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_name_marker: Option<String>,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, <code>TrafficPolicyInstanceTypeMarker</code> is the DNS type of the resource record sets that are associated with the first traffic policy instance that Amazon Route 53 will return if you submit another <code>ListTrafficPolicyInstances</code> request. </p>"]
+    #[serde(rename="TrafficPolicyInstanceTypeMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_type_marker: Option<String>,
     #[doc="<p>A list that contains one <code>TrafficPolicyInstance</code> element for each traffic policy instance that matches the elements in the request.</p>"]
+    #[serde(rename="TrafficPolicyInstances")]
     pub traffic_policy_instances: Vec<TrafficPolicyInstance>,
 }
 
@@ -5483,26 +5840,35 @@ impl ListTrafficPolicyInstancesResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the information about the request to list your traffic policies.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTrafficPolicyVersionsRequest {
     #[doc="<p>Specify the value of <code>Id</code> of the traffic policy for which you want to list all versions.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The maximum number of traffic policy versions that you want Amazon Route 53 to include in the response body for this request. If the specified traffic policy has more than <code>MaxItems</code> versions, the value of <code>IsTruncated</code> in the response is <code>true</code>, and the value of the <code>TrafficPolicyVersionMarker</code> element is the ID of the first version that Amazon Route 53 will return if you submit another request.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<String>,
     #[doc="<p>For your first request to <code>ListTrafficPolicyVersions</code>, don't include the <code>TrafficPolicyVersionMarker</code> parameter.</p> <p>If you have more traffic policy versions than the value of <code>MaxItems</code>, <code>ListTrafficPolicyVersions</code> returns only the first group of <code>MaxItems</code> versions. To get more traffic policy versions, submit another <code>ListTrafficPolicyVersions</code> request. For the value of <code>TrafficPolicyVersionMarker</code>, specify the value of <code>TrafficPolicyVersionMarker</code> in the previous response.</p>"]
+    #[serde(rename="TrafficPolicyVersionMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_version_marker: Option<String>,
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListTrafficPolicyVersionsResponse {
     #[doc="<p>A flag that indicates whether there are more traffic policies to be listed. If the response was truncated, you can get the next group of traffic policies by submitting another <code>ListTrafficPolicyVersions</code> request and specifying the value of <code>NextMarker</code> in the <code>marker</code> parameter.</p>"]
+    #[serde(rename="IsTruncated")]
     pub is_truncated: bool,
     #[doc="<p>The value that you specified for the <code>maxitems</code> parameter in the <code>ListTrafficPolicyVersions</code> request that produced the current response.</p>"]
+    #[serde(rename="MaxItems")]
     pub max_items: String,
     #[doc="<p>A list that contains one <code>TrafficPolicy</code> element for each traffic policy version that is associated with the specified traffic policy.</p>"]
+    #[serde(rename="TrafficPolicies")]
     pub traffic_policies: Vec<TrafficPolicy>,
     #[doc="<p>If <code>IsTruncated</code> is <code>true</code>, the value of <code>TrafficPolicyVersionMarker</code> identifies the first traffic policy that Amazon Route 53 will return if you submit another request. Call <code>ListTrafficPolicyVersions</code> again and specify the value of <code>TrafficPolicyVersionMarker</code> in the <code>TrafficPolicyVersionMarker</code> request parameter.</p> <p>This element is present only if <code>IsTruncated</code> is <code>true</code>.</p>"]
+    #[serde(rename="TrafficPolicyVersionMarker")]
     pub traffic_policy_version_marker: String,
 }
 
@@ -5564,24 +5930,33 @@ impl ListTrafficPolicyVersionsResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about that can be associated with your hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListVPCAssociationAuthorizationsRequest {
     #[doc="<p>The ID of the hosted zone for which you want a list of VPCs that can be associated with the hosted zone.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p> <i>Optional</i>: An integer that specifies the maximum number of VPCs that you want Amazon Route 53 to return. If you don't specify a value for <code>MaxResults</code>, Amazon Route 53 returns up to 50 VPCs per page.</p>"]
+    #[serde(rename="MaxResults")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_results: Option<String>,
     #[doc="<p> <i>Optional</i>: If a response includes a <code>NextToken</code> element, there are more VPCs that can be associated with the specified hosted zone. To get the next page of results, submit another request, and include the value of <code>NextToken</code> from the response in the <code>nexttoken</code> parameter in another <code>ListVPCAssociationAuthorizations</code> request.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
 #[doc="<p>A complex type that contains the response information for the request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListVPCAssociationAuthorizationsResponse {
     #[doc="<p>The ID of the hosted zone that you can associate the listed VPCs with.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p>When the response includes a <code>NextToken</code> element, there are more VPCs that can be associated with the specified hosted zone. To get the next page of VPCs, submit another <code>ListVPCAssociationAuthorizations</code> request, and include the value of the <code>NextToken</code> element from the response in the <code>nexttoken</code> request parameter.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The list of VPCs that are authorized to be associated with the specified hosted zone.</p>"]
+    #[serde(rename="VPCs")]
     pub vp_cs: Vec<VPC>,
 }
 
@@ -6179,9 +6554,10 @@ impl ResourcePathSerializer {
 }
 
 #[doc="<p>Information specific to the resource record.</p> <note> <p>If you're creating an alias resource record set, omit <code>ResourceRecord</code>.</p> </note>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ResourceRecord {
     #[doc="<p>The current or new DNS record value, not to exceed 4,000 characters. In the case of a <code>DELETE</code> action, if the current value does not match the actual value, an error is returned. For descriptions about how to format <code>Value</code> for different record types, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html\">Supported DNS Resource Record Types</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> <p>You can specify more than one value for all record types except <code>CNAME</code> and <code>SOA</code>. </p> <note> <p>If you're creating an alias resource record set, omit <code>Value</code>.</p> </note>"]
+    #[serde(rename="Value")]
     pub value: String,
 }
 
@@ -6246,33 +6622,57 @@ impl ResourceRecordSerializer {
 }
 
 #[doc="<p>Information about the resource record set to create or delete.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ResourceRecordSet {
     #[doc="<p> <i>Alias resource record sets only:</i> Information about the CloudFront distribution, AWS Elastic Beanstalk environment, ELB load balancer, Amazon S3 bucket, or Amazon Route 53 resource record set to which you're redirecting queries. The AWS Elastic Beanstalk environment must have a regionalized subdomain.</p> <p>If you're creating resource records sets for a private hosted zone, note the following:</p> <ul> <li> <p>You can't create alias resource record sets for CloudFront distributions in a private hosted zone.</p> </li> <li> <p>Creating geolocation alias resource record sets or latency alias resource record sets in a private hosted zone is unsupported.</p> </li> <li> <p>For information about creating failover resource record sets in a private hosted zone, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html\">Configuring Failover in a Private Hosted Zone</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> </li> </ul>"]
+    #[serde(rename="AliasTarget")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alias_target: Option<AliasTarget>,
     #[doc="<p> <i>Failover resource record sets only:</i> To configure failover, you add the <code>Failover</code> element to two resource record sets. For one resource record set, you specify <code>PRIMARY</code> as the value for <code>Failover</code>; for the other resource record set, you specify <code>SECONDARY</code>. In addition, you include the <code>HealthCheckId</code> element and specify the health check that you want Amazon Route 53 to perform for each resource record set.</p> <p>Except where noted, the following failover behaviors assume that you have included the <code>HealthCheckId</code> element in both resource record sets:</p> <ul> <li> <p>When the primary resource record set is healthy, Amazon Route 53 responds to DNS queries with the applicable value from the primary resource record set regardless of the health of the secondary resource record set.</p> </li> <li> <p>When the primary resource record set is unhealthy and the secondary resource record set is healthy, Amazon Route 53 responds to DNS queries with the applicable value from the secondary resource record set.</p> </li> <li> <p>When the secondary resource record set is unhealthy, Amazon Route 53 responds to DNS queries with the applicable value from the primary resource record set regardless of the health of the primary resource record set.</p> </li> <li> <p>If you omit the <code>HealthCheckId</code> element for the secondary resource record set, and if the primary resource record set is unhealthy, Amazon Route 53 always responds to DNS queries with the applicable value from the secondary resource record set. This is true regardless of the health of the associated endpoint.</p> </li> </ul> <p>You can't create non-failover resource record sets that have the same values for the <code>Name</code> and <code>Type</code> elements as failover resource record sets.</p> <p>For failover alias resource record sets, you must also include the <code>EvaluateTargetHealth</code> element and set the value to true.</p> <p>For more information about configuring failover for Amazon Route 53, see the following topics in the <i>Amazon Route 53 Developer Guide</i>: </p> <ul> <li> <p> <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html\">Amazon Route 53 Health Checks and DNS Failover</a> </p> </li> <li> <p> <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html\">Configuring Failover in a Private Hosted Zone</a> </p> </li> </ul>"]
+    #[serde(rename="Failover")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub failover: Option<String>,
     #[doc="<p> <i>Geo location resource record sets only:</i> A complex type that lets you control how Amazon Route 53 responds to DNS queries based on the geographic origin of the query. For example, if you want all queries from Africa to be routed to a web server with an IP address of <code>192.0.2.111</code>, create a resource record set with a <code>Type</code> of <code>A</code> and a <code>ContinentCode</code> of <code>AF</code>.</p> <note> <p>Creating geolocation and geolocation alias resource record sets in private hosted zones is not supported.</p> </note> <p>If you create separate resource record sets for overlapping geographic regions (for example, one resource record set for a continent and one for a country on the same continent), priority goes to the smallest geographic region. This allows you to route most queries for a continent to one resource and to route queries for a country on that continent to a different resource.</p> <p>You can't create two geolocation resource record sets that specify the same geographic location.</p> <p>The value <code>*</code> in the <code>CountryCode</code> element matches all geographic locations that aren't specified in other geolocation resource record sets that have the same values for the <code>Name</code> and <code>Type</code> elements.</p> <important> <p>Geolocation works by mapping IP addresses to locations. However, some IP addresses aren't mapped to geographic locations, so even if you create geolocation resource record sets that cover all seven continents, Amazon Route 53 will receive some DNS queries from locations that it can't identify. We recommend that you create a resource record set for which the value of <code>CountryCode</code> is <code>*</code>, which handles both queries that come from locations for which you haven't created geolocation resource record sets and queries from IP addresses that aren't mapped to a location. If you don't create a <code>*</code> resource record set, Amazon Route 53 returns a \"no answer\" response for queries from those locations.</p> </important> <p>You can't create non-geolocation resource record sets that have the same values for the <code>Name</code> and <code>Type</code> elements as geolocation resource record sets.</p>"]
+    #[serde(rename="GeoLocation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub geo_location: Option<GeoLocation>,
     #[doc="<p>If you want Amazon Route 53 to return this resource record set in response to a DNS query only when a health check is passing, include the <code>HealthCheckId</code> element and specify the ID of the applicable health check.</p> <p>Amazon Route 53 determines whether a resource record set is healthy based on one of the following:</p> <ul> <li> <p>By periodically sending a request to the endpoint that is specified in the health check</p> </li> <li> <p>By aggregating the status of a specified group of health checks (calculated health checks)</p> </li> <li> <p>By determining the current state of a CloudWatch alarm (CloudWatch metric health checks)</p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html\">How Amazon Route 53 Determines Whether an Endpoint Is Healthy</a>.</p> <p>The <code>HealthCheckId</code> element is only useful when Amazon Route 53 is choosing between two or more resource record sets to respond to a DNS query, and you want Amazon Route 53 to base the choice in part on the status of a health check. Configuring health checks only makes sense in the following configurations:</p> <ul> <li> <p>You're checking the health of the resource record sets in a group of weighted, latency, geolocation, or failover resource record sets, and you specify health check IDs for all of the resource record sets. If the health check for one resource record set specifies an endpoint that is not healthy, Amazon Route 53 stops responding to queries using the value for that resource record set.</p> </li> <li> <p>You set <code>EvaluateTargetHealth</code> to true for the resource record sets in a group of alias, weighted alias, latency alias, geolocation alias, or failover alias resource record sets, and you specify health check IDs for all of the resource record sets that are referenced by the alias resource record sets.</p> </li> </ul> <important> <p>Amazon Route 53 doesn't check the health of the endpoint specified in the resource record set, for example, the endpoint specified by the IP address in the <code>Value</code> element. When you add a <code>HealthCheckId</code> element to a resource record set, Amazon Route 53 checks the health of the endpoint that you specified in the health check. </p> </important> <p>For geolocation resource record sets, if an endpoint is unhealthy, Amazon Route 53 looks for a resource record set for the larger, associated geographic region. For example, suppose you have resource record sets for a state in the United States, for the United States, for North America, and for all locations. If the endpoint for the state resource record set is unhealthy, Amazon Route 53 checks the resource record sets for the United States, for North America, and for all locations (a resource record set for which the value of <code>CountryCode</code> is <code>*</code>), in that order, until it finds a resource record set for which the endpoint is healthy. </p> <p>If your health checks specify the endpoint only by domain name, we recommend that you create a separate health check for each endpoint. For example, create a health check for each <code>HTTP</code> server that is serving content for <code>www.example.com</code>. For the value of <code>FullyQualifiedDomainName</code>, specify the domain name of the server (such as <code>us-east-2-www.example.com</code>), not the name of the resource record sets (example.com).</p> <important> <p>n this configuration, if you create a health check for which the value of <code>FullyQualifiedDomainName</code> matches the name of the resource record sets and then associate the health check with those resource record sets, health check results will be unpredictable.</p> </important> <p>For more information, see the following topics in the <i>Amazon Route 53 Developer Guide</i>:</p> <ul> <li> <p> <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html\">Amazon Route 53 Health Checks and DNS Failover</a> </p> </li> <li> <p> <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html\">Configuring Failover in a Private Hosted Zone</a> </p> </li> </ul>"]
+    #[serde(rename="HealthCheckId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_id: Option<String>,
     #[doc="<p> <i>Multivalue answer resource record sets only</i>: To route traffic approximately randomly to multiple resources, such as web servers, create one multivalue answer record for each resource and specify <code>true</code> for <code>MultiValueAnswer</code>. Note the following:</p> <ul> <li> <p>If you associate a health check with a multivalue answer resource record set, Amazon Route 53 responds to DNS queries with the corresponding IP address only when the health check is healthy.</p> </li> <li> <p>If you don't associate a health check with a multivalue answer record, Amazon Route 53 always considers the record to be healthy.</p> </li> <li> <p>Amazon Route 53 responds to DNS queries with up to eight healthy records; if you have eight or fewer healthy records, Amazon Route 53 responds to all DNS queries with all the healthy records.</p> </li> <li> <p>If you have more than eight healthy records, Amazon Route 53 responds to different DNS resolvers with different combinations of healthy records.</p> </li> <li> <p>When all records are unhealthy, Amazon Route 53 responds to DNS queries with up to eight unhealthy records.</p> </li> <li> <p>If a resource becomes unavailable after a resolver caches a response, client software typically tries another of the IP addresses in the response.</p> </li> </ul> <p>You can't create multivalue answer alias records.</p>"]
+    #[serde(rename="MultiValueAnswer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multi_value_answer: Option<bool>,
     #[doc="<p>The name of the domain you want to perform the action on.</p> <p>Enter a fully qualified domain name, for example, <code>www.example.com</code>. You can optionally include a trailing dot. If you omit the trailing dot, Amazon Route 53 still assumes that the domain name that you specify is fully qualified. This means that Amazon Route 53 treats <code>www.example.com</code> (without a trailing dot) and <code>www.example.com.</code> (with a trailing dot) as identical.</p> <p>For information about how to specify characters other than <code>a-z</code>, <code>0-9</code>, and <code>-</code> (hyphen) and how to specify internationalized domain names, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html\">DNS Domain Name Format</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> <p>You can use the asterisk (*) wildcard to replace the leftmost label in a domain name, for example, <code>*.example.com</code>. Note the following:</p> <ul> <li> <p>The * must replace the entire label. For example, you can't specify <code>*prod.example.com</code> or <code>prod*.example.com</code>.</p> </li> <li> <p>The * can't replace any of the middle labels, for example, marketing.*.example.com.</p> </li> <li> <p>If you include * in any position other than the leftmost label in a domain name, DNS treats it as an * character (ASCII 42), not as a wildcard.</p> <important> <p>You can't use the * wildcard for resource records sets that have a type of NS.</p> </important> </li> </ul> <p>You can use the * wildcard as the leftmost label in a domain name, for example, <code>*.example.com</code>. You can't use an * for one of the middle labels, for example, <code>marketing.*.example.com</code>. In addition, the * must replace the entire label; for example, you can't specify <code>prod*.example.com</code>.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p> <i>Latency-based resource record sets only:</i> The Amazon EC2 Region where you created the resource that this resource record set refers to. The resource typically is an AWS resource, such as an EC2 instance or an ELB load balancer, and is referred to by an IP address or a DNS domain name, depending on the record type.</p> <note> <p>Creating latency and latency alias resource record sets in private hosted zones is not supported.</p> </note> <p>When Amazon Route 53 receives a DNS query for a domain name and type for which you have created latency resource record sets, Amazon Route 53 selects the latency resource record set that has the lowest latency between the end user and the associated Amazon EC2 Region. Amazon Route 53 then returns the value that is associated with the selected resource record set.</p> <p>Note the following:</p> <ul> <li> <p>You can only specify one <code>ResourceRecord</code> per latency resource record set.</p> </li> <li> <p>You can only create one latency resource record set for each Amazon EC2 Region.</p> </li> <li> <p>You aren't required to create latency resource record sets for all Amazon EC2 Regions. Amazon Route 53 will choose the region with the best latency from among the regions that you create latency resource record sets for.</p> </li> <li> <p>You can't create non-latency resource record sets that have the same values for the <code>Name</code> and <code>Type</code> elements as latency resource record sets.</p> </li> </ul>"]
+    #[serde(rename="Region")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub region: Option<String>,
     #[doc="<p>Information about the resource records to act upon.</p> <note> <p>If you're creating an alias resource record set, omit <code>ResourceRecords</code>.</p> </note>"]
+    #[serde(rename="ResourceRecords")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_records: Option<Vec<ResourceRecord>>,
     #[doc="<p> <i>Weighted, Latency, Geo, and Failover resource record sets only:</i> An identifier that differentiates among multiple resource record sets that have the same combination of DNS name and type. The value of <code>SetIdentifier</code> must be unique for each resource record set that has the same combination of DNS name and type. Omit <code>SetIdentifier</code> for any other types of record sets.</p>"]
+    #[serde(rename="SetIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub set_identifier: Option<String>,
     #[doc="<p>The resource record cache time to live (TTL), in seconds. Note the following:</p> <ul> <li> <p>If you're creating or updating an alias resource record set, omit <code>TTL</code>. Amazon Route 53 uses the value of <code>TTL</code> for the alias target. </p> </li> <li> <p>If you're associating this resource record set with a health check (if you're adding a <code>HealthCheckId</code> element), we recommend that you specify a <code>TTL</code> of 60 seconds or less so clients respond quickly to changes in health status.</p> </li> <li> <p>All of the resource record sets in a group of weighted resource record sets must have the same value for <code>TTL</code>.</p> </li> <li> <p>If a group of weighted resource record sets includes one or more weighted alias resource record sets for which the alias target is an ELB load balancer, we recommend that you specify a <code>TTL</code> of 60 seconds for all of the non-alias weighted resource record sets that have the same name and type. Values other than 60 seconds (the TTL for load balancers) will change the effect of the values that you specify for <code>Weight</code>.</p> </li> </ul>"]
+    #[serde(rename="TTL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ttl: Option<i64>,
     #[doc="<p>When you create a traffic policy instance, Amazon Route 53 automatically creates a resource record set. <code>TrafficPolicyInstanceId</code> is the ID of the traffic policy instance that Amazon Route 53 created this resource record set for.</p> <important> <p>To delete the resource record set that is associated with a traffic policy instance, use <code>DeleteTrafficPolicyInstance</code>. Amazon Route 53 will delete the resource record set automatically. If you delete the resource record set by using <code>ChangeResourceRecordSets</code>, Amazon Route 53 doesn't automatically delete the traffic policy instance, and you'll continue to be charged for it even though it's no longer in use. </p> </important>"]
+    #[serde(rename="TrafficPolicyInstanceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub traffic_policy_instance_id: Option<String>,
     #[doc="<p>The DNS record type. For information about different record types and how data is encoded for them, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html\">Supported DNS Resource Record Types</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> <p>Valid values for basic resource record sets: <code>A</code> | <code>AAAA</code> | <code>CAA</code> | <code>CNAME</code> | <code>MX</code> | <code>NAPTR</code> | <code>NS</code> | <code>PTR</code> | <code>SOA</code> | <code>SPF</code> | <code>SRV</code> | <code>TXT</code> </p> <p>Values for weighted, latency, geolocation, and failover resource record sets: <code>A</code> | <code>AAAA</code> | <code>CAA</code> | <code>CNAME</code> | <code>MX</code> | <code>NAPTR</code> | <code>PTR</code> | <code>SPF</code> | <code>SRV</code> | <code>TXT</code>. When creating a group of weighted, latency, geolocation, or failover resource record sets, specify the same value for all of the resource record sets in the group.</p> <p>Valid values for multivalue answer resource record sets: <code>A</code> | <code>AAAA</code> | <code>MX</code> | <code>NAPTR</code> | <code>PTR</code> | <code>SPF</code> | <code>SRV</code> | <code>TXT</code> </p> <note> <p>SPF records were formerly used to verify the identity of the sender of email messages. However, we no longer recommend that you create resource record sets for which the value of <code>Type</code> is <code>SPF</code>. RFC 7208, <i>Sender Policy Framework (SPF) for Authorizing Use of Domains in Email, Version 1</i>, has been updated to say, \"...[I]ts existence and mechanism defined in [RFC4408] have led to some interoperability issues. Accordingly, its use is no longer appropriate for SPF version 1; implementations are not to use it.\" In RFC 7208, see section 14.1, <a href=\"http://tools.ietf.org/html/rfc7208#section-14.1\">The SPF DNS Record Type</a>.</p> </note> <p>Values for alias resource record sets:</p> <ul> <li> <p> <b>CloudFront distributions:</b> <code>A</code> </p> <p>If IPv6 is enabled for the distribution, create two resource record sets to route traffic to your distribution, one with a value of <code>A</code> and one with a value of <code>AAAA</code>. </p> </li> <li> <p> <b>AWS Elastic Beanstalk environment that has a regionalized subdomain</b>: <code>A</code> </p> </li> <li> <p> <b>ELB load balancers:</b> <code>A</code> | <code>AAAA</code> </p> </li> <li> <p> <b>Amazon S3 buckets:</b> <code>A</code> </p> </li> <li> <p> <b>Another resource record set in this hosted zone:</b> Specify the type of the resource record set that you're creating the alias for. All values are supported except <code>NS</code> and <code>SOA</code>.</p> </li> </ul>"]
+    #[serde(rename="Type")]
     pub type_: String,
     #[doc="<p> <i>Weighted resource record sets only:</i> Among resource record sets that have the same combination of DNS name and type, a value that determines the proportion of DNS queries that Amazon Route 53 responds to using the current resource record set. Amazon Route 53 calculates the sum of the weights for the resource record sets that have the same combination of DNS name and type. Amazon Route 53 then responds to queries based on the ratio of a resource's weight to the total. Note the following:</p> <ul> <li> <p>You must specify a value for the <code>Weight</code> element for every weighted resource record set.</p> </li> <li> <p>You can only specify one <code>ResourceRecord</code> per weighted resource record set.</p> </li> <li> <p>You can't create latency, failover, or geolocation resource record sets that have the same values for the <code>Name</code> and <code>Type</code> elements as weighted resource record sets.</p> </li> <li> <p>You can create a maximum of 100 weighted resource record sets that have the same values for the <code>Name</code> and <code>Type</code> elements.</p> </li> <li> <p>For weighted (but not weighted alias) resource record sets, if you set <code>Weight</code> to <code>0</code> for a resource record set, Amazon Route 53 never responds to queries with the applicable value for that resource record set. However, if you set <code>Weight</code> to <code>0</code> for all resource record sets that have the same combination of DNS name and type, traffic is routed to all resources with equal probability.</p> <p>The effect of setting <code>Weight</code> to <code>0</code> is different when you associate health checks with weighted resource record sets. For more information, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html\">Options for Configuring Amazon Route 53 Active-Active and Active-Passive Failover</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> </li> </ul>"]
+    #[serde(rename="Weight")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub weight: Option<i64>,
 }
 
@@ -6709,13 +7109,19 @@ impl ResourceRecordsSerializer {
 }
 
 #[doc="<p>A complex type containing a resource and its associated tags.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ResourceTagSet {
     #[doc="<p>The ID for the specified resource.</p>"]
+    #[serde(rename="ResourceId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_id: Option<String>,
     #[doc="<p>The type of the resource.</p> <ul> <li> <p>The resource type for health checks is <code>healthcheck</code>.</p> </li> <li> <p>The resource type for hosted zones is <code>hostedzone</code>.</p> </li> </ul>"]
+    #[serde(rename="ResourceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_type: Option<String>,
     #[doc="<p>The tags associated with the specified resource.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -6873,11 +7279,15 @@ impl StatusDeserializer {
     }
 }
 #[doc="<p>A complex type that contains the status that one Amazon Route 53 health checker reports and the time of the health check.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct StatusReport {
     #[doc="<p>The date and time that the health checker performed the health check in <a href=\"https://en.wikipedia.org/wiki/ISO_8601\">ISO 8601 format</a> and Coordinated Universal Time (UTC). For example, the value <code>2017-03-27T17:48:16.751Z</code> represents March 27, 2017 at 17:48:16.751 UTC.</p>"]
+    #[serde(rename="CheckedTime")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub checked_time: Option<String>,
     #[doc="<p>A description of the status of the health check endpoint as reported by one of the Amazon Route 53 health checkers.</p>"]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -6979,11 +7389,15 @@ impl TTLSerializer {
 }
 
 #[doc="<p>A complex type that contains information about a tag that you want to add or edit for the specified health check or hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="<p>The value of <code>Key</code> depends on the operation that you want to perform:</p> <ul> <li> <p> <b>Add a tag to a health check or hosted zone</b>: <code>Key</code> is the name that you want to give the new tag.</p> </li> <li> <p> <b>Edit a tag</b>: <code>Key</code> is the name of the tag that you want to change the <code>Value</code> for.</p> </li> <li> <p> <b> Delete a key</b>: <code>Key</code> is the name of the tag you want to remove.</p> </li> <li> <p> <b>Give a name to a health check</b>: Edit the default <code>Name</code> tag. In the Amazon Route 53 console, the list of your health checks includes a <b>Name</b> column that lets you see the name that you've given to each health check.</p> </li> </ul>"]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="<p>The value of <code>Value</code> depends on the operation that you want to perform:</p> <ul> <li> <p> <b>Add a tag to a health check or hosted zone</b>: <code>Value</code> is the value that you want to give the new tag.</p> </li> <li> <p> <b>Edit a tag</b>: <code>Value</code> is the new value that you want to assign the tag.</p> </li> </ul>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -7284,36 +7698,51 @@ impl TagValueSerializer {
 }
 
 #[doc="<p>Gets the value that Amazon Route 53 returns in response to a DNS request for a specified record name and type. You can optionally specify the IP address of a DNS resolver, an EDNS0 client subnet IP address, and a subnet mask. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct TestDNSAnswerRequest {
     #[doc="<p>If the resolver that you specified for resolverip supports EDNS0, specify the IPv4 or IPv6 address of a client in the applicable location, for example, <code>192.0.2.44</code> or <code>2001:db8:85a3::8a2e:370:7334</code>.</p>"]
+    #[serde(rename="EDNS0ClientSubnetIP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub edns0_client_subnet_ip: Option<String>,
     #[doc="<p>If you specify an IP address for <code>edns0clientsubnetip</code>, you can optionally specify the number of bits of the IP address that you want the checking tool to include in the DNS query. For example, if you specify <code>192.0.2.44</code> for <code>edns0clientsubnetip</code> and <code>24</code> for <code>edns0clientsubnetmask</code>, the checking tool will simulate a request from 192.0.2.0/24. The default value is 24 bits for IPv4 addresses and 64 bits for IPv6 addresses.</p>"]
+    #[serde(rename="EDNS0ClientSubnetMask")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub edns0_client_subnet_mask: Option<String>,
     #[doc="<p>The ID of the hosted zone that you want Amazon Route 53 to simulate a query for.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p>The name of the resource record set that you want Amazon Route 53 to simulate a query for.</p>"]
+    #[serde(rename="RecordName")]
     pub record_name: String,
     #[doc="<p>The type of the resource record set.</p>"]
+    #[serde(rename="RecordType")]
     pub record_type: String,
     #[doc="<p>If you want to simulate a request from a specific DNS resolver, specify the IP address for that resolver. If you omit this value, <code>TestDnsAnswer</code> uses the IP address of a DNS resolver in the AWS US East (N. Virginia) Region (<code>us-east-1</code>).</p>"]
+    #[serde(rename="ResolverIP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resolver_ip: Option<String>,
 }
 
 #[doc="<p>A complex type that contains the response to a <code>TestDNSAnswer</code> request. </p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct TestDNSAnswerResponse {
     #[doc="<p>The Amazon Route 53 name server used to respond to the request.</p>"]
+    #[serde(rename="Nameserver")]
     pub nameserver: String,
     #[doc="<p>The protocol that Amazon Route 53 used to respond to the request, either <code>UDP</code> or <code>TCP</code>. </p>"]
+    #[serde(rename="Protocol")]
     pub protocol: String,
     #[doc="<p>A list that contains values that Amazon Route 53 returned for this resource record set.</p>"]
+    #[serde(rename="RecordData")]
     pub record_data: Vec<String>,
     #[doc="<p>The name of the resource record set that you submitted a request for.</p>"]
+    #[serde(rename="RecordName")]
     pub record_name: String,
     #[doc="<p>The type of the resource record set that you submitted a request for.</p>"]
+    #[serde(rename="RecordType")]
     pub record_type: String,
     #[doc="<p>A code that indicates whether the request is valid or not. The most common response code is <code>NOERROR</code>, meaning that the request is valid. If the response is not valid, Amazon Route 53 returns a response code that describes the error. For a list of possible response codes, see <a href=\"http://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6\">DNS RCODES</a> on the IANA website. </p>"]
+    #[serde(rename="ResponseCode")]
     pub response_code: String,
 }
 
@@ -7450,19 +7879,26 @@ impl TrafficPoliciesDeserializer {
     }
 }
 #[doc="<p>A complex type that contains settings for a traffic policy.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct TrafficPolicy {
     #[doc="<p>The comment that you specify in the <code>CreateTrafficPolicy</code> request, if any.</p>"]
+    #[serde(rename="Comment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub comment: Option<String>,
     #[doc="<p>The definition of a traffic policy in JSON format. You specify the JSON document to use for a new traffic policy in the <code>CreateTrafficPolicy</code> request. For more information about the JSON format, see <a href=\"http://docs.aws.amazon.com/Route53/latest/APIReference/api-policies-traffic-policy-document-format.html\">Traffic Policy Document Format</a>.</p>"]
+    #[serde(rename="Document")]
     pub document: String,
     #[doc="<p>The ID that Amazon Route 53 assigned to a traffic policy when you created it.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The name that you specified when you created the traffic policy.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The DNS type of the resource record sets that Amazon Route 53 creates when you use a traffic policy to create a traffic policy instance.</p>"]
+    #[serde(rename="Type")]
     pub type_: String,
     #[doc="<p>The version number that Amazon Route 53 assigns to a traffic policy. For a new traffic policy, the value of <code>Version</code> is always 1.</p>"]
+    #[serde(rename="Version")]
     pub version: i64,
 }
 
@@ -7626,25 +8062,34 @@ impl TrafficPolicyIdSerializer {
 }
 
 #[doc="<p>A complex type that contains settings for the new traffic policy instance.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct TrafficPolicyInstance {
     #[doc="<p>The ID of the hosted zone that Amazon Route 53 created resource record sets in.</p>"]
+    #[serde(rename="HostedZoneId")]
     pub hosted_zone_id: String,
     #[doc="<p>The ID that Amazon Route 53 assigned to the new traffic policy instance.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>If <code>State</code> is <code>Failed</code>, an explanation of the reason for the failure. If <code>State</code> is another value, <code>Message</code> is empty.</p>"]
+    #[serde(rename="Message")]
     pub message: String,
     #[doc="<p>The DNS name, such as www.example.com, for which Amazon Route 53 responds to queries by using the resource record sets that are associated with this traffic policy instance. </p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The value of <code>State</code> is one of the following values:</p> <dl> <dt>Applied</dt> <dd> <p>Amazon Route 53 has finished creating resource record sets, and changes have propagated to all Amazon Route 53 edge locations.</p> </dd> <dt>Creating</dt> <dd> <p>Amazon Route 53 is creating the resource record sets. Use <code>GetTrafficPolicyInstance</code> to confirm that the <code>CreateTrafficPolicyInstance</code> request completed successfully.</p> </dd> <dt>Failed</dt> <dd> <p>Amazon Route 53 wasn't able to create or update the resource record sets. When the value of <code>State</code> is <code>Failed</code>, see <code>Message</code> for an explanation of what caused the request to fail.</p> </dd> </dl>"]
+    #[serde(rename="State")]
     pub state: String,
     #[doc="<p>The TTL that Amazon Route 53 assigned to all of the resource record sets that it created in the specified hosted zone.</p>"]
+    #[serde(rename="TTL")]
     pub ttl: i64,
     #[doc="<p>The ID of the traffic policy that Amazon Route 53 used to create resource record sets in the specified hosted zone.</p>"]
+    #[serde(rename="TrafficPolicyId")]
     pub traffic_policy_id: String,
     #[doc="<p>The DNS type that Amazon Route 53 assigned to all of the resource record sets that it created for this traffic policy instance. </p>"]
+    #[serde(rename="TrafficPolicyType")]
     pub traffic_policy_type: String,
     #[doc="<p>The version of the traffic policy that Amazon Route 53 used to create resource record sets in the specified hosted zone.</p>"]
+    #[serde(rename="TrafficPolicyVersion")]
     pub traffic_policy_version: i64,
 }
 
@@ -7897,17 +8342,22 @@ impl TrafficPolicySummariesDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the latest version of one traffic policy that is associated with the current AWS account.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct TrafficPolicySummary {
     #[doc="<p>The ID that Amazon Route 53 assigned to the traffic policy when you created it.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The version number of the latest version of the traffic policy.</p>"]
+    #[serde(rename="LatestVersion")]
     pub latest_version: i64,
     #[doc="<p>The name that you specified for the traffic policy when you created it.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The number of traffic policies that are associated with the current AWS account.</p>"]
+    #[serde(rename="TrafficPolicyCount")]
     pub traffic_policy_count: i64,
     #[doc="<p>The DNS type of the resource record sets that Amazon Route 53 creates when you use a traffic policy to create a traffic policy instance.</p>"]
+    #[serde(rename="Type")]
     pub type_: String,
 }
 
@@ -8048,36 +8498,65 @@ impl TransportProtocolDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about a request to update a health check.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateHealthCheckRequest {
+    #[serde(rename="AlarmIdentifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alarm_identifier: Option<AlarmIdentifier>,
     #[doc="<p>A complex type that contains one <code>ChildHealthCheck</code> element for each health check that you want to associate with a <code>CALCULATED</code> health check.</p>"]
+    #[serde(rename="ChildHealthChecks")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub child_health_checks: Option<Vec<String>>,
     #[doc="<p>Specify whether you want Amazon Route 53 to send the value of <code>FullyQualifiedDomainName</code> to the endpoint in the <code>client_hello</code> message during <code>TLS</code> negotiation. This allows the endpoint to respond to <code>HTTPS</code> health check requests with the applicable SSL/TLS certificate.</p> <p>Some endpoints require that HTTPS requests include the host name in the <code>client_hello</code> message. If you don't enable SNI, the status of the health check will be SSL alert <code>handshake_failure</code>. A health check can also have that status for other reasons. If SNI is enabled and you're still getting the error, check the SSL/TLS configuration on your endpoint and confirm that your certificate is valid.</p> <p>The SSL/TLS certificate on your endpoint includes a domain name in the <code>Common Name</code> field and possibly several more in the <code>Subject Alternative Names</code> field. One of the domain names in the certificate should match the value that you specify for <code>FullyQualifiedDomainName</code>. If the endpoint responds to the <code>client_hello</code> message with a certificate that does not include the domain name that you specified in <code>FullyQualifiedDomainName</code>, a health checker will retry the handshake. In the second attempt, the health checker will omit <code>FullyQualifiedDomainName</code> from the <code>client_hello</code> message.</p>"]
+    #[serde(rename="EnableSNI")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enable_sni: Option<bool>,
     #[doc="<p>The number of consecutive health checks that an endpoint must pass or fail for Amazon Route 53 to change the current status of the endpoint from unhealthy to healthy or vice versa. For more information, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html\">How Amazon Route 53 Determines Whether an Endpoint Is Healthy</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> <p>If you don't specify a value for <code>FailureThreshold</code>, the default value is three health checks.</p>"]
+    #[serde(rename="FailureThreshold")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub failure_threshold: Option<i64>,
     #[doc="<p>Amazon Route 53 behavior depends on whether you specify a value for <code>IPAddress</code>.</p> <note> <p>If a health check already has a value for <code>IPAddress</code>, you can change the value. However, you can't update an existing health check to add or remove the value of <code>IPAddress</code>. </p> </note> <p> <b>If you specify a value for</b> <code>IPAddress</code>:</p> <p>Amazon Route 53 sends health check requests to the specified IPv4 or IPv6 address and passes the value of <code>FullyQualifiedDomainName</code> in the <code>Host</code> header for all health checks except TCP health checks. This is typically the fully qualified DNS name of the endpoint on which you want Amazon Route 53 to perform health checks.</p> <p>When Amazon Route 53 checks the health of an endpoint, here is how it constructs the <code>Host</code> header:</p> <ul> <li> <p>If you specify a value of <code>80</code> for <code>Port</code> and <code>HTTP</code> or <code>HTTP_STR_MATCH</code> for <code>Type</code>, Amazon Route 53 passes the value of <code>FullyQualifiedDomainName</code> to the endpoint in the <code>Host</code> header.</p> </li> <li> <p>If you specify a value of <code>443</code> for <code>Port</code> and <code>HTTPS</code> or <code>HTTPS_STR_MATCH</code> for <code>Type</code>, Amazon Route 53 passes the value of <code>FullyQualifiedDomainName</code> to the endpoint in the <code>Host</code> header.</p> </li> <li> <p>If you specify another value for <code>Port</code> and any value except <code>TCP</code> for <code>Type</code>, Amazon Route 53 passes <i> <code>FullyQualifiedDomainName</code>:<code>Port</code> </i> to the endpoint in the <code>Host</code> header.</p> </li> </ul> <p>If you don't specify a value for <code>FullyQualifiedDomainName</code>, Amazon Route 53 substitutes the value of <code>IPAddress</code> in the <code>Host</code> header in each of the above cases.</p> <p> <b>If you don't specify a value for</b> <code>IPAddress</code>:</p> <p>If you don't specify a value for <code>IPAddress</code>, Amazon Route 53 sends a DNS request to the domain that you specify in <code>FullyQualifiedDomainName</code> at the interval you specify in <code>RequestInterval</code>. Using an IPv4 address that is returned by DNS, Amazon Route 53 then checks the health of the endpoint.</p> <note> <p>If you don't specify a value for <code>IPAddress</code>, Amazon Route 53 uses only IPv4 to send health checks to the endpoint. If there's no resource record set with a type of A for the name that you specify for <code>FullyQualifiedDomainName</code>, the health check fails with a \"DNS resolution failed\" error.</p> </note> <p>If you want to check the health of weighted, latency, or failover resource record sets and you choose to specify the endpoint only by <code>FullyQualifiedDomainName</code>, we recommend that you create a separate health check for each endpoint. For example, create a health check for each HTTP server that is serving content for www.example.com. For the value of <code>FullyQualifiedDomainName</code>, specify the domain name of the server (such as <code>us-east-2-www.example.com</code>), not the name of the resource record sets (www.example.com).</p> <important> <p>In this configuration, if the value of <code>FullyQualifiedDomainName</code> matches the name of the resource record sets and you then associate the health check with those resource record sets, health check results will be unpredictable.</p> </important> <p>In addition, if the value of <code>Type</code> is <code>HTTP</code>, <code>HTTPS</code>, <code>HTTP_STR_MATCH</code>, or <code>HTTPS_STR_MATCH</code>, Amazon Route 53 passes the value of <code>FullyQualifiedDomainName</code> in the <code>Host</code> header, as it does when you specify a value for <code>IPAddress</code>. If the value of <code>Type</code> is <code>TCP</code>, Amazon Route 53 doesn't pass a <code>Host</code> header.</p>"]
+    #[serde(rename="FullyQualifiedDomainName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fully_qualified_domain_name: Option<String>,
     #[doc="<p>The ID for the health check for which you want detailed information. When you created the health check, <code>CreateHealthCheck</code> returned the ID in the response, in the <code>HealthCheckId</code> element.</p>"]
+    #[serde(rename="HealthCheckId")]
     pub health_check_id: String,
     #[doc="<p>A sequential counter that Amazon Route 53 sets to <code>1</code> when you create a health check and increments by 1 each time you update settings for the health check.</p> <p>We recommend that you use <code>GetHealthCheck</code> or <code>ListHealthChecks</code> to get the current value of <code>HealthCheckVersion</code> for the health check that you want to update, and that you include that value in your <code>UpdateHealthCheck</code> request. This prevents Amazon Route 53 from overwriting an intervening update:</p> <ul> <li> <p>If the value in the <code>UpdateHealthCheck</code> request matches the value of <code>HealthCheckVersion</code> in the health check, Amazon Route 53 updates the health check with the new settings.</p> </li> <li> <p>If the value of <code>HealthCheckVersion</code> in the health check is greater, the health check was changed after you got the version number. Amazon Route 53 does not update the health check, and it returns a <code>HealthCheckVersionMismatch</code> error.</p> </li> </ul>"]
+    #[serde(rename="HealthCheckVersion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_check_version: Option<i64>,
     #[doc="<p>The number of child health checks that are associated with a <code>CALCULATED</code> health that Amazon Route 53 must consider healthy for the <code>CALCULATED</code> health check to be considered healthy. To specify the child health checks that you want to associate with a <code>CALCULATED</code> health check, use the <code>ChildHealthChecks</code> and <code>ChildHealthCheck</code> elements.</p> <p>Note the following:</p> <ul> <li> <p>If you specify a number greater than the number of child health checks, Amazon Route 53 always considers this health check to be unhealthy.</p> </li> <li> <p>If you specify <code>0</code>, Amazon Route 53 always considers this health check to be healthy.</p> </li> </ul>"]
+    #[serde(rename="HealthThreshold")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub health_threshold: Option<i64>,
     #[doc="<p>The IPv4 or IPv6 IP address for the endpoint that you want Amazon Route 53 to perform health checks on. If you don't specify a value for <code>IPAddress</code>, Amazon Route 53 sends a DNS request to resolve the domain name that you specify in <code>FullyQualifiedDomainName</code> at the interval that you specify in <code>RequestInterval</code>. Using an IP address that is returned by DNS, Amazon Route 53 then checks the health of the endpoint.</p> <p>Use one of the following formats for the value of <code>IPAddress</code>: </p> <ul> <li> <p> <b>IPv4 address</b>: four values between 0 and 255, separated by periods (.), for example, <code>192.0.2.44</code>.</p> </li> <li> <p> <b>IPv6 address</b>: eight groups of four hexadecimal values, separated by colons (:), for example, <code>2001:0db8:85a3:0000:0000:abcd:0001:2345</code>. You can also shorten IPv6 addresses as described in RFC 5952, for example, <code>2001:db8:85a3::abcd:1:2345</code>.</p> </li> </ul> <p>If the endpoint is an EC2 instance, we recommend that you create an Elastic IP address, associate it with your EC2 instance, and specify the Elastic IP address for <code>IPAddress</code>. This ensures that the IP address of your instance never changes. For more information, see the applicable documentation:</p> <ul> <li> <p>Linux: <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html\">Elastic IP Addresses (EIP)</a> in the <i>Amazon EC2 User Guide for Linux Instances</i> </p> </li> <li> <p>Windows: <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/elastic-ip-addresses-eip.html\">Elastic IP Addresses (EIP)</a> in the <i>Amazon EC2 User Guide for Windows Instances</i> </p> </li> </ul> <note> <p>If a health check already has a value for <code>IPAddress</code>, you can change the value. However, you can't update an existing health check to add or remove the value of <code>IPAddress</code>. </p> </note> <p>For more information, see <a>UpdateHealthCheckRequest$FullyQualifiedDomainName</a>.</p> <p>Constraints: Amazon Route 53 can't check the health of endpoints for which the IP address is in local, private, non-routable, or multicast ranges. For more information about IP addresses for which you can't create health checks, see the following documents:</p> <ul> <li> <p> <a href=\"https://tools.ietf.org/html/rfc5735\">RFC 5735, Special Use IPv4 Addresses</a> </p> </li> <li> <p> <a href=\"https://tools.ietf.org/html/rfc6598\">RFC 6598, IANA-Reserved IPv4 Prefix for Shared Address Space</a> </p> </li> <li> <p> <a href=\"https://tools.ietf.org/html/rfc5156\">RFC 5156, Special-Use IPv6 Addresses</a> </p> </li> </ul>"]
+    #[serde(rename="IPAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ip_address: Option<String>,
     #[doc="<p>When CloudWatch has insufficient data about the metric to determine the alarm state, the status that you want Amazon Route 53 to assign to the health check:</p> <ul> <li> <p> <code>Healthy</code>: Amazon Route 53 considers the health check to be healthy.</p> </li> <li> <p> <code>Unhealthy</code>: Amazon Route 53 considers the health check to be unhealthy.</p> </li> <li> <p> <code>LastKnownStatus</code>: Amazon Route 53 uses the status of the health check from the last time CloudWatch had sufficient data to determine the alarm state. For new health checks that have no last known status, the default status for the health check is healthy.</p> </li> </ul>"]
+    #[serde(rename="InsufficientDataHealthStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub insufficient_data_health_status: Option<String>,
     #[doc="<p>Specify whether you want Amazon Route 53 to invert the status of a health check, for example, to consider a health check unhealthy when it otherwise would be considered healthy.</p>"]
+    #[serde(rename="Inverted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub inverted: Option<bool>,
     #[doc="<p>The port on the endpoint on which you want Amazon Route 53 to perform health checks.</p>"]
+    #[serde(rename="Port")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub port: Option<i64>,
     #[doc="<p>A complex type that contains one <code>Region</code> element for each region that you want Amazon Route 53 health checkers to check the specified endpoint from.</p>"]
+    #[serde(rename="Regions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub regions: Option<Vec<String>>,
     #[doc="<p>The path that you want Amazon Route 53 to request when performing health checks. The path can be any value for which your endpoint will return an HTTP status code of 2xx or 3xx when the endpoint is healthy, for example the file /docs/route53-health-check.html. </p> <p>Specify this value only if you want to change it.</p>"]
+    #[serde(rename="ResourcePath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub resource_path: Option<String>,
     #[doc="<p>If the value of <code>Type</code> is <code>HTTP_STR_MATCH</code> or <code>HTTP_STR_MATCH</code>, the string that you want Amazon Route 53 to search for in the response body from the specified resource. If the string appears in the response body, Amazon Route 53 considers the resource healthy. (You can't change the value of <code>Type</code> when you update a health check.)</p>"]
+    #[serde(rename="SearchString")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub search_string: Option<String>,
 }
 
@@ -8142,8 +8621,9 @@ impl UpdateHealthCheckRequestSerializer {
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateHealthCheckResponse {
+    #[serde(rename="HealthCheck")]
     pub health_check: HealthCheck,
 }
 
@@ -8190,11 +8670,14 @@ impl UpdateHealthCheckResponseDeserializer {
     }
 }
 #[doc="<p>A request to update the comment for a hosted zone.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateHostedZoneCommentRequest {
     #[doc="<p>The new comment for the hosted zone. If you don't specify a value for <code>Comment</code>, Amazon Route 53 deletes the existing value of the <code>Comment</code> element, if any.</p>"]
+    #[serde(rename="Comment")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub comment: Option<String>,
     #[doc="<p>The ID for the hosted zone that you want to update the comment for.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
@@ -8217,8 +8700,9 @@ impl UpdateHostedZoneCommentRequestSerializer {
     }
 }
 #[doc="<p>A complex type that contains the response to the <code>UpdateHostedZoneComment</code> request.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateHostedZoneCommentResponse {
+    #[serde(rename="HostedZone")]
     pub hosted_zone: HostedZone,
 }
 
@@ -8266,13 +8750,16 @@ impl UpdateHostedZoneCommentResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the traffic policy that you want to update the comment for.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateTrafficPolicyCommentRequest {
     #[doc="<p>The new comment for the specified traffic policy and version.</p>"]
+    #[serde(rename="Comment")]
     pub comment: String,
     #[doc="<p>The value of <code>Id</code> for the traffic policy that you want to update the comment for.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The value of <code>Version</code> for the traffic policy that you want to update the comment for.</p>"]
+    #[serde(rename="Version")]
     pub version: i64,
 }
 
@@ -8293,9 +8780,10 @@ impl UpdateTrafficPolicyCommentRequestSerializer {
     }
 }
 #[doc="<p>A complex type that contains the response information for the traffic policy.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateTrafficPolicyCommentResponse {
     #[doc="<p>A complex type that contains settings for the specified traffic policy.</p>"]
+    #[serde(rename="TrafficPolicy")]
     pub traffic_policy: TrafficPolicy,
 }
 
@@ -8344,15 +8832,19 @@ impl UpdateTrafficPolicyCommentResponseDeserializer {
     }
 }
 #[doc="<p>A complex type that contains information about the resource record sets that you want to update based on a specified traffic policy instance.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateTrafficPolicyInstanceRequest {
     #[doc="<p>The ID of the traffic policy instance that you want to update.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>The TTL that you want Amazon Route 53 to assign to all of the updated resource record sets.</p>"]
+    #[serde(rename="TTL")]
     pub ttl: i64,
     #[doc="<p>The ID of the traffic policy that you want Amazon Route 53 to use to update resource record sets for the specified traffic policy instance.</p>"]
+    #[serde(rename="TrafficPolicyId")]
     pub traffic_policy_id: String,
     #[doc="<p>The version of the traffic policy that you want Amazon Route 53 to use to update resource record sets for the specified traffic policy instance.</p>"]
+    #[serde(rename="TrafficPolicyVersion")]
     pub traffic_policy_version: i64,
 }
 
@@ -8379,9 +8871,10 @@ impl UpdateTrafficPolicyInstanceRequestSerializer {
     }
 }
 #[doc="<p>A complex type that contains information about the resource record sets that Amazon Route 53 created based on a specified traffic policy.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UpdateTrafficPolicyInstanceResponse {
     #[doc="<p>A complex type that contains settings for the updated traffic policy instance.</p>"]
+    #[serde(rename="TrafficPolicyInstance")]
     pub traffic_policy_instance: TrafficPolicyInstance,
 }
 
@@ -8430,10 +8923,14 @@ impl UpdateTrafficPolicyInstanceResponseDeserializer {
     }
 }
 #[doc="<p>(Private hosted zones only) A complex type that contains information about an Amazon VPC.</p>"]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct VPC {
+    #[serde(rename="VPCId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_id: Option<String>,
     #[doc="<p>(Private hosted zones only) The region in which you created an Amazon VPC.</p>"]
+    #[serde(rename="VPCRegion")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub vpc_region: Option<String>,
 }
 

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Information for one billing record.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BillingRecord {
     #[doc="<p>The date that the operation was billed, in Unix format.</p>"]
     #[serde(rename="BillDate")]
@@ -54,7 +54,7 @@ pub struct BillingRecord {
 }
 
 #[doc="<p>The CheckDomainAvailability request contains the following elements.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CheckDomainAvailabilityRequest {
     #[doc="<p>The name of the domain that you want to get availability for.</p> <p>Constraints: The domain name can contain only the letters a through z, the numbers 0 through 9, and hyphen (-). Internationalized Domain Names are not supported.</p>"]
     #[serde(rename="DomainName")]
@@ -66,7 +66,7 @@ pub struct CheckDomainAvailabilityRequest {
 }
 
 #[doc="<p>The CheckDomainAvailability response includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CheckDomainAvailabilityResponse {
     #[doc="<p>Whether the domain name is available for registering.</p> <note> <p>You can only register domains designated as <code>AVAILABLE</code>.</p> </note> <p>Valid values:</p> <dl> <dt>AVAILABLE</dt> <dd> <p>The domain name is available.</p> </dd> <dt>AVAILABLE_RESERVED</dt> <dd> <p>The domain name is reserved under specific conditions.</p> </dd> <dt>AVAILABLE_PREORDER</dt> <dd> <p>The domain name is available and can be preordered.</p> </dd> <dt>DONT_KNOW</dt> <dd> <p>The TLD registry didn't reply with a definitive answer about whether the domain name is available. Amazon Route 53 can return this response for a variety of reasons, for example, the registry is performing maintenance. Try again later.</p> </dd> <dt>PENDING</dt> <dd> <p>The TLD registry didn't return a response in the expected amount of time. When the response is delayed, it usually takes just a few extra seconds. You can resubmit the request immediately.</p> </dd> <dt>RESERVED</dt> <dd> <p>The domain name has been reserved for another person or organization.</p> </dd> <dt>UNAVAILABLE</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_PREMIUM</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_RESTRICTED</dt> <dd> <p>The domain name is forbidden.</p> </dd> </dl>"]
     #[serde(rename="Availability")]
@@ -135,7 +135,7 @@ pub struct ContactDetail {
 }
 
 #[doc="<p>The DeleteTagsForDomainRequest includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsForDomainRequest {
     #[doc="<p>The domain for which you want to delete one or more tags.</p>"]
     #[serde(rename="DomainName")]
@@ -145,21 +145,21 @@ pub struct DeleteTagsForDomainRequest {
     pub tags_to_delete: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsForDomainResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableDomainAutoRenewRequest {
     #[doc="<p>The name of the domain that you want to disable automatic renewal for.</p>"]
     #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableDomainAutoRenewResponse;
 
 #[doc="<p>The DisableDomainTransferLock request includes the following element.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableDomainTransferLockRequest {
     #[doc="<p>The name of the domain that you want to remove the transfer lock for.</p>"]
     #[serde(rename="DomainName")]
@@ -167,7 +167,7 @@ pub struct DisableDomainTransferLockRequest {
 }
 
 #[doc="<p>The DisableDomainTransferLock response includes the following element.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableDomainTransferLockResponse {
     #[doc="<p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>"]
     #[serde(rename="OperationId")]
@@ -175,7 +175,7 @@ pub struct DisableDomainTransferLockResponse {
 }
 
 #[doc="<p>Information about one suggested domain name.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainSuggestion {
     #[doc="<p>Whether the domain name is available for registering.</p> <note> <p>You can register only the domains that are designated as <code>AVAILABLE</code>.</p> </note> <p>Valid values:</p> <dl> <dt>AVAILABLE</dt> <dd> <p>The domain name is available.</p> </dd> <dt>AVAILABLE_RESERVED</dt> <dd> <p>The domain name is reserved under specific conditions.</p> </dd> <dt>AVAILABLE_PREORDER</dt> <dd> <p>The domain name is available and can be preordered.</p> </dd> <dt>DONT_KNOW</dt> <dd> <p>The TLD registry didn't reply with a definitive answer about whether the domain name is available. Amazon Route 53 can return this response for a variety of reasons, for example, the registry is performing maintenance. Try again later.</p> </dd> <dt>PENDING</dt> <dd> <p>The TLD registry didn't return a response in the expected amount of time. When the response is delayed, it usually takes just a few extra seconds. You can resubmit the request immediately.</p> </dd> <dt>RESERVED</dt> <dd> <p>The domain name has been reserved for another person or organization.</p> </dd> <dt>UNAVAILABLE</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_PREMIUM</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_RESTRICTED</dt> <dd> <p>The domain name is forbidden.</p> </dd> </dl>"]
     #[serde(rename="Availability")]
@@ -188,7 +188,7 @@ pub struct DomainSuggestion {
 }
 
 #[doc="<p>Summary information about one domain.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainSummary {
     #[doc="<p>Indicates whether the domain is automatically renewed upon expiration.</p>"]
     #[serde(rename="AutoRenew")]
@@ -207,18 +207,18 @@ pub struct DomainSummary {
     pub transfer_lock: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableDomainAutoRenewRequest {
     #[doc="<p>The name of the domain that you want to enable automatic renewal for.</p>"]
     #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableDomainAutoRenewResponse;
 
 #[doc="<p>A request to set the transfer lock for the specified domain.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableDomainTransferLockRequest {
     #[doc="<p>The name of the domain that you want to set the transfer lock for.</p>"]
     #[serde(rename="DomainName")]
@@ -226,7 +226,7 @@ pub struct EnableDomainTransferLockRequest {
 }
 
 #[doc="<p>The EnableDomainTransferLock response includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EnableDomainTransferLockResponse {
     #[doc="<p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use GetOperationDetail.</p>"]
     #[serde(rename="OperationId")]
@@ -244,7 +244,7 @@ pub struct ExtraParam {
     pub value: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetContactReachabilityStatusRequest {
     #[doc="<p>The name of the domain for which you want to know whether the registrant contact has confirmed that the email address is valid.</p>"]
     #[serde(rename="domainName")]
@@ -252,7 +252,7 @@ pub struct GetContactReachabilityStatusRequest {
     pub domain_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetContactReachabilityStatusResponse {
     #[doc="<p>The domain name for which you requested the reachability status.</p>"]
     #[serde(rename="domainName")]
@@ -265,7 +265,7 @@ pub struct GetContactReachabilityStatusResponse {
 }
 
 #[doc="<p>The GetDomainDetail request includes the following element.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDomainDetailRequest {
     #[doc="<p>The name of the domain that you want to get detailed information about.</p>"]
     #[serde(rename="DomainName")]
@@ -273,7 +273,7 @@ pub struct GetDomainDetailRequest {
 }
 
 #[doc="<p>The GetDomainDetail response includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDomainDetailResponse {
     #[doc="<p>Email address to contact to report incorrect contact information for a domain, to report that the domain is being used to send spam, to report that someone is cybersquatting on a domain name, or report some other type of abuse.</p>"]
     #[serde(rename="AbuseContactEmail")]
@@ -356,7 +356,7 @@ pub struct GetDomainDetailResponse {
     pub who_is_server: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDomainSuggestionsRequest {
     #[doc="<p>A domain name that you want to use as the basis for a list of possible domain names. The domain name must contain a top-level domain (TLD), such as .com, that Amazon Route 53 supports. For a list of TLDs, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/registrar-tld-list.html\">Domains that You Can Register with Amazon Route 53</a> in the <i>Amazon Route 53 Developer Guide</i>.</p>"]
     #[serde(rename="DomainName")]
@@ -369,7 +369,7 @@ pub struct GetDomainSuggestionsRequest {
     pub suggestion_count: i64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDomainSuggestionsResponse {
     #[doc="<p>A list of possible domain names. If you specified <code>true</code> for <code>OnlyAvailable</code> in the request, the list contains only domains that are available for registration.</p>"]
     #[serde(rename="SuggestionsList")]
@@ -378,7 +378,7 @@ pub struct GetDomainSuggestionsResponse {
 }
 
 #[doc="<p>The <a>GetOperationDetail</a> request includes the following element.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOperationDetailRequest {
     #[doc="<p>The identifier for the operation for which you want to get the status. Amazon Route 53 returned the identifier in the response to the original request.</p>"]
     #[serde(rename="OperationId")]
@@ -386,7 +386,7 @@ pub struct GetOperationDetailRequest {
 }
 
 #[doc="<p>The GetOperationDetail response includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetOperationDetailResponse {
     #[doc="<p>The name of a domain.</p>"]
     #[serde(rename="DomainName")]
@@ -415,7 +415,7 @@ pub struct GetOperationDetailResponse {
 }
 
 #[doc="<p>The ListDomains request includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDomainsRequest {
     #[doc="<p>For an initial request for a list of domains, omit this element. If the number of domains that are associated with the current AWS account is greater than the value that you specified for <code>MaxItems</code>, you can use <code>Marker</code> to return additional domains. Get the value of <code>NextPageMarker</code> from the previous response, and submit another request that includes the value of <code>NextPageMarker</code> in the <code>Marker</code> element.</p> <p>Constraints: The marker must match the value specified in the previous request.</p>"]
     #[serde(rename="Marker")]
@@ -428,7 +428,7 @@ pub struct ListDomainsRequest {
 }
 
 #[doc="<p>The ListDomains response includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDomainsResponse {
     #[doc="<p>A summary of domains.</p>"]
     #[serde(rename="Domains")]
@@ -440,7 +440,7 @@ pub struct ListDomainsResponse {
 }
 
 #[doc="<p>The ListOperations request includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOperationsRequest {
     #[doc="<p>For an initial request for a list of operations, omit this element. If the number of operations that are not yet complete is greater than the value that you specified for <code>MaxItems</code>, you can use <code>Marker</code> to return additional operations. Get the value of <code>NextPageMarker</code> from the previous response, and submit another request that includes the value of <code>NextPageMarker</code> in the <code>Marker</code> element.</p>"]
     #[serde(rename="Marker")]
@@ -453,7 +453,7 @@ pub struct ListOperationsRequest {
 }
 
 #[doc="<p>The ListOperations response includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOperationsResponse {
     #[doc="<p>If there are more operations than you specified for <code>MaxItems</code> in the request, submit another request and include the value of <code>NextPageMarker</code> in the value of <code>Marker</code>.</p>"]
     #[serde(rename="NextPageMarker")]
@@ -465,7 +465,7 @@ pub struct ListOperationsResponse {
 }
 
 #[doc="<p>The ListTagsForDomainRequest includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForDomainRequest {
     #[doc="<p>The domain for which you want to get a list of tags.</p>"]
     #[serde(rename="DomainName")]
@@ -473,7 +473,7 @@ pub struct ListTagsForDomainRequest {
 }
 
 #[doc="<p>The ListTagsForDomain response includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForDomainResponse {
     #[doc="<p>A list of the tags that are associated with the specified domain.</p>"]
     #[serde(rename="TagList")]
@@ -493,7 +493,7 @@ pub struct Nameserver {
 }
 
 #[doc="<p>OperationSummary includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OperationSummary {
     #[doc="<p>Identifier returned to track the requested action.</p>"]
     #[serde(rename="OperationId")]
@@ -510,7 +510,7 @@ pub struct OperationSummary {
 }
 
 #[doc="<p>The RegisterDomain request includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterDomainRequest {
     #[doc="<p>Provides detailed contact information.</p>"]
     #[serde(rename="AdminContact")]
@@ -550,7 +550,7 @@ pub struct RegisterDomainRequest {
 }
 
 #[doc="<p>The RegisterDomain response includes the following element.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterDomainResponse {
     #[doc="<p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>"]
     #[serde(rename="OperationId")]
@@ -558,7 +558,7 @@ pub struct RegisterDomainResponse {
 }
 
 #[doc="<p>A <code>RenewDomain</code> request includes the number of years that you want to renew for and the current expiration year.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RenewDomainRequest {
     #[doc="<p>The year when the registration for the domain is set to expire. This value must match the current expiration date for the domain.</p>"]
     #[serde(rename="CurrentExpiryYear")]
@@ -572,14 +572,14 @@ pub struct RenewDomainRequest {
     pub duration_in_years: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RenewDomainResponse {
     #[doc="<p>The identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>"]
     #[serde(rename="OperationId")]
     pub operation_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResendContactReachabilityEmailRequest {
     #[doc="<p>The name of the domain for which you want Amazon Route 53 to resend a confirmation email to the registrant contact.</p>"]
     #[serde(rename="domainName")]
@@ -587,7 +587,7 @@ pub struct ResendContactReachabilityEmailRequest {
     pub domain_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResendContactReachabilityEmailResponse {
     #[doc="<p>The domain name for which you requested a confirmation email.</p>"]
     #[serde(rename="domainName")]
@@ -604,7 +604,7 @@ pub struct ResendContactReachabilityEmailResponse {
 }
 
 #[doc="<p>A request for the authorization code for the specified domain. To transfer a domain to another registrar, you provide this value to the new registrar.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RetrieveDomainAuthCodeRequest {
     #[doc="<p>The name of the domain that you want to get an authorization code for.</p>"]
     #[serde(rename="DomainName")]
@@ -612,7 +612,7 @@ pub struct RetrieveDomainAuthCodeRequest {
 }
 
 #[doc="<p>The RetrieveDomainAuthCode response includes the following element.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RetrieveDomainAuthCodeResponse {
     #[doc="<p>The authorization code for the domain.</p>"]
     #[serde(rename="AuthCode")]
@@ -633,7 +633,7 @@ pub struct Tag {
 }
 
 #[doc="<p>The TransferDomain request includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TransferDomainRequest {
     #[doc="<p>Provides detailed contact information.</p>"]
     #[serde(rename="AdminContact")]
@@ -681,7 +681,7 @@ pub struct TransferDomainRequest {
 }
 
 #[doc="<p>The TranserDomain response includes the following element.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TransferDomainResponse {
     #[doc="<p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>"]
     #[serde(rename="OperationId")]
@@ -689,7 +689,7 @@ pub struct TransferDomainResponse {
 }
 
 #[doc="<p>The UpdateDomainContactPrivacy request includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDomainContactPrivacyRequest {
     #[doc="<p>Whether you want to conceal contact information from WHOIS queries. If you specify <code>true</code>, WHOIS (\"who is\") queries will return contact information for our registrar partner, Gandi, instead of the contact information that you enter.</p>"]
     #[serde(rename="AdminPrivacy")]
@@ -709,7 +709,7 @@ pub struct UpdateDomainContactPrivacyRequest {
 }
 
 #[doc="<p>The UpdateDomainContactPrivacy response includes the following element.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDomainContactPrivacyResponse {
     #[doc="<p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use GetOperationDetail.</p>"]
     #[serde(rename="OperationId")]
@@ -717,7 +717,7 @@ pub struct UpdateDomainContactPrivacyResponse {
 }
 
 #[doc="<p>The UpdateDomainContact request includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDomainContactRequest {
     #[doc="<p>Provides detailed contact information.</p>"]
     #[serde(rename="AdminContact")]
@@ -737,7 +737,7 @@ pub struct UpdateDomainContactRequest {
 }
 
 #[doc="<p>The UpdateDomainContact response includes the following element.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDomainContactResponse {
     #[doc="<p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>"]
     #[serde(rename="OperationId")]
@@ -745,7 +745,7 @@ pub struct UpdateDomainContactResponse {
 }
 
 #[doc="<p>Replaces the current set of name servers for the domain with the specified set of name servers. If you use Amazon Route 53 as your DNS service, specify the four name servers in the delegation set for the hosted zone for the domain.</p> <p>If successful, this operation returns an operation ID that you can use to track the progress and completion of the action. If the request is not completed successfully, the domain registrant will be notified by email. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDomainNameserversRequest {
     #[doc="<p>The name of the domain that you want to change name servers for.</p>"]
     #[serde(rename="DomainName")]
@@ -760,7 +760,7 @@ pub struct UpdateDomainNameserversRequest {
 }
 
 #[doc="<p>The UpdateDomainNameservers response includes the following element.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDomainNameserversResponse {
     #[doc="<p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>"]
     #[serde(rename="OperationId")]
@@ -768,7 +768,7 @@ pub struct UpdateDomainNameserversResponse {
 }
 
 #[doc="<p>The UpdateTagsForDomainRequest includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTagsForDomainRequest {
     #[doc="<p>The domain for which you want to add or update tags.</p>"]
     #[serde(rename="DomainName")]
@@ -779,11 +779,11 @@ pub struct UpdateTagsForDomainRequest {
     pub tags_to_update: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTagsForDomainResponse;
 
 #[doc="<p>The ViewBilling request includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ViewBillingRequest {
     #[doc="<p>The end date and time for the time period for which you want a list of billing records. Specify the date in Unix time format.</p>"]
     #[serde(rename="End")]
@@ -804,7 +804,7 @@ pub struct ViewBillingRequest {
 }
 
 #[doc="<p>The ViewBilling response includes the following elements.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ViewBillingResponse {
     #[doc="<p>A summary of billing records.</p>"]
     #[serde(rename="BillingRecords")]

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -45,9 +45,11 @@ enum DeserializerNext {
 use md5;
 use base64;
 #[doc="Specifies the days since the initiation of an Incomplete Multipart Upload that Lifecycle will wait before permanently removing all parts of the upload."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AbortIncompleteMultipartUpload {
     #[doc="Indicates the number of days that must pass since initiation for Lifecycle to abort an Incomplete Multipart Upload."]
+    #[serde(rename="DaysAfterInitiation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub days_after_initiation: Option<i64>,
 }
 
@@ -115,8 +117,10 @@ impl AbortIncompleteMultipartUploadSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AbortMultipartUploadOutput {
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
 }
 
@@ -136,17 +140,24 @@ impl AbortMultipartUploadOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AbortMultipartUploadRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="Key")]
     pub key: String,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
+    #[serde(rename="UploadId")]
     pub upload_id: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AccelerateConfiguration {
     #[doc="The accelerate configuration of the bucket."]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -171,10 +182,14 @@ impl AccelerateConfigurationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AccessControlPolicy {
     #[doc="A list of grants."]
+    #[serde(rename="Grants")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grants: Option<Vec<Grant>>,
+    #[serde(rename="Owner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner: Option<Owner>,
 }
 
@@ -465,11 +480,15 @@ impl AllowedOriginsSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AnalyticsAndOperator {
     #[doc="The prefix to use when evaluating an AND predicate."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="The list of tags to use when evaluating an AND predicate."]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -542,13 +561,17 @@ impl AnalyticsAndOperatorSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AnalyticsConfiguration {
     #[doc="The filter used to describe a set of objects for analyses. A filter must have exactly one prefix, one tag, or one conjunction (AnalyticsAndOperator). If no filter is provided, all objects will be considered in any analysis."]
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<AnalyticsFilter>,
     #[doc="The identifier used to represent an analytics configuration."]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="If present, it indicates that data related to access patterns will be collected and made available to analyze the tradeoffs between different storage classes."]
+    #[serde(rename="StorageClassAnalysis")]
     pub storage_class_analysis: StorageClassAnalysis,
 }
 
@@ -656,9 +679,10 @@ impl AnalyticsConfigurationListDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AnalyticsExportDestination {
     #[doc="A destination signifying output to an S3 bucket."]
+    #[serde(rename="S3BucketDestination")]
     pub s3_bucket_destination: AnalyticsS3BucketDestination,
 }
 
@@ -723,13 +747,19 @@ impl AnalyticsExportDestinationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AnalyticsFilter {
     #[doc="A conjunction (logical AND) of predicates, which is used in evaluating an analytics filter. The operator must have at least two predicates."]
+    #[serde(rename="And")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub and: Option<AnalyticsAndOperator>,
     #[doc="The prefix to use when evaluating an analytics filter."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="The tag to use when evaluating an analytics filter."]
+    #[serde(rename="Tag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag: Option<Tag>,
 }
 
@@ -842,15 +872,21 @@ impl AnalyticsIdSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct AnalyticsS3BucketDestination {
     #[doc="The Amazon resource name (ARN) of the bucket to which data is exported."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The account ID that owns the destination bucket. If no account ID is provided, the owner will not be validated prior to exporting data."]
+    #[serde(rename="BucketAccountId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bucket_account_id: Option<String>,
     #[doc="The file format used when exporting data to Amazon S3."]
+    #[serde(rename="Format")]
     pub format: String,
     #[doc="The prefix to use when exporting data. The exported data begins with this prefix."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
 }
 
@@ -1023,11 +1059,15 @@ impl BodySerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Bucket {
     #[doc="Date the bucket was created."]
+    #[serde(rename="CreationDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub creation_date: Option<String>,
     #[doc="The name of the bucket."]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -1110,8 +1150,9 @@ impl BucketAccelerateStatusSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct BucketLifecycleConfiguration {
+    #[serde(rename="Rules")]
     pub rules: Vec<LifecycleRule>,
 }
 
@@ -1163,8 +1204,10 @@ impl BucketLocationConstraintSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct BucketLoggingStatus {
+    #[serde(rename="LoggingEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub logging_enabled: Option<LoggingEnabled>,
 }
 
@@ -1323,8 +1366,9 @@ impl BucketsDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CORSConfiguration {
+    #[serde(rename="CORSRules")]
     pub cors_rules: Vec<CORSRule>,
 }
 
@@ -1344,17 +1388,25 @@ impl CORSConfigurationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CORSRule {
     #[doc="Specifies which headers are allowed in a pre-flight OPTIONS request."]
+    #[serde(rename="AllowedHeaders")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub allowed_headers: Option<Vec<String>>,
     #[doc="Identifies HTTP methods that the domain/origin specified in the rule is allowed to execute."]
+    #[serde(rename="AllowedMethods")]
     pub allowed_methods: Vec<String>,
     #[doc="One or more origins you want customers to be able to access the bucket from."]
+    #[serde(rename="AllowedOrigins")]
     pub allowed_origins: Vec<String>,
     #[doc="One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript XMLHttpRequest object)."]
+    #[serde(rename="ExposeHeaders")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expose_headers: Option<Vec<String>>,
     #[doc="The time in seconds that your browser is to cache the preflight response for the specified resource."]
+    #[serde(rename="MaxAgeSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_age_seconds: Option<i64>,
 }
 
@@ -1528,11 +1580,19 @@ impl CloudFunctionSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CloudFunctionConfiguration {
+    #[serde(rename="CloudFunction")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cloud_function: Option<String>,
+    #[serde(rename="Events")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<String>>,
+    #[serde(rename="Id")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
+    #[serde(rename="InvocationRole")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub invocation_role: Option<String>,
 }
 
@@ -1671,8 +1731,10 @@ impl CodeDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CommonPrefix {
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
 }
 
@@ -1746,21 +1808,39 @@ impl CommonPrefixListDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CompleteMultipartUploadOutput {
+    #[serde(rename="Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bucket: Option<String>,
     #[doc="Entity tag of the object."]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="If the object expiration is configured, this will contain the expiration date (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded."]
+    #[serde(rename="Expiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expiration: Option<String>,
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
+    #[serde(rename="Location")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location: Option<String>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
     #[doc="If present, specifies the ID of the AWS Key Management Service (KMS) master encryption key that was used for the object."]
+    #[serde(rename="SSEKMSKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssekms_key_id: Option<String>,
     #[doc="The Server-side encryption algorithm used when storing this object in S3 (e.g., AES256, aws:kms)."]
+    #[serde(rename="ServerSideEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_side_encryption: Option<String>,
     #[doc="Version of the object."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -1816,17 +1896,26 @@ impl CompleteMultipartUploadOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CompleteMultipartUploadRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="Key")]
     pub key: String,
+    #[serde(rename="MultipartUpload")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub multipart_upload: Option<CompletedMultipartUpload>,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
+    #[serde(rename="UploadId")]
     pub upload_id: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CompletedMultipartUpload {
+    #[serde(rename="Parts")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parts: Option<Vec<CompletedPart>>,
 }
 
@@ -1848,11 +1937,15 @@ impl CompletedMultipartUploadSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CompletedPart {
     #[doc="Entity tag returned when the part was uploaded."]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="Part number that identifies the part. This is a positive integer between 1 and 10,000."]
+    #[serde(rename="PartNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub part_number: Option<i64>,
 }
 
@@ -1900,11 +1993,15 @@ impl CompletedPartListSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Condition {
     #[doc="The HTTP error code when the redirect is applied. In the event of an error, if the error code equals this value, then the specified redirect is applied. Required when parent element Condition is specified and sibling KeyPrefixEquals is not specified. If both are specified, then both must be true for the redirect to be applied."]
+    #[serde(rename="HttpErrorCodeReturnedEquals")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub http_error_code_returned_equals: Option<String>,
     #[doc="The object key name prefix when the redirect is applied. For example, to redirect requests for ExamplePage.html, the key prefix will be ExamplePage.html. To redirect request for all pages with the prefix docs/, the key prefix will be /docs, which identifies all objects in the docs/ folder. Required when the parent element Condition is specified and sibling HttpErrorCodeReturnedEquals is not specified. If both conditions are specified, both must be true for the redirect to be applied."]
+    #[serde(rename="KeyPrefixEquals")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_prefix_equals: Option<String>,
 }
 
@@ -1981,22 +2078,40 @@ impl ConditionSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CopyObjectOutput {
+    #[serde(rename="CopyObjectResult")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_object_result: Option<CopyObjectResult>,
+    #[serde(rename="CopySourceVersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_version_id: Option<String>,
     #[doc="If the object expiration is configured, the response includes this header."]
+    #[serde(rename="Expiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expiration: Option<String>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header confirming the encryption algorithm used."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header to provide round trip message integrity verification of the customer-provided encryption key."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="If present, specifies the ID of the AWS Key Management Service (KMS) master encryption key that was used for the object."]
+    #[serde(rename="SSEKMSKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssekms_key_id: Option<String>,
     #[doc="The Server-side encryption algorithm used when storing this object in S3 (e.g., AES256, aws:kms)."]
+    #[serde(rename="ServerSideEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_side_encryption: Option<String>,
     #[doc="Version ID of the newly created copy."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -2043,76 +2158,143 @@ impl CopyObjectOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CopyObjectRequest {
     #[doc="The canned ACL to apply to the object."]
+    #[serde(rename="ACL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub acl: Option<String>,
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="Specifies caching behavior along the request/reply chain."]
+    #[serde(rename="CacheControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_control: Option<String>,
     #[doc="Specifies presentational information for the object."]
+    #[serde(rename="ContentDisposition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_disposition: Option<String>,
     #[doc="Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."]
+    #[serde(rename="ContentEncoding")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_encoding: Option<String>,
     #[doc="The language the content is in."]
+    #[serde(rename="ContentLanguage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_language: Option<String>,
     #[doc="A standard MIME type describing the format of the object data."]
+    #[serde(rename="ContentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_type: Option<String>,
     #[doc="The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded."]
+    #[serde(rename="CopySource")]
     pub copy_source: String,
     #[doc="Copies the object if its entity tag (ETag) matches the specified tag."]
+    #[serde(rename="CopySourceIfMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_if_match: Option<String>,
     #[doc="Copies the object if it has been modified since the specified time."]
+    #[serde(rename="CopySourceIfModifiedSince")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_if_modified_since: Option<String>,
     #[doc="Copies the object if its entity tag (ETag) is different than the specified ETag."]
+    #[serde(rename="CopySourceIfNoneMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_if_none_match: Option<String>,
     #[doc="Copies the object if it hasn't been modified since the specified time."]
+    #[serde(rename="CopySourceIfUnmodifiedSince")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_if_unmodified_since: Option<String>,
     #[doc="Specifies the algorithm to use when decrypting the source object (e.g., AES256)."]
+    #[serde(rename="CopySourceSSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_sse_customer_algorithm: Option<String>,
     #[doc="Specifies the customer-provided encryption key for Amazon S3 to use to decrypt the source object. The encryption key provided in this header must be one that was used when the source object was created."]
+    #[serde(rename="CopySourceSSECustomerKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_sse_customer_key: Option<String>,
     #[doc="Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header for a message integrity check to ensure the encryption key was transmitted without error."]
+    #[serde(rename="CopySourceSSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_sse_customer_key_md5: Option<String>,
     #[doc="The date and time at which the object is no longer cacheable."]
+    #[serde(rename="Expires")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expires: Option<String>,
     #[doc="Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object."]
+    #[serde(rename="GrantFullControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_full_control: Option<String>,
     #[doc="Allows grantee to read the object data and its metadata."]
+    #[serde(rename="GrantRead")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read: Option<String>,
     #[doc="Allows grantee to read the object ACL."]
+    #[serde(rename="GrantReadACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read_acp: Option<String>,
     #[doc="Allows grantee to write the ACL for the applicable object."]
+    #[serde(rename="GrantWriteACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_write_acp: Option<String>,
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="A map of metadata to store with the object in S3."]
+    #[serde(rename="Metadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metadata: Option<::std::collections::HashMap<String, String>>,
     #[doc="Specifies whether the metadata is copied from the source object or replaced with metadata provided in the request."]
+    #[serde(rename="MetadataDirective")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metadata_directive: Option<String>,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="Specifies the algorithm to use to when encrypting the object (e.g., AES256)."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This value is used to store the object and then it is discarded; Amazon does not store the encryption key. The key must be appropriate for use with the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm header."]
+    #[serde(rename="SSECustomerKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key: Option<String>,
     #[doc="Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header for a message integrity check to ensure the encryption key was transmitted without error."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="Specifies the AWS KMS key ID to use for object encryption. All GET and PUT requests for an object protected by AWS KMS will fail if not made via SSL or using SigV4. Documentation on configuring any of the officially supported AWS SDKs and CLI can be found at http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version"]
+    #[serde(rename="SSEKMSKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssekms_key_id: Option<String>,
     #[doc="The Server-side encryption algorithm used when storing this object in S3 (e.g., AES256, aws:kms)."]
+    #[serde(rename="ServerSideEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_side_encryption: Option<String>,
     #[doc="The type of storage to use for the object. Defaults to 'STANDARD'."]
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
     #[doc="The tag-set for the object destination object this value must be used in conjunction with the TaggingDirective. The tag-set must be encoded as URL Query parameters"]
+    #[serde(rename="Tagging")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tagging: Option<String>,
     #[doc="Specifies whether the object tag-set are copied from the source object or replaced with tag-set provided in the request."]
+    #[serde(rename="TaggingDirective")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tagging_directive: Option<String>,
     #[doc="If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."]
+    #[serde(rename="WebsiteRedirectLocation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub website_redirect_location: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CopyObjectResult {
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
+    #[serde(rename="LastModified")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_modified: Option<String>,
 }
 
@@ -2162,11 +2344,15 @@ impl CopyObjectResultDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CopyPartResult {
     #[doc="Entity tag of the object."]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="Date and time at which the object was uploaded."]
+    #[serde(rename="LastModified")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_modified: Option<String>,
 }
 
@@ -2216,9 +2402,11 @@ impl CopyPartResultDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateBucketConfiguration {
     #[doc="Specifies the region where the bucket will be created. If you don't specify a region, the bucket will be created in US Standard."]
+    #[serde(rename="LocationConstraint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location_constraint: Option<String>,
 }
 
@@ -2243,8 +2431,10 @@ impl CreateBucketConfigurationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateBucketOutput {
+    #[serde(rename="Location")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location: Option<String>,
 }
 
@@ -2264,44 +2454,79 @@ impl CreateBucketOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateBucketRequest {
     #[doc="The canned ACL to apply to the bucket."]
+    #[serde(rename="ACL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub acl: Option<String>,
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="CreateBucketConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub create_bucket_configuration: Option<CreateBucketConfiguration>,
     #[doc="Allows grantee the read, write, read ACP, and write ACP permissions on the bucket."]
+    #[serde(rename="GrantFullControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_full_control: Option<String>,
     #[doc="Allows grantee to list the objects in the bucket."]
+    #[serde(rename="GrantRead")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read: Option<String>,
     #[doc="Allows grantee to read the bucket ACL."]
+    #[serde(rename="GrantReadACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read_acp: Option<String>,
     #[doc="Allows grantee to create, overwrite, and delete any object in the bucket."]
+    #[serde(rename="GrantWrite")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_write: Option<String>,
     #[doc="Allows grantee to write the ACL for the applicable bucket."]
+    #[serde(rename="GrantWriteACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_write_acp: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateMultipartUploadOutput {
     #[doc="Date when multipart upload will become eligible for abort operation by lifecycle."]
+    #[serde(rename="AbortDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub abort_date: Option<String>,
     #[doc="Id of the lifecycle rule that makes a multipart upload eligible for abort operation."]
+    #[serde(rename="AbortRuleId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub abort_rule_id: Option<String>,
     #[doc="Name of the bucket to which the multipart upload was initiated."]
+    #[serde(rename="Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bucket: Option<String>,
     #[doc="Object key for which the multipart upload was initiated."]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header confirming the encryption algorithm used."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header to provide round trip message integrity verification of the customer-provided encryption key."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="If present, specifies the ID of the AWS Key Management Service (KMS) master encryption key that was used for the object."]
+    #[serde(rename="SSEKMSKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssekms_key_id: Option<String>,
     #[doc="The Server-side encryption algorithm used when storing this object in S3 (e.g., AES256, aws:kms)."]
+    #[serde(rename="ServerSideEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_side_encryption: Option<String>,
     #[doc="ID for the initiated multipart upload."]
+    #[serde(rename="UploadId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_id: Option<String>,
 }
 
@@ -2355,50 +2580,94 @@ impl CreateMultipartUploadOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct CreateMultipartUploadRequest {
     #[doc="The canned ACL to apply to the object."]
+    #[serde(rename="ACL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub acl: Option<String>,
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="Specifies caching behavior along the request/reply chain."]
+    #[serde(rename="CacheControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_control: Option<String>,
     #[doc="Specifies presentational information for the object."]
+    #[serde(rename="ContentDisposition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_disposition: Option<String>,
     #[doc="Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."]
+    #[serde(rename="ContentEncoding")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_encoding: Option<String>,
     #[doc="The language the content is in."]
+    #[serde(rename="ContentLanguage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_language: Option<String>,
     #[doc="A standard MIME type describing the format of the object data."]
+    #[serde(rename="ContentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_type: Option<String>,
     #[doc="The date and time at which the object is no longer cacheable."]
+    #[serde(rename="Expires")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expires: Option<String>,
     #[doc="Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object."]
+    #[serde(rename="GrantFullControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_full_control: Option<String>,
     #[doc="Allows grantee to read the object data and its metadata."]
+    #[serde(rename="GrantRead")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read: Option<String>,
     #[doc="Allows grantee to read the object ACL."]
+    #[serde(rename="GrantReadACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read_acp: Option<String>,
     #[doc="Allows grantee to write the ACL for the applicable object."]
+    #[serde(rename="GrantWriteACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_write_acp: Option<String>,
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="A map of metadata to store with the object in S3."]
+    #[serde(rename="Metadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metadata: Option<::std::collections::HashMap<String, String>>,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="Specifies the algorithm to use to when encrypting the object (e.g., AES256)."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This value is used to store the object and then it is discarded; Amazon does not store the encryption key. The key must be appropriate for use with the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm header."]
+    #[serde(rename="SSECustomerKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key: Option<String>,
     #[doc="Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header for a message integrity check to ensure the encryption key was transmitted without error."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="Specifies the AWS KMS key ID to use for object encryption. All GET and PUT requests for an object protected by AWS KMS will fail if not made via SSL or using SigV4. Documentation on configuring any of the officially supported AWS SDKs and CLI can be found at http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version"]
+    #[serde(rename="SSEKMSKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssekms_key_id: Option<String>,
     #[doc="The Server-side encryption algorithm used when storing this object in S3 (e.g., AES256, aws:kms)."]
+    #[serde(rename="ServerSideEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_side_encryption: Option<String>,
     #[doc="The type of storage to use for the object. Defaults to 'STANDARD'."]
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
     #[doc="The tag-set for the object. The tag-set must be encoded as URL Query parameters"]
+    #[serde(rename="Tagging")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tagging: Option<String>,
     #[doc="If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."]
+    #[serde(rename="WebsiteRedirectLocation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub website_redirect_location: Option<String>,
 }
 
@@ -2512,10 +2781,13 @@ impl DaysAfterInitiationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Delete {
+    #[serde(rename="Objects")]
     pub objects: Vec<ObjectIdentifier>,
     #[doc="Element to enable quiet mode for the request. When you add this element, you must set its value to true."]
+    #[serde(rename="Quiet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub quiet: Option<bool>,
 }
 
@@ -2540,62 +2812,75 @@ impl DeleteSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteBucketAnalyticsConfigurationRequest {
     #[doc="The name of the bucket from which an analytics configuration is deleted."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The identifier used to represent an analytics configuration."]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteBucketCorsRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteBucketInventoryConfigurationRequest {
     #[doc="The name of the bucket containing the inventory configuration to delete."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The ID used to identify the inventory configuration."]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteBucketLifecycleRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteBucketMetricsConfigurationRequest {
     #[doc="The name of the bucket containing the metrics configuration to delete."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The ID used to identify the metrics configuration."]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteBucketPolicyRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteBucketReplicationRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteBucketRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteBucketTaggingRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteBucketWebsiteRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
@@ -2613,16 +2898,26 @@ impl DeleteMarkerDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteMarkerEntry {
     #[doc="Specifies whether the object is (true) or is not (false) the latest version of an object."]
+    #[serde(rename="IsLatest")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_latest: Option<bool>,
     #[doc="The object key."]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="Date and time the object was last modified."]
+    #[serde(rename="LastModified")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_modified: Option<String>,
+    #[serde(rename="Owner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner: Option<Owner>,
     #[doc="Version ID of an object."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -2726,12 +3021,18 @@ impl DeleteMarkersDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteObjectOutput {
     #[doc="Specifies whether the versioned object that was permanently deleted was (true) or was not (false) a delete marker."]
+    #[serde(rename="DeleteMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_marker: Option<bool>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
     #[doc="Returns the version ID of the delete marker created as a result of the DELETE operation."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -2751,20 +3052,30 @@ impl DeleteObjectOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteObjectRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device."]
+    #[serde(rename="MFA")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub mfa: Option<String>,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="VersionId used to reference a specific version of the object."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteObjectTaggingOutput {
     #[doc="The versionId of the object the tag-set was removed from."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -2784,18 +3095,28 @@ impl DeleteObjectTaggingOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteObjectTaggingRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="The versionId of the object that the tag-set will be removed from."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteObjectsOutput {
+    #[serde(rename="Deleted")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub deleted: Option<Vec<DeletedObject>>,
+    #[serde(rename="Errors")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub errors: Option<Vec<S3Error>>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
 }
 
@@ -2846,20 +3167,34 @@ impl DeleteObjectsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeleteObjectsRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="Delete")]
     pub delete: Delete,
     #[doc="The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device."]
+    #[serde(rename="MFA")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub mfa: Option<String>,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct DeletedObject {
+    #[serde(rename="DeleteMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_marker: Option<bool>,
+    #[serde(rename="DeleteMarkerVersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_marker_version_id: Option<String>,
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -2979,11 +3314,14 @@ impl DelimiterSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Destination {
     #[doc="Amazon resource name (ARN) of the bucket where you want Amazon S3 to store replicas of the object identified by the rule."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The class of storage used to store the object."]
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
 }
 
@@ -3187,11 +3525,19 @@ impl EncodingTypeSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct S3Error {
+    #[serde(rename="Code")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<String>,
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -3248,9 +3594,10 @@ impl S3ErrorDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ErrorDocument {
     #[doc="The object key name to use when a 4XX class error occurs."]
+    #[serde(rename="Key")]
     pub key: String,
 }
 
@@ -3581,10 +3928,14 @@ impl FetchOwnerSerializer {
 }
 
 #[doc="Container for key value pair that defines the criteria for the filter rule."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct FilterRule {
     #[doc="Object key name prefix or suffix identifying one or more objects to which the filtering rule applies. Maximum prefix length can be up to 1,024 characters. Overlapping prefixes and suffixes are not supported. For more information, go to <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html\">Configuring Event Notifications</a> in the Amazon Simple Storage Service Developer Guide."]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -3769,9 +4120,11 @@ impl FilterRuleValueSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketAccelerateConfigurationOutput {
     #[doc="The accelerate configuration of the bucket."]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -3819,16 +4172,21 @@ impl GetBucketAccelerateConfigurationOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketAccelerateConfigurationRequest {
     #[doc="Name of the bucket for which the accelerate configuration is retrieved."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketAclOutput {
     #[doc="A list of grants."]
+    #[serde(rename="Grants")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grants: Option<Vec<Grant>>,
+    #[serde(rename="Owner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner: Option<Owner>,
 }
 
@@ -3877,14 +4235,17 @@ impl GetBucketAclOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketAclRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketAnalyticsConfigurationOutput {
     #[doc="The configuration and any analyses for the analytics filter."]
+    #[serde(rename="AnalyticsConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub analytics_configuration: Option<AnalyticsConfiguration>,
 }
 
@@ -3932,16 +4293,20 @@ impl GetBucketAnalyticsConfigurationOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketAnalyticsConfigurationRequest {
     #[doc="The name of the bucket from which an analytics configuration is retrieved."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The identifier used to represent an analytics configuration."]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketCorsOutput {
+    #[serde(rename="CORSRules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cors_rules: Option<Vec<CORSRule>>,
 }
 
@@ -3987,14 +4352,17 @@ impl GetBucketCorsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketCorsRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketInventoryConfigurationOutput {
     #[doc="Specifies the inventory configuration."]
+    #[serde(rename="InventoryConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub inventory_configuration: Option<InventoryConfiguration>,
 }
 
@@ -4042,16 +4410,20 @@ impl GetBucketInventoryConfigurationOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketInventoryConfigurationRequest {
     #[doc="The name of the bucket containing the inventory configuration to retrieve."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The ID used to identify the inventory configuration."]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketLifecycleConfigurationOutput {
+    #[serde(rename="Rules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rules: Option<Vec<LifecycleRule>>,
 }
 
@@ -4098,13 +4470,16 @@ impl GetBucketLifecycleConfigurationOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketLifecycleConfigurationRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketLifecycleOutput {
+    #[serde(rename="Rules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rules: Option<Vec<Rule>>,
 }
 
@@ -4149,13 +4524,16 @@ impl GetBucketLifecycleOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketLifecycleRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketLocationOutput {
+    #[serde(rename="LocationConstraint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub location_constraint: Option<String>,
 }
 
@@ -4172,13 +4550,16 @@ impl GetBucketLocationOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketLocationRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketLoggingOutput {
+    #[serde(rename="LoggingEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub logging_enabled: Option<LoggingEnabled>,
 }
 
@@ -4225,14 +4606,17 @@ impl GetBucketLoggingOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketLoggingRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketMetricsConfigurationOutput {
     #[doc="Specifies the metrics configuration."]
+    #[serde(rename="MetricsConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metrics_configuration: Option<MetricsConfiguration>,
 }
 
@@ -4280,33 +4664,41 @@ impl GetBucketMetricsConfigurationOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketMetricsConfigurationRequest {
     #[doc="The name of the bucket containing the metrics configuration to retrieve."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The ID used to identify the metrics configuration."]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketNotificationConfigurationRequest {
     #[doc="Name of the bucket to get the notification configuration for."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketPolicyOutput {
     #[doc="The bucket policy as a JSON document."]
+    #[serde(rename="Policy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketPolicyRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketReplicationOutput {
+    #[serde(rename="ReplicationConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_configuration: Option<ReplicationConfiguration>,
 }
 
@@ -4351,14 +4743,17 @@ impl GetBucketReplicationOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketReplicationRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketRequestPaymentOutput {
     #[doc="Specifies who pays for the download and request fees."]
+    #[serde(rename="Payer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub payer: Option<String>,
 }
 
@@ -4403,13 +4798,15 @@ impl GetBucketRequestPaymentOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketRequestPaymentRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketTaggingOutput {
+    #[serde(rename="TagSet")]
     pub tag_set: Vec<Tag>,
 }
 
@@ -4454,16 +4851,21 @@ impl GetBucketTaggingOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketTaggingRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketVersioningOutput {
     #[doc="Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned."]
+    #[serde(rename="MFADelete")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub mfa_delete: Option<String>,
     #[doc="The versioning state of the bucket."]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -4515,16 +4917,25 @@ impl GetBucketVersioningOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketVersioningRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketWebsiteOutput {
+    #[serde(rename="ErrorDocument")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub error_document: Option<ErrorDocument>,
+    #[serde(rename="IndexDocument")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub index_document: Option<IndexDocument>,
+    #[serde(rename="RedirectAllRequestsTo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub redirect_all_requests_to: Option<RedirectAllRequestsTo>,
+    #[serde(rename="RoutingRules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub routing_rules: Option<Vec<RoutingRule>>,
 }
 
@@ -4586,16 +4997,23 @@ impl GetBucketWebsiteOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetBucketWebsiteRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetObjectAclOutput {
     #[doc="A list of grants."]
+    #[serde(rename="Grants")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grants: Option<Vec<Grant>>,
+    #[serde(rename="Owner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner: Option<Owner>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
 }
 
@@ -4644,113 +5062,218 @@ impl GetObjectAclOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetObjectAclRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="Key")]
     pub key: String,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="VersionId used to reference a specific version of the object."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetObjectOutput {
+    #[serde(rename="AcceptRanges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub accept_ranges: Option<String>,
     #[doc="Object data."]
+    #[serde(rename="Body")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub body: Option<StreamingBody>,
     #[doc="Specifies caching behavior along the request/reply chain."]
+    #[serde(rename="CacheControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_control: Option<String>,
     #[doc="Specifies presentational information for the object."]
+    #[serde(rename="ContentDisposition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_disposition: Option<String>,
     #[doc="Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."]
+    #[serde(rename="ContentEncoding")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_encoding: Option<String>,
     #[doc="The language the content is in."]
+    #[serde(rename="ContentLanguage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_language: Option<String>,
     #[doc="Size of the body in bytes."]
+    #[serde(rename="ContentLength")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_length: Option<i64>,
     #[doc="The portion of the object returned in the response."]
+    #[serde(rename="ContentRange")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_range: Option<String>,
     #[doc="A standard MIME type describing the format of the object data."]
+    #[serde(rename="ContentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_type: Option<String>,
     #[doc="Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response."]
+    #[serde(rename="DeleteMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_marker: Option<bool>,
     #[doc="An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key value pairs providing object expiration information. The value of the rule-id is URL encoded."]
+    #[serde(rename="Expiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expiration: Option<String>,
     #[doc="The date and time at which the object is no longer cacheable."]
+    #[serde(rename="Expires")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expires: Option<String>,
     #[doc="Last modified date of the object"]
+    #[serde(rename="LastModified")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_modified: Option<String>,
     #[doc="A map of metadata to store with the object in S3."]
+    #[serde(rename="Metadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metadata: Option<::std::collections::HashMap<String, String>>,
     #[doc="This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers."]
+    #[serde(rename="MissingMeta")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub missing_meta: Option<i64>,
     #[doc="The count of parts this object has."]
+    #[serde(rename="PartsCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parts_count: Option<i64>,
+    #[serde(rename="ReplicationStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_status: Option<String>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
     #[doc="Provides information about object restoration operation and expiration time of the restored object copy."]
+    #[serde(rename="Restore")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub restore: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header confirming the encryption algorithm used."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header to provide round trip message integrity verification of the customer-provided encryption key."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="If present, specifies the ID of the AWS Key Management Service (KMS) master encryption key that was used for the object."]
+    #[serde(rename="SSEKMSKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssekms_key_id: Option<String>,
     #[doc="The Server-side encryption algorithm used when storing this object in S3 (e.g., AES256, aws:kms)."]
+    #[serde(rename="ServerSideEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_side_encryption: Option<String>,
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
     #[doc="The number of tags, if any, on the object."]
+    #[serde(rename="TagCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag_count: Option<i64>,
     #[doc="Version of the object."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
     #[doc="If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."]
+    #[serde(rename="WebsiteRedirectLocation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub website_redirect_location: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetObjectRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed)."]
+    #[serde(rename="IfMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_match: Option<String>,
     #[doc="Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified)."]
+    #[serde(rename="IfModifiedSince")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_modified_since: Option<String>,
     #[doc="Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified)."]
+    #[serde(rename="IfNoneMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_none_match: Option<String>,
     #[doc="Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed)."]
+    #[serde(rename="IfUnmodifiedSince")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_unmodified_since: Option<String>,
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="Part number of the object being read. This is a positive integer between 1 and 10,000. Effectively performs a 'ranged' GET request for the part specified. Useful for downloading just a part of an object."]
+    #[serde(rename="PartNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub part_number: Option<i64>,
     #[doc="Downloads the specified range bytes of an object. For more information about the HTTP Range header, go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35."]
+    #[serde(rename="Range")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub range: Option<String>,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="Sets the Cache-Control header of the response."]
+    #[serde(rename="ResponseCacheControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub response_cache_control: Option<String>,
     #[doc="Sets the Content-Disposition header of the response"]
+    #[serde(rename="ResponseContentDisposition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub response_content_disposition: Option<String>,
     #[doc="Sets the Content-Encoding header of the response."]
+    #[serde(rename="ResponseContentEncoding")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub response_content_encoding: Option<String>,
     #[doc="Sets the Content-Language header of the response."]
+    #[serde(rename="ResponseContentLanguage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub response_content_language: Option<String>,
     #[doc="Sets the Content-Type header of the response."]
+    #[serde(rename="ResponseContentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub response_content_type: Option<String>,
     #[doc="Sets the Expires header of the response."]
+    #[serde(rename="ResponseExpires")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub response_expires: Option<String>,
     #[doc="Specifies the algorithm to use to when encrypting the object (e.g., AES256)."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This value is used to store the object and then it is discarded; Amazon does not store the encryption key. The key must be appropriate for use with the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm header."]
+    #[serde(rename="SSECustomerKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key: Option<String>,
     #[doc="Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header for a message integrity check to ensure the encryption key was transmitted without error."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="VersionId used to reference a specific version of the object."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetObjectTaggingOutput {
+    #[serde(rename="TagSet")]
     pub tag_set: Vec<Tag>,
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -4795,29 +5318,46 @@ impl GetObjectTaggingOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetObjectTaggingRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="Key")]
     pub key: String,
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetObjectTorrentOutput {
+    #[serde(rename="Body")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub body: Option<StreamingBody>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GetObjectTorrentRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="Key")]
     pub key: String,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct GlacierJobParameters {
     #[doc="Glacier retrieval tier at which the restore will be processed."]
+    #[serde(rename="Tier")]
     pub tier: String,
 }
 
@@ -4840,10 +5380,14 @@ impl GlacierJobParametersSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Grant {
+    #[serde(rename="Grantee")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grantee: Option<Grantee>,
     #[doc="Specifies the permission given to the grantee."]
+    #[serde(rename="Permission")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub permission: Option<String>,
 }
 
@@ -4917,17 +5461,26 @@ impl GrantSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Grantee {
     #[doc="Screen name of the grantee."]
+    #[serde(rename="DisplayName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub display_name: Option<String>,
     #[doc="Email address of the grantee."]
+    #[serde(rename="EmailAddress")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub email_address: Option<String>,
     #[doc="The canonical user ID of the grantee."]
+    #[serde(rename="ID")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
     #[doc="Type of grantee"]
+    #[serde(rename="Type")]
     pub type_: String,
     #[doc="URI of the grantee group."]
+    #[serde(rename="URI")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub uri: Option<String>,
 }
 
@@ -5090,58 +5643,109 @@ impl GrantsSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct HeadBucketRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct HeadObjectOutput {
+    #[serde(rename="AcceptRanges")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub accept_ranges: Option<String>,
     #[doc="Specifies caching behavior along the request/reply chain."]
+    #[serde(rename="CacheControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_control: Option<String>,
     #[doc="Specifies presentational information for the object."]
+    #[serde(rename="ContentDisposition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_disposition: Option<String>,
     #[doc="Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."]
+    #[serde(rename="ContentEncoding")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_encoding: Option<String>,
     #[doc="The language the content is in."]
+    #[serde(rename="ContentLanguage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_language: Option<String>,
     #[doc="Size of the body in bytes."]
+    #[serde(rename="ContentLength")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_length: Option<i64>,
     #[doc="A standard MIME type describing the format of the object data."]
+    #[serde(rename="ContentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_type: Option<String>,
     #[doc="Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response."]
+    #[serde(rename="DeleteMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_marker: Option<bool>,
     #[doc="An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL"]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key value pairs providing object expiration information. The value of the rule-id is URL encoded."]
+    #[serde(rename="Expiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expiration: Option<String>,
     #[doc="The date and time at which the object is no longer cacheable."]
+    #[serde(rename="Expires")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expires: Option<String>,
     #[doc="Last modified date of the object"]
+    #[serde(rename="LastModified")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_modified: Option<String>,
     #[doc="A map of metadata to store with the object in S3."]
+    #[serde(rename="Metadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metadata: Option<::std::collections::HashMap<String, String>>,
     #[doc="This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers."]
+    #[serde(rename="MissingMeta")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub missing_meta: Option<i64>,
     #[doc="The count of parts this object has."]
+    #[serde(rename="PartsCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parts_count: Option<i64>,
+    #[serde(rename="ReplicationStatus")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replication_status: Option<String>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
     #[doc="Provides information about object restoration operation and expiration time of the restored object copy."]
+    #[serde(rename="Restore")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub restore: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header confirming the encryption algorithm used."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header to provide round trip message integrity verification of the customer-provided encryption key."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="If present, specifies the ID of the AWS Key Management Service (KMS) master encryption key that was used for the object."]
+    #[serde(rename="SSEKMSKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssekms_key_id: Option<String>,
     #[doc="The Server-side encryption algorithm used when storing this object in S3 (e.g., AES256, aws:kms)."]
+    #[serde(rename="ServerSideEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_side_encryption: Option<String>,
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
     #[doc="Version of the object."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
     #[doc="If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."]
+    #[serde(rename="WebsiteRedirectLocation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub website_redirect_location: Option<String>,
 }
 
@@ -5161,30 +5765,54 @@ impl HeadObjectOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct HeadObjectRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed)."]
+    #[serde(rename="IfMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_match: Option<String>,
     #[doc="Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified)."]
+    #[serde(rename="IfModifiedSince")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_modified_since: Option<String>,
     #[doc="Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified)."]
+    #[serde(rename="IfNoneMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_none_match: Option<String>,
     #[doc="Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed)."]
+    #[serde(rename="IfUnmodifiedSince")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub if_unmodified_since: Option<String>,
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="Part number of the object being read. This is a positive integer between 1 and 10,000. Effectively performs a 'ranged' HEAD request for the part specified. Useful querying about the size of the part and the number of parts in this object."]
+    #[serde(rename="PartNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub part_number: Option<i64>,
     #[doc="Downloads the specified range bytes of an object. For more information about the HTTP Range header, go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35."]
+    #[serde(rename="Range")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub range: Option<String>,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="Specifies the algorithm to use to when encrypting the object (e.g., AES256)."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This value is used to store the object and then it is discarded; Amazon does not store the encryption key. The key must be appropriate for use with the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm header."]
+    #[serde(rename="SSECustomerKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key: Option<String>,
     #[doc="Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header for a message integrity check to ensure the encryption key was transmitted without error."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="VersionId used to reference a specific version of the object."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -5316,9 +5944,10 @@ impl IDSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct IndexDocument {
     #[doc="A suffix that is appended to a request that is for a directory on the website endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/ the data that is returned will be for the object with the key name images/index.html) The suffix must not be empty and must not include a slash character."]
+    #[serde(rename="Suffix")]
     pub suffix: String,
 }
 
@@ -5397,11 +6026,15 @@ impl InitiatedDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Initiator {
     #[doc="Name of the Principal."]
+    #[serde(rename="DisplayName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub display_name: Option<String>,
     #[doc="If the principal is an AWS account, it provides the Canonical User ID. If the principal is an IAM User, it provides a user ARN value."]
+    #[serde(rename="ID")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
 }
 
@@ -5451,21 +6084,30 @@ impl InitiatorDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct InventoryConfiguration {
     #[doc="Contains information about where to publish the inventory results."]
+    #[serde(rename="Destination")]
     pub destination: InventoryDestination,
     #[doc="Specifies an inventory filter. The inventory only includes objects that meet the filter's criteria."]
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<InventoryFilter>,
     #[doc="The ID used to identify the inventory configuration."]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="Specifies which object version(s) to included in the inventory results."]
+    #[serde(rename="IncludedObjectVersions")]
     pub included_object_versions: String,
     #[doc="Specifies whether the inventory is enabled or disabled."]
+    #[serde(rename="IsEnabled")]
     pub is_enabled: bool,
     #[doc="Contains the optional fields that are included in the inventory results."]
+    #[serde(rename="OptionalFields")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub optional_fields: Option<Vec<String>>,
     #[doc="Specifies the schedule for generating inventory results."]
+    #[serde(rename="Schedule")]
     pub schedule: InventorySchedule,
 }
 
@@ -5603,9 +6245,10 @@ impl InventoryConfigurationListDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct InventoryDestination {
     #[doc="Contains the bucket name, file format, bucket owner (optional), and prefix (optional) where inventory results are published."]
+    #[serde(rename="S3BucketDestination")]
     pub s3_bucket_destination: InventoryS3BucketDestination,
 }
 
@@ -5670,9 +6313,10 @@ impl InventoryDestinationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct InventoryFilter {
     #[doc="The prefix that an object must have to be included in the inventory results."]
+    #[serde(rename="Prefix")]
     pub prefix: String,
 }
 
@@ -5958,15 +6602,21 @@ impl InventoryOptionalFieldsSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct InventoryS3BucketDestination {
     #[doc="The ID of the account that owns the destination bucket."]
+    #[serde(rename="AccountId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account_id: Option<String>,
     #[doc="The Amazon resource name (ARN) of the bucket where inventory results will be published."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="Specifies the output format of the inventory results."]
+    #[serde(rename="Format")]
     pub format: String,
     #[doc="The prefix that is prepended to all inventory results."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
 }
 
@@ -6060,9 +6710,10 @@ impl InventoryS3BucketDestinationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct InventorySchedule {
     #[doc="Specifies how frequently inventory results are produced."]
+    #[serde(rename="Frequency")]
     pub frequency: String,
 }
 
@@ -6300,12 +6951,18 @@ impl LambdaFunctionArnSerializer {
 }
 
 #[doc="Container for specifying the AWS Lambda notification configuration."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct LambdaFunctionConfiguration {
+    #[serde(rename="Events")]
     pub events: Vec<String>,
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<NotificationConfigurationFilter>,
+    #[serde(rename="Id")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
     #[doc="Lambda cloud function ARN that Amazon S3 can invoke when it detects events of the specified type."]
+    #[serde(rename="LambdaFunctionArn")]
     pub lambda_function_arn: String,
 }
 
@@ -6454,8 +7111,9 @@ impl LastModifiedDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct LifecycleConfiguration {
+    #[serde(rename="Rules")]
     pub rules: Vec<Rule>,
 }
 
@@ -6475,13 +7133,19 @@ impl LifecycleConfigurationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct LifecycleExpiration {
     #[doc="Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format."]
+    #[serde(rename="Date")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date: Option<String>,
     #[doc="Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer."]
+    #[serde(rename="Days")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub days: Option<i64>,
     #[doc="Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions. If set to true, the delete marker will be expired; if set to false the policy takes no action. This cannot be specified with Days or Date in a Lifecycle Expiration Policy."]
+    #[serde(rename="ExpiredObjectDeleteMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expired_object_delete_marker: Option<bool>,
 }
 
@@ -6563,17 +7227,32 @@ impl LifecycleExpirationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct LifecycleRule {
+    #[serde(rename="AbortIncompleteMultipartUpload")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub abort_incomplete_multipart_upload: Option<AbortIncompleteMultipartUpload>,
+    #[serde(rename="Expiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expiration: Option<LifecycleExpiration>,
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<LifecycleRuleFilter>,
     #[doc="Unique identifier for the rule. The value cannot be longer than 255 characters."]
+    #[serde(rename="ID")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
+    #[serde(rename="NoncurrentVersionExpiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub noncurrent_version_expiration: Option<NoncurrentVersionExpiration>,
+    #[serde(rename="NoncurrentVersionTransitions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub noncurrent_version_transitions: Option<Vec<NoncurrentVersionTransition>>,
     #[doc="If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not currently being applied."]
+    #[serde(rename="Status")]
     pub status: String,
+    #[serde(rename="Transitions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub transitions: Option<Vec<Transition>>,
 }
 
@@ -6696,10 +7375,14 @@ impl LifecycleRuleSerializer {
 }
 
 #[doc="This is used in a Lifecycle Rule Filter to apply a logical AND to two or more predicates. The Lifecycle Rule will apply to any object matching all of the predicates configured inside the And operator."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct LifecycleRuleAndOperator {
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="All of these tags must exist in the object's tag set in order for the rule to apply."]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -6773,12 +7456,18 @@ impl LifecycleRuleAndOperatorSerializer {
 }
 
 #[doc="The Filter is used to identify objects that a Lifecycle Rule applies to. A Filter must have exactly one of Prefix, Tag, or And specified."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct LifecycleRuleFilter {
+    #[serde(rename="And")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub and: Option<LifecycleRuleAndOperator>,
     #[doc="Prefix identifying one or more objects to which the rule applies."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="This tag must exist in the object's tag set in order for the rule to apply."]
+    #[serde(rename="Tag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag: Option<Tag>,
 }
 
@@ -6903,15 +7592,23 @@ impl LifecycleRulesSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListBucketAnalyticsConfigurationsOutput {
     #[doc="The list of analytics configurations for a bucket."]
+    #[serde(rename="AnalyticsConfigurationList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub analytics_configuration_list: Option<Vec<AnalyticsConfiguration>>,
     #[doc="The ContinuationToken that represents where this request began."]
+    #[serde(rename="ContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continuation_token: Option<String>,
     #[doc="Indicates whether the returned list of analytics configurations is complete. A value of true indicates that the list is not complete and the NextContinuationToken will be provided for a subsequent request."]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="NextContinuationToken is sent when isTruncated is true, which indicates that there are more analytics configurations to list. The next request must include this NextContinuationToken. The token is obfuscated and is not a usable value."]
+    #[serde(rename="NextContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_continuation_token: Option<String>,
 }
 
@@ -6972,23 +7669,34 @@ impl ListBucketAnalyticsConfigurationsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListBucketAnalyticsConfigurationsRequest {
     #[doc="The name of the bucket from which analytics configurations are retrieved."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The ContinuationToken that represents a placeholder from where this request should begin."]
+    #[serde(rename="ContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continuation_token: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListBucketInventoryConfigurationsOutput {
     #[doc="If sent in the request, the marker that is used as a starting point for this inventory configuration list response."]
+    #[serde(rename="ContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continuation_token: Option<String>,
     #[doc="The list of inventory configurations for a bucket."]
+    #[serde(rename="InventoryConfigurationList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub inventory_configuration_list: Option<Vec<InventoryConfiguration>>,
     #[doc="Indicates whether the returned list of inventory configurations is truncated in this response. A value of true indicates that the list is truncated."]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="The marker used to continue this inventory configuration listing. Use the NextContinuationToken from this response to continue the listing in a subsequent request. The continuation token is an opaque value that Amazon S3 understands."]
+    #[serde(rename="NextContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_continuation_token: Option<String>,
 }
 
@@ -7049,23 +7757,34 @@ impl ListBucketInventoryConfigurationsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListBucketInventoryConfigurationsRequest {
     #[doc="The name of the bucket containing the inventory configurations to retrieve."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The marker used to continue an inventory configuration listing that has been truncated. Use the NextContinuationToken from a previously truncated list response to continue the listing. The continuation token is an opaque value that Amazon S3 understands."]
+    #[serde(rename="ContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continuation_token: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListBucketMetricsConfigurationsOutput {
     #[doc="The marker that is used as a starting point for this metrics configuration list response. This value is present if it was sent in the request."]
+    #[serde(rename="ContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continuation_token: Option<String>,
     #[doc="Indicates whether the returned list of metrics configurations is complete. A value of true indicates that the list is not complete and the NextContinuationToken will be provided for a subsequent request."]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="The list of metrics configurations for a bucket."]
+    #[serde(rename="MetricsConfigurationList")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metrics_configuration_list: Option<Vec<MetricsConfiguration>>,
     #[doc="The marker used to continue a metrics configuration listing that has been truncated. Use the NextContinuationToken from a previously truncated list response to continue the listing. The continuation token is an opaque value that Amazon S3 understands."]
+    #[serde(rename="NextContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_continuation_token: Option<String>,
 }
 
@@ -7126,17 +7845,24 @@ impl ListBucketMetricsConfigurationsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListBucketMetricsConfigurationsRequest {
     #[doc="The name of the bucket containing the metrics configurations to retrieve."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The marker that is used to continue a metrics configuration listing that has been truncated. Use the NextContinuationToken from a previously truncated list response to continue the listing. The continuation token is an opaque value that Amazon S3 understands."]
+    #[serde(rename="ContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continuation_token: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListBucketsOutput {
+    #[serde(rename="Buckets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub buckets: Option<Vec<Bucket>>,
+    #[serde(rename="Owner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner: Option<Owner>,
 }
 
@@ -7185,28 +7911,52 @@ impl ListBucketsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListMultipartUploadsOutput {
     #[doc="Name of the bucket to which the multipart upload was initiated."]
+    #[serde(rename="Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bucket: Option<String>,
+    #[serde(rename="CommonPrefixes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub common_prefixes: Option<Vec<CommonPrefix>>,
+    #[serde(rename="Delimiter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delimiter: Option<String>,
     #[doc="Encoding type used by Amazon S3 to encode object keys in the response."]
+    #[serde(rename="EncodingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encoding_type: Option<String>,
     #[doc="Indicates whether the returned list of multipart uploads is truncated. A value of true indicates that the list was truncated. The list can be truncated if the number of multipart uploads exceeds the limit allowed or specified by max uploads."]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="The key at or after which the listing began."]
+    #[serde(rename="KeyMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_marker: Option<String>,
     #[doc="Maximum number of multipart uploads that could have been included in the response."]
+    #[serde(rename="MaxUploads")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_uploads: Option<i64>,
     #[doc="When a list is truncated, this element specifies the value that should be used for the key-marker request parameter in a subsequent request."]
+    #[serde(rename="NextKeyMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_key_marker: Option<String>,
     #[doc="When a list is truncated, this element specifies the value that should be used for the upload-id-marker request parameter in a subsequent request."]
+    #[serde(rename="NextUploadIdMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_upload_id_marker: Option<String>,
     #[doc="When a prefix is provided in the request, this field contains the specified prefix. The result contains only keys starting with the specified prefix."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="Upload ID after which listing began."]
+    #[serde(rename="UploadIdMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_id_marker: Option<String>,
+    #[serde(rename="Uploads")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub uploads: Option<Vec<MultipartUpload>>,
 }
 
@@ -7304,41 +8054,80 @@ impl ListMultipartUploadsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListMultipartUploadsRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="Character you use to group keys."]
+    #[serde(rename="Delimiter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delimiter: Option<String>,
+    #[serde(rename="EncodingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encoding_type: Option<String>,
     #[doc="Together with upload-id-marker, this parameter specifies the multipart upload after which listing should begin."]
+    #[serde(rename="KeyMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_marker: Option<String>,
     #[doc="Sets the maximum number of multipart uploads, from 1 to 1,000, to return in the response body. 1,000 is the maximum number of uploads that can be returned in a response."]
+    #[serde(rename="MaxUploads")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_uploads: Option<i64>,
     #[doc="Lists in-progress uploads only for those keys that begin with the specified prefix."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="Together with key-marker, specifies the multipart upload after which listing should begin. If key-marker is not specified, the upload-id-marker parameter is ignored."]
+    #[serde(rename="UploadIdMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_id_marker: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListObjectVersionsOutput {
+    #[serde(rename="CommonPrefixes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub common_prefixes: Option<Vec<CommonPrefix>>,
+    #[serde(rename="DeleteMarkers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delete_markers: Option<Vec<DeleteMarkerEntry>>,
+    #[serde(rename="Delimiter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delimiter: Option<String>,
     #[doc="Encoding type used by Amazon S3 to encode object keys in the response."]
+    #[serde(rename="EncodingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encoding_type: Option<String>,
     #[doc="A flag that indicates whether or not Amazon S3 returned all of the results that satisfied the search criteria. If your results were truncated, you can make a follow-up paginated request using the NextKeyMarker and NextVersionIdMarker response parameters as a starting place in another request to return the rest of the results."]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="Marks the last Key returned in a truncated response."]
+    #[serde(rename="KeyMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_marker: Option<String>,
+    #[serde(rename="MaxKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_keys: Option<i64>,
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="Use this value for the key marker request parameter in a subsequent request."]
+    #[serde(rename="NextKeyMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_key_marker: Option<String>,
     #[doc="Use this value for the next version id marker parameter in a subsequent request."]
+    #[serde(rename="NextVersionIdMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_version_id_marker: Option<String>,
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
+    #[serde(rename="VersionIdMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id_marker: Option<String>,
+    #[serde(rename="Versions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub versions: Option<Vec<ObjectVersion>>,
 }
 
@@ -7440,36 +8229,69 @@ impl ListObjectVersionsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListObjectVersionsRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="A delimiter is a character you use to group keys."]
+    #[serde(rename="Delimiter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delimiter: Option<String>,
+    #[serde(rename="EncodingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encoding_type: Option<String>,
     #[doc="Specifies the key to start with when listing objects in a bucket."]
+    #[serde(rename="KeyMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_marker: Option<String>,
     #[doc="Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more."]
+    #[serde(rename="MaxKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_keys: Option<i64>,
     #[doc="Limits the response to keys that begin with the specified prefix."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="Specifies the object version you want to start listing from."]
+    #[serde(rename="VersionIdMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id_marker: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListObjectsOutput {
+    #[serde(rename="CommonPrefixes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub common_prefixes: Option<Vec<CommonPrefix>>,
+    #[serde(rename="Contents")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub contents: Option<Vec<Object>>,
+    #[serde(rename="Delimiter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delimiter: Option<String>,
     #[doc="Encoding type used by Amazon S3 to encode object keys in the response."]
+    #[serde(rename="EncodingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encoding_type: Option<String>,
     #[doc="A flag that indicates whether or not Amazon S3 returned all of the results that satisfied the search criteria."]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
+    #[serde(rename="MaxKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_keys: Option<i64>,
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="When response is truncated (the IsTruncated element value in the response is true), you can use the key name in this field as marker in the subsequent request to get next set of objects. Amazon S3 lists objects in alphabetical order Note: This element is returned only if you have delimiter request parameter specified. If response does not include the NextMaker and it is truncated, you can use the value of the last Key in the response as the marker in the subsequent request to get the next set of object keys."]
+    #[serde(rename="NextMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_marker: Option<String>,
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
 }
 
@@ -7555,47 +8377,84 @@ impl ListObjectsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListObjectsRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="A delimiter is a character you use to group keys."]
+    #[serde(rename="Delimiter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delimiter: Option<String>,
+    #[serde(rename="EncodingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encoding_type: Option<String>,
     #[doc="Specifies the key to start with when listing objects in a bucket."]
+    #[serde(rename="Marker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub marker: Option<String>,
     #[doc="Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more."]
+    #[serde(rename="MaxKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_keys: Option<i64>,
     #[doc="Limits the response to keys that begin with the specified prefix."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="Confirms that the requester knows that she or he will be charged for the list objects request. Bucket owners need not specify this parameter in their requests."]
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListObjectsV2Output {
     #[doc="CommonPrefixes contains all (if there are any) keys between Prefix and the next occurrence of the string specified by delimiter"]
+    #[serde(rename="CommonPrefixes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub common_prefixes: Option<Vec<CommonPrefix>>,
     #[doc="Metadata about each object returned."]
+    #[serde(rename="Contents")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub contents: Option<Vec<Object>>,
     #[doc="ContinuationToken indicates Amazon S3 that the list is being continued on this bucket with a token. ContinuationToken is obfuscated and is not a real key"]
+    #[serde(rename="ContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continuation_token: Option<String>,
     #[doc="A delimiter is a character you use to group keys."]
+    #[serde(rename="Delimiter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delimiter: Option<String>,
     #[doc="Encoding type used by Amazon S3 to encode object keys in the response."]
+    #[serde(rename="EncodingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encoding_type: Option<String>,
     #[doc="A flag that indicates whether or not Amazon S3 returned all of the results that satisfied the search criteria."]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="KeyCount is the number of keys returned with this request. KeyCount will always be less than equals to MaxKeys field. Say you ask for 50 keys, your result will include less than equals 50 keys"]
+    #[serde(rename="KeyCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key_count: Option<i64>,
     #[doc="Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more."]
+    #[serde(rename="MaxKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_keys: Option<i64>,
     #[doc="Name of the bucket to list."]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="NextContinuationToken is sent when isTruncated is true which means there are more keys in the bucket that can be listed. The next list requests to Amazon S3 can be continued with this NextContinuationToken. NextContinuationToken is obfuscated and is not a real key"]
+    #[serde(rename="NextContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_continuation_token: Option<String>,
     #[doc="Limits the response to keys that begin with the specified prefix."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="StartAfter is where you want Amazon S3 to start listing from. Amazon S3 starts listing after this specified key. StartAfter can be any key in the bucket"]
+    #[serde(rename="StartAfter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_after: Option<String>,
 }
 
@@ -7691,54 +8550,99 @@ impl ListObjectsV2OutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListObjectsV2Request {
     #[doc="Name of the bucket to list."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="ContinuationToken indicates Amazon S3 that the list is being continued on this bucket with a token. ContinuationToken is obfuscated and is not a real key"]
+    #[serde(rename="ContinuationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub continuation_token: Option<String>,
     #[doc="A delimiter is a character you use to group keys."]
+    #[serde(rename="Delimiter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delimiter: Option<String>,
     #[doc="Encoding type used by Amazon S3 to encode object keys in the response."]
+    #[serde(rename="EncodingType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encoding_type: Option<String>,
     #[doc="The owner field is not present in listV2 by default, if you want to return owner field with each key in the result then set the fetch owner field to true"]
+    #[serde(rename="FetchOwner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub fetch_owner: Option<bool>,
     #[doc="Sets the maximum number of keys returned in the response. The response might contain fewer keys but will never contain more."]
+    #[serde(rename="MaxKeys")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_keys: Option<i64>,
     #[doc="Limits the response to keys that begin with the specified prefix."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="Confirms that the requester knows that she or he will be charged for the list objects request in V2 style. Bucket owners need not specify this parameter in their requests."]
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="StartAfter is where you want Amazon S3 to start listing from. Amazon S3 starts listing after this specified key. StartAfter can be any key in the bucket"]
+    #[serde(rename="StartAfter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub start_after: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListPartsOutput {
     #[doc="Date when multipart upload will become eligible for abort operation by lifecycle."]
+    #[serde(rename="AbortDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub abort_date: Option<String>,
     #[doc="Id of the lifecycle rule that makes a multipart upload eligible for abort operation."]
+    #[serde(rename="AbortRuleId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub abort_rule_id: Option<String>,
     #[doc="Name of the bucket to which the multipart upload was initiated."]
+    #[serde(rename="Bucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bucket: Option<String>,
     #[doc="Identifies who initiated the multipart upload."]
+    #[serde(rename="Initiator")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub initiator: Option<Initiator>,
     #[doc="Indicates whether the returned list of parts is truncated."]
+    #[serde(rename="IsTruncated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_truncated: Option<bool>,
     #[doc="Object key for which the multipart upload was initiated."]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="Maximum number of parts that were allowed in the response."]
+    #[serde(rename="MaxParts")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_parts: Option<i64>,
     #[doc="When a list is truncated, this element specifies the last part in the list, as well as the value to use for the part-number-marker request parameter in a subsequent request."]
+    #[serde(rename="NextPartNumberMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_part_number_marker: Option<i64>,
+    #[serde(rename="Owner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner: Option<Owner>,
     #[doc="Part number after which listing begins."]
+    #[serde(rename="PartNumberMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub part_number_marker: Option<i64>,
+    #[serde(rename="Parts")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub parts: Option<Vec<Part>>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
     #[doc="The class of storage used to store the object."]
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
     #[doc="Upload ID identifying the multipart upload whose parts are being listed."]
+    #[serde(rename="UploadId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_id: Option<String>,
 }
 
@@ -7826,16 +8730,25 @@ impl ListPartsOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ListPartsRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="Sets the maximum number of parts to return."]
+    #[serde(rename="MaxParts")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_parts: Option<i64>,
     #[doc="Specifies the part after which listing should begin. Only parts with higher part numbers will be listed."]
+    #[serde(rename="PartNumberMarker")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub part_number_marker: Option<i64>,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="Upload ID identifying the multipart upload whose parts are being listed."]
+    #[serde(rename="UploadId")]
     pub upload_id: String,
 }
 
@@ -7853,12 +8766,18 @@ impl LocationDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct LoggingEnabled {
     #[doc="Specifies the bucket where you want Amazon S3 to store server access logs. You can have your logs delivered to any bucket that you own, including the same bucket that is being logged. You can also configure multiple buckets to deliver their logs to the same target bucket. In this case you should choose a different TargetPrefix for each source bucket so that the delivered log files can be distinguished by key."]
+    #[serde(rename="TargetBucket")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_bucket: Option<String>,
+    #[serde(rename="TargetGrants")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_grants: Option<Vec<TargetGrant>>,
     #[doc="This element lets you specify a prefix for the keys that the log files will be stored under."]
+    #[serde(rename="TargetPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_prefix: Option<String>,
 }
 
@@ -8151,11 +9070,15 @@ impl MessageDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct MetricsAndOperator {
     #[doc="The prefix used when evaluating an AND predicate."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="The list of tags used when evaluating an AND predicate."]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<Tag>>,
 }
 
@@ -8228,11 +9151,14 @@ impl MetricsAndOperatorSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct MetricsConfiguration {
     #[doc="Specifies a metrics configuration filter. The metrics configuration will only include objects that meet the filter's criteria. A filter must be a prefix, a tag, or a conjunction (MetricsAndOperator)."]
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<MetricsFilter>,
     #[doc="The ID used to identify the metrics configuration."]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
@@ -8331,13 +9257,19 @@ impl MetricsConfigurationListDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct MetricsFilter {
     #[doc="A conjunction (logical AND) of predicates, which is used in evaluating a metrics filter. The operator must have at least two predicates, and an object must match all of the predicates in order for the filter to apply."]
+    #[serde(rename="And")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub and: Option<MetricsAndOperator>,
     #[doc="The prefix used when evaluating a metrics filter."]
+    #[serde(rename="Prefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub prefix: Option<String>,
     #[doc="The tag used when evaluating a metrics filter."]
+    #[serde(rename="Tag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tag: Option<Tag>,
 }
 
@@ -8450,18 +9382,30 @@ impl MetricsIdSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct MultipartUpload {
     #[doc="Date and time at which the multipart upload was initiated."]
+    #[serde(rename="Initiated")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub initiated: Option<String>,
     #[doc="Identifies who initiated the multipart upload."]
+    #[serde(rename="Initiator")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub initiator: Option<Initiator>,
     #[doc="Key of the object for which the multipart upload was initiated."]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
+    #[serde(rename="Owner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner: Option<Owner>,
     #[doc="The class of storage used to store the object."]
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
     #[doc="Upload ID that identifies the multipart upload."]
+    #[serde(rename="UploadId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub upload_id: Option<String>,
 }
 
@@ -8672,9 +9616,11 @@ impl NextVersionIdMarkerDeserializer {
     }
 }
 #[doc="Specifies when noncurrent object versions expire. Upon expiration, Amazon S3 permanently deletes the noncurrent object versions. You set this lifecycle configuration action on a bucket that has versioning enabled (or suspended) to request that Amazon S3 delete noncurrent object versions at a specific period in the object's lifetime."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct NoncurrentVersionExpiration {
     #[doc="Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days calculations, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-access-control.html\">How Amazon S3 Calculates When an Object Became Noncurrent</a> in the Amazon Simple Storage Service Developer Guide."]
+    #[serde(rename="NoncurrentDays")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub noncurrent_days: Option<i64>,
 }
 
@@ -8742,11 +9688,15 @@ impl NoncurrentVersionExpirationSerializer {
 }
 
 #[doc="Container for the transition rule that describes when noncurrent objects transition to the STANDARD_IA or GLACIER storage class. If your bucket is versioning-enabled (or versioning is suspended), you can set this action to request that Amazon S3 transition noncurrent object versions to the STANDARD_IA or GLACIER storage class at a specific period in the object's lifetime."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct NoncurrentVersionTransition {
     #[doc="Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days calculations, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-access-control.html\">How Amazon S3 Calculates When an Object Became Noncurrent</a> in the Amazon Simple Storage Service Developer Guide."]
+    #[serde(rename="NoncurrentDays")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub noncurrent_days: Option<i64>,
     #[doc="The class of storage used to store the object."]
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
 }
 
@@ -8873,10 +9823,16 @@ impl NoncurrentVersionTransitionListSerializer {
 }
 
 #[doc="Container for specifying the notification configuration of the bucket. If this element is empty, notifications are turned off on the bucket."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct NotificationConfiguration {
+    #[serde(rename="LambdaFunctionConfigurations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lambda_function_configurations: Option<Vec<LambdaFunctionConfiguration>>,
+    #[serde(rename="QueueConfigurations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub queue_configurations: Option<Vec<QueueConfiguration>>,
+    #[serde(rename="TopicConfigurations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_configurations: Option<Vec<TopicConfiguration>>,
 }
 
@@ -8957,10 +9913,16 @@ impl NotificationConfigurationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct NotificationConfigurationDeprecated {
+    #[serde(rename="CloudFunctionConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cloud_function_configuration: Option<CloudFunctionConfiguration>,
+    #[serde(rename="QueueConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub queue_configuration: Option<QueueConfigurationDeprecated>,
+    #[serde(rename="TopicConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_configuration: Option<TopicConfigurationDeprecated>,
 }
 
@@ -9043,8 +10005,10 @@ impl NotificationConfigurationDeprecatedSerializer {
 }
 
 #[doc="Container for object key name filtering rules. For information about key name filtering, go to <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html\">Configuring Event Notifications</a> in the Amazon Simple Storage Service Developer Guide."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct NotificationConfigurationFilter {
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<S3KeyFilter>,
 }
 
@@ -9141,14 +10105,26 @@ impl NotificationIdSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Object {
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
+    #[serde(rename="LastModified")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_modified: Option<String>,
+    #[serde(rename="Owner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner: Option<Owner>,
+    #[serde(rename="Size")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub size: Option<i64>,
     #[doc="The class of storage used to store the object."]
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
 }
 
@@ -9212,11 +10188,14 @@ impl ObjectDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ObjectIdentifier {
     #[doc="Key name of the object to delete."]
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="VersionId for the specific version of the object to delete."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -9337,21 +10316,37 @@ impl ObjectStorageClassDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ObjectVersion {
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="Specifies whether the object is (true) or is not (false) the latest version of an object."]
+    #[serde(rename="IsLatest")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_latest: Option<bool>,
     #[doc="The object key."]
+    #[serde(rename="Key")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub key: Option<String>,
     #[doc="Date and time the object was last modified."]
+    #[serde(rename="LastModified")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_modified: Option<String>,
+    #[serde(rename="Owner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner: Option<Owner>,
     #[doc="Size in bytes of the object."]
+    #[serde(rename="Size")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub size: Option<i64>,
     #[doc="The class of storage used to store the object."]
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
     #[doc="Version ID of an object."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -9496,9 +10491,13 @@ impl ObjectVersionStorageClassDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Owner {
+    #[serde(rename="DisplayName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub display_name: Option<String>,
+    #[serde(rename="ID")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
 }
 
@@ -9574,15 +10573,23 @@ impl OwnerSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Part {
     #[doc="Entity tag returned when the part was uploaded."]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="Date and time at which the part was uploaded."]
+    #[serde(rename="LastModified")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_modified: Option<String>,
     #[doc="Part number identifying the part. This is a positive integer between 1 and 10,000."]
+    #[serde(rename="PartNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub part_number: Option<i64>,
     #[doc="Size of the uploaded part data."]
+    #[serde(rename="Size")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub size: Option<i64>,
 }
 
@@ -9878,150 +10885,228 @@ impl ProtocolSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketAccelerateConfigurationRequest {
     #[doc="Specifies the Accelerate Configuration you want to set for the bucket."]
+    #[serde(rename="AccelerateConfiguration")]
     pub accelerate_configuration: AccelerateConfiguration,
     #[doc="Name of the bucket for which the accelerate configuration is set."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketAclRequest {
     #[doc="The canned ACL to apply to the bucket."]
+    #[serde(rename="ACL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub acl: Option<String>,
+    #[serde(rename="AccessControlPolicy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub access_control_policy: Option<AccessControlPolicy>,
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
     #[doc="Allows grantee the read, write, read ACP, and write ACP permissions on the bucket."]
+    #[serde(rename="GrantFullControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_full_control: Option<String>,
     #[doc="Allows grantee to list the objects in the bucket."]
+    #[serde(rename="GrantRead")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read: Option<String>,
     #[doc="Allows grantee to read the bucket ACL."]
+    #[serde(rename="GrantReadACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read_acp: Option<String>,
     #[doc="Allows grantee to create, overwrite, and delete any object in the bucket."]
+    #[serde(rename="GrantWrite")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_write: Option<String>,
     #[doc="Allows grantee to write the ACL for the applicable bucket."]
+    #[serde(rename="GrantWriteACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_write_acp: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketAnalyticsConfigurationRequest {
     #[doc="The configuration and any analyses for the analytics filter."]
+    #[serde(rename="AnalyticsConfiguration")]
     pub analytics_configuration: AnalyticsConfiguration,
     #[doc="The name of the bucket to which an analytics configuration is stored."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The identifier used to represent an analytics configuration."]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketCorsRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="CORSConfiguration")]
     pub cors_configuration: CORSConfiguration,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketInventoryConfigurationRequest {
     #[doc="The name of the bucket where the inventory configuration will be stored."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The ID used to identify the inventory configuration."]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="Specifies the inventory configuration."]
+    #[serde(rename="InventoryConfiguration")]
     pub inventory_configuration: InventoryConfiguration,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketLifecycleConfigurationRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="LifecycleConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lifecycle_configuration: Option<BucketLifecycleConfiguration>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketLifecycleRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
+    #[serde(rename="LifecycleConfiguration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lifecycle_configuration: Option<LifecycleConfiguration>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketLoggingRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="BucketLoggingStatus")]
     pub bucket_logging_status: BucketLoggingStatus,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketMetricsConfigurationRequest {
     #[doc="The name of the bucket for which the metrics configuration is set."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The ID used to identify the metrics configuration."]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="Specifies the metrics configuration."]
+    #[serde(rename="MetricsConfiguration")]
     pub metrics_configuration: MetricsConfiguration,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketNotificationConfigurationRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="NotificationConfiguration")]
     pub notification_configuration: NotificationConfiguration,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketNotificationRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
+    #[serde(rename="NotificationConfiguration")]
     pub notification_configuration: NotificationConfigurationDeprecated,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketPolicyRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
     #[doc="The bucket policy as a JSON document."]
+    #[serde(rename="Policy")]
     pub policy: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketReplicationRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
+    #[serde(rename="ReplicationConfiguration")]
     pub replication_configuration: ReplicationConfiguration,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketRequestPaymentRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
+    #[serde(rename="RequestPaymentConfiguration")]
     pub request_payment_configuration: RequestPaymentConfiguration,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketTaggingRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
+    #[serde(rename="Tagging")]
     pub tagging: Tagging,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketVersioningRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
     #[doc="The concatenation of the authentication device's serial number, a space, and the value that is displayed on your authentication device."]
+    #[serde(rename="MFA")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub mfa: Option<String>,
+    #[serde(rename="VersioningConfiguration")]
     pub versioning_configuration: VersioningConfiguration,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutBucketWebsiteRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
+    #[serde(rename="WebsiteConfiguration")]
     pub website_configuration: WebsiteConfiguration,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutObjectAclOutput {
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
 }
 
@@ -10041,45 +11126,83 @@ impl PutObjectAclOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutObjectAclRequest {
     #[doc="The canned ACL to apply to the object."]
+    #[serde(rename="ACL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub acl: Option<String>,
+    #[serde(rename="AccessControlPolicy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub access_control_policy: Option<AccessControlPolicy>,
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
     #[doc="Allows grantee the read, write, read ACP, and write ACP permissions on the bucket."]
+    #[serde(rename="GrantFullControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_full_control: Option<String>,
     #[doc="Allows grantee to list the objects in the bucket."]
+    #[serde(rename="GrantRead")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read: Option<String>,
     #[doc="Allows grantee to read the bucket ACL."]
+    #[serde(rename="GrantReadACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read_acp: Option<String>,
     #[doc="Allows grantee to create, overwrite, and delete any object in the bucket."]
+    #[serde(rename="GrantWrite")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_write: Option<String>,
     #[doc="Allows grantee to write the ACL for the applicable bucket."]
+    #[serde(rename="GrantWriteACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_write_acp: Option<String>,
+    #[serde(rename="Key")]
     pub key: String,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="VersionId used to reference a specific version of the object."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutObjectOutput {
     #[doc="Entity tag for the uploaded object."]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
     #[doc="If the object expiration is configured, this will contain the expiration date (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded."]
+    #[serde(rename="Expiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expiration: Option<String>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header confirming the encryption algorithm used."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header to provide round trip message integrity verification of the customer-provided encryption key."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="If present, specifies the ID of the AWS Key Management Service (KMS) master encryption key that was used for the object."]
+    #[serde(rename="SSEKMSKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssekms_key_id: Option<String>,
     #[doc="The Server-side encryption algorithm used when storing this object in S3 (e.g., AES256, aws:kms)."]
+    #[serde(rename="ServerSideEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_side_encryption: Option<String>,
     #[doc="Version of the object."]
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -10099,63 +11222,119 @@ impl PutObjectOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutObjectRequest {
     #[doc="The canned ACL to apply to the object."]
+    #[serde(rename="ACL")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub acl: Option<String>,
     #[doc="Object data."]
+    #[serde(rename="Body")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub body: Option<Vec<u8>>,
     #[doc="Name of the bucket to which the PUT operation was initiated."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="Specifies caching behavior along the request/reply chain."]
+    #[serde(rename="CacheControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cache_control: Option<String>,
     #[doc="Specifies presentational information for the object."]
+    #[serde(rename="ContentDisposition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_disposition: Option<String>,
     #[doc="Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field."]
+    #[serde(rename="ContentEncoding")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_encoding: Option<String>,
     #[doc="The language the content is in."]
+    #[serde(rename="ContentLanguage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_language: Option<String>,
     #[doc="Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically."]
+    #[serde(rename="ContentLength")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_length: Option<i64>,
     #[doc="The base64-encoded 128-bit MD5 digest of the part data."]
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
     #[doc="A standard MIME type describing the format of the object data."]
+    #[serde(rename="ContentType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_type: Option<String>,
     #[doc="The date and time at which the object is no longer cacheable."]
+    #[serde(rename="Expires")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expires: Option<String>,
     #[doc="Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object."]
+    #[serde(rename="GrantFullControl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_full_control: Option<String>,
     #[doc="Allows grantee to read the object data and its metadata."]
+    #[serde(rename="GrantRead")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read: Option<String>,
     #[doc="Allows grantee to read the object ACL."]
+    #[serde(rename="GrantReadACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_read_acp: Option<String>,
     #[doc="Allows grantee to write the ACL for the applicable object."]
+    #[serde(rename="GrantWriteACP")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grant_write_acp: Option<String>,
     #[doc="Object key for which the PUT operation was initiated."]
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="A map of metadata to store with the object in S3."]
+    #[serde(rename="Metadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metadata: Option<::std::collections::HashMap<String, String>>,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="Specifies the algorithm to use to when encrypting the object (e.g., AES256)."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This value is used to store the object and then it is discarded; Amazon does not store the encryption key. The key must be appropriate for use with the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm header."]
+    #[serde(rename="SSECustomerKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key: Option<String>,
     #[doc="Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header for a message integrity check to ensure the encryption key was transmitted without error."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="Specifies the AWS KMS key ID to use for object encryption. All GET and PUT requests for an object protected by AWS KMS will fail if not made via SSL or using SigV4. Documentation on configuring any of the officially supported AWS SDKs and CLI can be found at http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version"]
+    #[serde(rename="SSEKMSKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssekms_key_id: Option<String>,
     #[doc="The Server-side encryption algorithm used when storing this object in S3 (e.g., AES256, aws:kms)."]
+    #[serde(rename="ServerSideEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_side_encryption: Option<String>,
     #[doc="The type of storage to use for the object. Defaults to 'STANDARD'."]
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
     #[doc="The tag-set for the object. The tag-set must be encoded as URL Query parameters"]
+    #[serde(rename="Tagging")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tagging: Option<String>,
     #[doc="If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata."]
+    #[serde(rename="WebsiteRedirectLocation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub website_redirect_location: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutObjectTaggingOutput {
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -10175,12 +11354,19 @@ impl PutObjectTaggingOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct PutObjectTaggingRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
+    #[serde(rename="Key")]
     pub key: String,
+    #[serde(rename="Tagging")]
     pub tagging: Tagging,
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
@@ -10217,12 +11403,18 @@ impl QueueArnSerializer {
 }
 
 #[doc="Container for specifying an configuration when you want Amazon S3 to publish events to an Amazon Simple Queue Service (Amazon SQS) queue."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct QueueConfiguration {
+    #[serde(rename="Events")]
     pub events: Vec<String>,
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<NotificationConfigurationFilter>,
+    #[serde(rename="Id")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
     #[doc="Amazon SQS queue ARN to which Amazon S3 will publish a message when it detects events of specified type."]
+    #[serde(rename="QueueArn")]
     pub queue_arn: String,
 }
 
@@ -10305,10 +11497,16 @@ impl QueueConfigurationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct QueueConfigurationDeprecated {
+    #[serde(rename="Events")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<String>>,
+    #[serde(rename="Id")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
+    #[serde(rename="Queue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub queue: Option<String>,
 }
 
@@ -10454,17 +11652,27 @@ impl QuietSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Redirect {
     #[doc="The host name to use in the redirect request."]
+    #[serde(rename="HostName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub host_name: Option<String>,
     #[doc="The HTTP redirect code to use on the response. Not required if one of the siblings is present."]
+    #[serde(rename="HttpRedirectCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub http_redirect_code: Option<String>,
     #[doc="Protocol to use (http, https) when redirecting requests. The default is the protocol that is used in the original request."]
+    #[serde(rename="Protocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub protocol: Option<String>,
     #[doc="The object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix docs/ (objects in the docs/ folder) to documents/, you can set a condition block with KeyPrefixEquals set to docs/ and in the Redirect set ReplaceKeyPrefixWith to /documents. Not required if one of the siblings is present. Can be present only if ReplaceKeyWith is not provided."]
+    #[serde(rename="ReplaceKeyPrefixWith")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replace_key_prefix_with: Option<String>,
     #[doc="The specific object key to use in the redirect request. For example, redirect request to error.html. Not required if one of the sibling is present. Can be present only if ReplaceKeyPrefixWith is not provided."]
+    #[serde(rename="ReplaceKeyWith")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replace_key_with: Option<String>,
 }
 
@@ -10574,11 +11782,14 @@ impl RedirectSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct RedirectAllRequestsTo {
     #[doc="Name of the host where requests will be redirected."]
+    #[serde(rename="HostName")]
     pub host_name: String,
     #[doc="Protocol to use (http, https) when redirecting requests. The default is the protocol that is used in the original request."]
+    #[serde(rename="Protocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub protocol: Option<String>,
 }
 
@@ -10719,11 +11930,13 @@ impl ReplaceKeyWithSerializer {
 }
 
 #[doc="Container for replication rules. You can add as many as 1,000 rules. Total replication configuration size can be up to 2 MB."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ReplicationConfiguration {
     #[doc="Amazon Resource Name (ARN) of an IAM role for Amazon S3 to assume when replicating the objects."]
+    #[serde(rename="Role")]
     pub role: String,
     #[doc="Container for information about a particular replication rule. Replication configuration must have at least one rule and can contain up to 1,000 rules."]
+    #[serde(rename="Rules")]
     pub rules: Vec<ReplicationRule>,
 }
 
@@ -10792,14 +12005,19 @@ impl ReplicationConfigurationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct ReplicationRule {
+    #[serde(rename="Destination")]
     pub destination: Destination,
     #[doc="Unique identifier for the rule. The value cannot be longer than 255 characters."]
+    #[serde(rename="ID")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
     #[doc="Object keyname prefix identifying one or more objects to which the rule applies. Maximum prefix length can be up to 1,024 characters. Overlapping prefixes are not supported."]
+    #[serde(rename="Prefix")]
     pub prefix: String,
     #[doc="The rule is ignored if status is not Enabled."]
+    #[serde(rename="Status")]
     pub status: String,
 }
 
@@ -10965,9 +12183,10 @@ impl ReplicationRulesSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct RequestPaymentConfiguration {
     #[doc="Specifies who pays for the download and request fees."]
+    #[serde(rename="Payer")]
     pub payer: String,
 }
 
@@ -11098,8 +12317,10 @@ impl ResponseExpiresSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct RestoreObjectOutput {
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
 }
 
@@ -11119,20 +12340,31 @@ impl RestoreObjectOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct RestoreObjectRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
+    #[serde(rename="Key")]
     pub key: String,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
+    #[serde(rename="RestoreRequest")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub restore_request: Option<RestoreRequest>,
+    #[serde(rename="VersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct RestoreRequest {
     #[doc="Lifetime of the active copy in days"]
+    #[serde(rename="Days")]
     pub days: i64,
     #[doc="Glacier related prameters pertaining to this job."]
+    #[serde(rename="GlacierJobParameters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub glacier_job_parameters: Option<GlacierJobParameters>,
 }
 
@@ -11190,11 +12422,14 @@ impl RoleSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct RoutingRule {
     #[doc="A container for describing a condition that must be met for the specified redirect to apply. For example, 1. If request is for pages in the /docs folder, redirect to the /documents folder. 2. If request results in HTTP error 4xx, redirect request to another host where you might process the error."]
+    #[serde(rename="Condition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub condition: Option<Condition>,
     #[doc="Container for redirect information. You can redirect requests to another host, to another page, or with another protocol. In the event of an error, you can can specify a different error code to return."]
+    #[serde(rename="Redirect")]
     pub redirect: Redirect,
 }
 
@@ -11323,18 +12558,32 @@ impl RoutingRulesSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Rule {
+    #[serde(rename="AbortIncompleteMultipartUpload")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub abort_incomplete_multipart_upload: Option<AbortIncompleteMultipartUpload>,
+    #[serde(rename="Expiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expiration: Option<LifecycleExpiration>,
     #[doc="Unique identifier for the rule. The value cannot be longer than 255 characters."]
+    #[serde(rename="ID")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
+    #[serde(rename="NoncurrentVersionExpiration")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub noncurrent_version_expiration: Option<NoncurrentVersionExpiration>,
+    #[serde(rename="NoncurrentVersionTransition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub noncurrent_version_transition: Option<NoncurrentVersionTransition>,
     #[doc="Prefix identifying one or more objects to which the rule applies."]
+    #[serde(rename="Prefix")]
     pub prefix: String,
     #[doc="If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not currently being applied."]
+    #[serde(rename="Status")]
     pub status: String,
+    #[serde(rename="Transition")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub transition: Option<Transition>,
 }
 
@@ -11502,8 +12751,10 @@ impl RulesSerializer {
 }
 
 #[doc="Container for object key name prefix and suffix filtering rules."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct S3KeyFilter {
+    #[serde(rename="FilterRules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter_rules: Option<Vec<FilterRule>>,
 }
 
@@ -11646,9 +12897,11 @@ impl StorageClassSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct StorageClassAnalysis {
     #[doc="A container used to describe how data related to the storage class analysis should be exported."]
+    #[serde(rename="DataExport")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub data_export: Option<StorageClassAnalysisDataExport>,
 }
 
@@ -11711,11 +12964,13 @@ impl StorageClassAnalysisSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct StorageClassAnalysisDataExport {
     #[doc="The place to store the data for an analysis."]
+    #[serde(rename="Destination")]
     pub destination: AnalyticsExportDestination,
     #[doc="The version of the output schema to use when exporting data. Must be V_1."]
+    #[serde(rename="OutputSchemaVersion")]
     pub output_schema_version: String,
 }
 
@@ -11853,11 +13108,13 @@ impl SuffixSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Tag {
     #[doc="Name of the tag."]
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="Value of the tag."]
+    #[serde(rename="Value")]
     pub value: String,
 }
 
@@ -11988,8 +13245,9 @@ impl TagSetSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Tagging {
+    #[serde(rename="TagSet")]
     pub tag_set: Vec<Tag>,
 }
 
@@ -12041,10 +13299,14 @@ impl TargetBucketSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct TargetGrant {
+    #[serde(rename="Grantee")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub grantee: Option<Grantee>,
     #[doc="Logging permissions assigned to the Grantee for the bucket."]
+    #[serde(rename="Permission")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub permission: Option<String>,
 }
 
@@ -12294,12 +13556,18 @@ impl TopicArnSerializer {
 }
 
 #[doc="Container for specifying the configuration when you want Amazon S3 to publish events to an Amazon Simple Notification Service (Amazon SNS) topic."]
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct TopicConfiguration {
+    #[serde(rename="Events")]
     pub events: Vec<String>,
+    #[serde(rename="Filter")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filter: Option<NotificationConfigurationFilter>,
+    #[serde(rename="Id")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
     #[doc="Amazon SNS topic ARN to which Amazon S3 will publish a message when it detects events of specified type."]
+    #[serde(rename="TopicArn")]
     pub topic_arn: String,
 }
 
@@ -12382,11 +13650,17 @@ impl TopicConfigurationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct TopicConfigurationDeprecated {
+    #[serde(rename="Events")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub events: Option<Vec<String>>,
+    #[serde(rename="Id")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<String>,
     #[doc="Amazon SNS topic to which Amazon S3 will publish a message to report the specified events for the bucket."]
+    #[serde(rename="Topic")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic: Option<String>,
 }
 
@@ -12514,13 +13788,19 @@ impl TopicConfigurationListSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct Transition {
     #[doc="Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format."]
+    #[serde(rename="Date")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub date: Option<String>,
     #[doc="Indicates the lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer."]
+    #[serde(rename="Days")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub days: Option<i64>,
     #[doc="The class of storage used to store the object."]
+    #[serde(rename="StorageClass")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub storage_class: Option<String>,
 }
 
@@ -12778,19 +14058,33 @@ impl UploadIdMarkerSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UploadPartCopyOutput {
+    #[serde(rename="CopyPartResult")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_part_result: Option<CopyPartResult>,
     #[doc="The version of the source object that was copied, if you have enabled versioning on the source bucket."]
+    #[serde(rename="CopySourceVersionId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_version_id: Option<String>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header confirming the encryption algorithm used."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header to provide round trip message integrity verification of the customer-provided encryption key."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="If present, specifies the ID of the AWS Key Management Service (KMS) master encryption key that was used for the object."]
+    #[serde(rename="SSEKMSKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssekms_key_id: Option<String>,
     #[doc="The Server-side encryption algorithm used when storing this object in S3 (e.g., AES256, aws:kms)."]
+    #[serde(rename="ServerSideEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_side_encryption: Option<String>,
 }
 
@@ -12837,53 +14131,94 @@ impl UploadPartCopyOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UploadPartCopyRequest {
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded."]
+    #[serde(rename="CopySource")]
     pub copy_source: String,
     #[doc="Copies the object if its entity tag (ETag) matches the specified tag."]
+    #[serde(rename="CopySourceIfMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_if_match: Option<String>,
     #[doc="Copies the object if it has been modified since the specified time."]
+    #[serde(rename="CopySourceIfModifiedSince")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_if_modified_since: Option<String>,
     #[doc="Copies the object if its entity tag (ETag) is different than the specified ETag."]
+    #[serde(rename="CopySourceIfNoneMatch")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_if_none_match: Option<String>,
     #[doc="Copies the object if it hasn't been modified since the specified time."]
+    #[serde(rename="CopySourceIfUnmodifiedSince")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_if_unmodified_since: Option<String>,
     #[doc="The range of bytes to copy from the source object. The range value must use the form bytes=first-last, where the first and last are the zero-based byte offsets to copy. For example, bytes=0-9 indicates that you want to copy the first ten bytes of the source. You can copy a range only if the source object is greater than 5 GB."]
+    #[serde(rename="CopySourceRange")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_range: Option<String>,
     #[doc="Specifies the algorithm to use when decrypting the source object (e.g., AES256)."]
+    #[serde(rename="CopySourceSSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_sse_customer_algorithm: Option<String>,
     #[doc="Specifies the customer-provided encryption key for Amazon S3 to use to decrypt the source object. The encryption key provided in this header must be one that was used when the source object was created."]
+    #[serde(rename="CopySourceSSECustomerKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_sse_customer_key: Option<String>,
     #[doc="Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header for a message integrity check to ensure the encryption key was transmitted without error."]
+    #[serde(rename="CopySourceSSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub copy_source_sse_customer_key_md5: Option<String>,
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="Part number of part being copied. This is a positive integer between 1 and 10,000."]
+    #[serde(rename="PartNumber")]
     pub part_number: i64,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="Specifies the algorithm to use to when encrypting the object (e.g., AES256)."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This value is used to store the object and then it is discarded; Amazon does not store the encryption key. The key must be appropriate for use with the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm header. This must be the same encryption key specified in the initiate multipart upload request."]
+    #[serde(rename="SSECustomerKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key: Option<String>,
     #[doc="Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header for a message integrity check to ensure the encryption key was transmitted without error."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="Upload ID identifying the multipart upload whose part is being copied."]
+    #[serde(rename="UploadId")]
     pub upload_id: String,
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UploadPartOutput {
     #[doc="Entity tag for the uploaded object."]
+    #[serde(rename="ETag")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub e_tag: Option<String>,
+    #[serde(rename="RequestCharged")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_charged: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header confirming the encryption algorithm used."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="If server-side encryption with a customer-provided encryption key was requested, the response will include this header to provide round trip message integrity verification of the customer-provided encryption key."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="If present, specifies the ID of the AWS Key Management Service (KMS) master encryption key that was used for the object."]
+    #[serde(rename="SSEKMSKeyId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub ssekms_key_id: Option<String>,
     #[doc="The Server-side encryption algorithm used when storing this object in S3 (e.g., AES256, aws:kms)."]
+    #[serde(rename="ServerSideEncryption")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub server_side_encryption: Option<String>,
 }
 
@@ -12903,28 +14238,50 @@ impl UploadPartOutputDeserializer {
 
     }
 }
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct UploadPartRequest {
     #[doc="Object data."]
+    #[serde(rename="Body")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub body: Option<Vec<u8>>,
     #[doc="Name of the bucket to which the multipart upload was initiated."]
+    #[serde(rename="Bucket")]
     pub bucket: String,
     #[doc="Size of the body in bytes. This parameter is useful when the size of the body cannot be determined automatically."]
+    #[serde(rename="ContentLength")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_length: Option<i64>,
     #[doc="The base64-encoded 128-bit MD5 digest of the part data."]
+    #[serde(rename="ContentMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub content_md5: Option<String>,
     #[doc="Object key for which the multipart upload was initiated."]
+    #[serde(rename="Key")]
     pub key: String,
     #[doc="Part number of part being uploaded. This is a positive integer between 1 and 10,000."]
+    #[serde(rename="PartNumber")]
     pub part_number: i64,
+    #[serde(rename="RequestPayer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub request_payer: Option<String>,
     #[doc="Specifies the algorithm to use to when encrypting the object (e.g., AES256)."]
+    #[serde(rename="SSECustomerAlgorithm")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_algorithm: Option<String>,
     #[doc="Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This value is used to store the object and then it is discarded; Amazon does not store the encryption key. The key must be appropriate for use with the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm header. This must be the same encryption key specified in the initiate multipart upload request."]
+    #[serde(rename="SSECustomerKey")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key: Option<String>,
     #[doc="Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header for a message integrity check to ensure the encryption key was transmitted without error."]
+    #[serde(rename="SSECustomerKeyMD5")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sse_customer_key_md5: Option<String>,
     #[doc="Upload ID identifying the multipart upload whose part is being uploaded."]
+    #[serde(rename="UploadId")]
     pub upload_id: String,
 }
 
@@ -12992,11 +14349,15 @@ impl VersionIdMarkerSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct VersioningConfiguration {
     #[doc="Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned."]
+    #[serde(rename="MFADelete")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub mfa_delete: Option<String>,
     #[doc="The versioning state of the bucket."]
+    #[serde(rename="Status")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<String>,
 }
 
@@ -13027,11 +14388,19 @@ impl VersioningConfigurationSerializer {
     }
 }
 
-#[derive(Default,Debug)]
+#[derive(Default,Debug,Serialize,Deserialize)]
 pub struct WebsiteConfiguration {
+    #[serde(rename="ErrorDocument")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub error_document: Option<ErrorDocument>,
+    #[serde(rename="IndexDocument")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub index_document: Option<IndexDocument>,
+    #[serde(rename="RedirectAllRequestsTo")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub redirect_all_requests_to: Option<RedirectAllRequestsTo>,
+    #[serde(rename="RoutingRules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub routing_rules: Option<Vec<RoutingRule>>,
 }
 

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -40,15 +40,21 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p></p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Attribute {
     #[doc="<p></p>"]
+    #[serde(rename="AlternateNameEncoding")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alternate_name_encoding: Option<String>,
     #[doc="<p></p>"]
+    #[serde(rename="AlternateValueEncoding")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alternate_value_encoding: Option<String>,
     #[doc="The name of the attribute."]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="The value of the attribute."]
+    #[serde(rename="Value")]
     pub value: String,
 }
 
@@ -184,11 +190,13 @@ impl AttributeNameListSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchDeleteAttributesRequest {
     #[doc="The name of the domain in which the attributes are being deleted."]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="A list of items on which to perform the operation."]
+    #[serde(rename="Items")]
     pub items: Vec<DeletableItem>,
 }
 
@@ -211,11 +219,13 @@ impl BatchDeleteAttributesRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchPutAttributesRequest {
     #[doc="The name of the domain in which the attributes are being stored."]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="A list of items on which to perform the operation."]
+    #[serde(rename="Items")]
     pub items: Vec<ReplaceableItem>,
 }
 
@@ -238,9 +248,10 @@ impl BatchPutAttributesRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDomainRequest {
     #[doc="The name of the domain to create. The name can range between 3 and 255 characters and can contain the following characters: a-z, A-Z, 0-9, '_', '-', and '.'."]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -260,9 +271,12 @@ impl CreateDomainRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletableItem {
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<Vec<Attribute>>,
+    #[serde(rename="Name")]
     pub name: String,
 }
 
@@ -299,15 +313,21 @@ impl DeletableItemListSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAttributesRequest {
     #[doc="A list of Attributes. Similar to columns on a spreadsheet, attributes represent categories of data that can be assigned to items."]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<Vec<Attribute>>,
     #[doc="The name of the domain in which to perform the operation."]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="The update condition which, if specified, determines whether the specified attributes will be deleted or not. The update condition must be satisfied in order for this request to be processed and the attributes to be deleted."]
+    #[serde(rename="Expected")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expected: Option<UpdateCondition>,
     #[doc="The name of the item. Similar to rows on a spreadsheet, items represent individual objects that contain one or more value-attribute pairs."]
+    #[serde(rename="ItemName")]
     pub item_name: String,
 }
 
@@ -339,9 +359,10 @@ impl DeleteAttributesRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDomainRequest {
     #[doc="The name of the domain to delete."]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -361,9 +382,10 @@ impl DeleteDomainRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainMetadataRequest {
     #[doc="The name of the domain for which to display the metadata of."]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
 }
 
@@ -383,21 +405,35 @@ impl DomainMetadataRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainMetadataResult {
     #[doc="The number of unique attribute names in the domain."]
+    #[serde(rename="AttributeNameCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_name_count: Option<i64>,
     #[doc="The total size of all unique attribute names in the domain, in bytes."]
+    #[serde(rename="AttributeNamesSizeBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_names_size_bytes: Option<i64>,
     #[doc="The number of all attribute name/value pairs in the domain."]
+    #[serde(rename="AttributeValueCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_value_count: Option<i64>,
     #[doc="The total size of all attribute values in the domain, in bytes."]
+    #[serde(rename="AttributeValuesSizeBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_values_size_bytes: Option<i64>,
     #[doc="The number of all items in the domain."]
+    #[serde(rename="ItemCount")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub item_count: Option<i64>,
     #[doc="The total size of all item names in the domain, in bytes."]
+    #[serde(rename="ItemNamesSizeBytes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub item_names_size_bytes: Option<i64>,
     #[doc="The data and time when metadata was calculated, in Epoch (UNIX) seconds."]
+    #[serde(rename="Timestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timestamp: Option<i64>,
 }
 
@@ -500,15 +536,21 @@ impl DomainNameListDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAttributesRequest {
     #[doc="The names of the attributes."]
+    #[serde(rename="AttributeNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_names: Option<Vec<String>>,
     #[doc="Determines whether or not strong consistency should be enforced when data is read from SimpleDB. If <code>true</code>, any data previously written to SimpleDB will be returned. Otherwise, results will be consistent eventually, and the client may not see data that was written immediately before your read."]
+    #[serde(rename="ConsistentRead")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub consistent_read: Option<bool>,
     #[doc="The name of the domain in which to perform the operation."]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="The name of the item."]
+    #[serde(rename="ItemName")]
     pub item_name: String,
 }
 
@@ -539,9 +581,11 @@ impl GetAttributesRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAttributesResult {
     #[doc="The list of attributes returned by the operation."]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<Vec<Attribute>>,
 }
 
@@ -603,13 +647,17 @@ impl IntegerDeserializer {
     }
 }
 #[doc="<p></p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Item {
     #[doc="<p></p>"]
+    #[serde(rename="AlternateNameEncoding")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub alternate_name_encoding: Option<String>,
     #[doc="A list of attributes."]
+    #[serde(rename="Attributes")]
     pub attributes: Vec<Attribute>,
     #[doc="The name of the item."]
+    #[serde(rename="Name")]
     pub name: String,
 }
 
@@ -691,11 +739,15 @@ impl ItemListDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDomainsRequest {
     #[doc="The maximum number of domain names you want returned. The range is 1 to 100. The default setting is 100."]
+    #[serde(rename="MaxNumberOfDomains")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_number_of_domains: Option<i64>,
     #[doc="A string informing Amazon SimpleDB where to start the next list of domain names."]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -721,11 +773,15 @@ impl ListDomainsRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDomainsResult {
     #[doc="A list of domain names that match the expression."]
+    #[serde(rename="DomainNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub domain_names: Option<Vec<String>>,
     #[doc="An opaque token indicating that there are more domains than the specified <code>MaxNumberOfDomains</code> still available."]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -790,15 +846,20 @@ impl LongDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutAttributesRequest {
     #[doc="The list of attributes."]
+    #[serde(rename="Attributes")]
     pub attributes: Vec<ReplaceableAttribute>,
     #[doc="The name of the domain in which to perform the operation."]
+    #[serde(rename="DomainName")]
     pub domain_name: String,
     #[doc="The update condition which, if specified, determines whether the specified attributes will be updated or not. The update condition must be satisfied in order for this request to be processed and the attributes to be updated."]
+    #[serde(rename="Expected")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub expected: Option<UpdateCondition>,
     #[doc="The name of the item."]
+    #[serde(rename="ItemName")]
     pub item_name: String,
 }
 
@@ -829,13 +890,17 @@ impl PutAttributesRequestSerializer {
 }
 
 #[doc="<p></p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplaceableAttribute {
     #[doc="The name of the replaceable attribute."]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="A flag specifying whether or not to replace the attribute/value pair or to add a new attribute/value pair. The default setting is <code>false</code>."]
+    #[serde(rename="Replace")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub replace: Option<bool>,
     #[doc="The value of the replaceable attribute."]
+    #[serde(rename="Value")]
     pub value: String,
 }
 
@@ -874,11 +939,13 @@ impl ReplaceableAttributeListSerializer {
 }
 
 #[doc="<p></p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplaceableItem {
     #[doc="The list of attributes for a replaceable item."]
+    #[serde(rename="Attributes")]
     pub attributes: Vec<ReplaceableAttribute>,
     #[doc="The name of the replaceable item."]
+    #[serde(rename="Name")]
     pub name: String,
 }
 
@@ -913,13 +980,18 @@ impl ReplaceableItemListSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SelectRequest {
     #[doc="Determines whether or not strong consistency should be enforced when data is read from SimpleDB. If <code>true</code>, any data previously written to SimpleDB will be returned. Otherwise, results will be consistent eventually, and the client may not see data that was written immediately before your read."]
+    #[serde(rename="ConsistentRead")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub consistent_read: Option<bool>,
     #[doc="A string informing Amazon SimpleDB where to start the next list of <code>ItemNames</code>."]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="The expression used to query the domain."]
+    #[serde(rename="SelectExpression")]
     pub select_expression: String,
 }
 
@@ -947,11 +1019,15 @@ impl SelectRequestSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SelectResult {
     #[doc="A list of items that match the select expression."]
+    #[serde(rename="Items")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub items: Option<Vec<Item>>,
     #[doc="An opaque token indicating that more items than <code>MaxNumberOfItems</code> were matched, the response size exceeded 1 megabyte, or the execution time exceeded 5 seconds."]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1016,13 +1092,19 @@ impl StringDeserializer {
     }
 }
 #[doc="<p> Specifies the conditions under which data should be updated. If an update condition is specified for a request, the data will only be updated if the condition is satisfied. For example, if an attribute with a specific name and value exists, or if a specific attribute doesn't exist. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateCondition {
     #[doc="<p>A value specifying whether or not the specified attribute must exist with the specified value in order for the update condition to be satisfied. Specify <code>true</code> if the attribute must exist for the update condition to be satisfied. Specify <code>false</code> if the attribute should not exist in order for the update condition to be satisfied.</p>"]
+    #[serde(rename="Exists")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub exists: Option<bool>,
     #[doc="<p>The name of the attribute involved in the condition.</p>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
     #[doc="<p>The value of an attribute. This value can only be specified when the <code>Exists</code> parameter is equal to <code>true</code>.</p>"]
+    #[serde(rename="Value")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 }
 

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptPortfolioShareInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -39,11 +39,11 @@ pub struct AcceptPortfolioShareInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AcceptPortfolioShareOutput;
 
 #[doc="<p>The access level to limit results.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AccessLevelFilter {
     #[doc="<p>Specifies the access level.</p> <p> <code>Account</code> allows results at the account level. </p> <p> <code>Role</code> allows results based on the federated role of the specified user.</p> <p> <code>User</code> allows results limited to the specified user. </p>"]
     #[serde(rename="Key")]
@@ -55,7 +55,7 @@ pub struct AccessLevelFilter {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociatePrincipalWithPortfolioInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -72,10 +72,10 @@ pub struct AssociatePrincipalWithPortfolioInput {
     pub principal_type: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociatePrincipalWithPortfolioOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateProductWithPortfolioInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -93,10 +93,10 @@ pub struct AssociateProductWithPortfolioInput {
     pub source_portfolio_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateProductWithPortfolioOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateTagOptionWithResourceInput {
     #[doc="<p>The resource identifier.</p>"]
     #[serde(rename="ResourceId")]
@@ -106,11 +106,11 @@ pub struct AssociateTagOptionWithResourceInput {
     pub tag_option_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateTagOptionWithResourceOutput;
 
 #[doc="<p>Detailed constraint information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConstraintDetail {
     #[doc="<p>The identifier of the constraint.</p>"]
     #[serde(rename="ConstraintId")]
@@ -131,7 +131,7 @@ pub struct ConstraintDetail {
 }
 
 #[doc="<p>An administrator-specified constraint to apply when provisioning a product.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConstraintSummary {
     #[doc="<p>The text description of the constraint.</p>"]
     #[serde(rename="Description")]
@@ -143,7 +143,7 @@ pub struct ConstraintSummary {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConstraintInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -170,7 +170,7 @@ pub struct CreateConstraintInput {
     pub type_: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConstraintOutput {
     #[doc="<p>The resulting detailed constraint information.</p>"]
     #[serde(rename="ConstraintDetail")]
@@ -186,7 +186,7 @@ pub struct CreateConstraintOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePortfolioInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -211,7 +211,7 @@ pub struct CreatePortfolioInput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePortfolioOutput {
     #[doc="<p>The resulting detailed portfolio information.</p>"]
     #[serde(rename="PortfolioDetail")]
@@ -223,7 +223,7 @@ pub struct CreatePortfolioOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePortfolioShareInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -237,10 +237,10 @@ pub struct CreatePortfolioShareInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePortfolioShareOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProductInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -287,7 +287,7 @@ pub struct CreateProductInput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProductOutput {
     #[doc="<p>The resulting detailed product view information.</p>"]
     #[serde(rename="ProductViewDetail")]
@@ -303,7 +303,7 @@ pub struct CreateProductOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProvisioningArtifactInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -320,7 +320,7 @@ pub struct CreateProvisioningArtifactInput {
     pub product_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProvisioningArtifactOutput {
     #[doc="<p>Additional information about the creation request for the provisioning artifact.</p>"]
     #[serde(rename="Info")]
@@ -336,7 +336,7 @@ pub struct CreateProvisioningArtifactOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTagOptionInput {
     #[doc="<p>The TagOption key.</p>"]
     #[serde(rename="Key")]
@@ -346,7 +346,7 @@ pub struct CreateTagOptionInput {
     pub value: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTagOptionOutput {
     #[doc="<p>The resulting detailed TagOption information.</p>"]
     #[serde(rename="TagOptionDetail")]
@@ -354,7 +354,7 @@ pub struct CreateTagOptionOutput {
     pub tag_option_detail: Option<TagOptionDetail>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConstraintInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -365,10 +365,10 @@ pub struct DeleteConstraintInput {
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConstraintOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePortfolioInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -379,10 +379,10 @@ pub struct DeletePortfolioInput {
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePortfolioOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePortfolioShareInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -396,10 +396,10 @@ pub struct DeletePortfolioShareInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePortfolioShareOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProductInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -410,10 +410,10 @@ pub struct DeleteProductInput {
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProductOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProvisioningArtifactInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -427,10 +427,10 @@ pub struct DeleteProvisioningArtifactInput {
     pub provisioning_artifact_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProvisioningArtifactOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConstraintInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -441,7 +441,7 @@ pub struct DescribeConstraintInput {
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConstraintOutput {
     #[doc="<p>Detailed constraint information.</p>"]
     #[serde(rename="ConstraintDetail")]
@@ -457,7 +457,7 @@ pub struct DescribeConstraintOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePortfolioInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -468,7 +468,7 @@ pub struct DescribePortfolioInput {
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePortfolioOutput {
     #[doc="<p>Detailed portfolio information.</p>"]
     #[serde(rename="PortfolioDetail")]
@@ -484,7 +484,7 @@ pub struct DescribePortfolioOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProductAsAdminInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -495,7 +495,7 @@ pub struct DescribeProductAsAdminInput {
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProductAsAdminOutput {
     #[doc="<p>Detailed product view information.</p>"]
     #[serde(rename="ProductViewDetail")]
@@ -515,7 +515,7 @@ pub struct DescribeProductAsAdminOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProductInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -526,7 +526,7 @@ pub struct DescribeProductInput {
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProductOutput {
     #[doc="<p>The summary metadata about the specified product.</p>"]
     #[serde(rename="ProductViewSummary")]
@@ -538,7 +538,7 @@ pub struct DescribeProductOutput {
     pub provisioning_artifacts: Option<Vec<ProvisioningArtifact>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProductViewInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -549,7 +549,7 @@ pub struct DescribeProductViewInput {
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProductViewOutput {
     #[doc="<p>The summary metadata about the specified product.</p>"]
     #[serde(rename="ProductViewSummary")]
@@ -561,7 +561,7 @@ pub struct DescribeProductViewOutput {
     pub provisioning_artifacts: Option<Vec<ProvisioningArtifact>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProvisionedProductInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -572,7 +572,7 @@ pub struct DescribeProvisionedProductInput {
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProvisionedProductOutput {
     #[doc="<p>Detailed provisioned product information.</p>"]
     #[serde(rename="ProvisionedProductDetail")]
@@ -580,7 +580,7 @@ pub struct DescribeProvisionedProductOutput {
     pub provisioned_product_detail: Option<ProvisionedProductDetail>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProvisioningArtifactInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -598,7 +598,7 @@ pub struct DescribeProvisioningArtifactInput {
     pub verbose: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProvisioningArtifactOutput {
     #[doc="<p>Additional information about the provisioning artifact.</p>"]
     #[serde(rename="Info")]
@@ -614,7 +614,7 @@ pub struct DescribeProvisioningArtifactOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProvisioningParametersInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -632,7 +632,7 @@ pub struct DescribeProvisioningParametersInput {
     pub provisioning_artifact_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProvisioningParametersOutput {
     #[doc="<p>The list of constraint summaries that apply to provisioning this product.</p>"]
     #[serde(rename="ConstraintSummaries")]
@@ -652,7 +652,7 @@ pub struct DescribeProvisioningParametersOutput {
     pub usage_instructions: Option<Vec<UsageInstruction>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRecordInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -671,7 +671,7 @@ pub struct DescribeRecordInput {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRecordOutput {
     #[doc="<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextPageToken")]
@@ -687,14 +687,14 @@ pub struct DescribeRecordOutput {
     pub record_outputs: Option<Vec<RecordOutput>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagOptionInput {
     #[doc="<p>The identifier of the TagOption.</p>"]
     #[serde(rename="Id")]
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagOptionOutput {
     #[doc="<p>The resulting detailed TagOption information.</p>"]
     #[serde(rename="TagOptionDetail")]
@@ -702,7 +702,7 @@ pub struct DescribeTagOptionOutput {
     pub tag_option_detail: Option<TagOptionDetail>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociatePrincipalFromPortfolioInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -716,10 +716,10 @@ pub struct DisassociatePrincipalFromPortfolioInput {
     pub principal_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociatePrincipalFromPortfolioOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateProductFromPortfolioInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -733,10 +733,10 @@ pub struct DisassociateProductFromPortfolioInput {
     pub product_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateProductFromPortfolioOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateTagOptionFromResourceInput {
     #[doc="<p>Identifier of the resource from which to disassociate the TagOption.</p>"]
     #[serde(rename="ResourceId")]
@@ -746,11 +746,11 @@ pub struct DisassociateTagOptionFromResourceInput {
     pub tag_option_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateTagOptionFromResourceOutput;
 
 #[doc="<p>Summary information about a path for a user to have access to a specified product.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LaunchPathSummary {
     #[doc="<p>List of constraints on the portfolio-product relationship.</p>"]
     #[serde(rename="ConstraintSummaries")]
@@ -770,7 +770,7 @@ pub struct LaunchPathSummary {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAcceptedPortfolioSharesInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -786,7 +786,7 @@ pub struct ListAcceptedPortfolioSharesInput {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAcceptedPortfolioSharesOutput {
     #[doc="<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextPageToken")]
@@ -798,7 +798,7 @@ pub struct ListAcceptedPortfolioSharesOutput {
     pub portfolio_details: Option<Vec<PortfolioDetail>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListConstraintsForPortfolioInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -821,7 +821,7 @@ pub struct ListConstraintsForPortfolioInput {
     pub product_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListConstraintsForPortfolioOutput {
     #[doc="<p>List of detailed constraint information objects.</p>"]
     #[serde(rename="ConstraintDetails")]
@@ -833,7 +833,7 @@ pub struct ListConstraintsForPortfolioOutput {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLaunchPathsInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -852,7 +852,7 @@ pub struct ListLaunchPathsInput {
     pub product_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLaunchPathsOutput {
     #[doc="<p>List of launch path information summaries for the specified <code>PageToken</code>.</p>"]
     #[serde(rename="LaunchPathSummaries")]
@@ -864,7 +864,7 @@ pub struct ListLaunchPathsOutput {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPortfolioAccessInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -875,7 +875,7 @@ pub struct ListPortfolioAccessInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPortfolioAccessOutput {
     #[doc="<p>List of account IDs associated with access to the portfolio.</p>"]
     #[serde(rename="AccountIds")]
@@ -887,7 +887,7 @@ pub struct ListPortfolioAccessOutput {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPortfoliosForProductInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -906,7 +906,7 @@ pub struct ListPortfoliosForProductInput {
     pub product_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPortfoliosForProductOutput {
     #[doc="<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextPageToken")]
@@ -918,7 +918,7 @@ pub struct ListPortfoliosForProductOutput {
     pub portfolio_details: Option<Vec<PortfolioDetail>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPortfoliosInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -934,7 +934,7 @@ pub struct ListPortfoliosInput {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPortfoliosOutput {
     #[doc="<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextPageToken")]
@@ -946,7 +946,7 @@ pub struct ListPortfoliosOutput {
     pub portfolio_details: Option<Vec<PortfolioDetail>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPrincipalsForPortfolioInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -965,7 +965,7 @@ pub struct ListPrincipalsForPortfolioInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPrincipalsForPortfolioOutput {
     #[doc="<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextPageToken")]
@@ -977,7 +977,7 @@ pub struct ListPrincipalsForPortfolioOutput {
     pub principals: Option<Vec<Principal>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProvisioningArtifactsInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -988,7 +988,7 @@ pub struct ListProvisioningArtifactsInput {
     pub product_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProvisioningArtifactsOutput {
     #[doc="<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextPageToken")]
@@ -1000,7 +1000,7 @@ pub struct ListProvisioningArtifactsOutput {
     pub provisioning_artifact_details: Option<Vec<ProvisioningArtifactDetail>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRecordHistoryInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -1024,7 +1024,7 @@ pub struct ListRecordHistoryInput {
     pub search_filter: Option<ListRecordHistorySearchFilter>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRecordHistoryOutput {
     #[doc="<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextPageToken")]
@@ -1037,7 +1037,7 @@ pub struct ListRecordHistoryOutput {
 }
 
 #[doc="<p>The search filter to limit results when listing request history records.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRecordHistorySearchFilter {
     #[doc="<p>The filter key.</p>"]
     #[serde(rename="Key")]
@@ -1049,7 +1049,7 @@ pub struct ListRecordHistorySearchFilter {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourcesForTagOptionInput {
     #[doc="<p>The maximum number of items to return in the results. If more results exist than fit in the specified <code>PageSize</code>, the value of <code>NextPageToken</code> in the response is non-null.</p>"]
     #[serde(rename="PageSize")]
@@ -1068,7 +1068,7 @@ pub struct ListResourcesForTagOptionInput {
     pub tag_option_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourcesForTagOptionOutput {
     #[doc="<p>The page token of the first page retrieved. If null, this retrieves the first page of size <code>PageSize</code>.</p>"]
     #[serde(rename="PageToken")]
@@ -1081,7 +1081,7 @@ pub struct ListResourcesForTagOptionOutput {
 }
 
 #[doc="<p>The ListTagOptions filters.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagOptionsFilters {
     #[doc="<p>The ListTagOptionsFilters active state.</p>"]
     #[serde(rename="Active")]
@@ -1097,7 +1097,7 @@ pub struct ListTagOptionsFilters {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagOptionsInput {
     #[doc="<p>The list of filters with which to limit search results. If no search filters are specified, the output is all TagOptions. </p>"]
     #[serde(rename="Filters")]
@@ -1113,7 +1113,7 @@ pub struct ListTagOptionsInput {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagOptionsOutput {
     #[doc="<p>The page token of the first page retrieved. If null, this retrieves the first page of size <code>PageSize</code>.</p>"]
     #[serde(rename="PageToken")]
@@ -1126,7 +1126,7 @@ pub struct ListTagOptionsOutput {
 }
 
 #[doc="<p>The constraints that the administrator has put on the parameter.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ParameterConstraints {
     #[doc="<p>The values that the administrator has allowed for the parameter.</p>"]
     #[serde(rename="AllowedValues")]
@@ -1135,7 +1135,7 @@ pub struct ParameterConstraints {
 }
 
 #[doc="<p>Detailed portfolio information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PortfolioDetail {
     #[doc="<p>The ARN assigned to the portfolio.</p>"]
     #[serde(rename="ARN")]
@@ -1164,7 +1164,7 @@ pub struct PortfolioDetail {
 }
 
 #[doc="<p>A principal's ARN and type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Principal {
     #[doc="<p>The ARN representing the principal (IAM user, role, or group).</p>"]
     #[serde(rename="PrincipalARN")]
@@ -1177,7 +1177,7 @@ pub struct Principal {
 }
 
 #[doc="<p>A single product view aggregation value/count pair, containing metadata about each product to which the calling user has access.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProductViewAggregationValue {
     #[doc="<p>An approximate count of the products that match the value.</p>"]
     #[serde(rename="ApproximateCount")]
@@ -1190,7 +1190,7 @@ pub struct ProductViewAggregationValue {
 }
 
 #[doc="<p>Detailed product view information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProductViewDetail {
     #[doc="<p>The UTC timestamp of the creation time.</p>"]
     #[serde(rename="CreatedTime")]
@@ -1211,7 +1211,7 @@ pub struct ProductViewDetail {
 }
 
 #[doc="<p>The summary metadata about the specified product.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProductViewSummary {
     #[doc="<p>The distributor of the product. Contact the product administrator for the significance of this value.</p>"]
     #[serde(rename="Distributor")]
@@ -1259,7 +1259,7 @@ pub struct ProductViewSummary {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisionProductInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -1295,7 +1295,7 @@ pub struct ProvisionProductInput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisionProductOutput {
     #[doc="<p>The detailed result of the <a>ProvisionProduct</a> request, containing the inputs made to that request, the current state of the request, a pointer to the ProvisionedProduct object of the request, and a list of any errors that the request encountered. </p>"]
     #[serde(rename="RecordDetail")]
@@ -1304,7 +1304,7 @@ pub struct ProvisionProductOutput {
 }
 
 #[doc="<p>Detailed information about a ProvisionedProduct object.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisionedProductDetail {
     #[doc="<p>The ARN associated with the ProvisionedProduct object.</p>"]
     #[serde(rename="Arn")]
@@ -1345,7 +1345,7 @@ pub struct ProvisionedProductDetail {
 }
 
 #[doc="<p>Contains information indicating the ways in which a product can be provisioned.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisioningArtifact {
     #[doc="<p>The UTC timestamp of the creation time.</p>"]
     #[serde(rename="CreatedTime")]
@@ -1366,7 +1366,7 @@ pub struct ProvisioningArtifact {
 }
 
 #[doc="<p>Detailed provisioning artifact information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisioningArtifactDetail {
     #[doc="<p>The UTC timestamp of the creation time.</p>"]
     #[serde(rename="CreatedTime")]
@@ -1391,7 +1391,7 @@ pub struct ProvisioningArtifactDetail {
 }
 
 #[doc="<p>A parameter used to successfully provision the product. This value includes a list of allowable values and additional metadata. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisioningArtifactParameter {
     #[doc="<p>The default value for this parameter.</p>"]
     #[serde(rename="DefaultValue")]
@@ -1420,7 +1420,7 @@ pub struct ProvisioningArtifactParameter {
 }
 
 #[doc="<p>Provisioning artifact properties. For example request JSON, see <a>CreateProvisioningArtifact</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisioningArtifactProperties {
     #[doc="<p>The text description of the provisioning artifact properties.</p>"]
     #[serde(rename="Description")]
@@ -1440,7 +1440,7 @@ pub struct ProvisioningArtifactProperties {
 }
 
 #[doc="<p>Stores summary information about a provisioning artifact.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisioningArtifactSummary {
     #[doc="<p>The UTC timestamp of the creation time.</p>"]
     #[serde(rename="CreatedTime")]
@@ -1465,7 +1465,7 @@ pub struct ProvisioningArtifactSummary {
 }
 
 #[doc="<p>The parameter key-value pairs used to provision a product.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ProvisioningParameter {
     #[doc="<p>The <code>ProvisioningArtifactParameter.ParameterKey</code> parameter from <a>DescribeProvisioningParameters</a>.</p>"]
     #[serde(rename="Key")]
@@ -1478,7 +1478,7 @@ pub struct ProvisioningParameter {
 }
 
 #[doc="<p>The full details of a specific ProvisionedProduct object.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecordDetail {
     #[doc="<p>The UTC timestamp of the creation time.</p>"]
     #[serde(rename="CreatedTime")]
@@ -1535,7 +1535,7 @@ pub struct RecordDetail {
 }
 
 #[doc="<p>The error code and description resulting from an operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecordError {
     #[doc="<p>The numeric value of the error.</p>"]
     #[serde(rename="Code")]
@@ -1548,7 +1548,7 @@ pub struct RecordError {
 }
 
 #[doc="<p>An output for the specified Product object created as the result of a request. For example, a CloudFormation-backed product that creates an S3 bucket would have an output for the S3 bucket URL.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecordOutput {
     #[doc="<p>The text description of the output.</p>"]
     #[serde(rename="Description")]
@@ -1565,7 +1565,7 @@ pub struct RecordOutput {
 }
 
 #[doc="<p>A tag associated with the record, stored as a key-value pair.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecordTag {
     #[doc="<p>The key for this tag.</p>"]
     #[serde(rename="Key")]
@@ -1577,7 +1577,7 @@ pub struct RecordTag {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RejectPortfolioShareInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -1588,11 +1588,11 @@ pub struct RejectPortfolioShareInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RejectPortfolioShareOutput;
 
 #[doc="<p>Detailed resource information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceDetail {
     #[doc="<p>ARN of the resource.</p>"]
     #[serde(rename="ARN")]
@@ -1616,7 +1616,7 @@ pub struct ResourceDetail {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScanProvisionedProductsInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -1636,7 +1636,7 @@ pub struct ScanProvisionedProductsInput {
     pub page_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScanProvisionedProductsOutput {
     #[doc="<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextPageToken")]
@@ -1648,7 +1648,7 @@ pub struct ScanProvisionedProductsOutput {
     pub provisioned_products: Option<Vec<ProvisionedProductDetail>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchProductsAsAdminInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -1684,7 +1684,7 @@ pub struct SearchProductsAsAdminInput {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchProductsAsAdminOutput {
     #[doc="<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextPageToken")]
@@ -1696,7 +1696,7 @@ pub struct SearchProductsAsAdminOutput {
     pub product_view_details: Option<Vec<ProductViewDetail>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchProductsInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -1724,7 +1724,7 @@ pub struct SearchProductsInput {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SearchProductsOutput {
     #[doc="<p>The page token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>"]
     #[serde(rename="NextPageToken")]
@@ -1753,7 +1753,7 @@ pub struct Tag {
 }
 
 #[doc="<p>The TagOption details.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagOptionDetail {
     #[doc="<p>The TagOptionDetail active state.</p>"]
     #[serde(rename="Active")]
@@ -1774,7 +1774,7 @@ pub struct TagOptionDetail {
 }
 
 #[doc="<p>The TagOption summary key-value pair.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagOptionSummary {
     #[doc="<p>The TagOptionSummary key.</p>"]
     #[serde(rename="Key")]
@@ -1786,7 +1786,7 @@ pub struct TagOptionSummary {
     pub values: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateProvisionedProductInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -1809,7 +1809,7 @@ pub struct TerminateProvisionedProductInput {
     pub terminate_token: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateProvisionedProductOutput {
     #[doc="<p>The detailed result of the <a>TerminateProvisionedProduct</a> request, containing the inputs made to that request, the current state of the request, a pointer to the ProvisionedProduct object that the request is modifying, and a list of any errors that the request encountered.</p>"]
     #[serde(rename="RecordDetail")]
@@ -1817,7 +1817,7 @@ pub struct TerminateProvisionedProductOutput {
     pub record_detail: Option<RecordDetail>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateConstraintInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -1832,7 +1832,7 @@ pub struct UpdateConstraintInput {
     pub id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateConstraintOutput {
     #[doc="<p>The resulting detailed constraint information.</p>"]
     #[serde(rename="ConstraintDetail")]
@@ -1848,7 +1848,7 @@ pub struct UpdateConstraintOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePortfolioInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -1879,7 +1879,7 @@ pub struct UpdatePortfolioInput {
     pub remove_tags: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePortfolioOutput {
     #[doc="<p>The resulting detailed portfolio information.</p>"]
     #[serde(rename="PortfolioDetail")]
@@ -1891,7 +1891,7 @@ pub struct UpdatePortfolioOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProductInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -1938,7 +1938,7 @@ pub struct UpdateProductInput {
     pub support_url: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProductOutput {
     #[doc="<p>The resulting detailed product view information.</p>"]
     #[serde(rename="ProductViewDetail")]
@@ -1950,7 +1950,7 @@ pub struct UpdateProductOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProvisionedProductInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -1985,7 +1985,7 @@ pub struct UpdateProvisionedProductInput {
     pub update_token: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProvisionedProductOutput {
     #[doc="<p>The detailed result of the <a>UpdateProvisionedProduct</a> request, containing the inputs made to that request, the current state of the request, a pointer to the ProvisionedProduct object that the request is modifying, and a list of any errors that the request encountered.</p>"]
     #[serde(rename="RecordDetail")]
@@ -1993,7 +1993,7 @@ pub struct UpdateProvisionedProductOutput {
     pub record_detail: Option<RecordDetail>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProvisioningArtifactInput {
     #[doc="<p>The language code to use for this operation. Supported language codes are as follows:</p> <p>\"en\" (English)</p> <p>\"jp\" (Japanese)</p> <p>\"zh\" (Chinese)</p> <p>If no code is specified, \"en\" is used as the default.</p>"]
     #[serde(rename="AcceptLanguage")]
@@ -2015,7 +2015,7 @@ pub struct UpdateProvisioningArtifactInput {
     pub provisioning_artifact_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProvisioningArtifactOutput {
     #[doc="<p>Additional information about the provisioning artifact update request.</p>"]
     #[serde(rename="Info")]
@@ -2032,7 +2032,7 @@ pub struct UpdateProvisioningArtifactOutput {
 }
 
 #[doc="<p>The parameter key-value pair used to update a ProvisionedProduct object. If <code>UsePreviousValue</code> is set to true, <code>Value</code> is ignored and the value for <code>Key</code> is kept as previously set (current value).</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateProvisioningParameter {
     #[doc="<p>The <code>ProvisioningArtifactParameter.ParameterKey</code> parameter from <a>DescribeProvisioningParameters</a>.</p>"]
     #[serde(rename="Key")]
@@ -2048,7 +2048,7 @@ pub struct UpdateProvisioningParameter {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTagOptionInput {
     #[doc="<p>The updated active state.</p>"]
     #[serde(rename="Active")]
@@ -2063,7 +2063,7 @@ pub struct UpdateTagOptionInput {
     pub value: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateTagOptionOutput {
     #[doc="<p>The resulting detailed TagOption information.</p>"]
     #[serde(rename="TagOptionDetail")]
@@ -2072,7 +2072,7 @@ pub struct UpdateTagOptionOutput {
 }
 
 #[doc="<p>Additional information provided by the administrator.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UsageInstruction {
     #[doc="<p>The usage instruction type for the value.</p>"]
     #[serde(rename="Type")]

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -40,11 +40,13 @@ enum DeserializerNext {
     Element(String),
 }
 #[doc="<p>When included in a receipt rule, this action adds a header to the received email.</p> <p>For information about adding a header using a receipt rule, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-add-header.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddHeaderAction {
     #[doc="<p>The name of the header to add. Must be between 1 and 50 characters, inclusive, and consist of alphanumeric (a-z, A-Z, 0-9) characters and dashes only.</p>"]
+    #[serde(rename="HeaderName")]
     pub header_name: String,
     #[doc="<p>Must be less than 2048 characters, and must not contain newline characters (\"\\r\" or \"\\n\").</p>"]
+    #[serde(rename="HeaderValue")]
     pub header_value: String,
 }
 
@@ -208,11 +210,15 @@ impl BehaviorOnMXFailureDeserializer {
     }
 }
 #[doc="<p>Represents the body of the message. You can specify text, HTML, or both. If you use both, then the message should display correctly in the widest variety of email clients.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Body {
     #[doc="<p>The content of the message, in HTML format. Use this for email clients that can process HTML. You can include clickable links, formatted text, and much more in an HTML message.</p>"]
+    #[serde(rename="Html")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub html: Option<Content>,
     #[doc="<p>The content of the message, in text format. Use this for text-based email clients, or clients on high-latency networks (such as mobile devices).</p>"]
+    #[serde(rename="Text")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub text: Option<Content>,
 }
 
@@ -237,17 +243,24 @@ impl BodySerializer {
 }
 
 #[doc="<p>When included in a receipt rule, this action rejects the received email by returning a bounce response to the sender and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>For information about sending a bounce message in response to a received email, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-bounce.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BounceAction {
     #[doc="<p>Human-readable text to include in the bounce message.</p>"]
+    #[serde(rename="Message")]
     pub message: String,
     #[doc="<p>The email address of the sender of the bounced email. This is the address from which the bounce message will be sent.</p>"]
+    #[serde(rename="Sender")]
     pub sender: String,
     #[doc="<p>The SMTP reply code, as defined by <a href=\"https://tools.ietf.org/html/rfc5321\">RFC 5321</a>.</p>"]
+    #[serde(rename="SmtpReplyCode")]
     pub smtp_reply_code: String,
     #[doc="<p>The SMTP enhanced status code, as defined by <a href=\"https://tools.ietf.org/html/rfc3463\">RFC 3463</a>.</p>"]
+    #[serde(rename="StatusCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub status_code: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the bounce action is taken. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\"http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\">Amazon SNS Developer Guide</a>.</p>"]
+    #[serde(rename="TopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
 }
 
@@ -382,15 +395,22 @@ impl BounceStatusCodeDeserializer {
     }
 }
 #[doc="<p>Recipient-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BouncedRecipientInfo {
     #[doc="<p>The reason for the bounce. You must provide either this parameter or <code>RecipientDsnFields</code>.</p>"]
+    #[serde(rename="BounceType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bounce_type: Option<String>,
     #[doc="<p>The email address of the recipient of the bounced email.</p>"]
+    #[serde(rename="Recipient")]
     pub recipient: String,
     #[doc="<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to receive email for the recipient of the bounced email. For more information about sending authorization, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer Guide</a>.</p>"]
+    #[serde(rename="RecipientArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recipient_arn: Option<String>,
     #[doc="<p>Recipient-related DSN fields, most of which would normally be filled in automatically when provided with a <code>BounceType</code>. You must provide either this parameter or <code>BounceType</code>.</p>"]
+    #[serde(rename="RecipientDsnFields")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recipient_dsn_fields: Option<RecipientDsnFields>,
 }
 
@@ -450,11 +470,13 @@ impl CidrDeserializer {
     }
 }
 #[doc="<p>Represents a request to create a receipt rule set by cloning an existing one. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloneReceiptRuleSetRequest {
     #[doc="<p>The name of the rule set to clone.</p>"]
+    #[serde(rename="OriginalRuleSetName")]
     pub original_rule_set_name: String,
     #[doc="<p>The name of the rule set to create. The name must:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores (_), or dashes (-).</p> </li> <li> <p>Start and end with a letter or number.</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>"]
+    #[serde(rename="RuleSetName")]
     pub rule_set_name: String,
 }
 
@@ -477,7 +499,7 @@ impl CloneReceiptRuleSetRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloneReceiptRuleSetResponse;
 
 struct CloneReceiptRuleSetResponseDeserializer;
@@ -497,9 +519,10 @@ impl CloneReceiptRuleSetResponseDeserializer {
     }
 }
 #[doc="<p>Contains information associated with an Amazon CloudWatch event destination to which email sending events are published.</p> <p>Event destinations, such as Amazon CloudWatch, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloudWatchDestination {
     #[doc="<p>A list of dimensions upon which to categorize your emails when you publish email sending events to Amazon CloudWatch.</p>"]
+    #[serde(rename="DimensionConfigurations")]
     pub dimension_configurations: Vec<CloudWatchDimensionConfiguration>,
 }
 
@@ -564,13 +587,16 @@ impl CloudWatchDestinationSerializer {
 }
 
 #[doc="<p>Contains the dimension configuration to use when you publish email sending events to Amazon CloudWatch.</p> <p>For information about publishing email sending events to Amazon CloudWatch, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloudWatchDimensionConfiguration {
     #[doc="<p>The default value of the dimension that is published to Amazon CloudWatch if you do not provide the value of the dimension when you send an email. The default value must:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 256 characters.</p> </li> </ul>"]
+    #[serde(rename="DefaultDimensionValue")]
     pub default_dimension_value: String,
     #[doc="<p>The name of an Amazon CloudWatch dimension associated with an email sending metric. The name must:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 256 characters.</p> </li> </ul>"]
+    #[serde(rename="DimensionName")]
     pub dimension_name: String,
     #[doc="<p>The place where Amazon SES finds the value of a dimension to publish to Amazon CloudWatch. If you want Amazon SES to use the message tags that you specify using an <code>X-SES-MESSAGE-TAGS</code> header or a parameter to the <code>SendEmail</code>/<code>SendRawEmail</code> API, choose <code>messageTag</code>. If you want Amazon SES to use your own email headers, choose <code>emailHeader</code>.</p>"]
+    #[serde(rename="DimensionValueSource")]
     pub dimension_value_source: String,
 }
 
@@ -703,9 +729,10 @@ impl CloudWatchDimensionConfigurationsSerializer {
 }
 
 #[doc="<p>The name of the configuration set.</p> <p>Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfigurationSet {
     #[doc="<p>The name of the configuration set. The name must:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>"]
+    #[serde(rename="Name")]
     pub name: String,
 }
 
@@ -835,11 +862,14 @@ impl ConfigurationSetsDeserializer {
     }
 }
 #[doc="<p>Represents textual data, plus an optional character set specification.</p> <p>By default, the text must be 7-bit ASCII, due to the constraints of the SMTP protocol. If the text must contain any other characters, then you must also specify a character set. Examples include UTF-8, ISO-8859-1, and Shift_JIS.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Content {
     #[doc="<p>The character set of the content.</p>"]
+    #[serde(rename="Charset")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub charset: Option<String>,
     #[doc="<p>The textual data of the content.</p>"]
+    #[serde(rename="Data")]
     pub data: String,
 }
 
@@ -878,11 +908,13 @@ impl CounterDeserializer {
     }
 }
 #[doc="<p>Represents a request to create a configuration set event destination. A configuration set event destination, which can be either Amazon CloudWatch or Amazon Kinesis Firehose, describes an AWS service in which Amazon SES publishes the email sending events associated with a configuration set. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConfigurationSetEventDestinationRequest {
     #[doc="<p>The name of the configuration set to which to apply the event destination.</p>"]
+    #[serde(rename="ConfigurationSetName")]
     pub configuration_set_name: String,
     #[doc="<p>An object that describes the AWS service to which Amazon SES will publish the email sending events associated with the specified configuration set.</p>"]
+    #[serde(rename="EventDestination")]
     pub event_destination: EventDestination,
 }
 
@@ -908,7 +940,7 @@ impl CreateConfigurationSetEventDestinationRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConfigurationSetEventDestinationResponse;
 
 struct CreateConfigurationSetEventDestinationResponseDeserializer;
@@ -929,9 +961,10 @@ impl CreateConfigurationSetEventDestinationResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to create a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConfigurationSetRequest {
     #[doc="<p>A data structure that contains the name of the configuration set.</p>"]
+    #[serde(rename="ConfigurationSet")]
     pub configuration_set: ConfigurationSet,
 }
 
@@ -953,7 +986,7 @@ impl CreateConfigurationSetRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateConfigurationSetResponse;
 
 struct CreateConfigurationSetResponseDeserializer;
@@ -973,9 +1006,10 @@ impl CreateConfigurationSetResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to create a new IP address filter. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReceiptFilterRequest {
     #[doc="<p>A data structure that describes the IP address filter to create, which consists of a name, an IP address range, and whether to allow or block mail from it.</p>"]
+    #[serde(rename="Filter")]
     pub filter: ReceiptFilter,
 }
 
@@ -995,7 +1029,7 @@ impl CreateReceiptFilterRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReceiptFilterResponse;
 
 struct CreateReceiptFilterResponseDeserializer;
@@ -1015,13 +1049,17 @@ impl CreateReceiptFilterResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to create a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReceiptRuleRequest {
     #[doc="<p>The name of an existing rule after which the new rule will be placed. If this parameter is null, the new rule will be inserted at the beginning of the rule list.</p>"]
+    #[serde(rename="After")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub after: Option<String>,
     #[doc="<p>A data structure that contains the specified rule's name, actions, recipients, domains, enabled status, scan status, and TLS policy.</p>"]
+    #[serde(rename="Rule")]
     pub rule: ReceiptRule,
     #[doc="<p>The name of the rule set to which to add the rule.</p>"]
+    #[serde(rename="RuleSetName")]
     pub rule_set_name: String,
 }
 
@@ -1047,7 +1085,7 @@ impl CreateReceiptRuleRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReceiptRuleResponse;
 
 struct CreateReceiptRuleResponseDeserializer;
@@ -1067,9 +1105,10 @@ impl CreateReceiptRuleResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to create an empty receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReceiptRuleSetRequest {
     #[doc="<p>The name of the rule set to create. The name must:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores (_), or dashes (-).</p> </li> <li> <p>Start and end with a letter or number.</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>"]
+    #[serde(rename="RuleSetName")]
     pub rule_set_name: String,
 }
 
@@ -1090,7 +1129,7 @@ impl CreateReceiptRuleSetRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReceiptRuleSetResponse;
 
 struct CreateReceiptRuleSetResponseDeserializer;
@@ -1138,11 +1177,13 @@ impl DefaultDimensionValueDeserializer {
     }
 }
 #[doc="<p>Represents a request to delete a configuration set event destination. Configuration set event destinations are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConfigurationSetEventDestinationRequest {
     #[doc="<p>The name of the configuration set from which to delete the event destination.</p>"]
+    #[serde(rename="ConfigurationSetName")]
     pub configuration_set_name: String,
     #[doc="<p>The name of the event destination to delete.</p>"]
+    #[serde(rename="EventDestinationName")]
     pub event_destination_name: String,
 }
 
@@ -1167,7 +1208,7 @@ impl DeleteConfigurationSetEventDestinationRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConfigurationSetEventDestinationResponse;
 
 struct DeleteConfigurationSetEventDestinationResponseDeserializer;
@@ -1188,9 +1229,10 @@ impl DeleteConfigurationSetEventDestinationResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to delete a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConfigurationSetRequest {
     #[doc="<p>The name of the configuration set to delete.</p>"]
+    #[serde(rename="ConfigurationSetName")]
     pub configuration_set_name: String,
 }
 
@@ -1211,7 +1253,7 @@ impl DeleteConfigurationSetRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteConfigurationSetResponse;
 
 struct DeleteConfigurationSetResponseDeserializer;
@@ -1231,11 +1273,13 @@ impl DeleteConfigurationSetResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to delete a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIdentityPolicyRequest {
     #[doc="<p>The identity that is associated with the policy that you want to delete. You can specify the identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>"]
+    #[serde(rename="Identity")]
     pub identity: String,
     #[doc="<p>The name of the policy to be deleted.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -1258,7 +1302,7 @@ impl DeleteIdentityPolicyRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIdentityPolicyResponse;
 
 struct DeleteIdentityPolicyResponseDeserializer;
@@ -1278,9 +1322,10 @@ impl DeleteIdentityPolicyResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to delete one of your Amazon SES identities (an email address or domain).</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIdentityRequest {
     #[doc="<p>The identity to be removed from the list of identities for the AWS Account.</p>"]
+    #[serde(rename="Identity")]
     pub identity: String,
 }
 
@@ -1301,7 +1346,7 @@ impl DeleteIdentityRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIdentityResponse;
 
 struct DeleteIdentityResponseDeserializer;
@@ -1321,9 +1366,10 @@ impl DeleteIdentityResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to delete an IP address filter. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReceiptFilterRequest {
     #[doc="<p>The name of the IP address filter to delete.</p>"]
+    #[serde(rename="FilterName")]
     pub filter_name: String,
 }
 
@@ -1344,7 +1390,7 @@ impl DeleteReceiptFilterRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReceiptFilterResponse;
 
 struct DeleteReceiptFilterResponseDeserializer;
@@ -1364,11 +1410,13 @@ impl DeleteReceiptFilterResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to delete a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReceiptRuleRequest {
     #[doc="<p>The name of the receipt rule to delete.</p>"]
+    #[serde(rename="RuleName")]
     pub rule_name: String,
     #[doc="<p>The name of the receipt rule set that contains the receipt rule to delete.</p>"]
+    #[serde(rename="RuleSetName")]
     pub rule_set_name: String,
 }
 
@@ -1391,7 +1439,7 @@ impl DeleteReceiptRuleRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReceiptRuleResponse;
 
 struct DeleteReceiptRuleResponseDeserializer;
@@ -1411,9 +1459,10 @@ impl DeleteReceiptRuleResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to delete a receipt rule set and all of the receipt rules it contains. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReceiptRuleSetRequest {
     #[doc="<p>The name of the receipt rule set to delete.</p>"]
+    #[serde(rename="RuleSetName")]
     pub rule_set_name: String,
 }
 
@@ -1434,7 +1483,7 @@ impl DeleteReceiptRuleSetRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReceiptRuleSetResponse;
 
 struct DeleteReceiptRuleSetResponseDeserializer;
@@ -1454,9 +1503,10 @@ impl DeleteReceiptRuleSetResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to delete an email address from the list of email addresses you have attempted to verify under your AWS account.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVerifiedEmailAddressRequest {
     #[doc="<p>An email address to be removed from the list of verified addresses.</p>"]
+    #[serde(rename="EmailAddress")]
     pub email_address: String,
 }
 
@@ -1477,7 +1527,7 @@ impl DeleteVerifiedEmailAddressRequestSerializer {
 }
 
 #[doc="<p>Represents a request to return the metadata and receipt rules for the receipt rule set that is currently active. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeActiveReceiptRuleSetRequest;
 
 
@@ -1496,11 +1546,15 @@ impl DescribeActiveReceiptRuleSetRequestSerializer {
 }
 
 #[doc="<p>Represents the metadata and receipt rules for the receipt rule set that is currently active.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeActiveReceiptRuleSetResponse {
     #[doc="<p>The metadata for the currently active receipt rule set. The metadata consists of the rule set name and a timestamp of when the rule set was created.</p>"]
+    #[serde(rename="Metadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metadata: Option<ReceiptRuleSetMetadata>,
     #[doc="<p>The receipt rules that belong to the active rule set.</p>"]
+    #[serde(rename="Rules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rules: Option<Vec<ReceiptRule>>,
 }
 
@@ -1554,11 +1608,14 @@ impl DescribeActiveReceiptRuleSetResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to return the details of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigurationSetRequest {
     #[doc="<p>A list of configuration set attributes to return.</p>"]
+    #[serde(rename="ConfigurationSetAttributeNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub configuration_set_attribute_names: Option<Vec<String>>,
     #[doc="<p>The name of the configuration set to describe.</p>"]
+    #[serde(rename="ConfigurationSetName")]
     pub configuration_set_name: String,
 }
 
@@ -1586,11 +1643,15 @@ impl DescribeConfigurationSetRequestSerializer {
 }
 
 #[doc="<p>Represents the details of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeConfigurationSetResponse {
     #[doc="<p>The configuration set object associated with the specified configuration set.</p>"]
+    #[serde(rename="ConfigurationSet")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub configuration_set: Option<ConfigurationSet>,
     #[doc="<p>A list of event destinations associated with the configuration set. </p>"]
+    #[serde(rename="EventDestinations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub event_destinations: Option<Vec<EventDestination>>,
 }
 
@@ -1644,11 +1705,13 @@ impl DescribeConfigurationSetResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to return the details of a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReceiptRuleRequest {
     #[doc="<p>The name of the receipt rule.</p>"]
+    #[serde(rename="RuleName")]
     pub rule_name: String,
     #[doc="<p>The name of the receipt rule set to which the receipt rule belongs.</p>"]
+    #[serde(rename="RuleSetName")]
     pub rule_set_name: String,
 }
 
@@ -1671,9 +1734,11 @@ impl DescribeReceiptRuleRequestSerializer {
 }
 
 #[doc="<p>Represents the details of a receipt rule.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReceiptRuleResponse {
     #[doc="<p>A data structure that contains the specified receipt rule's name, actions, recipients, domains, enabled status, scan status, and Transport Layer Security (TLS) policy.</p>"]
+    #[serde(rename="Rule")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rule: Option<ReceiptRule>,
 }
 
@@ -1720,9 +1785,10 @@ impl DescribeReceiptRuleResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to return the details of a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReceiptRuleSetRequest {
     #[doc="<p>The name of the receipt rule set to describe.</p>"]
+    #[serde(rename="RuleSetName")]
     pub rule_set_name: String,
 }
 
@@ -1743,11 +1809,15 @@ impl DescribeReceiptRuleSetRequestSerializer {
 }
 
 #[doc="<p>Represents the details of the specified receipt rule set.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeReceiptRuleSetResponse {
     #[doc="<p>The metadata for the receipt rule set, which consists of the rule set name and the timestamp of when the rule set was created.</p>"]
+    #[serde(rename="Metadata")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub metadata: Option<ReceiptRuleSetMetadata>,
     #[doc="<p>A list of the receipt rules that belong to the specified receipt rule set.</p>"]
+    #[serde(rename="Rules")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rules: Option<Vec<ReceiptRule>>,
 }
 
@@ -1800,13 +1870,19 @@ impl DescribeReceiptRuleSetResponseDeserializer {
     }
 }
 #[doc="<p>Represents the destination of the message, consisting of To:, CC:, and BCC: fields.</p> <p> By default, the string must be 7-bit ASCII. If the text must contain any other characters, then you must use MIME encoded-word syntax (RFC 2047) instead of a literal string. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>. For more information, see <a href=\"http://tools.ietf.org/html/rfc2047\">RFC 2047</a>. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Destination {
     #[doc="<p>The BCC: field(s) of the message.</p>"]
+    #[serde(rename="BccAddresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bcc_addresses: Option<Vec<String>>,
     #[doc="<p>The CC: field(s) of the message.</p>"]
+    #[serde(rename="CcAddresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cc_addresses: Option<Vec<String>>,
     #[doc="<p>The To: field(s) of the message.</p>"]
+    #[serde(rename="ToAddresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub to_addresses: Option<Vec<String>>,
 }
 
@@ -1906,19 +1982,29 @@ impl EnabledDeserializer {
     }
 }
 #[doc="<p>Contains information about the event destination to which the specified email sending events are published.</p> <note> <p>When you create or update an event destination, you must provide one, and only one, destination. The destination can be Amazon CloudWatch, Amazon Kinesis Firehose or Amazon Simple Notification Service (Amazon SNS).</p> </note> <p>Event destinations are associated with configuration sets, which enable you to publish email sending events to Amazon CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS). For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EventDestination {
     #[doc="<p>An object that contains the names, default values, and sources of the dimensions associated with an Amazon CloudWatch event destination.</p>"]
+    #[serde(rename="CloudWatchDestination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub cloud_watch_destination: Option<CloudWatchDestination>,
     #[doc="<p>Sets whether Amazon SES publishes events to this destination when you send an email with the associated configuration set. Set to <code>true</code> to enable publishing to this destination; set to <code>false</code> to prevent publishing to this destination. The default value is <code>false</code>.</p>"]
+    #[serde(rename="Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled: Option<bool>,
     #[doc="<p>An object that contains the delivery stream ARN and the IAM role ARN associated with an Amazon Kinesis Firehose event destination.</p>"]
+    #[serde(rename="KinesisFirehoseDestination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kinesis_firehose_destination: Option<KinesisFirehoseDestination>,
     #[doc="<p>The type of email sending events to publish to the event destination.</p>"]
+    #[serde(rename="MatchingEventTypes")]
     pub matching_event_types: Vec<String>,
     #[doc="<p>The name of the event destination. The name must:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>An object that contains the topic ARN associated with an Amazon Simple Notification Service (Amazon SNS) event destination.</p>"]
+    #[serde(rename="SNSDestination")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sns_destination: Option<SNSDestination>,
 }
 
@@ -2151,11 +2237,13 @@ impl EventTypesSerializer {
 }
 
 #[doc="<p>Additional X-headers to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExtensionField {
     #[doc="<p>The name of the header to add. Must be between 1 and 50 characters, inclusive, and consist of alphanumeric (a-z, A-Z, 0-9) characters and dashes only.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The value of the header to add. Must be less than 2048 characters, and must not contain newline characters (\"\\r\" or \"\\n\").</p>"]
+    #[serde(rename="Value")]
     pub value: String,
 }
 
@@ -2190,9 +2278,10 @@ impl ExtensionFieldListSerializer {
 }
 
 #[doc="<p>Represents a request for the status of Amazon SES Easy DKIM signing for an identity. For domain identities, this request also returns the DKIM tokens that are required for Easy DKIM signing, and whether Amazon SES successfully verified that these tokens were published. For more information about Easy DKIM, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityDkimAttributesRequest {
     #[doc="<p>A list of one or more verified identities - email addresses, domains, or both.</p>"]
+    #[serde(rename="Identities")]
     pub identities: Vec<String>,
 }
 
@@ -2214,9 +2303,10 @@ impl GetIdentityDkimAttributesRequestSerializer {
 }
 
 #[doc="<p>Represents the status of Amazon SES Easy DKIM signing for an identity. For domain identities, this response also contains the DKIM tokens that are required for Easy DKIM signing, and whether Amazon SES successfully verified that these tokens were published.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityDkimAttributesResponse {
     #[doc="<p>The DKIM attributes for an email address or a domain.</p>"]
+    #[serde(rename="DkimAttributes")]
     pub dkim_attributes: ::std::collections::HashMap<String, IdentityDkimAttributes>,
 }
 
@@ -2265,9 +2355,10 @@ impl GetIdentityDkimAttributesResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to return the Amazon SES custom MAIL FROM attributes for a list of identities. For information about using a custom MAIL FROM domain, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityMailFromDomainAttributesRequest {
     #[doc="<p>A list of one or more identities.</p>"]
+    #[serde(rename="Identities")]
     pub identities: Vec<String>,
 }
 
@@ -2291,9 +2382,10 @@ impl GetIdentityMailFromDomainAttributesRequestSerializer {
 }
 
 #[doc="<p>Represents the custom MAIL FROM attributes for a list of identities.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityMailFromDomainAttributesResponse {
     #[doc="<p>A map of identities to custom MAIL FROM attributes.</p>"]
+    #[serde(rename="MailFromDomainAttributes")]
     pub mail_from_domain_attributes:
         ::std::collections::HashMap<String, IdentityMailFromDomainAttributes>,
 }
@@ -2343,9 +2435,10 @@ impl GetIdentityMailFromDomainAttributesResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to return the notification attributes for a list of identities you verified with Amazon SES. For information about Amazon SES notifications, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityNotificationAttributesRequest {
     #[doc="<p>A list of one or more identities. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p>"]
+    #[serde(rename="Identities")]
     pub identities: Vec<String>,
 }
 
@@ -2367,9 +2460,10 @@ impl GetIdentityNotificationAttributesRequestSerializer {
 }
 
 #[doc="<p>Represents the notification attributes for a list of identities.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityNotificationAttributesResponse {
     #[doc="<p>A map of Identity to IdentityNotificationAttributes.</p>"]
+    #[serde(rename="NotificationAttributes")]
     pub notification_attributes:
         ::std::collections::HashMap<String, IdentityNotificationAttributes>,
 }
@@ -2419,11 +2513,13 @@ impl GetIdentityNotificationAttributesResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to return the requested sending authorization policies for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityPoliciesRequest {
     #[doc="<p>The identity for which the policies will be retrieved. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>"]
+    #[serde(rename="Identity")]
     pub identity: String,
     #[doc="<p>A list of the names of policies to be retrieved. You can retrieve a maximum of 20 policies at a time. If you do not know the names of the policies that are attached to the identity, you can use <code>ListIdentityPolicies</code>.</p>"]
+    #[serde(rename="PolicyNames")]
     pub policy_names: Vec<String>,
 }
 
@@ -2447,9 +2543,10 @@ impl GetIdentityPoliciesRequestSerializer {
 }
 
 #[doc="<p>Represents the requested sending authorization policies.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityPoliciesResponse {
     #[doc="<p>A map of policy names to policies.</p>"]
+    #[serde(rename="Policies")]
     pub policies: ::std::collections::HashMap<String, String>,
 }
 
@@ -2496,9 +2593,10 @@ impl GetIdentityPoliciesResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to return the Amazon SES verification status of a list of identities. For domain identities, this request also returns the verification token. For information about verifying identities with Amazon SES, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityVerificationAttributesRequest {
     #[doc="<p>A list of identities.</p>"]
+    #[serde(rename="Identities")]
     pub identities: Vec<String>,
 }
 
@@ -2520,9 +2618,10 @@ impl GetIdentityVerificationAttributesRequestSerializer {
 }
 
 #[doc="<p>The Amazon SES verification status of a list of identities. For domain identities, this response also contains the verification token.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIdentityVerificationAttributesResponse {
     #[doc="<p>A map of Identities to IdentityVerificationAttributes objects.</p>"]
+    #[serde(rename="VerificationAttributes")]
     pub verification_attributes:
         ::std::collections::HashMap<String, IdentityVerificationAttributes>,
 }
@@ -2572,13 +2671,19 @@ impl GetIdentityVerificationAttributesResponseDeserializer {
     }
 }
 #[doc="<p>Represents your Amazon SES daily sending quota, maximum send rate, and the number of emails you have sent in the last 24 hours.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSendQuotaResponse {
     #[doc="<p>The maximum number of emails the user is allowed to send in a 24-hour interval. A value of -1 signifies an unlimited quota.</p>"]
+    #[serde(rename="Max24HourSend")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_24_hour_send: Option<f64>,
     #[doc="<p>The maximum number of emails that Amazon SES can accept from the user's account per second.</p> <note> <p>The rate at which Amazon SES accepts the user's messages might be less than the maximum send rate.</p> </note>"]
+    #[serde(rename="MaxSendRate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_send_rate: Option<f64>,
     #[doc="<p>The number of emails sent during the previous 24 hours.</p>"]
+    #[serde(rename="SentLast24Hours")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sent_last_24_hours: Option<f64>,
 }
 
@@ -2636,9 +2741,11 @@ impl GetSendQuotaResponseDeserializer {
     }
 }
 #[doc="<p>Represents a list of data points. This list contains aggregated data from the previous two weeks of your sending activity with Amazon SES.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSendStatisticsResponse {
     #[doc="<p>A list of data points, each of which represents 15 minutes of activity.</p>"]
+    #[serde(rename="SendDataPoints")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub send_data_points: Option<Vec<SendDataPoint>>,
 }
 
@@ -2728,13 +2835,17 @@ impl IdentityDeserializer {
     }
 }
 #[doc="<p>Represents the DKIM attributes of a verified email address or a domain.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IdentityDkimAttributes {
     #[doc="<p>True if DKIM signing is enabled for email sent from the identity; false otherwise. The default value is true.</p>"]
+    #[serde(rename="DkimEnabled")]
     pub dkim_enabled: bool,
     #[doc="<p>A set of character strings that represent the domain's identity. Using these tokens, you will need to create DNS CNAME records that point to DKIM public keys hosted by Amazon SES. Amazon Web Services will eventually detect that you have updated your DNS records; this detection process may take up to 72 hours. Upon successful detection, Amazon SES will be able to DKIM-sign email originating from that domain. (This only applies to domain identities, not email address identities.)</p> <p>For more information about creating DNS records using DKIM tokens, go to the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim-dns-records.html\">Amazon SES Developer Guide</a>.</p>"]
+    #[serde(rename="DkimTokens")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub dkim_tokens: Option<Vec<String>>,
     #[doc="<p>Describes whether Amazon SES has successfully verified the DKIM DNS records (tokens) published in the domain name's DNS. (This only applies to domain identities, not email address identities.)</p>"]
+    #[serde(rename="DkimVerificationStatus")]
     pub dkim_verification_status: String,
 }
 
@@ -2844,13 +2955,16 @@ impl IdentityListSerializer {
 }
 
 #[doc="<p>Represents the custom MAIL FROM domain attributes of a verified identity (email address or domain).</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IdentityMailFromDomainAttributes {
     #[doc="<p>The action that Amazon SES takes if it cannot successfully read the required MX record when you send an email. A value of <code>UseDefaultValue</code> indicates that if Amazon SES cannot read the required MX record, it uses amazonses.com (or a subdomain of that) as the MAIL FROM domain. A value of <code>RejectMessage</code> indicates that if Amazon SES cannot read the required MX record, Amazon SES returns a <code>MailFromDomainNotVerified</code> error and does not send the email.</p> <p>The custom MAIL FROM setup states that result in this behavior are <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code>.</p>"]
+    #[serde(rename="BehaviorOnMXFailure")]
     pub behavior_on_mx_failure: String,
     #[doc="<p>The custom MAIL FROM domain that the identity is configured to use.</p>"]
+    #[serde(rename="MailFromDomain")]
     pub mail_from_domain: String,
     #[doc="<p>The state that indicates whether Amazon SES has successfully read the MX record required for custom MAIL FROM domain setup. If the state is <code>Success</code>, Amazon SES uses the specified custom MAIL FROM domain when the verified identity sends an email. All other states indicate that Amazon SES takes the action described by <code>BehaviorOnMXFailure</code>.</p>"]
+    #[serde(rename="MailFromDomainStatus")]
     pub mail_from_domain_status: String,
 }
 
@@ -2909,21 +3023,31 @@ impl IdentityMailFromDomainAttributesDeserializer {
     }
 }
 #[doc="<p>Represents the notification attributes of an identity, including whether an identity has Amazon Simple Notification Service (Amazon SNS) topics set for bounce, complaint, and/or delivery notifications, and whether feedback forwarding is enabled for bounce and complaint notifications.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IdentityNotificationAttributes {
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic where Amazon SES will publish bounce notifications.</p>"]
+    #[serde(rename="BounceTopic")]
     pub bounce_topic: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic where Amazon SES will publish complaint notifications.</p>"]
+    #[serde(rename="ComplaintTopic")]
     pub complaint_topic: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic where Amazon SES will publish delivery notifications.</p>"]
+    #[serde(rename="DeliveryTopic")]
     pub delivery_topic: String,
     #[doc="<p>Describes whether Amazon SES will forward bounce and complaint notifications as email. <code>true</code> indicates that Amazon SES will forward bounce and complaint notifications as email, while <code>false</code> indicates that bounce and complaint notifications will be published only to the specified bounce and complaint Amazon SNS topics.</p>"]
+    #[serde(rename="ForwardingEnabled")]
     pub forwarding_enabled: bool,
     #[doc="<p>Describes whether Amazon SES includes the original email headers in Amazon SNS notifications of type <code>Bounce</code>. A value of <code>true</code> specifies that Amazon SES will include headers in bounce notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in bounce notifications.</p>"]
+    #[serde(rename="HeadersInBounceNotificationsEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub headers_in_bounce_notifications_enabled: Option<bool>,
     #[doc="<p>Describes whether Amazon SES includes the original email headers in Amazon SNS notifications of type <code>Complaint</code>. A value of <code>true</code> specifies that Amazon SES will include headers in complaint notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in complaint notifications.</p>"]
+    #[serde(rename="HeadersInComplaintNotificationsEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub headers_in_complaint_notifications_enabled: Option<bool>,
     #[doc="<p>Describes whether Amazon SES includes the original email headers in Amazon SNS notifications of type <code>Delivery</code>. A value of <code>true</code> specifies that Amazon SES will include headers in delivery notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in delivery notifications.</p>"]
+    #[serde(rename="HeadersInDeliveryNotificationsEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub headers_in_delivery_notifications_enabled: Option<bool>,
 }
 
@@ -3000,11 +3124,14 @@ impl IdentityNotificationAttributesDeserializer {
     }
 }
 #[doc="<p>Represents the verification attributes of a single identity.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IdentityVerificationAttributes {
     #[doc="<p>The verification status of the identity: \"Pending\", \"Success\", \"Failed\", or \"TemporaryFailure\".</p>"]
+    #[serde(rename="VerificationStatus")]
     pub verification_status: String,
     #[doc="<p>The verification token for a domain identity. Null for email address identities.</p>"]
+    #[serde(rename="VerificationToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub verification_token: Option<String>,
 }
 
@@ -3071,11 +3198,13 @@ impl InvocationTypeDeserializer {
     }
 }
 #[doc="<p>Contains the delivery stream ARN and the IAM role ARN associated with an Amazon Kinesis Firehose event destination.</p> <p>Event destinations, such as Amazon Kinesis Firehose, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct KinesisFirehoseDestination {
     #[doc="<p>The ARN of the Amazon Kinesis Firehose stream to which to publish email sending events.</p>"]
+    #[serde(rename="DeliveryStreamARN")]
     pub delivery_stream_arn: String,
     #[doc="<p>The ARN of the IAM role under which Amazon SES publishes email sending events to the Amazon Kinesis Firehose stream.</p>"]
+    #[serde(rename="IAMRoleARN")]
     pub iam_role_arn: String,
 }
 
@@ -3146,13 +3275,18 @@ impl KinesisFirehoseDestinationSerializer {
 }
 
 #[doc="<p>When included in a receipt rule, this action calls an AWS Lambda function and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>To enable Amazon SES to call your AWS Lambda function or to publish to an Amazon SNS topic of another account, Amazon SES must have permission to access those resources. For information about giving permissions, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\">Amazon SES Developer Guide</a>.</p> <p>For information about using AWS Lambda actions in receipt rules, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-lambda.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaAction {
     #[doc="<p>The Amazon Resource Name (ARN) of the AWS Lambda function. An example of an AWS Lambda function ARN is <code>arn:aws:lambda:us-west-2:account-id:function:MyFunction</code>. For more information about AWS Lambda, see the <a href=\"http://docs.aws.amazon.com/lambda/latest/dg/welcome.html\">AWS Lambda Developer Guide</a>.</p>"]
+    #[serde(rename="FunctionArn")]
     pub function_arn: String,
     #[doc="<p>The invocation type of the AWS Lambda function. An invocation type of <code>RequestResponse</code> means that the execution of the function will immediately result in a response, and a value of <code>Event</code> means that the function will be invoked asynchronously. The default value is <code>Event</code>. For information about AWS Lambda invocation types, see the <a href=\"http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html\">AWS Lambda Developer Guide</a>.</p> <important> <p>There is a 30-second timeout on <code>RequestResponse</code> invocations. You should use <code>Event</code> invocation in most cases. Use <code>RequestResponse</code> only when you want to make a mail flow decision, such as whether to stop the receipt rule or the receipt rule set.</p> </important>"]
+    #[serde(rename="InvocationType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub invocation_type: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the Lambda action is taken. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\"http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\">Amazon SNS Developer Guide</a>.</p>"]
+    #[serde(rename="TopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
 }
 
@@ -3234,11 +3368,15 @@ impl LambdaActionSerializer {
 }
 
 #[doc="<p>Represents a request to list the configuration sets associated with your AWS account. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListConfigurationSetsRequest {
     #[doc="<p>The number of configuration sets to return.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>A token returned from a previous call to <code>ListConfigurationSets</code> to indicate the position of the configuration set in the configuration set list.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3265,11 +3403,15 @@ impl ListConfigurationSetsRequestSerializer {
 }
 
 #[doc="<p>A list of configuration sets associated with your AWS account. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListConfigurationSetsResponse {
     #[doc="<p>A list of configuration sets.</p>"]
+    #[serde(rename="ConfigurationSets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub configuration_sets: Option<Vec<ConfigurationSet>>,
     #[doc="<p>A token indicating that there are additional configuration sets available to be listed. Pass this token to successive calls of <code>ListConfigurationSets</code>. </p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3321,13 +3463,19 @@ impl ListConfigurationSetsResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to return a list of all identities (email addresses and domains) that you have attempted to verify under your AWS account, regardless of verification status.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentitiesRequest {
     #[doc="<p>The type of the identities to list. Possible values are \"EmailAddress\" and \"Domain\". If this parameter is omitted, then all identities will be listed.</p>"]
+    #[serde(rename="IdentityType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub identity_type: Option<String>,
     #[doc="<p>The maximum number of identities per page. Possible values are 1-1000 inclusive.</p>"]
+    #[serde(rename="MaxItems")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_items: Option<i64>,
     #[doc="<p>The token to use for pagination.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3358,11 +3506,14 @@ impl ListIdentitiesRequestSerializer {
 }
 
 #[doc="<p>A list of all identities that you have attempted to verify under your AWS account, regardless of verification status.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentitiesResponse {
     #[doc="<p>A list of identities.</p>"]
+    #[serde(rename="Identities")]
     pub identities: Vec<String>,
     #[doc="<p>The token used for pagination.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3413,9 +3564,10 @@ impl ListIdentitiesResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to return a list of sending authorization policies that are attached to an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentityPoliciesRequest {
     #[doc="<p>The identity that is associated with the policy for which the policies will be listed. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>"]
+    #[serde(rename="Identity")]
     pub identity: String,
 }
 
@@ -3436,9 +3588,10 @@ impl ListIdentityPoliciesRequestSerializer {
 }
 
 #[doc="<p>A list of names of sending authorization policies that apply to an identity.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIdentityPoliciesResponse {
     #[doc="<p>A list of names of policies that apply to the specified identity.</p>"]
+    #[serde(rename="PolicyNames")]
     pub policy_names: Vec<String>,
 }
 
@@ -3485,7 +3638,7 @@ impl ListIdentityPoliciesResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to list the IP address filters that exist under your AWS account. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListReceiptFiltersRequest;
 
 
@@ -3504,9 +3657,11 @@ impl ListReceiptFiltersRequestSerializer {
 }
 
 #[doc="<p>A list of IP address filters that exist under your AWS account.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListReceiptFiltersResponse {
     #[doc="<p>A list of IP address filter data structures, which each consist of a name, an IP address range, and whether to allow or block mail from it.</p>"]
+    #[serde(rename="Filters")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub filters: Option<Vec<ReceiptFilter>>,
 }
 
@@ -3554,9 +3709,11 @@ impl ListReceiptFiltersResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to list the receipt rule sets that exist under your AWS account. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListReceiptRuleSetsRequest {
     #[doc="<p>A token returned from a previous call to <code>ListReceiptRuleSets</code> to indicate the position in the receipt rule set list.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -3579,11 +3736,15 @@ impl ListReceiptRuleSetsRequestSerializer {
 }
 
 #[doc="<p>A list of receipt rule sets that exist under your AWS account.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListReceiptRuleSetsResponse {
     #[doc="<p>A token indicating that there are additional receipt rule sets available to be listed. Pass this token to successive calls of <code>ListReceiptRuleSets</code> to retrieve up to 100 receipt rule sets at a time.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The metadata for the currently active receipt rule set. The metadata consists of the rule set name and the timestamp of when the rule set was created.</p>"]
+    #[serde(rename="RuleSets")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rule_sets: Option<Vec<ReceiptRuleSetMetadata>>,
 }
 
@@ -3635,9 +3796,11 @@ impl ListReceiptRuleSetsResponseDeserializer {
     }
 }
 #[doc="<p>A list of email addresses that you have verified with Amazon SES under your AWS account.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVerifiedEmailAddressesResponse {
     #[doc="<p>A list of email addresses that have been verified.</p>"]
+    #[serde(rename="VerifiedEmailAddresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub verified_email_addresses: Option<Vec<String>>,
 }
 
@@ -3754,11 +3917,13 @@ impl MaxSendRateDeserializer {
     }
 }
 #[doc="<p>Represents the message to be sent, composed of a subject and a body.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Message {
     #[doc="<p>The message body.</p>"]
+    #[serde(rename="Body")]
     pub body: Body,
     #[doc="<p>The subject of the message: A short summary of the content, which will appear in the recipient's inbox.</p>"]
+    #[serde(rename="Subject")]
     pub subject: Content,
 }
 
@@ -3779,13 +3944,18 @@ impl MessageSerializer {
 }
 
 #[doc="<p>Message-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MessageDsn {
     #[doc="<p>When the message was received by the reporting mail transfer agent (MTA), in <a href=\"https://www.ietf.org/rfc/rfc0822.txt\">RFC 822</a> date-time format.</p>"]
+    #[serde(rename="ArrivalDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arrival_date: Option<String>,
     #[doc="<p>Additional X-headers to include in the DSN.</p>"]
+    #[serde(rename="ExtensionFields")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub extension_fields: Option<Vec<ExtensionField>>,
     #[doc="<p>The reporting MTA that attempted to deliver the message, formatted as specified in <a href=\"https://tools.ietf.org/html/rfc3464\">RFC 3464</a> (<code>mta-name-type; mta-name</code>). The default value is <code>dns; inbound-smtp.[region].amazonaws.com</code>.</p>"]
+    #[serde(rename="ReportingMta")]
     pub reporting_mta: String,
 }
 
@@ -3829,11 +3999,13 @@ impl MessageIdDeserializer {
     }
 }
 #[doc="<p>Contains the name and value of a tag that you can provide to <code>SendEmail</code> or <code>SendRawEmail</code> to apply to an email.</p> <p>Message tags, which you use with configuration sets, enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MessageTag {
     #[doc="<p>The name of the tag. The name must:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 256 characters.</p> </li> </ul>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The value of the tag. The value must:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 256 characters.</p> </li> </ul>"]
+    #[serde(rename="Value")]
     pub value: String,
 }
 
@@ -4027,13 +4199,16 @@ impl PolicyNameListSerializer {
 }
 
 #[doc="<p>Represents a request to add or update a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutIdentityPolicyRequest {
     #[doc="<p>The identity to which the policy will apply. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>"]
+    #[serde(rename="Identity")]
     pub identity: String,
     #[doc="<p>The text of the policy in JSON format. The policy cannot exceed 4 KB.</p> <p>For information about the syntax of sending authorization policies, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html\">Amazon SES Developer Guide</a>. </p>"]
+    #[serde(rename="Policy")]
     pub policy: String,
     #[doc="<p>The name of the policy.</p> <p>The policy name cannot exceed 64 characters and can only include alphanumeric characters, dashes, and underscores.</p>"]
+    #[serde(rename="PolicyName")]
     pub policy_name: String,
 }
 
@@ -4058,7 +4233,7 @@ impl PutIdentityPolicyRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutIdentityPolicyResponse;
 
 struct PutIdentityPolicyResponseDeserializer;
@@ -4078,9 +4253,15 @@ impl PutIdentityPolicyResponseDeserializer {
     }
 }
 #[doc="<p>Represents the raw data of the message.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RawMessage {
     #[doc="<p>The raw data of the message. This data needs to base64-encoded if you are accessing Amazon SES directly through the HTTPS interface. If you are accessing Amazon SES using an AWS SDK, the SDK takes care of the base 64-encoding for you. In all cases, the client must ensure that the message format complies with Internet email standards regarding email header fields, MIME types, and MIME encoding.</p> <p>The To:, CC:, and BCC: headers in the raw message can contain a group list.</p> <p>If you are using <code>SendRawEmail</code> with sending authorization, you can include X-headers in the raw message to specify the \"Source,\" \"From,\" and \"Return-Path\" addresses. For more information, see the documentation for <code>SendRawEmail</code>. </p> <important> <p>Do not include these X-headers in the DKIM signature, because they are removed by Amazon SES before sending the email.</p> </important> <p>For more information, go to the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html\">Amazon SES Developer Guide</a>. </p>"]
+    #[serde(rename="Data")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub data: Vec<u8>,
 }
 
@@ -4103,21 +4284,35 @@ impl RawMessageSerializer {
 }
 
 #[doc="<p>An action that Amazon SES can take when it receives an email on behalf of one or more email addresses or domains that you own. An instance of this data type can represent only one action.</p> <p>For information about setting up receipt rules, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReceiptAction {
     #[doc="<p>Adds a header to the received email.</p>"]
+    #[serde(rename="AddHeaderAction")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub add_header_action: Option<AddHeaderAction>,
     #[doc="<p>Rejects the received email by returning a bounce response to the sender and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p>"]
+    #[serde(rename="BounceAction")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bounce_action: Option<BounceAction>,
     #[doc="<p>Calls an AWS Lambda function, and optionally, publishes a notification to Amazon SNS.</p>"]
+    #[serde(rename="LambdaAction")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub lambda_action: Option<LambdaAction>,
     #[doc="<p>Saves the received message to an Amazon Simple Storage Service (Amazon S3) bucket and, optionally, publishes a notification to Amazon SNS.</p>"]
+    #[serde(rename="S3Action")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub s3_action: Option<S3Action>,
     #[doc="<p>Publishes the email content within a notification to Amazon SNS.</p>"]
+    #[serde(rename="SNSAction")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sns_action: Option<SNSAction>,
     #[doc="<p>Terminates the evaluation of the receipt rule set and optionally publishes a notification to Amazon SNS.</p>"]
+    #[serde(rename="StopAction")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub stop_action: Option<StopAction>,
     #[doc="<p>Calls Amazon WorkMail and, optionally, publishes a notification to Amazon SNS.</p>"]
+    #[serde(rename="WorkmailAction")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub workmail_action: Option<WorkmailAction>,
 }
 
@@ -4295,11 +4490,13 @@ impl ReceiptActionsListSerializer {
 }
 
 #[doc="<p>A receipt IP address filter enables you to specify whether to accept or reject mail originating from an IP address or range of IP addresses.</p> <p>For information about setting up IP address filters, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReceiptFilter {
     #[doc="<p>A structure that provides the IP addresses to block or allow, and whether to block or allow incoming mail from them.</p>"]
+    #[serde(rename="IpFilter")]
     pub ip_filter: ReceiptIpFilter,
     #[doc="<p>The name of the IP address filter. The name must:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores (_), or dashes (-).</p> </li> <li> <p>Start and end with a letter or number.</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>"]
+    #[serde(rename="Name")]
     pub name: String,
 }
 
@@ -4438,11 +4635,13 @@ impl ReceiptFilterPolicyDeserializer {
     }
 }
 #[doc="<p>A receipt IP address filter enables you to specify whether to accept or reject mail originating from an IP address or range of IP addresses.</p> <p>For information about setting up IP address filters, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReceiptIpFilter {
     #[doc="<p>A single IP address or a range of IP addresses that you want to block or allow, specified in Classless Inter-Domain Routing (CIDR) notation. An example of a single email address is 10.0.0.1. An example of a range of IP addresses is 10.0.0.1/24. For more information about CIDR notation, see <a href=\"https://tools.ietf.org/html/rfc2317\">RFC 2317</a>.</p>"]
+    #[serde(rename="Cidr")]
     pub cidr: String,
     #[doc="<p>Indicates whether to block or allow incoming mail from the specified IP addresses.</p>"]
+    #[serde(rename="Policy")]
     pub policy: String,
 }
 
@@ -4510,19 +4709,30 @@ impl ReceiptIpFilterSerializer {
 }
 
 #[doc="<p>Receipt rules enable you to specify which actions Amazon SES should take when it receives mail on behalf of one or more email addresses or domains that you own.</p> <p>Each receipt rule defines a set of email addresses or domains to which it applies. If the email addresses or domains match at least one recipient address of the message, Amazon SES executes all of the receipt rule's actions on the message.</p> <p>For information about setting up receipt rules, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReceiptRule {
     #[doc="<p>An ordered list of actions to perform on messages that match at least one of the recipient email addresses or domains specified in the receipt rule.</p>"]
+    #[serde(rename="Actions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub actions: Option<Vec<ReceiptAction>>,
     #[doc="<p>If <code>true</code>, the receipt rule is active. The default value is <code>false</code>.</p>"]
+    #[serde(rename="Enabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub enabled: Option<bool>,
     #[doc="<p>The name of the receipt rule. The name must:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores (_), or dashes (-).</p> </li> <li> <p>Start and end with a letter or number.</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The recipient domains and email addresses to which the receipt rule applies. If this field is not specified, this rule will match all recipients under all verified domains.</p>"]
+    #[serde(rename="Recipients")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub recipients: Option<Vec<String>>,
     #[doc="<p>If <code>true</code>, then messages to which this receipt rule applies are scanned for spam and viruses. The default value is <code>false</code>.</p>"]
+    #[serde(rename="ScanEnabled")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub scan_enabled: Option<bool>,
     #[doc="<p>Specifies whether Amazon SES should require that incoming email is delivered over a connection encrypted with Transport Layer Security (TLS). If this parameter is set to <code>Require</code>, Amazon SES will bounce emails that are not received over TLS. The default is <code>Optional</code>.</p>"]
+    #[serde(rename="TlsPolicy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tls_policy: Option<String>,
 }
 
@@ -4655,11 +4865,15 @@ impl ReceiptRuleNamesListSerializer {
 }
 
 #[doc="<p>Information about a receipt rule set.</p> <p>A receipt rule set is a collection of rules that specify what Amazon SES should do with mail it receives on behalf of your account's verified domains.</p> <p>For information about setting up receipt rule sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReceiptRuleSetMetadata {
     #[doc="<p>The date and time the receipt rule set was created.</p>"]
+    #[serde(rename="CreatedTimestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub created_timestamp: Option<String>,
     #[doc="<p>The name of the receipt rule set. The name must:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores (_), or dashes (-).</p> </li> <li> <p>Start and end with a letter or number.</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>"]
+    #[serde(rename="Name")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -4823,21 +5037,33 @@ impl RecipientDeserializer {
     }
 }
 #[doc="<p>Recipient-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecipientDsnFields {
     #[doc="<p>The action performed by the reporting mail transfer agent (MTA) as a result of its attempt to deliver the message to the recipient address. This is required by <a href=\"https://tools.ietf.org/html/rfc3464\">RFC 3464</a>.</p>"]
+    #[serde(rename="Action")]
     pub action: String,
     #[doc="<p>An extended explanation of what went wrong; this is usually an SMTP response. See <a href=\"https://tools.ietf.org/html/rfc3463\">RFC 3463</a> for the correct formatting of this parameter.</p>"]
+    #[serde(rename="DiagnosticCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub diagnostic_code: Option<String>,
     #[doc="<p>Additional X-headers to include in the DSN.</p>"]
+    #[serde(rename="ExtensionFields")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub extension_fields: Option<Vec<ExtensionField>>,
     #[doc="<p>The email address to which the message was ultimately delivered. This corresponds to the <code>Final-Recipient</code> in the DSN. If not specified, <code>FinalRecipient</code> will be set to the <code>Recipient</code> specified in the <code>BouncedRecipientInfo</code> structure. Either <code>FinalRecipient</code> or the recipient in <code>BouncedRecipientInfo</code> must be a recipient of the original bounced message.</p> <note> <p>Do not prepend the <code>FinalRecipient</code> email address with <code>rfc 822;</code>, as described in <a href=\"https://tools.ietf.org/html/rfc3798\">RFC 3798</a>.</p> </note>"]
+    #[serde(rename="FinalRecipient")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub final_recipient: Option<String>,
     #[doc="<p>The time the final delivery attempt was made, in <a href=\"https://www.ietf.org/rfc/rfc0822.txt\">RFC 822</a> date-time format.</p>"]
+    #[serde(rename="LastAttemptDate")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub last_attempt_date: Option<String>,
     #[doc="<p>The MTA to which the remote MTA attempted to deliver the message, formatted as specified in <a href=\"https://tools.ietf.org/html/rfc3464\">RFC 3464</a> (<code>mta-name-type; mta-name</code>). This parameter typically applies only to propagating synchronous bounces.</p>"]
+    #[serde(rename="RemoteMta")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub remote_mta: Option<String>,
     #[doc="<p>The status code that indicates what went wrong. This is required by <a href=\"https://tools.ietf.org/html/rfc3464\">RFC 3464</a>.</p>"]
+    #[serde(rename="Status")]
     pub status: String,
 }
 
@@ -4934,11 +5160,13 @@ impl RecipientsListSerializer {
 }
 
 #[doc="<p>Represents a request to reorder the receipt rules within a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReorderReceiptRuleSetRequest {
     #[doc="<p>A list of the specified receipt rule set's receipt rules in the order that you want to put them.</p>"]
+    #[serde(rename="RuleNames")]
     pub rule_names: Vec<String>,
     #[doc="<p>The name of the receipt rule set to reorder.</p>"]
+    #[serde(rename="RuleSetName")]
     pub rule_set_name: String,
 }
 
@@ -4962,7 +5190,7 @@ impl ReorderReceiptRuleSetRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReorderReceiptRuleSetResponse;
 
 struct ReorderReceiptRuleSetResponseDeserializer;
@@ -4982,15 +5210,22 @@ impl ReorderReceiptRuleSetResponseDeserializer {
     }
 }
 #[doc="<p>When included in a receipt rule, this action saves the received message to an Amazon Simple Storage Service (Amazon S3) bucket and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>To enable Amazon SES to write emails to your Amazon S3 bucket, use an AWS KMS key to encrypt your emails, or publish to an Amazon SNS topic of another account, Amazon SES must have permission to access those resources. For information about giving permissions, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\">Amazon SES Developer Guide</a>.</p> <note> <p>When you save your emails to an Amazon S3 bucket, the maximum email size (including headers) is 30 MB. Emails larger than that will bounce.</p> </note> <p>For information about specifying Amazon S3 actions in receipt rules, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-s3.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3Action {
     #[doc="<p>The name of the Amazon S3 bucket to which to save the received email.</p>"]
+    #[serde(rename="BucketName")]
     pub bucket_name: String,
     #[doc="<p>The customer master key that Amazon SES should use to encrypt your emails before saving them to the Amazon S3 bucket. You can use the default master key or a custom master key you created in AWS KMS as follows:</p> <ul> <li> <p>To use the default master key, provide an ARN in the form of <code>arn:aws:kms:REGION:ACCOUNT-ID-WITHOUT-HYPHENS:alias/aws/ses</code>. For example, if your AWS account ID is 123456789012 and you want to use the default master key in the US West (Oregon) region, the ARN of the default master key would be <code>arn:aws:kms:us-west-2:123456789012:alias/aws/ses</code>. If you use the default master key, you don't need to perform any extra steps to give Amazon SES permission to use the key.</p> </li> <li> <p>To use a custom master key you created in AWS KMS, provide the ARN of the master key and ensure that you add a statement to your key's policy to give Amazon SES permission to use it. For more information about giving permissions, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\">Amazon SES Developer Guide</a>.</p> </li> </ul> <p>For more information about key policies, see the <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html\">AWS KMS Developer Guide</a>. If you do not specify a master key, Amazon SES will not encrypt your emails.</p> <important> <p>Your mail is encrypted by Amazon SES using the Amazon S3 encryption client before the mail is submitted to Amazon S3 for storage. It is not encrypted using Amazon S3 server-side encryption. This means that you must use the Amazon S3 encryption client to decrypt the email after retrieving it from Amazon S3, as the service has no access to use your AWS KMS keys for decryption. This encryption client is currently available with the <a href=\"http://aws.amazon.com/sdk-for-java/\">AWS Java SDK</a> and <a href=\"http://aws.amazon.com/sdk-for-ruby/\">AWS Ruby SDK</a> only. For more information about client-side encryption using AWS KMS master keys, see the <a href=\"http://alpha-docs-aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html\">Amazon S3 Developer Guide</a>.</p> </important>"]
+    #[serde(rename="KmsKeyArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub kms_key_arn: Option<String>,
     #[doc="<p>The key prefix of the Amazon S3 bucket. The key prefix is similar to a directory name that enables you to store similar data under the same directory in a bucket.</p>"]
+    #[serde(rename="ObjectKeyPrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub object_key_prefix: Option<String>,
     #[doc="<p>The ARN of the Amazon SNS topic to notify when the message is saved to the Amazon S3 bucket. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\"http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\">Amazon SNS Developer Guide</a>.</p>"]
+    #[serde(rename="TopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
 }
 
@@ -5108,11 +5343,14 @@ impl S3KeyPrefixDeserializer {
     }
 }
 #[doc="<p>When included in a receipt rule, this action publishes a notification to Amazon Simple Notification Service (Amazon SNS). This action includes a complete copy of the email content in the Amazon SNS notifications. Amazon SNS notifications for all other actions simply provide information about the email. They do not include the email content itself.</p> <p>If you own the Amazon SNS topic, you don't need to do anything to give Amazon SES permission to publish emails to it. However, if you don't own the Amazon SNS topic, you need to attach a policy to the topic to give Amazon SES permissions to access it. For information about giving permissions, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\">Amazon SES Developer Guide</a>.</p> <important> <p>You can only publish emails that are 150 KB or less (including the header) to Amazon SNS. Larger emails will bounce. If you anticipate emails larger than 150 KB, use the S3 action instead.</p> </important> <p>For information about using a receipt rule to publish an Amazon SNS notification, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-sns.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SNSAction {
     #[doc="<p>The encoding to use for the email within the Amazon SNS notification. UTF-8 is easier to use, but may not preserve all special characters when a message was encoded with a different encoding format. Base64 preserves all special characters. The default value is UTF-8.</p>"]
+    #[serde(rename="Encoding")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub encoding: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\"http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\">Amazon SNS Developer Guide</a>.</p>"]
+    #[serde(rename="TopicArn")]
     pub topic_arn: String,
 }
 
@@ -5199,9 +5437,10 @@ impl SNSActionEncodingDeserializer {
     }
 }
 #[doc="<p>Contains the topic ARN associated with an Amazon Simple Notification Service (Amazon SNS) event destination.</p> <p>Event destinations, such as Amazon SNS, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SNSDestination {
     #[doc="<p>The ARN of the Amazon SNS topic to which you want to publish email sending events. An example of an Amazon SNS topic ARN is arn:aws:sns:us-west-2:123456789012:MyTopic. For more information about Amazon SNS topics, see the <a href=\"http://docs.aws.amazon.com/http:/alpha-docs-aws.amazon.com/sns/latest/dg/CreateTopic.html\"> <i>Amazon SNS Developer Guide</i> </a>.</p>"]
+    #[serde(rename="TopicARN")]
     pub topic_arn: String,
 }
 
@@ -5265,19 +5504,28 @@ impl SNSDestinationSerializer {
 }
 
 #[doc="<p>Represents a request to send a bounce message to the sender of an email you received through Amazon SES.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendBounceRequest {
     #[doc="<p>The address to use in the \"From\" header of the bounce message. This must be an identity that you have verified with Amazon SES.</p>"]
+    #[serde(rename="BounceSender")]
     pub bounce_sender: String,
     #[doc="<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the address in the \"From\" header of the bounce. For more information about sending authorization, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer Guide</a>.</p>"]
+    #[serde(rename="BounceSenderArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bounce_sender_arn: Option<String>,
     #[doc="<p>A list of recipients of the bounced message, including the information required to create the Delivery Status Notifications (DSNs) for the recipients. You must specify at least one <code>BouncedRecipientInfo</code> in the list.</p>"]
+    #[serde(rename="BouncedRecipientInfoList")]
     pub bounced_recipient_info_list: Vec<BouncedRecipientInfo>,
     #[doc="<p>Human-readable text for the bounce message to explain the failure. If not specified, the text will be auto-generated based on the bounced recipient information.</p>"]
+    #[serde(rename="Explanation")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub explanation: Option<String>,
     #[doc="<p>Message-related DSN fields. If not specified, Amazon SES will choose the values.</p>"]
+    #[serde(rename="MessageDsn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_dsn: Option<MessageDsn>,
     #[doc="<p>The message ID of the message to be bounced.</p>"]
+    #[serde(rename="OriginalMessageId")]
     pub original_message_id: String,
 }
 
@@ -5318,9 +5566,11 @@ impl SendBounceRequestSerializer {
 }
 
 #[doc="<p>Represents a unique message ID.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendBounceResponse {
     #[doc="<p>The message ID of the bounce message.</p>"]
+    #[serde(rename="MessageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_id: Option<String>,
 }
 
@@ -5367,17 +5617,27 @@ impl SendBounceResponseDeserializer {
     }
 }
 #[doc="<p>Represents sending statistics data. Each <code>SendDataPoint</code> contains statistics for a 15-minute period of sending activity. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendDataPoint {
     #[doc="<p>Number of emails that have bounced.</p>"]
+    #[serde(rename="Bounces")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub bounces: Option<i64>,
     #[doc="<p>Number of unwanted emails that were rejected by recipients.</p>"]
+    #[serde(rename="Complaints")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub complaints: Option<i64>,
     #[doc="<p>Number of emails that have been sent.</p>"]
+    #[serde(rename="DeliveryAttempts")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delivery_attempts: Option<i64>,
     #[doc="<p>Number of emails rejected by Amazon SES.</p>"]
+    #[serde(rename="Rejects")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rejects: Option<i64>,
     #[doc="<p>Time of the data point.</p>"]
+    #[serde(rename="Timestamp")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub timestamp: Option<String>,
 }
 
@@ -5482,25 +5742,40 @@ impl SendDataPointListDeserializer {
     }
 }
 #[doc="<p>Represents a request to send a single formatted email using Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-formatted.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendEmailRequest {
     #[doc="<p>The name of the configuration set to use when you send an email using <code>SendEmail</code>.</p>"]
+    #[serde(rename="ConfigurationSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub configuration_set_name: Option<String>,
     #[doc="<p>The destination for this email, composed of To:, CC:, and BCC: fields.</p>"]
+    #[serde(rename="Destination")]
     pub destination: Destination,
     #[doc="<p>The message to be sent.</p>"]
+    #[serde(rename="Message")]
     pub message: Message,
     #[doc="<p>The reply-to email address(es) for the message. If the recipient replies to the message, each reply-to address will receive the reply.</p>"]
+    #[serde(rename="ReplyToAddresses")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub reply_to_addresses: Option<Vec<String>>,
     #[doc="<p>The email address to which bounces and complaints are to be forwarded when feedback forwarding is enabled. If the message cannot be delivered to the recipient, then an error message will be returned from the recipient's ISP; this message will then be forwarded to the email address specified by the <code>ReturnPath</code> parameter. The <code>ReturnPath</code> parameter is never overwritten. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. </p>"]
+    #[serde(rename="ReturnPath")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_path: Option<String>,
     #[doc="<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>ReturnPath</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to use <code>feedback@example.com</code>, then you would specify the <code>ReturnPathArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>ReturnPath</code> to be <code>feedback@example.com</code>.</p> <p>For more information about sending authorization, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer Guide</a>. </p>"]
+    #[serde(rename="ReturnPathArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_path_arn: Option<String>,
     #[doc="<p>The email address that is sending the email. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. For information about verifying identities, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html\">Amazon SES Developer Guide</a>.</p> <p>If you are sending on behalf of another user and have been permitted to do so by a sending authorization policy, then you must also specify the <code>SourceArn</code> parameter. For more information about sending authorization, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer Guide</a>.</p> <p> In all cases, the email address must be 7-bit ASCII. If the text must contain any other characters, then you must use MIME encoded-word syntax (RFC 2047) instead of a literal string. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>. For more information, see <a href=\"http://tools.ietf.org/html/rfc2047\">RFC 2047</a>. </p>"]
+    #[serde(rename="Source")]
     pub source: String,
     #[doc="<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the <code>Source</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to send from <code>user@example.com</code>, then you would specify the <code>SourceArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>Source</code> to be <code>user@example.com</code>.</p> <p>For more information about sending authorization, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\">Amazon SES Developer Guide</a>. </p>"]
+    #[serde(rename="SourceArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_arn: Option<String>,
     #[doc="<p>A list of tags, in the form of name/value pairs, to apply to an email that you send using <code>SendEmail</code>. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<MessageTag>>,
 }
 
@@ -5551,9 +5826,10 @@ impl SendEmailRequestSerializer {
 }
 
 #[doc="<p>Represents a unique message ID.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendEmailResponse {
     #[doc="<p>The unique message identifier returned from the <code>SendEmail</code> action. </p>"]
+    #[serde(rename="MessageId")]
     pub message_id: String,
 }
 
@@ -5600,23 +5876,38 @@ impl SendEmailResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to send a single raw email using Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendRawEmailRequest {
     #[doc="<p>The name of the configuration set to use when you send an email using <code>SendRawEmail</code>.</p>"]
+    #[serde(rename="ConfigurationSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub configuration_set_name: Option<String>,
     #[doc="<p>A list of destinations for the message, consisting of To:, CC:, and BCC: addresses.</p>"]
+    #[serde(rename="Destinations")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub destinations: Option<Vec<String>>,
     #[doc="<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to specify a particular \"From\" address in the header of the raw email.</p> <p>Instead of using this parameter, you can use the X-header <code>X-SES-FROM-ARN</code> in the raw message of the email. If you use both the <code>FromArn</code> parameter and the corresponding X-header, Amazon SES uses the value of the <code>FromArn</code> parameter.</p> <note> <p>For information about when to use this parameter, see the description of <code>SendRawEmail</code> in this guide, or see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html\">Amazon SES Developer Guide</a>.</p> </note>"]
+    #[serde(rename="FromArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub from_arn: Option<String>,
     #[doc="<p>The raw text of the message. The client is responsible for ensuring the following:</p> <ul> <li> <p>Message must contain a header and a body, separated by a blank line.</p> </li> <li> <p>All required header fields must be present.</p> </li> <li> <p>Each part of a multipart MIME message must be formatted properly.</p> </li> <li> <p>MIME content types must be among those supported by Amazon SES. For more information, go to the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/mime-types.html\">Amazon SES Developer Guide</a>.</p> </li> <li> <p>Must be base64-encoded.</p> </li> <li> <p>Per <a href=\"https://tools.ietf.org/html/rfc5321#section-4.5.3.1.6\">RFC 5321</a>, the maximum length of each line of text, including the &lt;CRLF&gt;, must not exceed 1,000 characters.</p> </li> </ul>"]
+    #[serde(rename="RawMessage")]
     pub raw_message: RawMessage,
     #[doc="<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>ReturnPath</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to use <code>feedback@example.com</code>, then you would specify the <code>ReturnPathArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>ReturnPath</code> to be <code>feedback@example.com</code>.</p> <p>Instead of using this parameter, you can use the X-header <code>X-SES-RETURN-PATH-ARN</code> in the raw message of the email. If you use both the <code>ReturnPathArn</code> parameter and the corresponding X-header, Amazon SES uses the value of the <code>ReturnPathArn</code> parameter.</p> <note> <p>For information about when to use this parameter, see the description of <code>SendRawEmail</code> in this guide, or see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html\">Amazon SES Developer Guide</a>.</p> </note>"]
+    #[serde(rename="ReturnPathArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub return_path_arn: Option<String>,
     #[doc="<p>The identity's email address. If you do not provide a value for this parameter, you must specify a \"From\" address in the raw text of the message. (You can also specify both.)</p> <p> By default, the string must be 7-bit ASCII. If the text must contain any other characters, then you must use MIME encoded-word syntax (RFC 2047) instead of a literal string. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>. For more information, see <a href=\"http://tools.ietf.org/html/rfc2047\">RFC 2047</a>. </p> <note> <p>If you specify the <code>Source</code> parameter and have feedback forwarding enabled, then bounces and complaints will be sent to this email address. This takes precedence over any <i>Return-Path</i> header that you might include in the raw text of the message.</p> </note>"]
+    #[serde(rename="Source")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source: Option<String>,
     #[doc="<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the <code>Source</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to send from <code>user@example.com</code>, then you would specify the <code>SourceArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>Source</code> to be <code>user@example.com</code>.</p> <p>Instead of using this parameter, you can use the X-header <code>X-SES-SOURCE-ARN</code> in the raw message of the email. If you use both the <code>SourceArn</code> parameter and the corresponding X-header, Amazon SES uses the value of the <code>SourceArn</code> parameter.</p> <note> <p>For information about when to use this parameter, see the description of <code>SendRawEmail</code> in this guide, or see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html\">Amazon SES Developer Guide</a>.</p> </note>"]
+    #[serde(rename="SourceArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub source_arn: Option<String>,
     #[doc="<p>A list of tags, in the form of name/value pairs, to apply to an email that you send using <code>SendRawEmail</code>. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>"]
+    #[serde(rename="Tags")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<MessageTag>>,
 }
 
@@ -5668,9 +5959,10 @@ impl SendRawEmailRequestSerializer {
 }
 
 #[doc="<p>Represents a unique message ID.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendRawEmailResponse {
     #[doc="<p>The unique message identifier returned from the <code>SendRawEmail</code> action. </p>"]
+    #[serde(rename="MessageId")]
     pub message_id: String,
 }
 
@@ -5731,9 +6023,11 @@ impl SentLast24HoursDeserializer {
     }
 }
 #[doc="<p>Represents a request to set a receipt rule set as the active receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetActiveReceiptRuleSetRequest {
     #[doc="<p>The name of the receipt rule set to make active. Setting this value to null disables all email receiving.</p>"]
+    #[serde(rename="RuleSetName")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub rule_set_name: Option<String>,
 }
 
@@ -5756,7 +6050,7 @@ impl SetActiveReceiptRuleSetRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetActiveReceiptRuleSetResponse;
 
 struct SetActiveReceiptRuleSetResponseDeserializer;
@@ -5777,11 +6071,13 @@ impl SetActiveReceiptRuleSetResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to enable or disable Amazon SES Easy DKIM signing for an identity. For more information about setting up Easy DKIM, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityDkimEnabledRequest {
     #[doc="<p>Sets whether DKIM signing is enabled for an identity. Set to <code>true</code> to enable DKIM signing for this identity; <code>false</code> to disable it. </p>"]
+    #[serde(rename="DkimEnabled")]
     pub dkim_enabled: bool,
     #[doc="<p>The identity for which DKIM signing should be enabled or disabled.</p>"]
+    #[serde(rename="Identity")]
     pub identity: String,
 }
 
@@ -5804,7 +6100,7 @@ impl SetIdentityDkimEnabledRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityDkimEnabledResponse;
 
 struct SetIdentityDkimEnabledResponseDeserializer;
@@ -5824,11 +6120,13 @@ impl SetIdentityDkimEnabledResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to enable or disable whether Amazon SES forwards you bounce and complaint notifications through email. For information about email feedback forwarding, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-email.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityFeedbackForwardingEnabledRequest {
     #[doc="<p>Sets whether Amazon SES will forward bounce and complaint notifications as email. <code>true</code> specifies that Amazon SES will forward bounce and complaint notifications as email, in addition to any Amazon SNS topic publishing otherwise specified. <code>false</code> specifies that Amazon SES will publish bounce and complaint notifications only through Amazon SNS. This value can only be set to <code>false</code> when Amazon SNS topics are set for both <code>Bounce</code> and <code>Complaint</code> notification types.</p>"]
+    #[serde(rename="ForwardingEnabled")]
     pub forwarding_enabled: bool,
     #[doc="<p>The identity for which to set bounce and complaint notification forwarding. Examples: <code>user@example.com</code>, <code>example.com</code>.</p>"]
+    #[serde(rename="Identity")]
     pub identity: String,
 }
 
@@ -5853,7 +6151,7 @@ impl SetIdentityFeedbackForwardingEnabledRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityFeedbackForwardingEnabledResponse;
 
 struct SetIdentityFeedbackForwardingEnabledResponseDeserializer;
@@ -5874,13 +6172,16 @@ impl SetIdentityFeedbackForwardingEnabledResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to set whether Amazon SES includes the original email headers in the Amazon SNS notifications of a specified type. For information about notifications, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-sns.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityHeadersInNotificationsEnabledRequest {
     #[doc="<p>Sets whether Amazon SES includes the original email headers in Amazon SNS notifications of the specified notification type. A value of <code>true</code> specifies that Amazon SES will include headers in notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in notifications.</p> <p>This value can only be set when <code>NotificationType</code> is already set to use a particular Amazon SNS topic.</p>"]
+    #[serde(rename="Enabled")]
     pub enabled: bool,
     #[doc="<p>The identity for which to enable or disable headers in notifications. Examples: <code>user@example.com</code>, <code>example.com</code>.</p>"]
+    #[serde(rename="Identity")]
     pub identity: String,
     #[doc="<p>The notification type for which to enable or disable headers in notifications. </p>"]
+    #[serde(rename="NotificationType")]
     pub notification_type: String,
 }
 
@@ -5907,7 +6208,7 @@ impl SetIdentityHeadersInNotificationsEnabledRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityHeadersInNotificationsEnabledResponse;
 
 struct SetIdentityHeadersInNotificationsEnabledResponseDeserializer;
@@ -5928,13 +6229,18 @@ impl SetIdentityHeadersInNotificationsEnabledResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to enable or disable the Amazon SES custom MAIL FROM domain setup for a verified identity. For information about using a custom MAIL FROM domain, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityMailFromDomainRequest {
     #[doc="<p>The action that you want Amazon SES to take if it cannot successfully read the required MX record when you send an email. If you choose <code>UseDefaultValue</code>, Amazon SES will use amazonses.com (or a subdomain of that) as the MAIL FROM domain. If you choose <code>RejectMessage</code>, Amazon SES will return a <code>MailFromDomainNotVerified</code> error and not send the email.</p> <p>The action specified in <code>BehaviorOnMXFailure</code> is taken when the custom MAIL FROM domain setup is in the <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code> states.</p>"]
+    #[serde(rename="BehaviorOnMXFailure")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub behavior_on_mx_failure: Option<String>,
     #[doc="<p>The verified identity for which you want to enable or disable the specified custom MAIL FROM domain.</p>"]
+    #[serde(rename="Identity")]
     pub identity: String,
     #[doc="<p>The custom MAIL FROM domain that you want the verified identity to use. The MAIL FROM domain must 1) be a subdomain of the verified identity, 2) not be used in a \"From\" address if the MAIL FROM domain is the destination of email feedback forwarding (for more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html\">Amazon SES Developer Guide</a>), and 3) not be used to receive emails. A value of <code>null</code> disables the custom MAIL FROM setting for the identity.</p>"]
+    #[serde(rename="MailFromDomain")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub mail_from_domain: Option<String>,
 }
 
@@ -5963,7 +6269,7 @@ impl SetIdentityMailFromDomainRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityMailFromDomainResponse;
 
 struct SetIdentityMailFromDomainResponseDeserializer;
@@ -5984,13 +6290,17 @@ impl SetIdentityMailFromDomainResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to specify the Amazon SNS topic to which Amazon SES will publish bounce, complaint, or delivery notifications for emails sent with that identity as the Source. For information about Amazon SES notifications, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-sns.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityNotificationTopicRequest {
     #[doc="<p>The identity for which the Amazon SNS topic will be set. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p>"]
+    #[serde(rename="Identity")]
     pub identity: String,
     #[doc="<p>The type of notifications that will be published to the specified Amazon SNS topic.</p>"]
+    #[serde(rename="NotificationType")]
     pub notification_type: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic. If the parameter is omitted from the request or a null value is passed, <code>SnsTopic</code> is cleared and publishing is disabled.</p>"]
+    #[serde(rename="SnsTopic")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sns_topic: Option<String>,
 }
 
@@ -6017,7 +6327,7 @@ impl SetIdentityNotificationTopicRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetIdentityNotificationTopicResponse;
 
 struct SetIdentityNotificationTopicResponseDeserializer;
@@ -6038,13 +6348,17 @@ impl SetIdentityNotificationTopicResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to set the position of a receipt rule in a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetReceiptRulePositionRequest {
     #[doc="<p>The name of the receipt rule after which to place the specified receipt rule.</p>"]
+    #[serde(rename="After")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub after: Option<String>,
     #[doc="<p>The name of the receipt rule to reposition.</p>"]
+    #[serde(rename="RuleName")]
     pub rule_name: String,
     #[doc="<p>The name of the receipt rule set that contains the receipt rule to reposition.</p>"]
+    #[serde(rename="RuleSetName")]
     pub rule_set_name: String,
 }
 
@@ -6071,7 +6385,7 @@ impl SetReceiptRulePositionRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetReceiptRulePositionResponse;
 
 struct SetReceiptRulePositionResponseDeserializer;
@@ -6091,11 +6405,14 @@ impl SetReceiptRulePositionResponseDeserializer {
     }
 }
 #[doc="<p>When included in a receipt rule, this action terminates the evaluation of the receipt rule set and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>For information about setting a stop action in a receipt rule, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-stop.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopAction {
     #[doc="<p>The scope to which the Stop action applies. That is, what is being stopped.</p>"]
+    #[serde(rename="Scope")]
     pub scope: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the stop action is taken. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\"http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\">Amazon SNS Developer Guide</a>.</p>"]
+    #[serde(rename="TopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
 }
 
@@ -6208,11 +6525,13 @@ impl TlsPolicyDeserializer {
     }
 }
 #[doc="<p>Represents a request to update the event destination of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateConfigurationSetEventDestinationRequest {
     #[doc="<p>The name of the configuration set that you want to update.</p>"]
+    #[serde(rename="ConfigurationSetName")]
     pub configuration_set_name: String,
     #[doc="<p>The event destination object that you want to apply to the specified configuration set.</p>"]
+    #[serde(rename="EventDestination")]
     pub event_destination: EventDestination,
 }
 
@@ -6238,7 +6557,7 @@ impl UpdateConfigurationSetEventDestinationRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateConfigurationSetEventDestinationResponse;
 
 struct UpdateConfigurationSetEventDestinationResponseDeserializer;
@@ -6259,11 +6578,13 @@ impl UpdateConfigurationSetEventDestinationResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to update a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateReceiptRuleRequest {
     #[doc="<p>A data structure that contains the updated receipt rule information.</p>"]
+    #[serde(rename="Rule")]
     pub rule: ReceiptRule,
     #[doc="<p>The name of the receipt rule set to which the receipt rule belongs.</p>"]
+    #[serde(rename="RuleSetName")]
     pub rule_set_name: String,
 }
 
@@ -6285,7 +6606,7 @@ impl UpdateReceiptRuleRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateReceiptRuleResponse;
 
 struct UpdateReceiptRuleResponseDeserializer;
@@ -6400,9 +6721,10 @@ impl VerificationTokenListDeserializer {
     }
 }
 #[doc="<p>Represents a request to generate the CNAME records needed to set up Easy DKIM with Amazon SES. For more information about setting up Easy DKIM, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerifyDomainDkimRequest {
     #[doc="<p>The name of the domain to be verified for Easy DKIM signing.</p>"]
+    #[serde(rename="Domain")]
     pub domain: String,
 }
 
@@ -6423,9 +6745,10 @@ impl VerifyDomainDkimRequestSerializer {
 }
 
 #[doc="<p>Returns CNAME records that you must publish to the DNS server of your domain to set up Easy DKIM with Amazon SES.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerifyDomainDkimResponse {
     #[doc="<p>A set of character strings that represent the domain's identity. If the identity is an email address, the tokens represent the domain of that address.</p> <p>Using these tokens, you will need to create DNS CNAME records that point to DKIM public keys hosted by Amazon SES. Amazon Web Services will eventually detect that you have updated your DNS records; this detection process may take up to 72 hours. Upon successful detection, Amazon SES will be able to DKIM-sign emails originating from that domain.</p> <p>For more information about creating DNS records using DKIM tokens, go to the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim-dns-records.html\">Amazon SES Developer Guide</a>.</p>"]
+    #[serde(rename="DkimTokens")]
     pub dkim_tokens: Vec<String>,
 }
 
@@ -6473,9 +6796,10 @@ impl VerifyDomainDkimResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to begin Amazon SES domain verification and to generate the TXT records that you must publish to the DNS server of your domain to complete the verification. For information about domain verification, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerifyDomainIdentityRequest {
     #[doc="<p>The domain to be verified.</p>"]
+    #[serde(rename="Domain")]
     pub domain: String,
 }
 
@@ -6496,9 +6820,10 @@ impl VerifyDomainIdentityRequestSerializer {
 }
 
 #[doc="<p>Returns a TXT record that you must publish to the DNS server of your domain to complete domain verification with Amazon SES.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerifyDomainIdentityResponse {
     #[doc="<p>A TXT record that you must place in the DNS settings of the domain to complete domain verification with Amazon SES.</p> <p>As Amazon SES searches for the TXT record, the domain's verification status is \"Pending\". When Amazon SES detects the record, the domain's verification status changes to \"Success\". If Amazon SES is unable to detect the record within 72 hours, the domain's verification status changes to \"Failed.\" In that case, if you still want to verify the domain, you must restart the verification process from the beginning.</p>"]
+    #[serde(rename="VerificationToken")]
     pub verification_token: String,
 }
 
@@ -6546,9 +6871,10 @@ impl VerifyDomainIdentityResponseDeserializer {
     }
 }
 #[doc="<p>Represents a request to begin email address verification with Amazon SES. For information about email address verification, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerifyEmailAddressRequest {
     #[doc="<p>The email address to be verified.</p>"]
+    #[serde(rename="EmailAddress")]
     pub email_address: String,
 }
 
@@ -6569,9 +6895,10 @@ impl VerifyEmailAddressRequestSerializer {
 }
 
 #[doc="<p>Represents a request to begin email address verification with Amazon SES. For information about email address verification, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerifyEmailIdentityRequest {
     #[doc="<p>The email address to be verified.</p>"]
+    #[serde(rename="EmailAddress")]
     pub email_address: String,
 }
 
@@ -6592,7 +6919,7 @@ impl VerifyEmailIdentityRequestSerializer {
 }
 
 #[doc="<p>An empty element returned on a successful request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VerifyEmailIdentityResponse;
 
 struct VerifyEmailIdentityResponseDeserializer;
@@ -6612,11 +6939,14 @@ impl VerifyEmailIdentityResponseDeserializer {
     }
 }
 #[doc="<p>When included in a receipt rule, this action calls Amazon WorkMail and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS). You will typically not use this action directly because Amazon WorkMail adds the rule automatically during its setup procedure.</p> <p>For information using a receipt rule to call Amazon WorkMail, see the <a href=\"http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-workmail.html\">Amazon SES Developer Guide</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkmailAction {
     #[doc="<p>The ARN of the Amazon WorkMail organization. An example of an Amazon WorkMail organization ARN is <code>arn:aws:workmail:us-west-2:123456789012:organization/m-68755160c4cb4e29a2b2f8fb58f359d7</code>. For information about Amazon WorkMail organizations, see the <a href=\"http://docs.aws.amazon.com/workmail/latest/adminguide/organizations_overview.html\">Amazon WorkMail Administrator Guide</a>.</p>"]
+    #[serde(rename="OrganizationArn")]
     pub organization_arn: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the WorkMail action is called. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\"http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\">Amazon SNS Developer Guide</a>.</p>"]
+    #[serde(rename="TopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
 }
 

--- a/rusoto/services/shield/src/generated.rs
+++ b/rusoto/services/shield/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>The details of a DDoS attack.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttackDetail {
     #[doc="<p>List of counters that describe the attack for the specified time period.</p>"]
     #[serde(rename="AttackCounters")]
@@ -62,7 +62,7 @@ pub struct AttackDetail {
 }
 
 #[doc="<p>Summarizes all DDoS attacks for a specified time period.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttackSummary {
     #[doc="<p>The unique identifier (ID) of the attack.</p>"]
     #[serde(rename="AttackId")]
@@ -87,14 +87,14 @@ pub struct AttackSummary {
 }
 
 #[doc="<p>Describes the attack.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttackVectorDescription {
     #[doc="<p>The attack type, for example, SNMP reflection or SYN flood.</p>"]
     #[serde(rename="VectorType")]
     pub vector_type: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProtectionRequest {
     #[doc="<p>Friendly name for the <code>Protection</code> you are creating.</p>"]
     #[serde(rename="Name")]
@@ -104,7 +104,7 @@ pub struct CreateProtectionRequest {
     pub resource_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateProtectionResponse {
     #[doc="<p>The unique identifier (ID) for the <a>Protection</a> object that is created.</p>"]
     #[serde(rename="ProtectionId")]
@@ -112,36 +112,36 @@ pub struct CreateProtectionResponse {
     pub protection_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubscriptionRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSubscriptionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProtectionRequest {
     #[doc="<p>The unique identifier (ID) for the <a>Protection</a> object to be deleted.</p>"]
     #[serde(rename="ProtectionId")]
     pub protection_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteProtectionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSubscriptionRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSubscriptionResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAttackRequest {
     #[doc="<p>The unique identifier (ID) for the attack that to be described.</p>"]
     #[serde(rename="AttackId")]
     pub attack_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAttackResponse {
     #[doc="<p>The attack that is described.</p>"]
     #[serde(rename="Attack")]
@@ -149,14 +149,14 @@ pub struct DescribeAttackResponse {
     pub attack: Option<AttackDetail>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProtectionRequest {
     #[doc="<p>The unique identifier (ID) for the <a>Protection</a> object that is described.</p>"]
     #[serde(rename="ProtectionId")]
     pub protection_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeProtectionResponse {
     #[doc="<p>The <a>Protection</a> object that is described.</p>"]
     #[serde(rename="Protection")]
@@ -164,10 +164,10 @@ pub struct DescribeProtectionResponse {
     pub protection: Option<Protection>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSubscriptionRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSubscriptionResponse {
     #[doc="<p>The AWS Shield Advanced subscription details for an account.</p>"]
     #[serde(rename="Subscription")]
@@ -175,7 +175,7 @@ pub struct DescribeSubscriptionResponse {
     pub subscription: Option<Subscription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttacksRequest {
     #[doc="<p>The end of the time period for the attacks.</p>"]
     #[serde(rename="EndTime")]
@@ -199,7 +199,7 @@ pub struct ListAttacksRequest {
     pub start_time: Option<TimeRange>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAttacksResponse {
     #[doc="<p>The attack information for the specified time range.</p>"]
     #[serde(rename="AttackSummaries")]
@@ -211,7 +211,7 @@ pub struct ListAttacksResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProtectionsRequest {
     #[doc="<p>The maximum number of <a>Protection</a> objects to be returned. If this is left blank the first 20 results will be returned.</p>"]
     #[serde(rename="MaxResults")]
@@ -223,7 +223,7 @@ pub struct ListProtectionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListProtectionsResponse {
     #[doc="<p>If you specify a value for <code>MaxResults</code> and you have more Protections than the value of MaxResults, AWS Shield Advanced returns a NextToken value in the response that allows you to list another group of Protections. For the second and subsequent ListProtections requests, specify the value of NextToken from the previous response to get information about another batch of Protections.</p>"]
     #[serde(rename="NextToken")]
@@ -236,7 +236,7 @@ pub struct ListProtectionsResponse {
 }
 
 #[doc="<p>The mitigation applied to a DDoS attack.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Mitigation {
     #[doc="<p>The name of the mitigation taken for this attack.</p>"]
     #[serde(rename="MitigationName")]
@@ -245,7 +245,7 @@ pub struct Mitigation {
 }
 
 #[doc="<p>An object that represents a resource that is under DDoS protection.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Protection {
     #[doc="<p>The unique identifier (ID) of the protection.</p>"]
     #[serde(rename="Id")]
@@ -262,7 +262,7 @@ pub struct Protection {
 }
 
 #[doc="<p>The attack information for the specified SubResource.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubResourceSummary {
     #[doc="<p>The list of attack types and associated counters.</p>"]
     #[serde(rename="AttackVectors")]
@@ -283,7 +283,7 @@ pub struct SubResourceSummary {
 }
 
 #[doc="<p>Information about the AWS Shield Advanced subscription for an account.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Subscription {
     #[doc="<p>The start time of the subscription, in the format \"2016-12-16T13:50Z\".</p>"]
     #[serde(rename="StartTime")]
@@ -296,7 +296,7 @@ pub struct Subscription {
 }
 
 #[doc="<p>A summary of information about the attack.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SummarizedAttackVector {
     #[doc="<p>The list of counters that describe the details of the attack.</p>"]
     #[serde(rename="VectorCounters")]
@@ -308,7 +308,7 @@ pub struct SummarizedAttackVector {
 }
 
 #[doc="<p>The counter that describes a DDoS attack.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SummarizedCounter {
     #[doc="<p>The average value of the counter for a specified time period.</p>"]
     #[serde(rename="Average")]
@@ -337,7 +337,7 @@ pub struct SummarizedCounter {
 }
 
 #[doc="<p>The time range.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TimeRange {
     #[doc="<p>The start time, in the format 2016-12-16T13:50Z.</p>"]
     #[serde(rename="FromInclusive")]

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="Object representing a Connector"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Connector {
     #[serde(rename="associatedOn")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -63,7 +63,7 @@ pub struct Connector {
     pub vm_manager_type: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReplicationJobRequest {
     #[serde(rename="description")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -82,38 +82,38 @@ pub struct CreateReplicationJobRequest {
     pub server_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateReplicationJobResponse {
     #[serde(rename="replicationJobId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub replication_job_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReplicationJobRequest {
     #[serde(rename="replicationJobId")]
     pub replication_job_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteReplicationJobResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteServerCatalogRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteServerCatalogResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateConnectorRequest {
     #[serde(rename="connectorId")]
     pub connector_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateConnectorResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConnectorsRequest {
     #[serde(rename="maxResults")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -123,7 +123,7 @@ pub struct GetConnectorsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetConnectorsResponse {
     #[serde(rename="connectorList")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -133,7 +133,7 @@ pub struct GetConnectorsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetReplicationJobsRequest {
     #[serde(rename="maxResults")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -146,7 +146,7 @@ pub struct GetReplicationJobsRequest {
     pub replication_job_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetReplicationJobsResponse {
     #[serde(rename="nextToken")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -156,7 +156,7 @@ pub struct GetReplicationJobsResponse {
     pub replication_job_list: Option<Vec<ReplicationJob>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetReplicationRunsRequest {
     #[serde(rename="maxResults")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -168,7 +168,7 @@ pub struct GetReplicationRunsRequest {
     pub replication_job_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetReplicationRunsResponse {
     #[serde(rename="nextToken")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -181,7 +181,7 @@ pub struct GetReplicationRunsResponse {
     pub replication_run_list: Option<Vec<ReplicationRun>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetServersRequest {
     #[serde(rename="maxResults")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -191,7 +191,7 @@ pub struct GetServersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetServersResponse {
     #[serde(rename="lastModifiedOn")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -207,14 +207,14 @@ pub struct GetServersResponse {
     pub server_list: Option<Vec<Server>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportServerCatalogRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ImportServerCatalogResponse;
 
 #[doc="Object representing a Replication Job"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplicationJob {
     #[serde(rename="description")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -261,7 +261,7 @@ pub struct ReplicationJob {
 }
 
 #[doc="Object representing a Replication Run"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReplicationRun {
     #[serde(rename="amiId")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -290,7 +290,7 @@ pub struct ReplicationRun {
 }
 
 #[doc="Object representing a server"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Server {
     #[serde(rename="replicationJobId")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -309,7 +309,7 @@ pub struct Server {
     pub vm_server: Option<VmServer>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartOnDemandReplicationRunRequest {
     #[serde(rename="description")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -318,14 +318,14 @@ pub struct StartOnDemandReplicationRunRequest {
     pub replication_job_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartOnDemandReplicationRunResponse {
     #[serde(rename="replicationRunId")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub replication_run_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateReplicationJobRequest {
     #[serde(rename="description")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -346,11 +346,11 @@ pub struct UpdateReplicationJobRequest {
     pub role_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateReplicationJobResponse;
 
 #[doc="Object representing a VM server"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VmServer {
     #[serde(rename="vmManagerName")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -370,7 +370,7 @@ pub struct VmServer {
 }
 
 #[doc="Object representing a server's location"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VmServerAddress {
     #[serde(rename="vmId")]
     #[serde(skip_serializing_if="Option::is_none")]

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -89,28 +89,28 @@ pub struct Address {
     pub street_3: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelClusterRequest {
     #[doc="<p>The 39-character ID for the cluster that you want to cancel, for example <code>CID123e4567-e89b-12d3-a456-426655440000</code>.</p>"]
     #[serde(rename="ClusterId")]
     pub cluster_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelClusterResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelJobRequest {
     #[doc="<p>The 39-character job ID for the job that you want to cancel, for example <code>JID123e4567-e89b-12d3-a456-426655440000</code>.</p>"]
     #[serde(rename="JobId")]
     pub job_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelJobResult;
 
 #[doc="<p>Contains a cluster's state, a cluster's ID, and other important information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterListEntry {
     #[doc="<p>The 39-character ID for the cluster that you want to list, for example <code>CID123e4567-e89b-12d3-a456-426655440000</code>.</p>"]
     #[serde(rename="ClusterId")]
@@ -131,7 +131,7 @@ pub struct ClusterListEntry {
 }
 
 #[doc="<p>Contains metadata about a specific cluster.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ClusterMetadata {
     #[doc="<p>The automatically generated ID for a specific address.</p>"]
     #[serde(rename="AddressId")]
@@ -187,14 +187,14 @@ pub struct ClusterMetadata {
     pub snowball_type: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAddressRequest {
     #[doc="<p>The address that you want the Snowball shipped to.</p>"]
     #[serde(rename="Address")]
     pub address: Address,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAddressResult {
     #[doc="<p>The automatically generated ID for a specific address. You'll use this ID when you create a job to specify which address you want the Snowball for that job shipped to.</p>"]
     #[serde(rename="AddressId")]
@@ -202,7 +202,7 @@ pub struct CreateAddressResult {
     pub address_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterRequest {
     #[doc="<p>The ID for the address that you want the cluster shipped to.&gt;</p>"]
     #[serde(rename="AddressId")]
@@ -241,7 +241,7 @@ pub struct CreateClusterRequest {
     pub snowball_type: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateClusterResult {
     #[doc="<p>The automatically generated ID for a cluster.</p>"]
     #[serde(rename="ClusterId")]
@@ -249,7 +249,7 @@ pub struct CreateClusterResult {
     pub cluster_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobRequest {
     #[doc="<p>The ID for the address that you want the Snowball shipped to.</p>"]
     #[serde(rename="AddressId")]
@@ -301,7 +301,7 @@ pub struct CreateJobRequest {
     pub snowball_type: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateJobResult {
     #[doc="<p>The automatically generated ID for a job, for example <code>JID123e4567-e89b-12d3-a456-426655440000</code>.</p>"]
     #[serde(rename="JobId")]
@@ -310,7 +310,7 @@ pub struct CreateJobResult {
 }
 
 #[doc="<p>Defines the real-time status of a Snowball's data transfer while the appliance is at AWS. This data is only available while a job has a <code>JobState</code> value of <code>InProgress</code>, for both import and export jobs.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DataTransfer {
     #[doc="<p>The number of bytes transferred between a Snowball and Amazon S3.</p>"]
     #[serde(rename="BytesTransferred")]
@@ -330,14 +330,14 @@ pub struct DataTransfer {
     pub total_objects: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAddressRequest {
     #[doc="<p>The automatically generated ID for a specific address.</p>"]
     #[serde(rename="AddressId")]
     pub address_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAddressResult {
     #[doc="<p>The address that you want the Snowball or Snowballs associated with a specific job to be shipped to.</p>"]
     #[serde(rename="Address")]
@@ -345,7 +345,7 @@ pub struct DescribeAddressResult {
     pub address: Option<Address>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAddressesRequest {
     #[doc="<p>The number of <code>ADDRESS</code> objects to return.</p>"]
     #[serde(rename="MaxResults")]
@@ -357,7 +357,7 @@ pub struct DescribeAddressesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAddressesResult {
     #[doc="<p>The Snowball shipping addresses that were created for this account.</p>"]
     #[serde(rename="Addresses")]
@@ -369,14 +369,14 @@ pub struct DescribeAddressesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClusterRequest {
     #[doc="<p>The automatically generated ID for a cluster.</p>"]
     #[serde(rename="ClusterId")]
     pub cluster_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeClusterResult {
     #[doc="<p>Information about a specific cluster, including shipping information, cluster status, and other important metadata.</p>"]
     #[serde(rename="ClusterMetadata")]
@@ -384,14 +384,14 @@ pub struct DescribeClusterResult {
     pub cluster_metadata: Option<ClusterMetadata>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeJobRequest {
     #[doc="<p>The automatically generated ID for a job, for example <code>JID123e4567-e89b-12d3-a456-426655440000</code>.</p>"]
     #[serde(rename="JobId")]
     pub job_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeJobResult {
     #[doc="<p>Information about a specific job, including shipping information, job status, and other important metadata.</p>"]
     #[serde(rename="JobMetadata")]
@@ -412,14 +412,14 @@ pub struct EventTriggerDefinition {
     pub event_resource_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobManifestRequest {
     #[doc="<p>The ID for a job that you want to get the manifest file for, for example <code>JID123e4567-e89b-12d3-a456-426655440000</code>.</p>"]
     #[serde(rename="JobId")]
     pub job_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobManifestResult {
     #[doc="<p>The Amazon S3 presigned URL for the manifest file associated with the specified <code>JobId</code> value.</p>"]
     #[serde(rename="ManifestURI")]
@@ -427,14 +427,14 @@ pub struct GetJobManifestResult {
     pub manifest_uri: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobUnlockCodeRequest {
     #[doc="<p>The ID for the job that you want to get the <code>UnlockCode</code> value for, for example <code>JID123e4567-e89b-12d3-a456-426655440000</code>.</p>"]
     #[serde(rename="JobId")]
     pub job_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetJobUnlockCodeResult {
     #[doc="<p>The <code>UnlockCode</code> value for the specified job. The <code>UnlockCode</code> value can be accessed for up to 90 days after the job has been created.</p>"]
     #[serde(rename="UnlockCode")]
@@ -442,10 +442,10 @@ pub struct GetJobUnlockCodeResult {
     pub unlock_code: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSnowballUsageRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSnowballUsageResult {
     #[doc="<p>The service limit for number of Snowballs this account can have at once. The default service limit is 1 (one).</p>"]
     #[serde(rename="SnowballLimit")]
@@ -458,7 +458,7 @@ pub struct GetSnowballUsageResult {
 }
 
 #[doc="<p>Each <code>JobListEntry</code> object contains a job's state, a job's ID, and a value that indicates whether the job is a job part, in the case of an export job.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobListEntry {
     #[doc="<p>The creation date for this job.</p>"]
     #[serde(rename="CreationDate")]
@@ -491,7 +491,7 @@ pub struct JobListEntry {
 }
 
 #[doc="<p>Contains job logs. Whenever Snowball is used to import data into or export data out of Amazon S3, you'll have the option of downloading a PDF job report. Job logs are returned as a part of the response syntax of the <code>DescribeJob</code> action in the <code>JobMetadata</code> data type. The job logs can be accessed for up to 60 minutes after this request has been made. To access any of the job logs after 60 minutes have passed, you'll have to make another call to the <code>DescribeJob</code> action.</p> <p>For import jobs, the PDF job report becomes available at the end of the import process. For export jobs, your job report typically becomes available while the Snowball for your job part is being delivered to you.</p> <p>The job report provides you insight into the state of your Amazon S3 data transfer. The report includes details about your job or job part for your records.</p> <p>For deeper visibility into the status of your transferred objects, you can look at the two associated logs: a success log and a failure log. The logs are saved in comma-separated value (CSV) format, and the name of each log includes the ID of the job or job part that the log describes.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobLogs {
     #[doc="<p>A link to an Amazon S3 presigned URL where the job completion report is located.</p>"]
     #[serde(rename="JobCompletionReportURI")]
@@ -508,7 +508,7 @@ pub struct JobLogs {
 }
 
 #[doc="<p>Contains information about a specific job including shipping information, job status, and other important metadata. This information is returned as a part of the response syntax of the <code>DescribeJob</code> action.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct JobMetadata {
     #[doc="<p>The ID for the address that you want the Snowball shipped to.</p>"]
     #[serde(rename="AddressId")]
@@ -619,7 +619,7 @@ pub struct LambdaResource {
     pub lambda_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListClusterJobsRequest {
     #[doc="<p>The 39-character ID for the cluster that you want to list, for example <code>CID123e4567-e89b-12d3-a456-426655440000</code>.</p>"]
     #[serde(rename="ClusterId")]
@@ -634,7 +634,7 @@ pub struct ListClusterJobsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListClusterJobsResult {
     #[doc="<p>Each <code>JobListEntry</code> object contains a job's state, a job's ID, and a value that indicates whether the job is a job part, in the case of export jobs. </p>"]
     #[serde(rename="JobListEntries")]
@@ -646,7 +646,7 @@ pub struct ListClusterJobsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListClustersRequest {
     #[doc="<p>The number of <code>ClusterListEntry</code> objects to return.</p>"]
     #[serde(rename="MaxResults")]
@@ -658,7 +658,7 @@ pub struct ListClustersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListClustersResult {
     #[doc="<p>Each <code>ClusterListEntry</code> object contains a cluster's state, a cluster's ID, and other important status information.</p>"]
     #[serde(rename="ClusterListEntries")]
@@ -670,7 +670,7 @@ pub struct ListClustersResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsRequest {
     #[doc="<p>The number of <code>JobListEntry</code> objects to return.</p>"]
     #[serde(rename="MaxResults")]
@@ -682,7 +682,7 @@ pub struct ListJobsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListJobsResult {
     #[doc="<p>Each <code>JobListEntry</code> object contains a job's state, a job's ID, and a value that indicates whether the job is a job part, in the case of export jobs. </p>"]
     #[serde(rename="JobListEntries")]
@@ -725,7 +725,7 @@ pub struct S3Resource {
 }
 
 #[doc="<p>The <code>Status</code> and <code>TrackingNumber</code> information for an inbound or outbound shipment.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Shipment {
     #[doc="<p>Status information for a shipment.</p>"]
     #[serde(rename="Status")]
@@ -738,7 +738,7 @@ pub struct Shipment {
 }
 
 #[doc="<p>A job's shipping information, including inbound and outbound tracking numbers and shipping speed options.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ShippingDetails {
     #[doc="<p>The <code>Status</code> and <code>TrackingNumber</code> values for a Snowball being delivered to the address that you specified for a particular job.</p>"]
     #[serde(rename="InboundShipment")]
@@ -754,7 +754,7 @@ pub struct ShippingDetails {
     pub shipping_option: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateClusterRequest {
     #[doc="<p>The ID of the updated <a>Address</a> object.</p>"]
     #[serde(rename="AddressId")]
@@ -789,10 +789,10 @@ pub struct UpdateClusterRequest {
     pub shipping_option: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateClusterResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateJobRequest {
     #[doc="<p>The ID of the updated <a>Address</a> object.</p>"]
     #[serde(rename="AddressId")]
@@ -831,7 +831,7 @@ pub struct UpdateJobRequest {
     pub snowball_capacity_preference: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateJobResult;
 
 /// Errors returned by CancelCluster

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -65,15 +65,19 @@ impl ActionsListSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddPermissionInput {
     #[doc="<p>The AWS account IDs of the users (principals) who will be given access to the specified actions. The users must have AWS accounts, but do not need to be signed up for this service.</p>"]
+    #[serde(rename="AWSAccountId")]
     pub aws_account_id: Vec<String>,
     #[doc="<p>The action you want to allow for the specified principal(s).</p> <p>Valid values: any Amazon SNS action name.</p>"]
+    #[serde(rename="ActionName")]
     pub action_name: Vec<String>,
     #[doc="<p>A unique identifier for the new policy statement.</p>"]
+    #[serde(rename="Label")]
     pub label: String,
     #[doc="<p>The ARN of the topic whose access control policy you wish to modify.</p>"]
+    #[serde(rename="TopicArn")]
     pub topic_arn: String,
 }
 
@@ -144,9 +148,10 @@ impl BooleanDeserializer {
     }
 }
 #[doc="<p>The input for the <code>CheckIfPhoneNumberIsOptedOut</code> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CheckIfPhoneNumberIsOptedOutInput {
     #[doc="<p>The phone number for which you want to check the opt out status.</p>"]
+    #[serde(rename="phoneNumber")]
     pub phone_number: String,
 }
 
@@ -167,9 +172,11 @@ impl CheckIfPhoneNumberIsOptedOutInputSerializer {
 }
 
 #[doc="<p>The response from the <code>CheckIfPhoneNumberIsOptedOut</code> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CheckIfPhoneNumberIsOptedOutResponse {
     #[doc="<p>Indicates whether the phone number is opted out:</p> <ul> <li> <p> <code>true</code> – The phone number is opted out, meaning you cannot publish SMS messages to it.</p> </li> <li> <p> <code>false</code> – The phone number is opted in, meaning you can publish SMS messages to it.</p> </li> </ul>"]
+    #[serde(rename="isOptedOut")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub is_opted_out: Option<bool>,
 }
 
@@ -217,13 +224,17 @@ impl CheckIfPhoneNumberIsOptedOutResponseDeserializer {
     }
 }
 #[doc="<p>Input for ConfirmSubscription action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmSubscriptionInput {
     #[doc="<p>Disallows unauthenticated unsubscribes of the subscription. If the value of this parameter is <code>true</code> and the request has an AWS signature, then only the topic owner and the subscription owner can unsubscribe the endpoint. The unsubscribe action requires AWS authentication. </p>"]
+    #[serde(rename="AuthenticateOnUnsubscribe")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub authenticate_on_unsubscribe: Option<String>,
     #[doc="<p>Short-lived token sent to an endpoint during the <code>Subscribe</code> action.</p>"]
+    #[serde(rename="Token")]
     pub token: String,
     #[doc="<p>The ARN of the topic for which you wish to confirm a subscription.</p>"]
+    #[serde(rename="TopicArn")]
     pub topic_arn: String,
 }
 
@@ -250,9 +261,11 @@ impl ConfirmSubscriptionInputSerializer {
 }
 
 #[doc="<p>Response for ConfirmSubscriptions action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ConfirmSubscriptionResponse {
     #[doc="<p>The ARN of the created subscription.</p>"]
+    #[serde(rename="SubscriptionArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subscription_arn: Option<String>,
 }
 
@@ -300,9 +313,11 @@ impl ConfirmSubscriptionResponseDeserializer {
     }
 }
 #[doc="<p>Response from CreateEndpoint action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateEndpointResponse {
     #[doc="<p>EndpointArn returned from CreateEndpoint action.</p>"]
+    #[serde(rename="EndpointArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoint_arn: Option<String>,
 }
 
@@ -349,13 +364,16 @@ impl CreateEndpointResponseDeserializer {
     }
 }
 #[doc="<p>Input for CreatePlatformApplication action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePlatformApplicationInput {
     #[doc="<p>For a list of attributes, see <a href=\"http://docs.aws.amazon.com/sns/latest/api/API_SetPlatformApplicationAttributes.html\">SetPlatformApplicationAttributes</a> </p>"]
+    #[serde(rename="Attributes")]
     pub attributes: ::std::collections::HashMap<String, String>,
     #[doc="<p>Application names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, hyphens, and periods, and must be between 1 and 256 characters long.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>The following platforms are supported: ADM (Amazon Device Messaging), APNS (Apple Push Notification Service), APNS_SANDBOX, and GCM (Google Cloud Messaging).</p>"]
+    #[serde(rename="Platform")]
     pub platform: String,
 }
 
@@ -381,9 +399,11 @@ impl CreatePlatformApplicationInputSerializer {
 }
 
 #[doc="<p>Response from CreatePlatformApplication action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePlatformApplicationResponse {
     #[doc="<p>PlatformApplicationArn is returned.</p>"]
+    #[serde(rename="PlatformApplicationArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_application_arn: Option<String>,
 }
 
@@ -432,15 +452,21 @@ impl CreatePlatformApplicationResponseDeserializer {
     }
 }
 #[doc="<p>Input for CreatePlatformEndpoint action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePlatformEndpointInput {
     #[doc="<p>For a list of attributes, see <a href=\"http://docs.aws.amazon.com/sns/latest/api/API_SetEndpointAttributes.html\">SetEndpointAttributes</a>.</p>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<::std::collections::HashMap<String, String>>,
     #[doc="<p>Arbitrary user data to associate with the endpoint. Amazon SNS does not use this data. The data must be in UTF-8 format and less than 2KB.</p>"]
+    #[serde(rename="CustomUserData")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub custom_user_data: Option<String>,
     #[doc="<p>PlatformApplicationArn returned from CreatePlatformApplication is used to create a an endpoint.</p>"]
+    #[serde(rename="PlatformApplicationArn")]
     pub platform_application_arn: String,
     #[doc="<p>Unique identifier created by the notification service for an app on a device. The specific name for Token will vary, depending on which notification service is being used. For example, when using APNS as the notification service, you need the device token. Alternatively, when using GCM or ADM, the device token equivalent is called the registration ID.</p>"]
+    #[serde(rename="Token")]
     pub token: String,
 }
 
@@ -472,9 +498,10 @@ impl CreatePlatformEndpointInputSerializer {
 }
 
 #[doc="<p>Input for CreateTopic action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTopicInput {
     #[doc="<p>The name of the topic you want to create.</p> <p>Constraints: Topic names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long.</p>"]
+    #[serde(rename="Name")]
     pub name: String,
 }
 
@@ -495,9 +522,11 @@ impl CreateTopicInputSerializer {
 }
 
 #[doc="<p>Response from CreateTopic action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTopicResponse {
     #[doc="<p>The Amazon Resource Name (ARN) assigned to the created topic.</p>"]
+    #[serde(rename="TopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
 }
 
@@ -556,9 +585,10 @@ impl DelegatesListSerializer {
 }
 
 #[doc="<p>Input for DeleteEndpoint action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteEndpointInput {
     #[doc="<p>EndpointArn of endpoint to delete.</p>"]
+    #[serde(rename="EndpointArn")]
     pub endpoint_arn: String,
 }
 
@@ -579,9 +609,10 @@ impl DeleteEndpointInputSerializer {
 }
 
 #[doc="<p>Input for DeletePlatformApplication action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePlatformApplicationInput {
     #[doc="<p>PlatformApplicationArn of platform application object to delete.</p>"]
+    #[serde(rename="PlatformApplicationArn")]
     pub platform_application_arn: String,
 }
 
@@ -601,9 +632,10 @@ impl DeletePlatformApplicationInputSerializer {
     }
 }
 
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTopicInput {
     #[doc="<p>The ARN of the topic you want to delete.</p>"]
+    #[serde(rename="TopicArn")]
     pub topic_arn: String,
 }
 
@@ -638,9 +670,10 @@ impl EndpointDeserializer {
     }
 }
 #[doc="<p>Input for GetEndpointAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetEndpointAttributesInput {
     #[doc="<p>EndpointArn for GetEndpointAttributes input.</p>"]
+    #[serde(rename="EndpointArn")]
     pub endpoint_arn: String,
 }
 
@@ -661,9 +694,11 @@ impl GetEndpointAttributesInputSerializer {
 }
 
 #[doc="<p>Response from GetEndpointAttributes of the EndpointArn.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetEndpointAttributesResponse {
     #[doc="<p>Attributes include the following:</p> <ul> <li> <p> <code>CustomUserData</code> -- arbitrary user data to associate with the endpoint. Amazon SNS does not use this data. The data must be in UTF-8 format and less than 2KB.</p> </li> <li> <p> <code>Enabled</code> -- flag that enables/disables delivery to the endpoint. Amazon SNS will set this to false when a notification service indicates to Amazon SNS that the endpoint is invalid. Users can set it back to true, typically after updating Token.</p> </li> <li> <p> <code>Token</code> -- device token, also referred to as a registration id, for an app and mobile device. This is returned from the notification service when an app and mobile device are registered with the notification service.</p> </li> </ul>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
@@ -711,9 +746,10 @@ impl GetEndpointAttributesResponseDeserializer {
     }
 }
 #[doc="<p>Input for GetPlatformApplicationAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPlatformApplicationAttributesInput {
     #[doc="<p>PlatformApplicationArn for GetPlatformApplicationAttributesInput.</p>"]
+    #[serde(rename="PlatformApplicationArn")]
     pub platform_application_arn: String,
 }
 
@@ -734,9 +770,11 @@ impl GetPlatformApplicationAttributesInputSerializer {
 }
 
 #[doc="<p>Response for GetPlatformApplicationAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPlatformApplicationAttributesResponse {
     #[doc="<p>Attributes include the following:</p> <ul> <li> <p> <code>EventEndpointCreated</code> -- Topic ARN to which EndpointCreated event notifications should be sent.</p> </li> <li> <p> <code>EventEndpointDeleted</code> -- Topic ARN to which EndpointDeleted event notifications should be sent.</p> </li> <li> <p> <code>EventEndpointUpdated</code> -- Topic ARN to which EndpointUpdate event notifications should be sent.</p> </li> <li> <p> <code>EventDeliveryFailure</code> -- Topic ARN to which DeliveryFailure event notifications should be sent upon Direct Publish delivery failure (permanent) to one of the application's endpoints.</p> </li> </ul>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
@@ -785,9 +823,11 @@ impl GetPlatformApplicationAttributesResponseDeserializer {
     }
 }
 #[doc="<p>The input for the <code>GetSMSAttributes</code> request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSMSAttributesInput {
     #[doc="<p>A list of the individual attribute names, such as <code>MonthlySpendLimit</code>, for which you want values.</p> <p>For all attribute names, see <a href=\"http://docs.aws.amazon.com/sns/latest/api/API_SetSMSAttributes.html\">SetSMSAttributes</a>.</p> <p>If you don't use this parameter, Amazon SNS returns all SMS attributes.</p>"]
+    #[serde(rename="attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<Vec<String>>,
 }
 
@@ -811,9 +851,11 @@ impl GetSMSAttributesInputSerializer {
 }
 
 #[doc="<p>The response from the <code>GetSMSAttributes</code> request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSMSAttributesResponse {
     #[doc="<p>The SMS attribute names and their values.</p>"]
+    #[serde(rename="attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
@@ -861,9 +903,10 @@ impl GetSMSAttributesResponseDeserializer {
     }
 }
 #[doc="<p>Input for GetSubscriptionAttributes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSubscriptionAttributesInput {
     #[doc="<p>The ARN of the subscription whose properties you want to get.</p>"]
+    #[serde(rename="SubscriptionArn")]
     pub subscription_arn: String,
 }
 
@@ -884,9 +927,11 @@ impl GetSubscriptionAttributesInputSerializer {
 }
 
 #[doc="<p>Response for GetSubscriptionAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSubscriptionAttributesResponse {
     #[doc="<p>A map of the subscription's attributes. Attributes in this map include the following:</p> <ul> <li> <p> <code>SubscriptionArn</code> -- the subscription's ARN</p> </li> <li> <p> <code>TopicArn</code> -- the topic ARN that the subscription is associated with</p> </li> <li> <p> <code>Owner</code> -- the AWS account ID of the subscription's owner</p> </li> <li> <p> <code>ConfirmationWasAuthenticated</code> -- true if the subscription confirmation request was authenticated</p> </li> <li> <p> <code>DeliveryPolicy</code> -- the JSON serialization of the subscription's delivery policy</p> </li> <li> <p> <code>EffectiveDeliveryPolicy</code> -- the JSON serialization of the effective delivery policy that takes into account the topic delivery policy and account system defaults</p> </li> </ul>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
@@ -933,9 +978,10 @@ impl GetSubscriptionAttributesResponseDeserializer {
     }
 }
 #[doc="<p>Input for GetTopicAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTopicAttributesInput {
     #[doc="<p>The ARN of the topic whose properties you want to get.</p>"]
+    #[serde(rename="TopicArn")]
     pub topic_arn: String,
 }
 
@@ -956,9 +1002,11 @@ impl GetTopicAttributesInputSerializer {
 }
 
 #[doc="<p>Response for GetTopicAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTopicAttributesResponse {
     #[doc="<p>A map of the topic's attributes. Attributes in this map include the following:</p> <ul> <li> <p> <code>TopicArn</code> -- the topic's ARN</p> </li> <li> <p> <code>Owner</code> -- the AWS account ID of the topic's owner</p> </li> <li> <p> <code>Policy</code> -- the JSON serialization of the topic's access control policy</p> </li> <li> <p> <code>DisplayName</code> -- the human-readable name used in the \"From\" field for notifications to email and email-json endpoints</p> </li> <li> <p> <code>SubscriptionsPending</code> -- the number of subscriptions pending confirmation on this topic</p> </li> <li> <p> <code>SubscriptionsConfirmed</code> -- the number of confirmed subscriptions on this topic</p> </li> <li> <p> <code>SubscriptionsDeleted</code> -- the number of deleted subscriptions on this topic</p> </li> <li> <p> <code>DeliveryPolicy</code> -- the JSON serialization of the topic's delivery policy</p> </li> <li> <p> <code>EffectiveDeliveryPolicy</code> -- the JSON serialization of the effective delivery policy that takes into account system defaults</p> </li> </ul>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
@@ -1006,11 +1054,14 @@ impl GetTopicAttributesResponseDeserializer {
     }
 }
 #[doc="<p>Input for ListEndpointsByPlatformApplication action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListEndpointsByPlatformApplicationInput {
     #[doc="<p>NextToken string is used when calling ListEndpointsByPlatformApplication action to retrieve additional records that are available after the first page results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>PlatformApplicationArn for ListEndpointsByPlatformApplicationInput action.</p>"]
+    #[serde(rename="PlatformApplicationArn")]
     pub platform_application_arn: String,
 }
 
@@ -1035,11 +1086,15 @@ impl ListEndpointsByPlatformApplicationInputSerializer {
 }
 
 #[doc="<p>Response for ListEndpointsByPlatformApplication action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListEndpointsByPlatformApplicationResponse {
     #[doc="<p>Endpoints returned for ListEndpointsByPlatformApplication action.</p>"]
+    #[serde(rename="Endpoints")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoints: Option<Vec<String>>,
     #[doc="<p>NextToken string is returned when calling ListEndpointsByPlatformApplication action if additional records are available after the first page results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1175,9 +1230,11 @@ impl ListOfPlatformApplicationsDeserializer {
     }
 }
 #[doc="<p>The input for the <code>ListPhoneNumbersOptedOut</code> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPhoneNumbersOptedOutInput {
     #[doc="<p>A <code>NextToken</code> string is used when you call the <code>ListPhoneNumbersOptedOut</code> action to retrieve additional records that are available after the first page of results.</p>"]
+    #[serde(rename="nextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1200,11 +1257,15 @@ impl ListPhoneNumbersOptedOutInputSerializer {
 }
 
 #[doc="<p>The response from the <code>ListPhoneNumbersOptedOut</code> action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPhoneNumbersOptedOutResponse {
     #[doc="<p>A <code>NextToken</code> string is returned when you call the <code>ListPhoneNumbersOptedOut</code> action if additional records are available after the first page of results.</p>"]
+    #[serde(rename="nextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of phone numbers that are opted out of receiving SMS messages. The list is paginated, and each page can contain up to 100 phone numbers.</p>"]
+    #[serde(rename="phoneNumbers")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub phone_numbers: Option<Vec<String>>,
 }
 
@@ -1257,9 +1318,11 @@ impl ListPhoneNumbersOptedOutResponseDeserializer {
     }
 }
 #[doc="<p>Input for ListPlatformApplications action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPlatformApplicationsInput {
     #[doc="<p>NextToken string is used when calling ListPlatformApplications action to retrieve additional records that are available after the first page results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1282,11 +1345,15 @@ impl ListPlatformApplicationsInputSerializer {
 }
 
 #[doc="<p>Response for ListPlatformApplications action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListPlatformApplicationsResponse {
     #[doc="<p>NextToken string is returned when calling ListPlatformApplications action if additional records are available after the first page results.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>Platform applications returned when calling ListPlatformApplications action.</p>"]
+    #[serde(rename="PlatformApplications")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_applications: Option<Vec<PlatformApplication>>,
 }
 
@@ -1349,11 +1416,14 @@ impl ListStringSerializer {
 }
 
 #[doc="<p>Input for ListSubscriptionsByTopic action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSubscriptionsByTopicInput {
     #[doc="<p>Token returned by the previous <code>ListSubscriptionsByTopic</code> request.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>The ARN of the topic for which you wish to find subscriptions.</p>"]
+    #[serde(rename="TopicArn")]
     pub topic_arn: String,
 }
 
@@ -1378,11 +1448,15 @@ impl ListSubscriptionsByTopicInputSerializer {
 }
 
 #[doc="<p>Response for ListSubscriptionsByTopic action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSubscriptionsByTopicResponse {
     #[doc="<p>Token to pass along to the next <code>ListSubscriptionsByTopic</code> request. This element is returned if there are more subscriptions to retrieve.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of subscriptions.</p>"]
+    #[serde(rename="Subscriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subscriptions: Option<Vec<Subscription>>,
 }
 
@@ -1435,9 +1509,11 @@ impl ListSubscriptionsByTopicResponseDeserializer {
     }
 }
 #[doc="<p>Input for ListSubscriptions action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSubscriptionsInput {
     #[doc="<p>Token returned by the previous <code>ListSubscriptions</code> request.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1460,11 +1536,15 @@ impl ListSubscriptionsInputSerializer {
 }
 
 #[doc="<p>Response for ListSubscriptions action</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSubscriptionsResponse {
     #[doc="<p>Token to pass along to the next <code>ListSubscriptions</code> request. This element is returned if there are more subscriptions to retrieve.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of subscriptions.</p>"]
+    #[serde(rename="Subscriptions")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subscriptions: Option<Vec<Subscription>>,
 }
 
@@ -1515,9 +1595,11 @@ impl ListSubscriptionsResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTopicsInput {
     #[doc="<p>Token returned by the previous <code>ListTopics</code> request.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
 }
 
@@ -1540,11 +1622,15 @@ impl ListTopicsInputSerializer {
 }
 
 #[doc="<p>Response for ListTopics action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTopicsResponse {
     #[doc="<p>Token to pass along to the next <code>ListTopics</code> request. This element is returned if there are additional topics to retrieve.</p>"]
+    #[serde(rename="NextToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub next_token: Option<String>,
     #[doc="<p>A list of topic ARNs.</p>"]
+    #[serde(rename="Topics")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topics: Option<Vec<Topic>>,
 }
 
@@ -1651,13 +1737,22 @@ impl MessageAttributeMapSerializer {
 }
 
 #[doc="<p>The user-specified message attribute value. For string data types, the value attribute has the same restrictions on the content as the message body. For more information, see <a href=\"http://docs.aws.amazon.com/sns/latest/api/API_Publish.html\">Publish</a>.</p> <p>Name, type, and value must not be empty or null. In addition, the message body should not be empty or null. All parts of the message attribute, including name, type, and value, are included in the message size restriction, which is currently 256 KB (262,144 bytes). For more information, see <a href=\"http://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html\">Using Amazon SNS Message Attributes</a>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MessageAttributeValue {
     #[doc="<p>Binary type attributes can store any binary data, for example, compressed data, encrypted data, or images.</p>"]
+    #[serde(rename="BinaryValue")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub binary_value: Option<Vec<u8>>,
     #[doc="<p>Amazon SNS supports the following logical data types: String, Number, and Binary. For more information, see <a href=\"http://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html#SNSMessageAttributes.DataTypes\">Message Attribute Data Types</a>.</p>"]
+    #[serde(rename="DataType")]
     pub data_type: String,
     #[doc="<p>Strings are Unicode with UTF8 binary encoding. For a list of code values, see <a href=\"http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters\">http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.</p>"]
+    #[serde(rename="StringValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub string_value: Option<String>,
 }
 
@@ -1716,9 +1811,10 @@ impl NextTokenDeserializer {
     }
 }
 #[doc="<p>Input for the OptInPhoneNumber action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptInPhoneNumberInput {
     #[doc="<p>The phone number to opt in.</p>"]
+    #[serde(rename="phoneNumber")]
     pub phone_number: String,
 }
 
@@ -1739,7 +1835,7 @@ impl OptInPhoneNumberInputSerializer {
 }
 
 #[doc="<p>The response for the OptInPhoneNumber action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct OptInPhoneNumberResponse;
 
 struct OptInPhoneNumberResponseDeserializer;
@@ -1814,11 +1910,15 @@ impl PhoneNumberListDeserializer {
     }
 }
 #[doc="<p>Platform application object.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PlatformApplication {
     #[doc="<p>Attributes for platform application object.</p>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<::std::collections::HashMap<String, String>>,
     #[doc="<p>PlatformApplicationArn for platform application object.</p>"]
+    #[serde(rename="PlatformApplicationArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub platform_application_arn: Option<String>,
 }
 
@@ -1885,21 +1985,34 @@ impl ProtocolDeserializer {
     }
 }
 #[doc="<p>Input for Publish action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PublishInput {
     #[doc="<p>The message you want to send to the topic.</p> <p>If you want to send the same message to all transport protocols, include the text of the message as a String value.</p> <p>If you want to send different messages for each transport protocol, set the value of the <code>MessageStructure</code> parameter to <code>json</code> and use a JSON object for the <code>Message</code> parameter. </p> <p>Constraints: Messages must be UTF-8 encoded strings at most 256 KB in size (262144 bytes, not 262144 characters).</p> <p>JSON-specific constraints:</p> <ul> <li> <p>Keys in the JSON object that correspond to supported transport protocols must have simple JSON string values.</p> </li> <li> <p>The values will be parsed (unescaped) before they are used in outgoing messages.</p> </li> <li> <p>Outbound notifications are JSON encoded (meaning that the characters will be reescaped for sending).</p> </li> <li> <p>Values have a minimum length of 0 (the empty string, \"\", is allowed).</p> </li> <li> <p>Values have a maximum length bounded by the overall message size (so, including multiple protocols may limit message sizes).</p> </li> <li> <p>Non-string values will cause the key to be ignored.</p> </li> <li> <p>Keys that do not correspond to supported transport protocols are ignored.</p> </li> <li> <p>Duplicate keys are not allowed.</p> </li> <li> <p>Failure to parse or validate any key or value in the message will cause the <code>Publish</code> call to return an error (no partial delivery).</p> </li> </ul>"]
+    #[serde(rename="Message")]
     pub message: String,
     #[doc="<p>Message attributes for Publish action.</p>"]
+    #[serde(rename="MessageAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_attributes: Option<::std::collections::HashMap<String, MessageAttributeValue>>,
     #[doc="<p>Set <code>MessageStructure</code> to <code>json</code> if you want to send a different message for each protocol. For example, using one publish action, you can send a short message to your SMS subscribers and a longer message to your email subscribers. If you set <code>MessageStructure</code> to <code>json</code>, the value of the <code>Message</code> parameter must: </p> <ul> <li> <p>be a syntactically valid JSON object; and</p> </li> <li> <p>contain at least a top-level JSON key of \"default\" with a value that is a string.</p> </li> </ul> <p>You can define other top-level keys that define the message you want to send to a specific transport protocol (e.g., \"http\").</p> <p>For information about sending different messages for each protocol using the AWS Management Console, go to <a href=\"http://docs.aws.amazon.com/sns/latest/gsg/Publish.html#sns-message-formatting-by-protocol\">Create Different Messages for Each Protocol</a> in the <i>Amazon Simple Notification Service Getting Started Guide</i>. </p> <p>Valid value: <code>json</code> </p>"]
+    #[serde(rename="MessageStructure")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_structure: Option<String>,
     #[doc="<p>The phone number to which you want to deliver an SMS message. Use E.164 format.</p> <p>If you don't specify a value for the <code>PhoneNumber</code> parameter, you must specify a value for the <code>TargetArn</code> or <code>TopicArn</code> parameters.</p>"]
+    #[serde(rename="PhoneNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub phone_number: Option<String>,
     #[doc="<p>Optional parameter to be used as the \"Subject\" line when the message is delivered to email endpoints. This field will also be included, if present, in the standard JSON messages delivered to other endpoints.</p> <p>Constraints: Subjects must be ASCII text that begins with a letter, number, or punctuation mark; must not include line breaks or control characters; and must be less than 100 characters long.</p>"]
+    #[serde(rename="Subject")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subject: Option<String>,
     #[doc="<p>Either TopicArn or EndpointArn, but not both.</p> <p>If you don't specify a value for the <code>TargetArn</code> parameter, you must specify a value for the <code>PhoneNumber</code> or <code>TopicArn</code> parameters.</p>"]
+    #[serde(rename="TargetArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub target_arn: Option<String>,
     #[doc="<p>The topic you want to publish to.</p> <p>If you don't specify a value for the <code>TopicArn</code> parameter, you must specify a value for the <code>PhoneNumber</code> or <code>TargetArn</code> parameters.</p>"]
+    #[serde(rename="TopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
 }
 
@@ -1945,9 +2058,11 @@ impl PublishInputSerializer {
 }
 
 #[doc="<p>Response for Publish action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PublishResponse {
     #[doc="<p>Unique identifier assigned to the published message.</p> <p>Length Constraint: Maximum 100 characters</p>"]
+    #[serde(rename="MessageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_id: Option<String>,
 }
 
@@ -1994,11 +2109,13 @@ impl PublishResponseDeserializer {
     }
 }
 #[doc="<p>Input for RemovePermission action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemovePermissionInput {
     #[doc="<p>The unique label of the statement you want to remove.</p>"]
+    #[serde(rename="Label")]
     pub label: String,
     #[doc="<p>The ARN of the topic whose access control policy you wish to modify.</p>"]
+    #[serde(rename="TopicArn")]
     pub topic_arn: String,
 }
 
@@ -2021,11 +2138,13 @@ impl RemovePermissionInputSerializer {
 }
 
 #[doc="<p>Input for SetEndpointAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetEndpointAttributesInput {
     #[doc="<p>A map of the endpoint attributes. Attributes in this map include the following:</p> <ul> <li> <p> <code>CustomUserData</code> -- arbitrary user data to associate with the endpoint. Amazon SNS does not use this data. The data must be in UTF-8 format and less than 2KB.</p> </li> <li> <p> <code>Enabled</code> -- flag that enables/disables delivery to the endpoint. Amazon SNS will set this to false when a notification service indicates to Amazon SNS that the endpoint is invalid. Users can set it back to true, typically after updating Token.</p> </li> <li> <p> <code>Token</code> -- device token, also referred to as a registration id, for an app and mobile device. This is returned from the notification service when an app and mobile device are registered with the notification service.</p> </li> </ul>"]
+    #[serde(rename="Attributes")]
     pub attributes: ::std::collections::HashMap<String, String>,
     #[doc="<p>EndpointArn used for SetEndpointAttributes action.</p>"]
+    #[serde(rename="EndpointArn")]
     pub endpoint_arn: String,
 }
 
@@ -2049,11 +2168,13 @@ impl SetEndpointAttributesInputSerializer {
 }
 
 #[doc="<p>Input for SetPlatformApplicationAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetPlatformApplicationAttributesInput {
     #[doc="<p>A map of the platform application attributes. Attributes in this map include the following:</p> <ul> <li> <p> <code>PlatformCredential</code> -- The credential received from the notification service. For APNS/APNS_SANDBOX, PlatformCredential is private key. For GCM, PlatformCredential is \"API key\". For ADM, PlatformCredential is \"client secret\".</p> </li> <li> <p> <code>PlatformPrincipal</code> -- The principal received from the notification service. For APNS/APNS_SANDBOX, PlatformPrincipal is SSL certificate. For GCM, PlatformPrincipal is not applicable. For ADM, PlatformPrincipal is \"client id\".</p> </li> <li> <p> <code>EventEndpointCreated</code> -- Topic ARN to which EndpointCreated event notifications should be sent.</p> </li> <li> <p> <code>EventEndpointDeleted</code> -- Topic ARN to which EndpointDeleted event notifications should be sent.</p> </li> <li> <p> <code>EventEndpointUpdated</code> -- Topic ARN to which EndpointUpdate event notifications should be sent.</p> </li> <li> <p> <code>EventDeliveryFailure</code> -- Topic ARN to which DeliveryFailure event notifications should be sent upon Direct Publish delivery failure (permanent) to one of the application's endpoints.</p> </li> <li> <p> <code>SuccessFeedbackRoleArn</code> -- IAM role ARN used to give Amazon SNS write access to use CloudWatch Logs on your behalf.</p> </li> <li> <p> <code>FailureFeedbackRoleArn</code> -- IAM role ARN used to give Amazon SNS write access to use CloudWatch Logs on your behalf.</p> </li> <li> <p> <code>SuccessFeedbackSampleRate</code> -- Sample rate percentage (0-100) of successfully delivered messages.</p> </li> </ul>"]
+    #[serde(rename="Attributes")]
     pub attributes: ::std::collections::HashMap<String, String>,
     #[doc="<p>PlatformApplicationArn for SetPlatformApplicationAttributes action.</p>"]
+    #[serde(rename="PlatformApplicationArn")]
     pub platform_application_arn: String,
 }
 
@@ -2077,9 +2198,10 @@ impl SetPlatformApplicationAttributesInputSerializer {
 }
 
 #[doc="<p>The input for the SetSMSAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetSMSAttributesInput {
     #[doc="<p>The default settings for sending SMS messages from your account. You can set values for the following attribute names:</p> <p> <code>MonthlySpendLimit</code> – The maximum amount in USD that you are willing to spend each month to send SMS messages. When Amazon SNS determines that sending an SMS message would incur a cost that exceeds this limit, it stops sending SMS messages within minutes.</p> <important> <p>Amazon SNS stops sending SMS messages within minutes of the limit being crossed. During that interval, if you continue to send SMS messages, you will incur costs that exceed your limit.</p> </important> <p>By default, the spend limit is set to the maximum allowed by Amazon SNS. If you want to exceed the maximum, contact <a href=\"https://aws.amazon.com/premiumsupport/\">AWS Support</a> or your AWS sales representative for a service limit increase.</p> <p> <code>DeliveryStatusIAMRole</code> – The ARN of the IAM role that allows Amazon SNS to write logs about SMS deliveries in CloudWatch Logs. For each SMS message that you send, Amazon SNS writes a log that includes the message price, the success or failure status, the reason for failure (if the message failed), the message dwell time, and other information.</p> <p> <code>DeliveryStatusSuccessSamplingRate</code> – The percentage of successful SMS deliveries for which Amazon SNS will write logs in CloudWatch Logs. The value can be an integer from 0 - 100. For example, to write logs only for failed deliveries, set this value to <code>0</code>. To write logs for 10% of your successful deliveries, set it to <code>10</code>.</p> <p> <code>DefaultSenderID</code> – A string, such as your business brand, that is displayed as the sender on the receiving device. Support for sender IDs varies by country. The sender ID can be 1 - 11 alphanumeric characters, and it must contain at least one letter.</p> <p> <code>DefaultSMSType</code> – The type of SMS message that you will send by default. You can assign the following values:</p> <ul> <li> <p> <code>Promotional</code> – (Default) Noncritical messages, such as marketing messages. Amazon SNS optimizes the message delivery to incur the lowest cost.</p> </li> <li> <p> <code>Transactional</code> – Critical messages that support customer transactions, such as one-time passcodes for multi-factor authentication. Amazon SNS optimizes the message delivery to achieve the highest reliability.</p> </li> </ul> <p> <code>UsageReportS3Bucket</code> – The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS. Each day, Amazon SNS will deliver a usage report as a CSV file to the bucket. The report includes the following information for each SMS message that was successfully delivered by your account:</p> <ul> <li> <p>Time that the message was published (in UTC)</p> </li> <li> <p>Message ID</p> </li> <li> <p>Destination phone number</p> </li> <li> <p>Message type</p> </li> <li> <p>Delivery status</p> </li> <li> <p>Message price (in USD)</p> </li> <li> <p>Part number (a message is split into multiple parts if it is too long for a single message)</p> </li> <li> <p>Total number of parts</p> </li> </ul> <p>To receive the report, the bucket must have a policy that allows the Amazon SNS service principle to perform the <code>s3:PutObject</code> and <code>s3:GetBucketLocation</code> actions.</p> <p>For an example bucket policy and usage report, see <a href=\"http://docs.aws.amazon.com/sns/latest/dg/sms_stats.html\">Monitoring SMS Activity</a> in the <i>Amazon SNS Developer Guide</i>.</p>"]
+    #[serde(rename="attributes")]
     pub attributes: ::std::collections::HashMap<String, String>,
 }
 
@@ -2101,7 +2223,7 @@ impl SetSMSAttributesInputSerializer {
 }
 
 #[doc="<p>The response for the SetSMSAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetSMSAttributesResponse;
 
 struct SetSMSAttributesResponseDeserializer;
@@ -2121,13 +2243,17 @@ impl SetSMSAttributesResponseDeserializer {
     }
 }
 #[doc="<p>Input for SetSubscriptionAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetSubscriptionAttributesInput {
     #[doc="<p>The name of the attribute you want to set. Only a subset of the subscriptions attributes are mutable.</p> <p>Valid values: <code>DeliveryPolicy</code> | <code>RawMessageDelivery</code> </p>"]
+    #[serde(rename="AttributeName")]
     pub attribute_name: String,
     #[doc="<p>The new value for the attribute in JSON format.</p>"]
+    #[serde(rename="AttributeValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_value: Option<String>,
     #[doc="<p>The ARN of the subscription to modify.</p>"]
+    #[serde(rename="SubscriptionArn")]
     pub subscription_arn: String,
 }
 
@@ -2154,13 +2280,17 @@ impl SetSubscriptionAttributesInputSerializer {
 }
 
 #[doc="<p>Input for SetTopicAttributes action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetTopicAttributesInput {
     #[doc="<p>The name of the attribute you want to set. Only a subset of the topic's attributes are mutable.</p> <p>Valid values: <code>Policy</code> | <code>DisplayName</code> | <code>DeliveryPolicy</code> </p>"]
+    #[serde(rename="AttributeName")]
     pub attribute_name: String,
     #[doc="<p>The new value for the attribute.</p>"]
+    #[serde(rename="AttributeValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_value: Option<String>,
     #[doc="<p>The ARN of the topic to modify.</p>"]
+    #[serde(rename="TopicArn")]
     pub topic_arn: String,
 }
 
@@ -2201,13 +2331,17 @@ impl StringDeserializer {
     }
 }
 #[doc="<p>Input for Subscribe action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubscribeInput {
     #[doc="<p>The endpoint that you want to receive notifications. Endpoints vary by protocol:</p> <ul> <li> <p>For the <code>http</code> protocol, the endpoint is an URL beginning with \"http://\"</p> </li> <li> <p>For the <code>https</code> protocol, the endpoint is a URL beginning with \"https://\"</p> </li> <li> <p>For the <code>email</code> protocol, the endpoint is an email address</p> </li> <li> <p>For the <code>email-json</code> protocol, the endpoint is an email address</p> </li> <li> <p>For the <code>sms</code> protocol, the endpoint is a phone number of an SMS-enabled device</p> </li> <li> <p>For the <code>sqs</code> protocol, the endpoint is the ARN of an Amazon SQS queue</p> </li> <li> <p>For the <code>application</code> protocol, the endpoint is the EndpointArn of a mobile app and device.</p> </li> <li> <p>For the <code>lambda</code> protocol, the endpoint is the ARN of an AWS Lambda function.</p> </li> </ul>"]
+    #[serde(rename="Endpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoint: Option<String>,
     #[doc="<p>The protocol you want to use. Supported protocols include:</p> <ul> <li> <p> <code>http</code> -- delivery of JSON-encoded message via HTTP POST</p> </li> <li> <p> <code>https</code> -- delivery of JSON-encoded message via HTTPS POST</p> </li> <li> <p> <code>email</code> -- delivery of message via SMTP</p> </li> <li> <p> <code>email-json</code> -- delivery of JSON-encoded message via SMTP</p> </li> <li> <p> <code>sms</code> -- delivery of message via SMS</p> </li> <li> <p> <code>sqs</code> -- delivery of JSON-encoded message to an Amazon SQS queue</p> </li> <li> <p> <code>application</code> -- delivery of JSON-encoded message to an EndpointArn for a mobile app and device.</p> </li> <li> <p> <code>lambda</code> -- delivery of JSON-encoded message to an AWS Lambda function.</p> </li> </ul>"]
+    #[serde(rename="Protocol")]
     pub protocol: String,
     #[doc="<p>The ARN of the topic you want to subscribe to.</p>"]
+    #[serde(rename="TopicArn")]
     pub topic_arn: String,
 }
 
@@ -2234,9 +2368,11 @@ impl SubscribeInputSerializer {
 }
 
 #[doc="<p>Response for Subscribe action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SubscribeResponse {
     #[doc="<p>The ARN of the subscription, if the service was able to create a subscription immediately (without requiring endpoint owner confirmation).</p>"]
+    #[serde(rename="SubscriptionArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subscription_arn: Option<String>,
 }
 
@@ -2284,17 +2420,27 @@ impl SubscribeResponseDeserializer {
     }
 }
 #[doc="<p>A wrapper type for the attributes of an Amazon SNS subscription.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Subscription {
     #[doc="<p>The subscription's endpoint (format depends on the protocol).</p>"]
+    #[serde(rename="Endpoint")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub endpoint: Option<String>,
     #[doc="<p>The subscription's owner.</p>"]
+    #[serde(rename="Owner")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub owner: Option<String>,
     #[doc="<p>The subscription's protocol.</p>"]
+    #[serde(rename="Protocol")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub protocol: Option<String>,
     #[doc="<p>The subscription's ARN.</p>"]
+    #[serde(rename="SubscriptionArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subscription_arn: Option<String>,
     #[doc="<p>The ARN of the subscription's topic.</p>"]
+    #[serde(rename="TopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
 }
 
@@ -2437,9 +2583,11 @@ impl SubscriptionsListDeserializer {
     }
 }
 #[doc="<p>A wrapper type for the topic's Amazon Resource Name (ARN). To retrieve a topic's attributes, use <code>GetTopicAttributes</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Topic {
     #[doc="<p>The topic's ARN.</p>"]
+    #[serde(rename="TopicArn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub topic_arn: Option<String>,
 }
 
@@ -2565,9 +2713,10 @@ impl TopicsListDeserializer {
     }
 }
 #[doc="<p>Input for Unsubscribe action.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnsubscribeInput {
     #[doc="<p>The ARN of the subscription to be deleted.</p>"]
+    #[serde(rename="SubscriptionArn")]
     pub subscription_arn: String,
 }
 

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -64,15 +64,19 @@ impl ActionNameListSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddPermissionRequest {
     #[doc="<p>The AWS account number of the <a href=\"http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#P\">principal</a> who is given permission. The principal must have an AWS account, but does not need to be signed up for Amazon SQS. For information about locating the AWS account identification, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AWSCredentials.html\">Your AWS Identifiers</a> in the <i>Amazon SQS Developer Guide</i>.</p>"]
+    #[serde(rename="AWSAccountIds")]
     pub aws_account_ids: Vec<String>,
     #[doc="<p>The action the client wants to allow for the specified principal. The following values are valid:</p> <ul> <li> <p> <code>*</code> </p> </li> <li> <p> <code>ChangeMessageVisibility</code> </p> </li> <li> <p> <code>DeleteMessage</code> </p> </li> <li> <p> <code>GetQueueAttributes</code> </p> </li> <li> <p> <code>GetQueueUrl</code> </p> </li> <li> <p> <code>ReceiveMessage</code> </p> </li> <li> <p> <code>SendMessage</code> </p> </li> </ul> <p>For more information about these actions, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/acp-overview.html#PermissionTypes\">Understanding Permissions</a> in the <i>Amazon SQS Developer Guide</i>.</p> <p>Specifying <code>SendMessage</code>, <code>DeleteMessage</code>, or <code>ChangeMessageVisibility</code> for <code>ActionName.n</code> also grants permissions for the corresponding batch versions of those actions: <code>SendMessageBatch</code>, <code>DeleteMessageBatch</code>, and <code>ChangeMessageVisibilityBatch</code>.</p>"]
+    #[serde(rename="Actions")]
     pub actions: Vec<String>,
     #[doc="<p>The unique identification of the permission you're setting (for example, <code>AliceSendMessage</code>). Maximum 80 characters. Allowed characters include alphanumeric characters, hyphens (<code>-</code>), and underscores (<code>_</code>).</p>"]
+    #[serde(rename="Label")]
     pub label: String,
     #[doc="<p>The URL of the Amazon SQS queue to which permissions are added.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
 }
 
@@ -113,15 +117,20 @@ impl AttributeNameListSerializer {
 }
 
 #[doc="<p>This is used in the responses of batch API to give a detailed description of the result of an action on each entry in the request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchResultErrorEntry {
     #[doc="<p>An error code representing why the action failed on this entry.</p>"]
+    #[serde(rename="Code")]
     pub code: String,
     #[doc="<p>The <code>Id</code> of an entry in a batch request.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>A message explaining why the action failed on this entry.</p>"]
+    #[serde(rename="Message")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
     #[doc="<p>Specifies whether the error happened due to the sender's fault.</p>"]
+    #[serde(rename="SenderFault")]
     pub sender_fault: bool,
 }
 
@@ -287,11 +296,13 @@ impl BooleanDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChangeMessageVisibilityBatchRequest {
     #[doc="<p>A list of receipt handles of the messages for which the visibility timeout must be changed.</p>"]
+    #[serde(rename="Entries")]
     pub entries: Vec<ChangeMessageVisibilityBatchRequestEntry>,
     #[doc="<p>The URL of the Amazon SQS queue whose messages' visibility is changed.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
 }
 
@@ -317,13 +328,17 @@ impl ChangeMessageVisibilityBatchRequestSerializer {
 }
 
 #[doc="<p>Encloses a receipt handle and an entry id for each message in <code> <a>ChangeMessageVisibilityBatch</a>.</code> </p> <important> <p>All of the following list parameters must be prefixed with <code>ChangeMessageVisibilityBatchRequestEntry.n</code>, where <code>n</code> is an integer value starting with <code>1</code>. For example, a parameter list for this action might look like this:</p> </important> <p> <code>&amp;amp;ChangeMessageVisibilityBatchRequestEntry.1.Id=change_visibility_msg_2</code> </p> <p> <code>&amp;amp;ChangeMessageVisibilityBatchRequestEntry.1.ReceiptHandle=&lt;replaceable&gt;Your_Receipt_Handle&lt;/replaceable&gt;</code> </p> <p> <code>&amp;amp;ChangeMessageVisibilityBatchRequestEntry.1.VisibilityTimeout=45</code> </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChangeMessageVisibilityBatchRequestEntry {
     #[doc="<p>An identifier for this particular receipt handle used to communicate the result.</p> <note> <p>The <code>Id</code>s of a batch request need to be unique within a request</p> </note>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>A receipt handle.</p>"]
+    #[serde(rename="ReceiptHandle")]
     pub receipt_handle: String,
     #[doc="<p>The new value (in seconds) for the message's visibility timeout.</p>"]
+    #[serde(rename="VisibilityTimeout")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub visibility_timeout: Option<i64>,
 }
 
@@ -363,11 +378,13 @@ impl ChangeMessageVisibilityBatchRequestEntryListSerializer {
 }
 
 #[doc="<p>For each message in the batch, the response contains a <code> <a>ChangeMessageVisibilityBatchResultEntry</a> </code> tag if the message succeeds or a <code> <a>BatchResultErrorEntry</a> </code> tag if the message fails.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChangeMessageVisibilityBatchResult {
     #[doc="<p>A list of <code> <a>BatchResultErrorEntry</a> </code> items.</p>"]
+    #[serde(rename="Failed")]
     pub failed: Vec<BatchResultErrorEntry>,
     #[doc="<p>A list of <code> <a>ChangeMessageVisibilityBatchResultEntry</a> </code> items.</p>"]
+    #[serde(rename="Successful")]
     pub successful: Vec<ChangeMessageVisibilityBatchResultEntry>,
 }
 
@@ -419,9 +436,10 @@ impl ChangeMessageVisibilityBatchResultDeserializer {
     }
 }
 #[doc="<p>Encloses the <code>Id</code> of an entry in <code> <a>ChangeMessageVisibilityBatch</a>.</code> </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChangeMessageVisibilityBatchResultEntry {
     #[doc="<p>Represents a message whose visibility timeout has been changed successfully.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
@@ -496,13 +514,16 @@ impl ChangeMessageVisibilityBatchResultEntryListDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChangeMessageVisibilityRequest {
     #[doc="<p>The URL of the Amazon SQS queue whose message's visibility is changed.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
     #[doc="<p>The receipt handle associated with the message whose visibility timeout is changed. This parameter is returned by the <code> <a>ReceiveMessage</a> </code> action.</p>"]
+    #[serde(rename="ReceiptHandle")]
     pub receipt_handle: String,
     #[doc="<p>The new value for the message's visibility timeout (in seconds). Values values: <code>0</code> to <code>43200</code>. Maximum: 12 hours.</p>"]
+    #[serde(rename="VisibilityTimeout")]
     pub visibility_timeout: i64,
 }
 
@@ -527,11 +548,14 @@ impl ChangeMessageVisibilityRequestSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateQueueRequest {
     #[doc="<p>A map of attributes with their corresponding values.</p> <p>The following lists the names, descriptions, and values of the special request parameters that the <code>CreateQueue</code> action uses:</p> <ul> <li> <p> <code>DelaySeconds</code> - The length of time, in seconds, for which the delivery of all messages in the queue is delayed. Valid values: An integer from 0 to 900 seconds (15 minutes). The default is 0 (zero). </p> </li> <li> <p> <code>MaximumMessageSize</code> - The limit of how many bytes a message can contain before Amazon SQS rejects it. Valid values: An integer from 1,024 bytes (1 KiB) to 262,144 bytes (256 KiB). The default is 262,144 (256 KiB). </p> </li> <li> <p> <code>MessageRetentionPeriod</code> - The length of time, in seconds, for which Amazon SQS retains a message. Valid values: An integer from 60 seconds (1 minute) to 1,209,600 seconds (14 days). The default is 345,600 (4 days). </p> </li> <li> <p> <code>Policy</code> - The queue's policy. A valid AWS policy. For more information about policy structure, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/PoliciesOverview.html\">Overview of AWS IAM Policies</a> in the <i>Amazon IAM User Guide</i>. </p> </li> <li> <p> <code>ReceiveMessageWaitTimeSeconds</code> - The length of time, in seconds, for which a <code> <a>ReceiveMessage</a> </code> action waits for a message to arrive. Valid values: An integer from 0 to 20 (seconds). The default is 0 (zero). </p> </li> <li> <p> <code>RedrivePolicy</code> - The parameters for the dead letter queue functionality of the source queue. For more information about the redrive policy and dead letter queues, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html\">Using Amazon SQS Dead Letter Queues</a> in the <i>Amazon SQS Developer Guide</i>. </p> <note> <p>The dead letter queue of a FIFO queue must also be a FIFO queue. Similarly, the dead letter queue of a standard queue must also be a standard queue.</p> </note> </li> <li> <p> <code>VisibilityTimeout</code> - The visibility timeout for the queue. Valid values: An integer from 0 to 43,200 (12 hours). The default is 30. For more information about the visibility timeout, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html\">Visibility Timeout</a> in the <i>Amazon SQS Developer Guide</i>.</p> </li> </ul> <p>The following attributes apply only to <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html\">server-side-encryption</a>:</p> <ul> <li> <p> <code>KmsMasterKeyId</code> - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms\">Key Terms</a>. While the alias of the AWS-managed CMK for Amazon SQS is always <code>alias/aws/sqs</code>, the alias of a custom CMK can, for example, be <code>alias/aws/sqs</code>. For more examples, see <a href=\"http://docs.aws.amazon.com/kms/latest/APIReference/API_DescribeKey.html#API_DescribeKey_RequestParameters\">KeyId</a> in the <i>AWS Key Management Service API Reference</i>. </p> </li> <li> <p> <code>KmsDataKeyReusePeriodSeconds</code> - The length of time, in seconds, for which Amazon SQS can reuse a <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys\">data key</a> to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). The default is 300 (5 minutes). A shorter time period provides better security but results in more calls to KMS which incur charges after Free Tier. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work\">How Does the Data Key Reuse Period Work?</a>. </p> </li> </ul> <p>The following attributes apply only to <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO (first-in-first-out) queues</a>:</p> <ul> <li> <p> <code>FifoQueue</code> - Designates a queue as FIFO. Valid values: <code>true</code>, <code>false</code>. You can provide this attribute only during queue creation. You can't change it for an existing queue. When you set this attribute, you must also provide the <code>MessageGroupId</code> for your messages explicitly.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-understanding-logic\">FIFO Queue Logic</a> in the <i>Amazon SQS Developer Guide</i>.</p> </li> <li> <p> <code>ContentBasedDeduplication</code> - Enables content-based deduplication. Valid values: <code>true</code>, <code>false</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing\">Exactly-Once Processing</a> in the <i>Amazon SQS Developer Guide</i>. </p> <ul> <li> <p>Every message must have a unique <code>MessageDeduplicationId</code>,</p> <ul> <li> <p>You may provide a <code>MessageDeduplicationId</code> explicitly.</p> </li> <li> <p>If you aren't able to provide a <code>MessageDeduplicationId</code> and you enable <code>ContentBasedDeduplication</code> for your queue, Amazon SQS uses a SHA-256 hash to generate the <code>MessageDeduplicationId</code> using the body of the message (but not the attributes of the message). </p> </li> <li> <p>If you don't provide a <code>MessageDeduplicationId</code> and the queue doesn't have <code>ContentBasedDeduplication</code> set, the action fails with an error.</p> </li> <li> <p>If the queue has <code>ContentBasedDeduplication</code> set, your <code>MessageDeduplicationId</code> overrides the generated one.</p> </li> </ul> </li> <li> <p>When <code>ContentBasedDeduplication</code> is in effect, messages with identical content sent within the deduplication interval are treated as duplicates and only one copy of the message is delivered.</p> </li> <li> <p>If you send one message with <code>ContentBasedDeduplication</code> enabled and then another message with a <code>MessageDeduplicationId</code> that is the same as the one generated for the first <code>MessageDeduplicationId</code>, the two messages are treated as duplicates and only one copy of the message is delivered. </p> </li> </ul> </li> </ul> <p>Any other valid special request parameters (such as the following) are ignored:</p> <ul> <li> <p> <code>ApproximateNumberOfMessages</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesDelayed</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesNotVisible</code> </p> </li> <li> <p> <code>CreatedTimestamp</code> </p> </li> <li> <p> <code>LastModifiedTimestamp</code> </p> </li> <li> <p> <code>QueueArn</code> </p> </li> </ul>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<::std::collections::HashMap<String, String>>,
     #[doc="<p>The name of the new queue. The following limits apply to this name:</p> <ul> <li> <p>A queue name can have up to 80 characters.</p> </li> <li> <p>Valid values: alphanumeric characters, hyphens (<code>-</code>), and underscores (<code>_</code>).</p> </li> <li> <p>A FIFO queue name must end with the <code>.fifo</code> suffix.</p> </li> </ul> <p>Queue names are case-sensitive.</p>"]
+    #[serde(rename="QueueName")]
     pub queue_name: String,
 }
 
@@ -557,9 +581,11 @@ impl CreateQueueRequestSerializer {
 }
 
 #[doc="<p>Returns the <code>QueueUrl</code> attribute of the created queue.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateQueueResult {
     #[doc="<p>The URL of the created Amazon SQS queue.</p>"]
+    #[serde(rename="QueueUrl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub queue_url: Option<String>,
 }
 
@@ -606,11 +632,13 @@ impl CreateQueueResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMessageBatchRequest {
     #[doc="<p>A list of receipt handles for the messages to be deleted.</p>"]
+    #[serde(rename="Entries")]
     pub entries: Vec<DeleteMessageBatchRequestEntry>,
     #[doc="<p>The URL of the Amazon SQS queue from which messages are deleted.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
 }
 
@@ -636,11 +664,13 @@ impl DeleteMessageBatchRequestSerializer {
 }
 
 #[doc="<p>Encloses a receipt handle and an identifier for it.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMessageBatchRequestEntry {
     #[doc="<p>An identifier for this particular receipt handle. This is used to communicate the result.</p> <note> <p>The <code>Id</code>s of a batch request need to be unique within a request</p> </note>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>A receipt handle.</p>"]
+    #[serde(rename="ReceiptHandle")]
     pub receipt_handle: String,
 }
 
@@ -674,11 +704,13 @@ impl DeleteMessageBatchRequestEntryListSerializer {
 }
 
 #[doc="<p>For each message in the batch, the response contains a <code> <a>DeleteMessageBatchResultEntry</a> </code> tag if the message is deleted or a <code> <a>BatchResultErrorEntry</a> </code> tag if the message can't be deleted.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMessageBatchResult {
     #[doc="<p>A list of <code> <a>BatchResultErrorEntry</a> </code> items.</p>"]
+    #[serde(rename="Failed")]
     pub failed: Vec<BatchResultErrorEntry>,
     #[doc="<p>A list of <code> <a>DeleteMessageBatchResultEntry</a> </code> items.</p>"]
+    #[serde(rename="Successful")]
     pub successful: Vec<DeleteMessageBatchResultEntry>,
 }
 
@@ -729,9 +761,10 @@ impl DeleteMessageBatchResultDeserializer {
     }
 }
 #[doc="<p>Encloses the <code>Id</code> of an entry in <code> <a>DeleteMessageBatch</a>.</code> </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMessageBatchResultEntry {
     #[doc="<p>Represents a successfully deleted message.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
 }
 
@@ -807,11 +840,13 @@ impl DeleteMessageBatchResultEntryListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMessageRequest {
     #[doc="<p>The URL of the Amazon SQS queue from which messages are deleted.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
     #[doc="<p>The receipt handle associated with the message to delete.</p>"]
+    #[serde(rename="ReceiptHandle")]
     pub receipt_handle: String,
 }
 
@@ -834,9 +869,10 @@ impl DeleteMessageRequestSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteQueueRequest {
     #[doc="<p>The URL of the Amazon SQS queue to delete.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
 }
 
@@ -857,11 +893,14 @@ impl DeleteQueueRequestSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQueueAttributesRequest {
     #[doc="<p>A list of attributes for which to retrieve information.</p> <note> <p>In the future, new attributes might be added. If you write code that calls this action, we recommend that you structure your code so that it can handle new attributes gracefully.</p> </note> <p>The following attributes are supported:</p> <ul> <li> <p> <code>All</code> - Returns all values. </p> </li> <li> <p> <code>ApproximateNumberOfMessages</code> - Returns the approximate number of visible messages in a queue. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-resources-required-process-messages.html\">Resources Required to Process Messages</a> in the <i>Amazon SQS Developer Guide</i>. </p> </li> <li> <p> <code>ApproximateNumberOfMessagesDelayed</code> - Returns the approximate number of messages that are waiting to be added to the queue. </p> </li> <li> <p> <code>ApproximateNumberOfMessagesNotVisible</code> - Returns the approximate number of messages that have not timed-out and aren't deleted. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-resources-required-process-messages.html\">Resources Required to Process Messages</a> in the <i>Amazon SQS Developer Guide</i>. </p> </li> <li> <p> <code>CreatedTimestamp</code> - Returns the time when the queue was created in seconds (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a>).</p> </li> <li> <p> <code>DelaySeconds</code> - Returns the default delay on the queue in seconds.</p> </li> <li> <p> <code>LastModifiedTimestamp</code> - Returns the time when the queue was last changed in seconds (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a>).</p> </li> <li> <p> <code>MaximumMessageSize</code> - Returns the limit of how many bytes a message can contain before Amazon SQS rejects it.</p> </li> <li> <p> <code>MessageRetentionPeriod</code> - Returns the length of time, in seconds, for which Amazon SQS retains a message.</p> </li> <li> <p> <code>Policy</code> - Returns the policy of the queue.</p> </li> <li> <p> <code>QueueArn</code> - Returns the Amazon resource name (ARN) of the queue.</p> </li> <li> <p> <code>ReceiveMessageWaitTimeSeconds</code> - Returns the length of time, in seconds, for which the <code>ReceiveMessage</code> action waits for a message to arrive. </p> </li> <li> <p> <code>RedrivePolicy</code> - Returns the parameters for dead letter queue functionality of the source queue. For more information about the redrive policy and dead letter queues, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html\">Using Amazon SQS Dead Letter Queues</a> in the <i>Amazon SQS Developer Guide</i>. </p> </li> <li> <p> <code>VisibilityTimeout</code> - Returns the visibility timeout for the queue. For more information about the visibility timeout, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html\">Visibility Timeout</a> in the <i>Amazon SQS Developer Guide</i>. </p> </li> </ul> <p>The following attributes apply only to <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html\">server-side-encryption</a>:</p> <ul> <li> <p> <code>KmsMasterKeyId</code> - Returns the ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms\">Key Terms</a>. </p> </li> <li> <p> <code>KmsDataKeyReusePeriodSeconds</code> - Returns the length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. </p> </li> </ul> <p>The following attributes apply only to <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO (first-in-first-out) queues</a>:</p> <ul> <li> <p> <code>FifoQueue</code> - Returns whether the queue is FIFO. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-understanding-logic\">FIFO Queue Logic</a> in the <i>Amazon SQS Developer Guide</i>.</p> <note> <p>To determine whether a queue is <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO</a>, you can check whether <code>QueueName</code> ends with the <code>.fifo</code> suffix.</p> </note> </li> <li> <p> <code>ContentBasedDeduplication</code> - Returns whether content-based deduplication is enabled for the queue. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing\">Exactly-Once Processing</a> in the <i>Amazon SQS Developer Guide</i>. </p> </li> </ul>"]
+    #[serde(rename="AttributeNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_names: Option<Vec<String>>,
     #[doc="<p>The URL of the Amazon SQS queue whose attribute information is retrieved.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
 }
 
@@ -887,9 +926,11 @@ impl GetQueueAttributesRequestSerializer {
 }
 
 #[doc="<p>A list of returned queue attributes.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQueueAttributesResult {
     #[doc="<p>A map of attributes to their respective values.</p>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
@@ -937,11 +978,14 @@ impl GetQueueAttributesResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQueueUrlRequest {
     #[doc="<p>The name of the queue whose URL must be fetched. Maximum 80 characters. Valid values: alphanumeric characters, hyphens (<code>-</code>), and underscores (<code>_</code>).</p> <p>Queue names are case-sensitive.</p>"]
+    #[serde(rename="QueueName")]
     pub queue_name: String,
     #[doc="<p>The AWS account ID of the account that created the queue.</p>"]
+    #[serde(rename="QueueOwnerAWSAccountId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub queue_owner_aws_account_id: Option<String>,
 }
 
@@ -966,9 +1010,11 @@ impl GetQueueUrlRequestSerializer {
 }
 
 #[doc="<p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/UnderstandingResponses.html\">Responses</a> in the <i>Amazon SQS Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetQueueUrlResult {
     #[doc="<p>The URL of the queue.</p>"]
+    #[serde(rename="QueueUrl")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub queue_url: Option<String>,
 }
 
@@ -1015,9 +1061,10 @@ impl GetQueueUrlResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeadLetterSourceQueuesRequest {
     #[doc="<p>The URL of a dead letter queue.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
 }
 
@@ -1038,9 +1085,10 @@ impl ListDeadLetterSourceQueuesRequestSerializer {
 }
 
 #[doc="<p>A list of your dead letter source queues.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDeadLetterSourceQueuesResult {
     #[doc="<p>A list of source queue URLs that have the <code>RedrivePolicy</code> queue attribute configured with a dead letter queue.</p>"]
+    #[serde(rename="queueUrls")]
     pub queue_urls: Vec<String>,
 }
 
@@ -1088,9 +1136,11 @@ impl ListDeadLetterSourceQueuesResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListQueuesRequest {
     #[doc="<p>A string to use for filtering the list results. Only those queues whose name begins with the specified string are returned.</p> <p>Queue names are case-sensitive.</p>"]
+    #[serde(rename="QueueNamePrefix")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub queue_name_prefix: Option<String>,
 }
 
@@ -1113,9 +1163,11 @@ impl ListQueuesRequestSerializer {
 }
 
 #[doc="<p>A list of your queues.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListQueuesResult {
     #[doc="<p>A list of queue URLs, up to 1,000 entries.</p>"]
+    #[serde(rename="QueueUrls")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub queue_urls: Option<Vec<String>>,
 }
 
@@ -1163,21 +1215,35 @@ impl ListQueuesResultDeserializer {
     }
 }
 #[doc="<p>An Amazon SQS message.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Message {
     #[doc="<p> <code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a> in milliseconds.</p>"]
+    #[serde(rename="Attributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attributes: Option<::std::collections::HashMap<String, String>>,
     #[doc="<p>The message's contents (not URL-encoded).</p>"]
+    #[serde(rename="Body")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub body: Option<String>,
     #[doc="<p>An MD5 digest of the non-URL-encoded message body string.</p>"]
+    #[serde(rename="MD5OfBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub md5_of_body: Option<String>,
     #[doc="<p>An MD5 digest of the non-URL-encoded message attribute string. You can use this attribute to verify that Amazon SQS received the message correctly. Amazon SQS URL-decodes the message before creating the MD5 digest. For information about MD5, see <a href=\"https://www.ietf.org/rfc/rfc1321.txt\">RFC1321</a>.</p>"]
+    #[serde(rename="MD5OfMessageAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub md5_of_message_attributes: Option<String>,
     #[doc="<p>Each message attribute consists of a <code>Name</code>, <code>Type</code>, and <code>Value</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html#message-attributes-items-validation\">Message Attribute Items and Validation</a> in the <i>Amazon SQS Developer Guide</i>.</p>"]
+    #[serde(rename="MessageAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_attributes: Option<::std::collections::HashMap<String, MessageAttributeValue>>,
     #[doc="<p>A unique identifier for the message. A <code>MessageId</code>is considered unique across all AWS accounts for an extended period of time.</p>"]
+    #[serde(rename="MessageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_id: Option<String>,
     #[doc="<p>An identifier associated with the act of receiving the message. A new receipt handle is returned every time you receive a message. When deleting a message, you provide the last received receipt handle to delete the message.</p>"]
+    #[serde(rename="ReceiptHandle")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub receipt_handle: Option<String>,
 }
 
@@ -1260,17 +1326,30 @@ impl MessageAttributeNameListSerializer {
 }
 
 #[doc="<p>The user-specified message attribute value. For string data types, the <code>Value</code> attribute has the same restrictions on the content as the message body. For more information, see <code> <a>SendMessage</a>.</code> </p> <p> <code>Name</code>, <code>type</code>, <code>value</code> and the message body must not be empty or null. All parts of the message attribute, including <code>Name</code>, <code>Type</code>, and <code>Value</code>, are part of the message size restriction (256 KB or 262,144 bytes).</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MessageAttributeValue {
     #[doc="<p>Not implemented. Reserved for future use.</p>"]
+    #[serde(rename="BinaryListValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub binary_list_values: Option<Vec<Vec<u8>>>,
     #[doc="<p>Binary type attributes can store any binary data, such as compressed data, encrypted data, or images.</p>"]
+    #[serde(rename="BinaryValue")]
+    #[serde(
+                            deserialize_with="::rusoto_core::serialization::SerdeBlob::deserialize_blob",
+                            serialize_with="::rusoto_core::serialization::SerdeBlob::serialize_blob",
+                            default,
+                        )]
     pub binary_value: Option<Vec<u8>>,
     #[doc="<p>Amazon SQS supports the following logical data types: <code>String</code>, <code>Number</code>, and <code>Binary</code>. For the <code>Number</code> data type, you must use <code>StringValue</code>.</p> <p>You can also append custom labels. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html#message-attributes-data-types-validation\">Message Attribute Data Types and Validation</a> in the <i>Amazon SQS Developer Guide</i>.</p>"]
+    #[serde(rename="DataType")]
     pub data_type: String,
     #[doc="<p>Not implemented. Reserved for future use.</p>"]
+    #[serde(rename="StringListValues")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub string_list_values: Option<Vec<String>>,
     #[doc="<p>Strings are Unicode with UTF-8 binary encoding. For a list of code values, see <a href=\"http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters\">ASCII Printable Characters</a>.</p>"]
+    #[serde(rename="StringValue")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub string_value: Option<String>,
 }
 
@@ -1472,9 +1551,10 @@ impl MessageSystemAttributeNameDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PurgeQueueRequest {
     #[doc="<p>The URL of the queue from which the <code>PurgeQueue</code> action deletes messages.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
 }
 
@@ -1573,21 +1653,34 @@ impl QueueUrlListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReceiveMessageRequest {
     #[doc="<p>A list of attributes that need to be returned along with each message. These attributes include:</p> <ul> <li> <p> <code>All</code> - Returns all values.</p> </li> <li> <p> <code>ApproximateFirstReceiveTimestamp</code> - Returns the time the message was first received from the queue (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a> in milliseconds).</p> </li> <li> <p> <code>ApproximateReceiveCount</code> - Returns the number of times a message has been received from the queue but not deleted.</p> </li> <li> <p> <code>SenderId</code> </p> <ul> <li> <p>For an IAM user, returns the IAM user ID, for example <code>ABCDEFGHI1JKLMNOPQ23R</code>.</p> </li> <li> <p>For an IAM role, returns the IAM role ID, for example <code>ABCDE1F2GH3I4JK5LMNOP:i-a123b456</code>.</p> </li> </ul> </li> <li> <p> <code>SentTimestamp</code> - Returns the time the message was sent to the queue (<a href=\"http://en.wikipedia.org/wiki/Unix_time\">epoch time</a> in milliseconds).</p> </li> <li> <p> <code>MessageDeduplicationId</code> - Returns the value provided by the sender that calls the <code> <a>SendMessage</a> </code> action.</p> </li> <li> <p> <code>MessageGroupId</code> - Returns the value provided by the sender that calls the <code> <a>SendMessage</a> </code> action. Messages with the same <code>MessageGroupId</code> are returned in sequence.</p> </li> <li> <p> <code>SequenceNumber</code> - Returns the value provided by Amazon SQS.</p> </li> </ul> <p>Any other valid special request parameters (such as the following) are ignored:</p> <ul> <li> <p> <code>ApproximateNumberOfMessages</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesDelayed</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesNotVisible</code> </p> </li> <li> <p> <code>CreatedTimestamp</code> </p> </li> <li> <p> <code>ContentBasedDeduplication</code> </p> </li> <li> <p> <code>DelaySeconds</code> </p> </li> <li> <p> <code>FifoQueue</code> </p> </li> <li> <p> <code>LastModifiedTimestamp</code> </p> </li> <li> <p> <code>MaximumMessageSize</code> </p> </li> <li> <p> <code>MessageRetentionPeriod</code> </p> </li> <li> <p> <code>Policy</code> </p> </li> <li> <p> <code>QueueArn</code>, </p> </li> <li> <p> <code>ReceiveMessageWaitTimeSeconds</code> </p> </li> <li> <p> <code>RedrivePolicy</code> </p> </li> <li> <p> <code>VisibilityTimeout</code> </p> </li> </ul>"]
+    #[serde(rename="AttributeNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub attribute_names: Option<Vec<String>>,
     #[doc="<p>The maximum number of messages to return. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values are 1 to 10. Default is 1.</p>"]
+    #[serde(rename="MaxNumberOfMessages")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub max_number_of_messages: Option<i64>,
     #[doc="<p>The name of the message attribute, where <i>N</i> is the index.</p> <ul> <li> <p>The name can contain alphanumeric characters and the underscore (<code>_</code>), hyphen (<code>-</code>), and period (<code>.</code>).</p> </li> <li> <p>The name is case-sensitive and must be unique among all attribute names for the message.</p> </li> <li> <p>The name must not start with AWS-reserved prefixes such as <code>AWS.</code> or <code>Amazon.</code> (or any casing variants).</p> </li> <li> <p>The name must not start or end with a period (<code>.</code>), and it should not have periods in succession (<code>..</code>).</p> </li> <li> <p>The name can be up to 256 characters long.</p> </li> </ul> <p>When using <code>ReceiveMessage</code>, you can send a list of attribute names to receive, or you can return all of the attributes by specifying <code>All</code> or <code>.*</code> in your request. You can also use all message attributes starting with a prefix, for example <code>bar.*</code>.</p>"]
+    #[serde(rename="MessageAttributeNames")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_attribute_names: Option<Vec<String>>,
     #[doc="<p>The URL of the Amazon SQS queue from which messages are received.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
     #[doc="<p>This parameter applies only to FIFO (first-in-first-out) queues.</p> <p>The token used for deduplication of <code>ReceiveMessage</code> calls. If a networking issue occurs after a <code>ReceiveMessage</code> action, and instead of a response you receive a generic error, you can retry the same action with an identical <code>ReceiveRequestAttemptId</code> to retrieve the same set of messages, even if their visibility timeout has not yet expired.</p> <ul> <li> <p>You can use <code>ReceiveRequestAttemptId</code> only for 5 minutes after a <code>ReceiveMessage</code> action.</p> </li> <li> <p>When you set <code>FifoQueue</code>, a caller of the <code>ReceiveMessage</code> action can provide a <code>ReceiveRequestAttemptId</code> explicitly.</p> </li> <li> <p>If a caller of the <code>ReceiveMessage</code> action doesn't provide a <code>ReceiveRequestAttemptId</code>, Amazon SQS generates a <code>ReceiveRequestAttemptId</code>.</p> </li> <li> <p>You can retry the <code>ReceiveMessage</code> action with the same <code>ReceiveRequestAttemptId</code> if none of the messages have been modified (deleted or had their visibility changes).</p> </li> <li> <p>During a visibility timeout, subsequent calls with the same <code>ReceiveRequestAttemptId</code> return the same messages and receipt handles. If a retry occurs within the deduplication interval, it resets the visibility timeout. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html\">Visibility Timeout</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p> <important> <p>If a caller of the <code>ReceiveMessage</code> action is still processing messages when the visibility timeout expires and messages become visible, another worker reading from the same queue can receive the same messages and therefore process duplicates. Also, if a reader whose message processing time is longer than the visibility timeout tries to delete the processed messages, the action fails with an error.</p> <p>To mitigate this effect, ensure that your application observes a safe threshold before the visibility timeout expires and extend the visibility timeout as necessary.</p> </important> </li> <li> <p>While messages with a particular <code>MessageGroupId</code> are invisible, no more messages belonging to the same <code>MessageGroupId</code> are returned until the visibility timeout expires. You can still receive messages with another <code>MessageGroupId</code> as long as it is also visible.</p> </li> <li> <p>If a caller of <code>ReceiveMessage</code> can't track the <code>ReceiveRequestAttemptId</code>, no retries work until the original visibility timeout expires. As a result, delays might occur but the messages in the queue remain in a strict order.</p> </li> </ul> <p>The length of <code>ReceiveRequestAttemptId</code> is 128 characters. <code>ReceiveRequestAttemptId</code> can contain alphanumeric characters (<code>a-z</code>, <code>A-Z</code>, <code>0-9</code>) and punctuation (<code>!\"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</code>).</p> <p>For best practices of using <code>ReceiveRequestAttemptId</code>, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queue-recommendations.html#using-receiverequestattemptid-request-parameter\">Using the ReceiveRequestAttemptId Request Parameter</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>"]
+    #[serde(rename="ReceiveRequestAttemptId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub receive_request_attempt_id: Option<String>,
     #[doc="<p>The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a <code>ReceiveMessage</code> request.</p>"]
+    #[serde(rename="VisibilityTimeout")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub visibility_timeout: Option<i64>,
     #[doc="<p>The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. If a message is available, the call returns sooner than <code>WaitTimeSeconds</code>.</p>"]
+    #[serde(rename="WaitTimeSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub wait_time_seconds: Option<i64>,
 }
 
@@ -1636,9 +1729,11 @@ impl ReceiveMessageRequestSerializer {
 }
 
 #[doc="<p>A list of received messages.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ReceiveMessageResult {
     #[doc="<p>A list of messages.</p>"]
+    #[serde(rename="Messages")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub messages: Option<Vec<Message>>,
 }
 
@@ -1685,11 +1780,13 @@ impl ReceiveMessageResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemovePermissionRequest {
     #[doc="<p>The identification of the permission to remove. This is the label added using the <code> <a>AddPermission</a> </code> action.</p>"]
+    #[serde(rename="Label")]
     pub label: String,
     #[doc="<p>The URL of the Amazon SQS queue from which permissions are removed.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
 }
 
@@ -1712,11 +1809,13 @@ impl RemovePermissionRequestSerializer {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendMessageBatchRequest {
     #[doc="<p>A list of <code> <a>SendMessageBatchRequestEntry</a> </code> items.</p>"]
+    #[serde(rename="Entries")]
     pub entries: Vec<SendMessageBatchRequestEntry>,
     #[doc="<p>The URL of the Amazon SQS queue to which batched messages are sent.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
 }
 
@@ -1740,19 +1839,29 @@ impl SendMessageBatchRequestSerializer {
 }
 
 #[doc="<p>Contains the details of a single Amazon SQS message along with an <code>Id</code>.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendMessageBatchRequestEntry {
     #[doc="<p>The length of time, in seconds, for which a specific message is delayed. Valid values: 0 to 900. Maximum: 15 minutes. Messages with a positive <code>DelaySeconds</code> value become available for processing after the delay period is finished. If you don't specify a value, the default value for the queue is applied. </p> <note> <p>When you set <code>FifoQueue</code>, you can't set <code>DelaySeconds</code> per message. You can set this parameter only on a queue level.</p> </note>"]
+    #[serde(rename="DelaySeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delay_seconds: Option<i64>,
     #[doc="<p>An identifier for a message in this batch used to communicate the result.</p> <note> <p>The <code>Id</code>s of a batch request need to be unique within a request</p> </note>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>Each message attribute consists of a <code>Name</code>, <code>Type</code>, and <code>Value</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html#message-attributes-items-validation\">Message Attribute Items and Validation</a> in the <i>Amazon SQS Developer Guide</i>.</p>"]
+    #[serde(rename="MessageAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_attributes: Option<::std::collections::HashMap<String, MessageAttributeValue>>,
     #[doc="<p>The body of the message.</p>"]
+    #[serde(rename="MessageBody")]
     pub message_body: String,
     #[doc="<p>This parameter applies only to FIFO (first-in-first-out) queues.</p> <p>The token used for deduplication of messages within a 5-minute minimum deduplication interval. If a message with a particular <code>MessageDeduplicationId</code> is sent successfully, subsequent messages with the same <code>MessageDeduplicationId</code> are accepted successfully but aren't delivered. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing\"> Exactly-Once Processing</a> in the <i>Amazon SQS Developer Guide</i>.</p> <ul> <li> <p>Every message must have a unique <code>MessageDeduplicationId</code>,</p> <ul> <li> <p>You may provide a <code>MessageDeduplicationId</code> explicitly.</p> </li> <li> <p>If you aren't able to provide a <code>MessageDeduplicationId</code> and you enable <code>ContentBasedDeduplication</code> for your queue, Amazon SQS uses a SHA-256 hash to generate the <code>MessageDeduplicationId</code> using the body of the message (but not the attributes of the message). </p> </li> <li> <p>If you don't provide a <code>MessageDeduplicationId</code> and the queue doesn't have <code>ContentBasedDeduplication</code> set, the action fails with an error.</p> </li> <li> <p>If the queue has <code>ContentBasedDeduplication</code> set, your <code>MessageDeduplicationId</code> overrides the generated one.</p> </li> </ul> </li> <li> <p>When <code>ContentBasedDeduplication</code> is in effect, messages with identical content sent within the deduplication interval are treated as duplicates and only one copy of the message is delivered.</p> </li> <li> <p>If you send one message with <code>ContentBasedDeduplication</code> enabled and then another message with a <code>MessageDeduplicationId</code> that is the same as the one generated for the first <code>MessageDeduplicationId</code>, the two messages are treated as duplicates and only one copy of the message is delivered. </p> </li> </ul> <note> <p>The <code>MessageDeduplicationId</code> is available to the recipient of the message (this can be useful for troubleshooting delivery issues).</p> <p>If a message is sent successfully but the acknowledgement is lost and the message is resent with the same <code>MessageDeduplicationId</code> after the deduplication interval, Amazon SQS can't detect duplicate messages.</p> </note> <p>The length of <code>MessageDeduplicationId</code> is 128 characters. <code>MessageDeduplicationId</code> can contain alphanumeric characters (<code>a-z</code>, <code>A-Z</code>, <code>0-9</code>) and punctuation (<code>!\"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</code>).</p> <p>For best practices of using <code>MessageDeduplicationId</code>, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queue-recommendations.html#using-messagededuplicationid-property\">Using the MessageDeduplicationId Property</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>"]
+    #[serde(rename="MessageDeduplicationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_deduplication_id: Option<String>,
     #[doc="<p>This parameter applies only to FIFO (first-in-first-out) queues.</p> <p>The tag that specifies that a message belongs to a specific message group. Messages that belong to the same message group are processed in a FIFO manner (however, messages in different message groups might be processed out of order). To interleave multiple ordered streams within a single queue, use <code>MessageGroupId</code> values (for example, session data for multiple users). In this scenario, multiple readers can process the queue, but the session data of each user is processed in a FIFO fashion.</p> <ul> <li> <p>You must associate a non-empty <code>MessageGroupId</code> with a message. If you don't provide a <code>MessageGroupId</code>, the action fails.</p> </li> <li> <p> <code>ReceiveMessage</code> might return messages with multiple <code>MessageGroupId</code> values. For each <code>MessageGroupId</code>, the messages are sorted by time sent. The caller can't specify a <code>MessageGroupId</code>.</p> </li> </ul> <p>The length of <code>MessageGroupId</code> is 128 characters. Valid values are alphanumeric characters and punctuation <code>(!\"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~)</code>.</p> <p>For best practices of using <code>MessageGroupId</code>, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queue-recommendations.html#using-messagegroupid-property\">Using the MessageGroupId Property</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p> <important> <p> <code>MessageGroupId</code> is required for FIFO queues. You can't use it for Standard queues.</p> </important>"]
+    #[serde(rename="MessageGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_group_id: Option<String>,
 }
 
@@ -1805,11 +1914,13 @@ impl SendMessageBatchRequestEntryListSerializer {
 }
 
 #[doc="<p>For each message in the batch, the response contains a <code> <a>SendMessageBatchResultEntry</a> </code> tag if the message succeeds or a <code> <a>BatchResultErrorEntry</a> </code> tag if the message fails.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendMessageBatchResult {
     #[doc="<p>A list of <code> <a>BatchResultErrorEntry</a> </code> items with error details about each message that can't be enqueued.</p>"]
+    #[serde(rename="Failed")]
     pub failed: Vec<BatchResultErrorEntry>,
     #[doc="<p>A list of <code> <a>SendMessageBatchResultEntry</a> </code> items.</p>"]
+    #[serde(rename="Successful")]
     pub successful: Vec<SendMessageBatchResultEntry>,
 }
 
@@ -1860,17 +1971,24 @@ impl SendMessageBatchResultDeserializer {
     }
 }
 #[doc="<p>Encloses a <code>MessageId</code> for a successfully-enqueued message in a <code> <a>SendMessageBatch</a>.</code> </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendMessageBatchResultEntry {
     #[doc="<p>An identifier for the message in this batch.</p>"]
+    #[serde(rename="Id")]
     pub id: String,
     #[doc="<p>An MD5 digest of the non-URL-encoded message attribute string. You can use this attribute to verify that Amazon SQS received the message correctly. Amazon SQS URL-decodes the message before creating the MD5 digest. For information about MD5, see <a href=\"https://www.ietf.org/rfc/rfc1321.txt\">RFC1321</a>.</p>"]
+    #[serde(rename="MD5OfMessageAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub md5_of_message_attributes: Option<String>,
     #[doc="<p>An MD5 digest of the non-URL-encoded message attribute string. You can use this attribute to verify that Amazon SQS received the message correctly. Amazon SQS URL-decodes the message before creating the MD5 digest. For information about MD5, see <a href=\"https://www.ietf.org/rfc/rfc1321.txt\">RFC1321</a>.</p>"]
+    #[serde(rename="MD5OfMessageBody")]
     pub md5_of_message_body: String,
     #[doc="<p>An identifier for the message.</p>"]
+    #[serde(rename="MessageId")]
     pub message_id: String,
     #[doc="<p>This parameter applies only to FIFO (first-in-first-out) queues.</p> <p>The large, non-consecutive number that Amazon SQS assigns to each message.</p> <p>The length of <code>SequenceNumber</code> is 128 bits. As <code>SequenceNumber</code> continues to increase for a particular <code>MessageGroupId</code>.</p>"]
+    #[serde(rename="SequenceNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sequence_number: Option<String>,
 }
 
@@ -1964,19 +2082,29 @@ impl SendMessageBatchResultEntryListDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendMessageRequest {
     #[doc="<p> The length of time, in seconds, for which to delay a specific message. Valid values: 0 to 900. Maximum: 15 minutes. Messages with a positive <code>DelaySeconds</code> value become available for processing after the delay period is finished. If you don't specify a value, the default value for the queue applies. </p> <note> <p>When you set <code>FifoQueue</code>, you can't set <code>DelaySeconds</code> per message. You can set this parameter only on a queue level.</p> </note>"]
+    #[serde(rename="DelaySeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub delay_seconds: Option<i64>,
     #[doc="<p>Each message attribute consists of a <code>Name</code>, <code>Type</code>, and <code>Value</code>. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html#message-attributes-items-validation\">Message Attribute Items and Validation</a> in the <i>Amazon SQS Developer Guide</i>.</p>"]
+    #[serde(rename="MessageAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_attributes: Option<::std::collections::HashMap<String, MessageAttributeValue>>,
     #[doc="<p>The message to send. The maximum string size is 256 KB.</p> <important> <p>A message can include only XML, JSON, and unformatted text. The following Unicode characters are allowed:</p> <p> <code>#x9</code> | <code>#xA</code> | <code>#xD</code> | <code>#x20</code> to <code>#xD7FF</code> | <code>#xE000</code> to <code>#xFFFD</code> | <code>#x10000</code> to <code>#x10FFFF</code> </p> <p>Any characters not included in this list will be rejected. For more information, see the <a href=\"http://www.w3.org/TR/REC-xml/#charsets\">W3C specification for characters</a>.</p> </important>"]
+    #[serde(rename="MessageBody")]
     pub message_body: String,
     #[doc="<p>This parameter applies only to FIFO (first-in-first-out) queues.</p> <p>The token used for deduplication of sent messages. If a message with a particular <code>MessageDeduplicationId</code> is sent successfully, any messages sent with the same <code>MessageDeduplicationId</code> are accepted successfully but aren't delivered during the 5-minute deduplication interval. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing\"> Exactly-Once Processing</a> in the <i>Amazon SQS Developer Guide</i>.</p> <ul> <li> <p>Every message must have a unique <code>MessageDeduplicationId</code>,</p> <ul> <li> <p>You may provide a <code>MessageDeduplicationId</code> explicitly.</p> </li> <li> <p>If you aren't able to provide a <code>MessageDeduplicationId</code> and you enable <code>ContentBasedDeduplication</code> for your queue, Amazon SQS uses a SHA-256 hash to generate the <code>MessageDeduplicationId</code> using the body of the message (but not the attributes of the message). </p> </li> <li> <p>If you don't provide a <code>MessageDeduplicationId</code> and the queue doesn't have <code>ContentBasedDeduplication</code> set, the action fails with an error.</p> </li> <li> <p>If the queue has <code>ContentBasedDeduplication</code> set, your <code>MessageDeduplicationId</code> overrides the generated one.</p> </li> </ul> </li> <li> <p>When <code>ContentBasedDeduplication</code> is in effect, messages with identical content sent within the deduplication interval are treated as duplicates and only one copy of the message is delivered.</p> </li> <li> <p>If you send one message with <code>ContentBasedDeduplication</code> enabled and then another message with a <code>MessageDeduplicationId</code> that is the same as the one generated for the first <code>MessageDeduplicationId</code>, the two messages are treated as duplicates and only one copy of the message is delivered. </p> </li> </ul> <note> <p>The <code>MessageDeduplicationId</code> is available to the recipient of the message (this can be useful for troubleshooting delivery issues).</p> <p>If a message is sent successfully but the acknowledgement is lost and the message is resent with the same <code>MessageDeduplicationId</code> after the deduplication interval, Amazon SQS can't detect duplicate messages.</p> </note> <p>The length of <code>MessageDeduplicationId</code> is 128 characters. <code>MessageDeduplicationId</code> can contain alphanumeric characters (<code>a-z</code>, <code>A-Z</code>, <code>0-9</code>) and punctuation (<code>!\"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</code>).</p> <p>For best practices of using <code>MessageDeduplicationId</code>, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queue-recommendations.html#using-messagededuplicationid-property\">Using the MessageDeduplicationId Property</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>"]
+    #[serde(rename="MessageDeduplicationId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_deduplication_id: Option<String>,
     #[doc="<p>This parameter applies only to FIFO (first-in-first-out) queues.</p> <p>The tag that specifies that a message belongs to a specific message group. Messages that belong to the same message group are processed in a FIFO manner (however, messages in different message groups might be processed out of order). To interleave multiple ordered streams within a single queue, use <code>MessageGroupId</code> values (for example, session data for multiple users). In this scenario, multiple readers can process the queue, but the session data of each user is processed in a FIFO fashion.</p> <ul> <li> <p>You must associate a non-empty <code>MessageGroupId</code> with a message. If you don't provide a <code>MessageGroupId</code>, the action fails.</p> </li> <li> <p> <code>ReceiveMessage</code> might return messages with multiple <code>MessageGroupId</code> values. For each <code>MessageGroupId</code>, the messages are sorted by time sent. The caller can't specify a <code>MessageGroupId</code>.</p> </li> </ul> <p>The length of <code>MessageGroupId</code> is 128 characters. Valid values are alphanumeric characters and punctuation <code>(!\"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~)</code>.</p> <p>For best practices of using <code>MessageGroupId</code>, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queue-recommendations.html#using-messagegroupid-property\">Using the MessageGroupId Property</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p> <important> <p> <code>MessageGroupId</code> is required for FIFO queues. You can't use it for Standard queues.</p> </important>"]
+    #[serde(rename="MessageGroupId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_group_id: Option<String>,
     #[doc="<p>The URL of the Amazon SQS queue to which a message is sent.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
 }
 
@@ -2018,15 +2146,23 @@ impl SendMessageRequestSerializer {
 }
 
 #[doc="<p>The <code>MD5OfMessageBody</code> and <code>MessageId</code> elements.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendMessageResult {
     #[doc="<p>An MD5 digest of the non-URL-encoded message attribute string. You can use this attribute to verify that Amazon SQS received the message correctly. Amazon SQS URL-decodes the message before creating the MD5 digest. For information about MD5, see <a href=\"https://www.ietf.org/rfc/rfc1321.txt\">RFC1321</a>.</p>"]
+    #[serde(rename="MD5OfMessageAttributes")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub md5_of_message_attributes: Option<String>,
     #[doc="<p>An MD5 digest of the non-URL-encoded message attribute string. You can use this attribute to verify that Amazon SQS received the message correctly. Amazon SQS URL-decodes the message before creating the MD5 digest. For information about MD5, see <a href=\"https://www.ietf.org/rfc/rfc1321.txt\">RFC1321</a>.</p>"]
+    #[serde(rename="MD5OfMessageBody")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub md5_of_message_body: Option<String>,
     #[doc="<p>An attribute containing the <code>MessageId</code> of the message sent to the queue. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html\">Queue and Message Identifiers</a> in the <i>Amazon SQS Developer Guide</i>. </p>"]
+    #[serde(rename="MessageId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub message_id: Option<String>,
     #[doc="<p>This parameter applies only to FIFO (first-in-first-out) queues.</p> <p>The large, non-consecutive number that Amazon SQS assigns to each message.</p> <p>The length of <code>SequenceNumber</code> is 128 bits. <code>SequenceNumber</code> continues to increase for a particular <code>MessageGroupId</code>.</p>"]
+    #[serde(rename="SequenceNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub sequence_number: Option<String>,
 }
 
@@ -2088,11 +2224,13 @@ impl SendMessageResultDeserializer {
     }
 }
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetQueueAttributesRequest {
     #[doc="<p>A map of attributes to set.</p> <p>The following lists the names, descriptions, and values of the special request parameters that the <code>SetQueueAttributes</code> action uses:</p> <ul> <li> <p> <code>DelaySeconds</code> - The length of time, in seconds, for which the delivery of all messages in the queue is delayed. Valid values: An integer from 0 to 900 (15 minutes). The default is 0 (zero). </p> </li> <li> <p> <code>MaximumMessageSize</code> - The limit of how many bytes a message can contain before Amazon SQS rejects it. Valid values: An integer from 1,024 bytes (1 KiB) up to 262,144 bytes (256 KiB). The default is 262,144 (256 KiB). </p> </li> <li> <p> <code>MessageRetentionPeriod</code> - The length of time, in seconds, for which Amazon SQS retains a message. Valid values: An integer representing seconds, from 60 (1 minute) to 1,209,600 (14 days). The default is 345,600 (4 days). </p> </li> <li> <p> <code>Policy</code> - The queue's policy. A valid AWS policy. For more information about policy structure, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/PoliciesOverview.html\">Overview of AWS IAM Policies</a> in the <i>Amazon IAM User Guide</i>. </p> </li> <li> <p> <code>ReceiveMessageWaitTimeSeconds</code> - The length of time, in seconds, for which a <code> <a>ReceiveMessage</a> </code> action waits for a message to arrive. Valid values: an integer from 0 to 20 (seconds). The default is 0. </p> </li> <li> <p> <code>RedrivePolicy</code> - The parameters for the dead letter queue functionality of the source queue. For more information about the redrive policy and dead letter queues, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html\">Using Amazon SQS Dead Letter Queues</a> in the <i>Amazon SQS Developer Guide</i>. </p> <note> <p>The dead letter queue of a FIFO queue must also be a FIFO queue. Similarly, the dead letter queue of a standard queue must also be a standard queue.</p> </note> </li> <li> <p> <code>VisibilityTimeout</code> - The visibility timeout for the queue. Valid values: an integer from 0 to 43,200 (12 hours). The default is 30. For more information about the visibility timeout, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html\">Visibility Timeout</a> in the <i>Amazon SQS Developer Guide</i>.</p> </li> </ul> <p>The following attributes apply only to <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html\">server-side-encryption</a>:</p> <ul> <li> <p> <code>KmsMasterKeyId</code> - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms\">Key Terms</a>. While the alias of the AWS-managed CMK for Amazon SQS is always <code>alias/aws/sqs</code>, the alias of a custom CMK can, for example, be <code>alias/aws/sqs</code>. For more examples, see <a href=\"http://docs.aws.amazon.com/kms/latest/APIReference/API_DescribeKey.html#API_DescribeKey_RequestParameters\">KeyId</a> in the <i>AWS Key Management Service API Reference</i>. </p> </li> <li> <p> <code>KmsDataKeyReusePeriodSeconds</code> - The length of time, in seconds, for which Amazon SQS can reuse a <a href=\"http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys\">data key</a> to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). The default is 300 (5 minutes). A shorter time period provides better security but results in more calls to KMS which incur charges after Free Tier. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work\">How Does the Data Key Reuse Period Work?</a>. </p> </li> </ul> <p>The following attribute applies only to <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO (first-in-first-out) queues</a>:</p> <ul> <li> <p> <code>ContentBasedDeduplication</code> - Enables content-based deduplication. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing\">Exactly-Once Processing</a> in the <i>Amazon SQS Developer Guide</i>. </p> <ul> <li> <p>Every message must have a unique <code>MessageDeduplicationId</code>,</p> <ul> <li> <p>You may provide a <code>MessageDeduplicationId</code> explicitly.</p> </li> <li> <p>If you aren't able to provide a <code>MessageDeduplicationId</code> and you enable <code>ContentBasedDeduplication</code> for your queue, Amazon SQS uses a SHA-256 hash to generate the <code>MessageDeduplicationId</code> using the body of the message (but not the attributes of the message). </p> </li> <li> <p>If you don't provide a <code>MessageDeduplicationId</code> and the queue doesn't have <code>ContentBasedDeduplication</code> set, the action fails with an error.</p> </li> <li> <p>If the queue has <code>ContentBasedDeduplication</code> set, your <code>MessageDeduplicationId</code> overrides the generated one.</p> </li> </ul> </li> <li> <p>When <code>ContentBasedDeduplication</code> is in effect, messages with identical content sent within the deduplication interval are treated as duplicates and only one copy of the message is delivered.</p> </li> <li> <p>If you send one message with <code>ContentBasedDeduplication</code> enabled and then another message with a <code>MessageDeduplicationId</code> that is the same as the one generated for the first <code>MessageDeduplicationId</code>, the two messages are treated as duplicates and only one copy of the message is delivered. </p> </li> </ul> </li> </ul> <p>Any other valid special request parameters (such as the following) are ignored:</p> <ul> <li> <p> <code>ApproximateNumberOfMessages</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesDelayed</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesNotVisible</code> </p> </li> <li> <p> <code>CreatedTimestamp</code> </p> </li> <li> <p> <code>LastModifiedTimestamp</code> </p> </li> <li> <p> <code>QueueArn</code> </p> </li> </ul>"]
+    #[serde(rename="Attributes")]
     pub attributes: ::std::collections::HashMap<String, String>,
     #[doc="<p>The URL of the Amazon SQS queue whose attributes are set.</p> <p>Queue URLs are case-sensitive.</p>"]
+    #[serde(rename="QueueUrl")]
     pub queue_url: String,
 }
 

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>An activation registers one or more on-premises servers or virtual machines (VMs) with AWS so that you can configure those servers or VMs using Run Command. A server or VM that has been registered with AWS is called a managed instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Activation {
     #[doc="<p>The ID created by Systems Manager when you submitted the activation.</p>"]
     #[serde(rename="ActivationId")]
@@ -69,7 +69,7 @@ pub struct Activation {
     pub registrations_count: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceRequest {
     #[doc="<p>The resource ID you want to tag.</p>"]
     #[serde(rename="ResourceId")]
@@ -82,11 +82,11 @@ pub struct AddTagsToResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceResult;
 
 #[doc="<p>Describes an association of a Systems Manager document and an instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Association {
     #[doc="<p>The ID created by the system when you create an association. An association is a binding between a document and a set of targets with a schedule.</p>"]
     #[serde(rename="AssociationId")]
@@ -131,7 +131,7 @@ pub struct Association {
 }
 
 #[doc="<p>Describes the parameters for a document.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociationDescription {
     #[doc="<p>The association ID.</p>"]
     #[serde(rename="AssociationId")]
@@ -200,7 +200,7 @@ pub struct AssociationDescription {
 }
 
 #[doc="<p>Describes a filter.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociationFilter {
     #[doc="<p>The name of the filter.</p>"]
     #[serde(rename="key")]
@@ -211,7 +211,7 @@ pub struct AssociationFilter {
 }
 
 #[doc="<p>Information about the association.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociationOverview {
     #[doc="<p>Returns the number of targets for the association status. For example, if you created an association with two instances, and one of them was successful, this would return the count of instances by status.</p>"]
     #[serde(rename="AssociationStatusAggregatedCount")]
@@ -246,7 +246,7 @@ pub struct AssociationStatus {
 }
 
 #[doc="<p>Information about the association version.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociationVersionInfo {
     #[doc="<p>The ID created by the system when the association was created.</p>"]
     #[serde(rename="AssociationId")]
@@ -291,7 +291,7 @@ pub struct AssociationVersionInfo {
 }
 
 #[doc="<p>Detailed information about the current state of an individual Automation execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutomationExecution {
     #[doc="<p>The execution ID.</p>"]
     #[serde(rename="AutomationExecutionId")]
@@ -336,7 +336,7 @@ pub struct AutomationExecution {
 }
 
 #[doc="<p>A filter used to match specific automation executions. This is used to limit the scope of Automation execution information returned.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutomationExecutionFilter {
     #[doc="<p>The aspect of the Automation execution information that should be limited.</p>"]
     #[serde(rename="Key")]
@@ -347,7 +347,7 @@ pub struct AutomationExecutionFilter {
 }
 
 #[doc="<p>Details about a specific Automation execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AutomationExecutionMetadata {
     #[doc="<p>The execution ID.</p>"]
     #[serde(rename="AutomationExecutionId")]
@@ -388,7 +388,7 @@ pub struct AutomationExecutionMetadata {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelCommandRequest {
     #[doc="<p>The ID of the command you want to cancel.</p>"]
     #[serde(rename="CommandId")]
@@ -400,11 +400,11 @@ pub struct CancelCommandRequest {
 }
 
 #[doc="<p>Whether or not the command was successfully canceled. There is no guarantee that a request can be canceled.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelCommandResult;
 
 #[doc="<p>Describes a command request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Command {
     #[doc="<p>A unique identifier for this command.</p>"]
     #[serde(rename="CommandId")]
@@ -489,7 +489,7 @@ pub struct Command {
 }
 
 #[doc="<p>Describes a command filter.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CommandFilter {
     #[doc="<p>The name of the filter.</p>"]
     #[serde(rename="key")]
@@ -500,7 +500,7 @@ pub struct CommandFilter {
 }
 
 #[doc="<p>An invocation is copy of a command sent to a specific instance. A command can apply to one or more instances. A command invocation applies to one instance. For example, if a user executes SendCommand against three instances, then a command invocation is created for each requested instance ID. A command invocation returns status and detail information about a command you executed. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CommandInvocation {
     #[doc="<p>The command against which this invocation was requested.</p>"]
     #[serde(rename="CommandId")]
@@ -560,7 +560,7 @@ pub struct CommandInvocation {
 }
 
 #[doc="<p>Describes plugin details.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CommandPlugin {
     #[doc="<p>The name of the plugin. Must be one of the following: aws:updateAgent, aws:domainjoin, aws:applications, aws:runPowerShellScript, aws:psmodule, aws:cloudWatch, aws:runShellScript, or aws:updateSSMAgent. </p>"]
     #[serde(rename="Name")]
@@ -629,7 +629,7 @@ pub struct ComplianceExecutionSummary {
 }
 
 #[doc="<p>Information about the compliance as defined by the resource type. For example, for a patch resource type, <code>Items</code> includes information about the PatchSeverity, Classification, etc.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComplianceItem {
     #[doc="<p>The compliance type. For example, Association (for a State Manager association), Patch, or Custom:<code>string</code> are all valid compliance types.</p>"]
     #[serde(rename="ComplianceType")]
@@ -670,7 +670,7 @@ pub struct ComplianceItem {
 }
 
 #[doc="<p>Information about a compliance item.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComplianceItemEntry {
     #[doc="<p>A \"Key\": \"Value\" tag combination for the compliance item.</p>"]
     #[serde(rename="Details")]
@@ -693,7 +693,7 @@ pub struct ComplianceItemEntry {
 }
 
 #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComplianceStringFilter {
     #[doc="<p>The name of the filter.</p>"]
     #[serde(rename="Key")]
@@ -710,7 +710,7 @@ pub struct ComplianceStringFilter {
 }
 
 #[doc="<p>A summary of compliance information by compliance type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComplianceSummaryItem {
     #[doc="<p>The type of compliance item. For example, the compliance type can be Association, Patch, or Custom:string.</p>"]
     #[serde(rename="ComplianceType")]
@@ -727,7 +727,7 @@ pub struct ComplianceSummaryItem {
 }
 
 #[doc="<p>A summary of resources that are compliant. The summary is organized according to the resource count for each compliance type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompliantSummary {
     #[doc="<p>The total number of resources that are compliant.</p>"]
     #[serde(rename="CompliantCount")]
@@ -739,7 +739,7 @@ pub struct CompliantSummary {
     pub severity_summary: Option<SeveritySummary>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateActivationRequest {
     #[doc="<p>The name of the registered, managed instance as it will appear in the Amazon EC2 console or when you use the AWS command line tools to list EC2 resources.</p>"]
     #[serde(rename="DefaultInstanceName")]
@@ -762,7 +762,7 @@ pub struct CreateActivationRequest {
     pub registration_limit: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateActivationResult {
     #[doc="<p>The code the system generates when it processes the activation. The activation code functions like a password to validate the activation ID. </p>"]
     #[serde(rename="ActivationCode")]
@@ -774,7 +774,7 @@ pub struct CreateActivationResult {
     pub activation_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAssociationBatchRequest {
     #[doc="<p>One or more associations.</p>"]
     #[serde(rename="Entries")]
@@ -817,7 +817,7 @@ pub struct CreateAssociationBatchRequestEntry {
     pub targets: Option<Vec<Target>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAssociationBatchResult {
     #[doc="<p>Information about the associations that failed.</p>"]
     #[serde(rename="Failed")]
@@ -829,7 +829,7 @@ pub struct CreateAssociationBatchResult {
     pub successful: Option<Vec<AssociationDescription>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAssociationRequest {
     #[doc="<p>Specify a descriptive name for the association.</p>"]
     #[serde(rename="AssociationName")]
@@ -864,7 +864,7 @@ pub struct CreateAssociationRequest {
     pub targets: Option<Vec<Target>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateAssociationResult {
     #[doc="<p>Information about the association.</p>"]
     #[serde(rename="AssociationDescription")]
@@ -872,7 +872,7 @@ pub struct CreateAssociationResult {
     pub association_description: Option<AssociationDescription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDocumentRequest {
     #[doc="<p>A valid JSON string.</p>"]
     #[serde(rename="Content")]
@@ -886,7 +886,7 @@ pub struct CreateDocumentRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateDocumentResult {
     #[doc="<p>Information about the Systems Manager document.</p>"]
     #[serde(rename="DocumentDescription")]
@@ -894,7 +894,7 @@ pub struct CreateDocumentResult {
     pub document_description: Option<DocumentDescription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateMaintenanceWindowRequest {
     #[doc="<p>Enables a Maintenance Window task to execute on managed instances, even if you have not registered those instances as targets. If enabled, then you must specify the unregistered instances (by instance ID) when you register a task with the Maintenance Window </p> <p>If you don't enable this option, then you must specify previously-registered targets when you register a task with the Maintenance Window. </p>"]
     #[serde(rename="AllowUnassociatedTargets")]
@@ -921,7 +921,7 @@ pub struct CreateMaintenanceWindowRequest {
     pub schedule: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateMaintenanceWindowResult {
     #[doc="<p>The ID of the created Maintenance Window.</p>"]
     #[serde(rename="WindowId")]
@@ -929,7 +929,7 @@ pub struct CreateMaintenanceWindowResult {
     pub window_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePatchBaselineRequest {
     #[doc="<p>A set of rules used to include patches in the baseline.</p>"]
     #[serde(rename="ApprovalRules")]
@@ -968,7 +968,7 @@ pub struct CreatePatchBaselineRequest {
     pub rejected_patches: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreatePatchBaselineResult {
     #[doc="<p>The ID of the created patch baseline.</p>"]
     #[serde(rename="BaselineId")]
@@ -976,7 +976,7 @@ pub struct CreatePatchBaselineResult {
     pub baseline_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateResourceDataSyncRequest {
     #[doc="<p>Amazon S3 configuration details for the sync.</p>"]
     #[serde(rename="S3Destination")]
@@ -986,20 +986,20 @@ pub struct CreateResourceDataSyncRequest {
     pub sync_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateResourceDataSyncResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteActivationRequest {
     #[doc="<p>The ID of the activation that you want to delete.</p>"]
     #[serde(rename="ActivationId")]
     pub activation_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteActivationResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAssociationRequest {
     #[doc="<p>The association ID that you want to delete.</p>"]
     #[serde(rename="AssociationId")]
@@ -1015,27 +1015,27 @@ pub struct DeleteAssociationRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteAssociationResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDocumentRequest {
     #[doc="<p>The name of the document.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDocumentResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMaintenanceWindowRequest {
     #[doc="<p>The ID of the Maintenance Window to delete.</p>"]
     #[serde(rename="WindowId")]
     pub window_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteMaintenanceWindowResult {
     #[doc="<p>The ID of the deleted Maintenance Window.</p>"]
     #[serde(rename="WindowId")]
@@ -1043,24 +1043,24 @@ pub struct DeleteMaintenanceWindowResult {
     pub window_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteParameterRequest {
     #[doc="<p>The name of the parameter to delete.</p>"]
     #[serde(rename="Name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteParameterResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteParametersRequest {
     #[doc="<p>The names of the parameters to delete.</p>"]
     #[serde(rename="Names")]
     pub names: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteParametersResult {
     #[doc="<p>The names of the deleted parameters.</p>"]
     #[serde(rename="DeletedParameters")]
@@ -1072,14 +1072,14 @@ pub struct DeleteParametersResult {
     pub invalid_parameters: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePatchBaselineRequest {
     #[doc="<p>The ID of the patch baseline to delete.</p>"]
     #[serde(rename="BaselineId")]
     pub baseline_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeletePatchBaselineResult {
     #[doc="<p>The ID of the deleted patch baseline.</p>"]
     #[serde(rename="BaselineId")]
@@ -1087,27 +1087,27 @@ pub struct DeletePatchBaselineResult {
     pub baseline_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteResourceDataSyncRequest {
     #[doc="<p>The name of the configuration to delete.</p>"]
     #[serde(rename="SyncName")]
     pub sync_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteResourceDataSyncResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterManagedInstanceRequest {
     #[doc="<p>The ID assigned to the managed instance when you registered it using the activation process. </p>"]
     #[serde(rename="InstanceId")]
     pub instance_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterManagedInstanceResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterPatchBaselineForPatchGroupRequest {
     #[doc="<p>The ID of the patch baseline to deregister the patch group from.</p>"]
     #[serde(rename="BaselineId")]
@@ -1117,7 +1117,7 @@ pub struct DeregisterPatchBaselineForPatchGroupRequest {
     pub patch_group: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterPatchBaselineForPatchGroupResult {
     #[doc="<p>The ID of the patch baseline the patch group was deregistered from.</p>"]
     #[serde(rename="BaselineId")]
@@ -1129,7 +1129,7 @@ pub struct DeregisterPatchBaselineForPatchGroupResult {
     pub patch_group: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterTargetFromMaintenanceWindowRequest {
     #[doc="<p>The system checks if the target is being referenced by a task. If the target is being referenced, the system returns an error and does not deregister the target from the Maintenance Window.</p>"]
     #[serde(rename="Safe")]
@@ -1143,7 +1143,7 @@ pub struct DeregisterTargetFromMaintenanceWindowRequest {
     pub window_target_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterTargetFromMaintenanceWindowResult {
     #[doc="<p>The ID of the Maintenance Window the target was removed from.</p>"]
     #[serde(rename="WindowId")]
@@ -1155,7 +1155,7 @@ pub struct DeregisterTargetFromMaintenanceWindowResult {
     pub window_target_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterTaskFromMaintenanceWindowRequest {
     #[doc="<p>The ID of the Maintenance Window the task should be removed from.</p>"]
     #[serde(rename="WindowId")]
@@ -1165,7 +1165,7 @@ pub struct DeregisterTaskFromMaintenanceWindowRequest {
     pub window_task_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeregisterTaskFromMaintenanceWindowResult {
     #[doc="<p>The ID of the Maintenance Window the task was removed from.</p>"]
     #[serde(rename="WindowId")]
@@ -1178,7 +1178,7 @@ pub struct DeregisterTaskFromMaintenanceWindowResult {
 }
 
 #[doc="<p>Filter for the DescribeActivation API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeActivationsFilter {
     #[doc="<p>The name of the filter.</p>"]
     #[serde(rename="FilterKey")]
@@ -1190,7 +1190,7 @@ pub struct DescribeActivationsFilter {
     pub filter_values: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeActivationsRequest {
     #[doc="<p>A filter to view information about your activations.</p>"]
     #[serde(rename="Filters")]
@@ -1206,7 +1206,7 @@ pub struct DescribeActivationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeActivationsResult {
     #[doc="<p>A list of activations for your AWS account.</p>"]
     #[serde(rename="ActivationList")]
@@ -1218,7 +1218,7 @@ pub struct DescribeActivationsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAssociationRequest {
     #[doc="<p>The association ID for which you want information.</p>"]
     #[serde(rename="AssociationId")]
@@ -1238,7 +1238,7 @@ pub struct DescribeAssociationRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAssociationResult {
     #[doc="<p>Information about the association.</p>"]
     #[serde(rename="AssociationDescription")]
@@ -1246,7 +1246,7 @@ pub struct DescribeAssociationResult {
     pub association_description: Option<AssociationDescription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAutomationExecutionsRequest {
     #[doc="<p>Filters used to limit the scope of executions that are requested.</p>"]
     #[serde(rename="Filters")]
@@ -1262,7 +1262,7 @@ pub struct DescribeAutomationExecutionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAutomationExecutionsResult {
     #[doc="<p>The list of details about each automation execution which has occurred which matches the filter specification, if any.</p>"]
     #[serde(rename="AutomationExecutionMetadataList")]
@@ -1274,7 +1274,7 @@ pub struct DescribeAutomationExecutionsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAvailablePatchesRequest {
     #[doc="<p>Filters used to scope down the returned patches.</p>"]
     #[serde(rename="Filters")]
@@ -1290,7 +1290,7 @@ pub struct DescribeAvailablePatchesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAvailablePatchesResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
     #[serde(rename="NextToken")]
@@ -1302,7 +1302,7 @@ pub struct DescribeAvailablePatchesResult {
     pub patches: Option<Vec<Patch>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDocumentPermissionRequest {
     #[doc="<p>The name of the document for which you are the owner.</p>"]
     #[serde(rename="Name")]
@@ -1312,7 +1312,7 @@ pub struct DescribeDocumentPermissionRequest {
     pub permission_type: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDocumentPermissionResponse {
     #[doc="<p>The account IDs that have permission to use this document. The ID can be either an AWS account or <i>All</i>.</p>"]
     #[serde(rename="AccountIds")]
@@ -1320,7 +1320,7 @@ pub struct DescribeDocumentPermissionResponse {
     pub account_ids: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDocumentRequest {
     #[doc="<p>The document version for which you want information. Can be a specific version or the default version.</p>"]
     #[serde(rename="DocumentVersion")]
@@ -1331,7 +1331,7 @@ pub struct DescribeDocumentRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDocumentResult {
     #[doc="<p>Information about the SSM document.</p>"]
     #[serde(rename="Document")]
@@ -1339,7 +1339,7 @@ pub struct DescribeDocumentResult {
     pub document: Option<DocumentDescription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEffectiveInstanceAssociationsRequest {
     #[doc="<p>The instance ID for which you want to view all associations.</p>"]
     #[serde(rename="InstanceId")]
@@ -1354,7 +1354,7 @@ pub struct DescribeEffectiveInstanceAssociationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEffectiveInstanceAssociationsResult {
     #[doc="<p>The associations for the requested instance.</p>"]
     #[serde(rename="Associations")]
@@ -1366,7 +1366,7 @@ pub struct DescribeEffectiveInstanceAssociationsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEffectivePatchesForPatchBaselineRequest {
     #[doc="<p>The ID of the patch baseline to retrieve the effective patches for.</p>"]
     #[serde(rename="BaselineId")]
@@ -1381,7 +1381,7 @@ pub struct DescribeEffectivePatchesForPatchBaselineRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeEffectivePatchesForPatchBaselineResult {
     #[doc="<p>An array of patches and patch status.</p>"]
     #[serde(rename="EffectivePatches")]
@@ -1393,7 +1393,7 @@ pub struct DescribeEffectivePatchesForPatchBaselineResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstanceAssociationsStatusRequest {
     #[doc="<p>The instance IDs for which you want association status information.</p>"]
     #[serde(rename="InstanceId")]
@@ -1408,7 +1408,7 @@ pub struct DescribeInstanceAssociationsStatusRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstanceAssociationsStatusResult {
     #[doc="<p>Status information about the association.</p>"]
     #[serde(rename="InstanceAssociationStatusInfos")]
@@ -1420,7 +1420,7 @@ pub struct DescribeInstanceAssociationsStatusResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstanceInformationRequest {
     #[doc="<p>One or more filters. Use a filter to return a more specific list of instances.</p>"]
     #[serde(rename="Filters")]
@@ -1440,7 +1440,7 @@ pub struct DescribeInstanceInformationRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstanceInformationResult {
     #[doc="<p>The instance information list.</p>"]
     #[serde(rename="InstanceInformationList")]
@@ -1452,7 +1452,7 @@ pub struct DescribeInstanceInformationResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancePatchStatesForPatchGroupRequest {
     #[doc="<p>Each entry in the array is a structure containing:</p> <p>Key (string between 1 and 200 characters)</p> <p> Values (array containing a single string)</p> <p> Type (string \"Equal\", \"NotEqual\", \"LessThan\", \"GreaterThan\")</p>"]
     #[serde(rename="Filters")]
@@ -1471,7 +1471,7 @@ pub struct DescribeInstancePatchStatesForPatchGroupRequest {
     pub patch_group: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancePatchStatesForPatchGroupResult {
     #[doc="<p>The high-level patch state for the requested instances. </p>"]
     #[serde(rename="InstancePatchStates")]
@@ -1483,7 +1483,7 @@ pub struct DescribeInstancePatchStatesForPatchGroupResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancePatchStatesRequest {
     #[doc="<p>The ID of the instance whose patch state information should be retrieved.</p>"]
     #[serde(rename="InstanceIds")]
@@ -1498,7 +1498,7 @@ pub struct DescribeInstancePatchStatesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancePatchStatesResult {
     #[doc="<p>The high-level patch state for the requested instances.</p>"]
     #[serde(rename="InstancePatchStates")]
@@ -1510,7 +1510,7 @@ pub struct DescribeInstancePatchStatesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancePatchesRequest {
     #[doc="<p>Each entry in the array is a structure containing:</p> <p>Key (string, between 1 and 128 characters)</p> <p>Values (array of strings, each string between 1 and 256 characters)</p>"]
     #[serde(rename="Filters")]
@@ -1529,7 +1529,7 @@ pub struct DescribeInstancePatchesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeInstancePatchesResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
     #[serde(rename="NextToken")]
@@ -1541,7 +1541,7 @@ pub struct DescribeInstancePatchesResult {
     pub patches: Option<Vec<PatchComplianceData>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowExecutionTaskInvocationsRequest {
     #[doc="<p>Optional filters used to scope down the returned task invocations. The supported filter key is STATUS with the corresponding values PENDING, IN_PROGRESS, SUCCESS, FAILED, TIMED_OUT, CANCELLING, and CANCELLED.</p>"]
     #[serde(rename="Filters")]
@@ -1563,7 +1563,7 @@ pub struct DescribeMaintenanceWindowExecutionTaskInvocationsRequest {
     pub window_execution_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowExecutionTaskInvocationsResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
     #[serde(rename="NextToken")]
@@ -1576,7 +1576,7 @@ pub struct DescribeMaintenanceWindowExecutionTaskInvocationsResult {
         Option<Vec<MaintenanceWindowExecutionTaskInvocationIdentity>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowExecutionTasksRequest {
     #[doc="<p>Optional filters used to scope down the returned tasks. The supported filter key is STATUS with the corresponding values PENDING, IN_PROGRESS, SUCCESS, FAILED, TIMED_OUT, CANCELLING, and CANCELLED. </p>"]
     #[serde(rename="Filters")]
@@ -1595,7 +1595,7 @@ pub struct DescribeMaintenanceWindowExecutionTasksRequest {
     pub window_execution_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowExecutionTasksResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
     #[serde(rename="NextToken")]
@@ -1607,7 +1607,7 @@ pub struct DescribeMaintenanceWindowExecutionTasksResult {
     pub window_execution_task_identities: Option<Vec<MaintenanceWindowExecutionTaskIdentity>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowExecutionsRequest {
     #[doc="<p>Each entry in the array is a structure containing:</p> <p>Key (string, between 1 and 128 characters)</p> <p>Values (array of strings, each string is between 1 and 256 characters)</p> <p>The supported Keys are ExecutedBefore and ExecutedAfter with the value being a date/time string such as 2016-11-04T05:00:00Z.</p>"]
     #[serde(rename="Filters")]
@@ -1626,7 +1626,7 @@ pub struct DescribeMaintenanceWindowExecutionsRequest {
     pub window_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowExecutionsResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
     #[serde(rename="NextToken")]
@@ -1638,7 +1638,7 @@ pub struct DescribeMaintenanceWindowExecutionsResult {
     pub window_executions: Option<Vec<MaintenanceWindowExecution>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowTargetsRequest {
     #[doc="<p>Optional filters that can be used to narrow down the scope of the returned window targets. The supported filter keys are Type, WindowTargetId and OwnerInformation.</p>"]
     #[serde(rename="Filters")]
@@ -1657,7 +1657,7 @@ pub struct DescribeMaintenanceWindowTargetsRequest {
     pub window_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowTargetsResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
     #[serde(rename="NextToken")]
@@ -1669,7 +1669,7 @@ pub struct DescribeMaintenanceWindowTargetsResult {
     pub targets: Option<Vec<MaintenanceWindowTarget>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowTasksRequest {
     #[doc="<p>Optional filters used to narrow down the scope of the returned tasks. The supported filter keys are WindowTaskId, TaskArn, Priority, and TaskType.</p>"]
     #[serde(rename="Filters")]
@@ -1688,7 +1688,7 @@ pub struct DescribeMaintenanceWindowTasksRequest {
     pub window_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowTasksResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
     #[serde(rename="NextToken")]
@@ -1700,7 +1700,7 @@ pub struct DescribeMaintenanceWindowTasksResult {
     pub tasks: Option<Vec<MaintenanceWindowTask>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowsRequest {
     #[doc="<p>Optional filters used to narrow down the scope of the returned Maintenance Windows. Supported filter keys are Name and Enabled.</p>"]
     #[serde(rename="Filters")]
@@ -1716,7 +1716,7 @@ pub struct DescribeMaintenanceWindowsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceWindowsResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
     #[serde(rename="NextToken")]
@@ -1728,7 +1728,7 @@ pub struct DescribeMaintenanceWindowsResult {
     pub window_identities: Option<Vec<MaintenanceWindowIdentity>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeParametersRequest {
     #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
     #[serde(rename="Filters")]
@@ -1748,7 +1748,7 @@ pub struct DescribeParametersRequest {
     pub parameter_filters: Option<Vec<ParameterStringFilter>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeParametersResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
     #[serde(rename="NextToken")]
@@ -1760,7 +1760,7 @@ pub struct DescribeParametersResult {
     pub parameters: Option<Vec<ParameterMetadata>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePatchBaselinesRequest {
     #[doc="<p>Each element in the array is a structure containing: </p> <p>Key: (string, \"NAME_PREFIX\" or \"OWNER\")</p> <p>Value: (array of strings, exactly 1 entry, between 1 and 255 characters)</p>"]
     #[serde(rename="Filters")]
@@ -1776,7 +1776,7 @@ pub struct DescribePatchBaselinesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePatchBaselinesResult {
     #[doc="<p>An array of PatchBaselineIdentity elements.</p>"]
     #[serde(rename="BaselineIdentities")]
@@ -1788,14 +1788,14 @@ pub struct DescribePatchBaselinesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePatchGroupStateRequest {
     #[doc="<p>The name of the patch group whose patch snapshot should be retrieved.</p>"]
     #[serde(rename="PatchGroup")]
     pub patch_group: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePatchGroupStateResult {
     #[doc="<p>The number of instances in the patch group.</p>"]
     #[serde(rename="Instances")]
@@ -1823,7 +1823,7 @@ pub struct DescribePatchGroupStateResult {
     pub instances_with_not_applicable_patches: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePatchGroupsRequest {
     #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
     #[serde(rename="Filters")]
@@ -1839,7 +1839,7 @@ pub struct DescribePatchGroupsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribePatchGroupsResult {
     #[doc="<p>Each entry in the array contains:</p> <p>PatchGroup: string (between 1 and 256 characters, Regex: ^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$)</p> <p>PatchBaselineIdentity: A PatchBaselineIdentity element. </p>"]
     #[serde(rename="Mappings")]
@@ -1852,7 +1852,7 @@ pub struct DescribePatchGroupsResult {
 }
 
 #[doc="<p>A default version of a document.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentDefaultVersionDescription {
     #[doc="<p>The default version of the document.</p>"]
     #[serde(rename="DefaultVersion")]
@@ -1865,7 +1865,7 @@ pub struct DocumentDefaultVersionDescription {
 }
 
 #[doc="<p>Describes an SSM document. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentDescription {
     #[doc="<p>The date when the document was created.</p>"]
     #[serde(rename="CreatedDate")]
@@ -1930,7 +1930,7 @@ pub struct DocumentDescription {
 }
 
 #[doc="<p>Describes a filter.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentFilter {
     #[doc="<p>The name of the filter.</p>"]
     #[serde(rename="key")]
@@ -1941,7 +1941,7 @@ pub struct DocumentFilter {
 }
 
 #[doc="<p>Describes the name of an SSM document.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentIdentifier {
     #[doc="<p>The document type.</p>"]
     #[serde(rename="DocumentType")]
@@ -1970,7 +1970,7 @@ pub struct DocumentIdentifier {
 }
 
 #[doc="<p>Parameters specified in a System Manager document that execute on the server when the command is run. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentParameter {
     #[doc="<p>If specified, the default values for the parameters. Parameters without a default value are required. Parameters with a default value are optional.</p>"]
     #[serde(rename="DefaultValue")]
@@ -1991,7 +1991,7 @@ pub struct DocumentParameter {
 }
 
 #[doc="<p>Version information about the document.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentVersionInfo {
     #[doc="<p>The date the document was created.</p>"]
     #[serde(rename="CreatedDate")]
@@ -2012,7 +2012,7 @@ pub struct DocumentVersionInfo {
 }
 
 #[doc="<p>The EffectivePatch structure defines metadata about a patch along with the approval state of the patch in a particular patch baseline. The approval state includes information about whether the patch is currently approved, due to be approved by a rule, explicitly approved, or explicitly rejected and the date the patch was or will be approved.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EffectivePatch {
     #[doc="<p>Provides metadata for a patch, including information such as the KB ID, severity, classification and a URL for where more information can be obtained about the patch.</p>"]
     #[serde(rename="Patch")]
@@ -2025,7 +2025,7 @@ pub struct EffectivePatch {
 }
 
 #[doc="<p>Describes a failed association.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailedCreateAssociation {
     #[doc="<p>The association.</p>"]
     #[serde(rename="Entry")]
@@ -2042,7 +2042,7 @@ pub struct FailedCreateAssociation {
 }
 
 #[doc="<p>Information about an Automation failure.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailureDetails {
     #[doc="<p>Detailed information about the Automation step failure.</p>"]
     #[serde(rename="Details")]
@@ -2058,14 +2058,14 @@ pub struct FailureDetails {
     pub failure_type: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAutomationExecutionRequest {
     #[doc="<p>The unique identifier for an existing automation execution to examine. The execution ID is returned by StartAutomationExecution when the execution of an Automation document is initiated.</p>"]
     #[serde(rename="AutomationExecutionId")]
     pub automation_execution_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetAutomationExecutionResult {
     #[doc="<p>Detailed information about the current state of an automation execution.</p>"]
     #[serde(rename="AutomationExecution")]
@@ -2073,7 +2073,7 @@ pub struct GetAutomationExecutionResult {
     pub automation_execution: Option<AutomationExecution>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCommandInvocationRequest {
     #[doc="<p>(Required) The parent command ID of the invocation plugin.</p>"]
     #[serde(rename="CommandId")]
@@ -2087,7 +2087,7 @@ pub struct GetCommandInvocationRequest {
     pub plugin_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCommandInvocationResult {
     #[doc="<p>The parent command ID of the invocation plugin.</p>"]
     #[serde(rename="CommandId")]
@@ -2151,7 +2151,7 @@ pub struct GetCommandInvocationResult {
     pub status_details: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDefaultPatchBaselineRequest {
     #[doc="<p>Returns the default patch baseline for the specified operating system.</p>"]
     #[serde(rename="OperatingSystem")]
@@ -2159,7 +2159,7 @@ pub struct GetDefaultPatchBaselineRequest {
     pub operating_system: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDefaultPatchBaselineResult {
     #[doc="<p>The ID of the default patch baseline.</p>"]
     #[serde(rename="BaselineId")]
@@ -2171,7 +2171,7 @@ pub struct GetDefaultPatchBaselineResult {
     pub operating_system: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeployablePatchSnapshotForInstanceRequest {
     #[doc="<p>The ID of the instance for which the appropriate patch snapshot should be retrieved.</p>"]
     #[serde(rename="InstanceId")]
@@ -2181,7 +2181,7 @@ pub struct GetDeployablePatchSnapshotForInstanceRequest {
     pub snapshot_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDeployablePatchSnapshotForInstanceResult {
     #[doc="<p>The ID of the instance.</p>"]
     #[serde(rename="InstanceId")]
@@ -2201,7 +2201,7 @@ pub struct GetDeployablePatchSnapshotForInstanceResult {
     pub snapshot_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentRequest {
     #[doc="<p>The document version for which you want information.</p>"]
     #[serde(rename="DocumentVersion")]
@@ -2212,7 +2212,7 @@ pub struct GetDocumentRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentResult {
     #[doc="<p>The contents of the SSM document.</p>"]
     #[serde(rename="Content")]
@@ -2232,7 +2232,7 @@ pub struct GetDocumentResult {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInventoryRequest {
     #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
     #[serde(rename="Filters")]
@@ -2252,7 +2252,7 @@ pub struct GetInventoryRequest {
     pub result_attributes: Option<Vec<ResultAttribute>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInventoryResult {
     #[doc="<p>Collection of inventory entities such as a collection of instance inventory. </p>"]
     #[serde(rename="Entities")]
@@ -2264,7 +2264,7 @@ pub struct GetInventoryResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInventorySchemaRequest {
     #[doc="<p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>"]
     #[serde(rename="MaxResults")]
@@ -2284,7 +2284,7 @@ pub struct GetInventorySchemaRequest {
     pub type_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetInventorySchemaResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
     #[serde(rename="NextToken")]
@@ -2296,14 +2296,14 @@ pub struct GetInventorySchemaResult {
     pub schemas: Option<Vec<InventoryItemSchema>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMaintenanceWindowExecutionRequest {
     #[doc="<p>The ID of the Maintenance Window execution that includes the task.</p>"]
     #[serde(rename="WindowExecutionId")]
     pub window_execution_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMaintenanceWindowExecutionResult {
     #[doc="<p>The time the Maintenance Window finished executing.</p>"]
     #[serde(rename="EndTime")]
@@ -2331,7 +2331,7 @@ pub struct GetMaintenanceWindowExecutionResult {
     pub window_execution_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMaintenanceWindowExecutionTaskInvocationRequest {
     #[doc="<p>The invocation ID to retrieve.</p>"]
     #[serde(rename="InvocationId")]
@@ -2344,7 +2344,7 @@ pub struct GetMaintenanceWindowExecutionTaskInvocationRequest {
     pub window_execution_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMaintenanceWindowExecutionTaskInvocationResult {
     #[doc="<p>The time that the task finished executing on the target.</p>"]
     #[serde(rename="EndTime")]
@@ -2396,7 +2396,7 @@ pub struct GetMaintenanceWindowExecutionTaskInvocationResult {
     pub window_target_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMaintenanceWindowExecutionTaskRequest {
     #[doc="<p>The ID of the specific task execution in the Maintenance Window task that should be retrieved.</p>"]
     #[serde(rename="TaskId")]
@@ -2406,7 +2406,7 @@ pub struct GetMaintenanceWindowExecutionTaskRequest {
     pub window_execution_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMaintenanceWindowExecutionTaskResult {
     #[doc="<p>The time the task execution completed.</p>"]
     #[serde(rename="EndTime")]
@@ -2464,14 +2464,14 @@ pub struct GetMaintenanceWindowExecutionTaskResult {
     pub window_execution_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMaintenanceWindowRequest {
     #[doc="<p>The ID of the desired Maintenance Window.</p>"]
     #[serde(rename="WindowId")]
     pub window_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMaintenanceWindowResult {
     #[doc="<p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>"]
     #[serde(rename="AllowUnassociatedTargets")]
@@ -2515,7 +2515,7 @@ pub struct GetMaintenanceWindowResult {
     pub window_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMaintenanceWindowTaskRequest {
     #[doc="<p>The Maintenance Window ID that includes the task to retrieve.</p>"]
     #[serde(rename="WindowId")]
@@ -2525,7 +2525,7 @@ pub struct GetMaintenanceWindowTaskRequest {
     pub window_task_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetMaintenanceWindowTaskResult {
     #[doc="<p>The retrieved task description.</p>"]
     #[serde(rename="Description")]
@@ -2586,7 +2586,7 @@ pub struct GetMaintenanceWindowTaskResult {
     pub window_task_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetParameterHistoryRequest {
     #[doc="<p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>"]
     #[serde(rename="MaxResults")]
@@ -2605,7 +2605,7 @@ pub struct GetParameterHistoryRequest {
     pub with_decryption: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetParameterHistoryResult {
     #[doc="<p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>"]
     #[serde(rename="NextToken")]
@@ -2617,7 +2617,7 @@ pub struct GetParameterHistoryResult {
     pub parameters: Option<Vec<ParameterHistory>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetParameterRequest {
     #[doc="<p>The name of the parameter you want to query.</p>"]
     #[serde(rename="Name")]
@@ -2628,7 +2628,7 @@ pub struct GetParameterRequest {
     pub with_decryption: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetParameterResult {
     #[doc="<p>Information about a parameter.</p>"]
     #[serde(rename="Parameter")]
@@ -2636,7 +2636,7 @@ pub struct GetParameterResult {
     pub parameter: Option<Parameter>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetParametersByPathRequest {
     #[doc="<p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>"]
     #[serde(rename="MaxResults")]
@@ -2663,7 +2663,7 @@ pub struct GetParametersByPathRequest {
     pub with_decryption: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetParametersByPathResult {
     #[doc="<p>The token for the next set of items to return. Use this token to get the next set of results.</p>"]
     #[serde(rename="NextToken")]
@@ -2675,7 +2675,7 @@ pub struct GetParametersByPathResult {
     pub parameters: Option<Vec<Parameter>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetParametersRequest {
     #[doc="<p>Names of the parameters for which you want to query information.</p>"]
     #[serde(rename="Names")]
@@ -2686,7 +2686,7 @@ pub struct GetParametersRequest {
     pub with_decryption: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetParametersResult {
     #[doc="<p>A list of parameters that are not formatted correctly or do not run when executed.</p>"]
     #[serde(rename="InvalidParameters")]
@@ -2698,7 +2698,7 @@ pub struct GetParametersResult {
     pub parameters: Option<Vec<Parameter>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPatchBaselineForPatchGroupRequest {
     #[doc="<p>Returns he operating system rule specified for patch groups using the patch baseline.</p>"]
     #[serde(rename="OperatingSystem")]
@@ -2709,7 +2709,7 @@ pub struct GetPatchBaselineForPatchGroupRequest {
     pub patch_group: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPatchBaselineForPatchGroupResult {
     #[doc="<p>The ID of the patch baseline that should be used for the patch group.</p>"]
     #[serde(rename="BaselineId")]
@@ -2725,14 +2725,14 @@ pub struct GetPatchBaselineForPatchGroupResult {
     pub patch_group: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPatchBaselineRequest {
     #[doc="<p>The ID of the patch baseline to retrieve.</p>"]
     #[serde(rename="BaselineId")]
     pub baseline_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetPatchBaselineResult {
     #[doc="<p>A set of rules used to include patches in the baseline.</p>"]
     #[serde(rename="ApprovalRules")]
@@ -2785,7 +2785,7 @@ pub struct GetPatchBaselineResult {
 }
 
 #[doc="<p>Status information about the aggregated associations.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceAggregatedAssociationOverview {
     #[doc="<p>Detailed status information about the aggregated associations.</p>"]
     #[serde(rename="DetailedStatus")]
@@ -2799,7 +2799,7 @@ pub struct InstanceAggregatedAssociationOverview {
 }
 
 #[doc="<p>One or more association documents on the instance. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceAssociation {
     #[doc="<p>The association ID.</p>"]
     #[serde(rename="AssociationId")]
@@ -2829,7 +2829,7 @@ pub struct InstanceAssociationOutputLocation {
 }
 
 #[doc="<p>The URL of Amazon S3 bucket where you want to store the results of this request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceAssociationOutputUrl {
     #[doc="<p>The URL of Amazon S3 bucket where you want to store the results of this request.</p>"]
     #[serde(rename="S3OutputUrl")]
@@ -2838,7 +2838,7 @@ pub struct InstanceAssociationOutputUrl {
 }
 
 #[doc="<p>Status information about the instance association.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceAssociationStatusInfo {
     #[doc="<p>The association ID.</p>"]
     #[serde(rename="AssociationId")]
@@ -2891,7 +2891,7 @@ pub struct InstanceAssociationStatusInfo {
 }
 
 #[doc="<p>Describes a filter for a specific list of instances. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceInformation {
     #[doc="<p>The activation ID created by Systems Manager when the server or VM was registered.</p>"]
     #[serde(rename="ActivationId")]
@@ -2972,7 +2972,7 @@ pub struct InstanceInformation {
 }
 
 #[doc="<p>Describes a filter for a specific list of instances. </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceInformationFilter {
     #[doc="<p>The name of the filter. </p>"]
     #[serde(rename="key")]
@@ -2983,7 +2983,7 @@ pub struct InstanceInformationFilter {
 }
 
 #[doc="<p>The filters to describe or get information about your managed instances.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstanceInformationStringFilter {
     #[doc="<p>The filter key name to describe your instances. For example:</p> <p>\"InstanceIds\"|\"AgentVersion\"|\"PingStatus\"|\"PlatformTypes\"|\"ActivationIds\"|\"IamRole\"|\"ResourceType\"|\"AssociationStatus\"|\"Tag Key\"</p>"]
     #[serde(rename="Key")]
@@ -2994,7 +2994,7 @@ pub struct InstanceInformationStringFilter {
 }
 
 #[doc="<p>Defines the high-level patch compliance state for a managed instance, providing information about the number of installed, missing, not applicable, and failed patches along with metadata about the operation when this information was gathered for the instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstancePatchState {
     #[doc="<p>The ID of the patch baseline used to patch the instance.</p>"]
     #[serde(rename="BaselineId")]
@@ -3045,7 +3045,7 @@ pub struct InstancePatchState {
 }
 
 #[doc="<p>Defines a filter used in DescribeInstancePatchStatesForPatchGroup used to scope down the information returned by the API.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InstancePatchStateFilter {
     #[doc="<p>The key for the filter. Supported values are FailedCount, InstalledCount, InstalledOtherCount, MissingCount and NotApplicableCount.</p>"]
     #[serde(rename="Key")]
@@ -3059,7 +3059,7 @@ pub struct InstancePatchStateFilter {
 }
 
 #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InventoryFilter {
     #[doc="<p>The name of the filter key.</p>"]
     #[serde(rename="Key")]
@@ -3074,7 +3074,7 @@ pub struct InventoryFilter {
 }
 
 #[doc="<p>Information collected from managed instances based on your inventory policy document</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InventoryItem {
     #[doc="<p>The time the inventory information was collected.</p>"]
     #[serde(rename="CaptureTime")]
@@ -3100,7 +3100,7 @@ pub struct InventoryItem {
 }
 
 #[doc="<p>Attributes are the entries within the inventory item content. It contains name and value.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InventoryItemAttribute {
     #[doc="<p>The data type of the inventory item attribute. </p>"]
     #[serde(rename="DataType")]
@@ -3111,7 +3111,7 @@ pub struct InventoryItemAttribute {
 }
 
 #[doc="<p>The inventory item schema definition. Users can use this to compose inventory query filters.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InventoryItemSchema {
     #[doc="<p>The schema attributes for inventory. This contains data type and attribute name.</p>"]
     #[serde(rename="Attributes")]
@@ -3126,7 +3126,7 @@ pub struct InventoryItemSchema {
 }
 
 #[doc="<p>Inventory query results.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InventoryResultEntity {
     #[doc="<p>The data section in the inventory result entity json.</p>"]
     #[serde(rename="Data")]
@@ -3139,7 +3139,7 @@ pub struct InventoryResultEntity {
 }
 
 #[doc="<p>The inventory result item.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InventoryResultItem {
     #[doc="<p>The time inventory item data was captured.</p>"]
     #[serde(rename="CaptureTime")]
@@ -3160,7 +3160,7 @@ pub struct InventoryResultItem {
     pub type_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssociationVersionsRequest {
     #[doc="<p>The association ID for which you want to view all versions.</p>"]
     #[serde(rename="AssociationId")]
@@ -3175,7 +3175,7 @@ pub struct ListAssociationVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssociationVersionsResult {
     #[doc="<p>Information about all versions of the association for the specified association ID.</p>"]
     #[serde(rename="AssociationVersions")]
@@ -3187,7 +3187,7 @@ pub struct ListAssociationVersionsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssociationsRequest {
     #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
     #[serde(rename="AssociationFilterList")]
@@ -3203,7 +3203,7 @@ pub struct ListAssociationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListAssociationsResult {
     #[doc="<p>The associations.</p>"]
     #[serde(rename="Associations")]
@@ -3215,7 +3215,7 @@ pub struct ListAssociationsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCommandInvocationsRequest {
     #[doc="<p>(Optional) The invocations for a specific command ID.</p>"]
     #[serde(rename="CommandId")]
@@ -3243,7 +3243,7 @@ pub struct ListCommandInvocationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCommandInvocationsResult {
     #[doc="<p>(Optional) A list of all invocations. </p>"]
     #[serde(rename="CommandInvocations")]
@@ -3255,7 +3255,7 @@ pub struct ListCommandInvocationsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCommandsRequest {
     #[doc="<p>(Optional) If provided, lists only the specified command.</p>"]
     #[serde(rename="CommandId")]
@@ -3279,7 +3279,7 @@ pub struct ListCommandsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListCommandsResult {
     #[doc="<p>(Optional) The list of commands requested by the user. </p>"]
     #[serde(rename="Commands")]
@@ -3291,7 +3291,7 @@ pub struct ListCommandsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListComplianceItemsRequest {
     #[doc="<p>One or more compliance filters. Use a filter to return a more specific list of results.</p>"]
     #[serde(rename="Filters")]
@@ -3315,7 +3315,7 @@ pub struct ListComplianceItemsRequest {
     pub resource_types: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListComplianceItemsResult {
     #[doc="<p>A list of compliance information for the specified resource ID. </p>"]
     #[serde(rename="ComplianceItems")]
@@ -3327,7 +3327,7 @@ pub struct ListComplianceItemsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListComplianceSummariesRequest {
     #[doc="<p>One or more compliance or inventory filters. Use a filter to return a more specific list of results.</p>"]
     #[serde(rename="Filters")]
@@ -3343,7 +3343,7 @@ pub struct ListComplianceSummariesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListComplianceSummariesResult {
     #[doc="<p>A list of compliant and non-compliant summary counts based on compliance types. For example, this call returns State Manager associations, patches, or custom compliance types according to the filter criteria that you specified.</p>"]
     #[serde(rename="ComplianceSummaryItems")]
@@ -3355,7 +3355,7 @@ pub struct ListComplianceSummariesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDocumentVersionsRequest {
     #[doc="<p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>"]
     #[serde(rename="MaxResults")]
@@ -3370,7 +3370,7 @@ pub struct ListDocumentVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDocumentVersionsResult {
     #[doc="<p>The document versions.</p>"]
     #[serde(rename="DocumentVersions")]
@@ -3382,7 +3382,7 @@ pub struct ListDocumentVersionsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDocumentsRequest {
     #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
     #[serde(rename="DocumentFilterList")]
@@ -3398,7 +3398,7 @@ pub struct ListDocumentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDocumentsResult {
     #[doc="<p>The names of the SSM documents.</p>"]
     #[serde(rename="DocumentIdentifiers")]
@@ -3410,7 +3410,7 @@ pub struct ListDocumentsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInventoryEntriesRequest {
     #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
     #[serde(rename="Filters")]
@@ -3432,7 +3432,7 @@ pub struct ListInventoryEntriesRequest {
     pub type_name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListInventoryEntriesResult {
     #[doc="<p>The time that inventory information was collected for the instance(s).</p>"]
     #[serde(rename="CaptureTime")]
@@ -3460,7 +3460,7 @@ pub struct ListInventoryEntriesResult {
     pub type_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourceComplianceSummariesRequest {
     #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
     #[serde(rename="Filters")]
@@ -3476,7 +3476,7 @@ pub struct ListResourceComplianceSummariesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourceComplianceSummariesResult {
     #[doc="<p>The token for the next set of items to return. Use this token to get the next set of results.</p>"]
     #[serde(rename="NextToken")]
@@ -3488,7 +3488,7 @@ pub struct ListResourceComplianceSummariesResult {
     pub resource_compliance_summary_items: Option<Vec<ResourceComplianceSummaryItem>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourceDataSyncRequest {
     #[doc="<p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>"]
     #[serde(rename="MaxResults")]
@@ -3500,7 +3500,7 @@ pub struct ListResourceDataSyncRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourceDataSyncResult {
     #[doc="<p>The token for the next set of items to return. Use this token to get the next set of results.</p>"]
     #[serde(rename="NextToken")]
@@ -3512,7 +3512,7 @@ pub struct ListResourceDataSyncResult {
     pub resource_data_sync_items: Option<Vec<ResourceDataSyncItem>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceRequest {
     #[doc="<p>The resource ID for which you want to see a list of tags.</p>"]
     #[serde(rename="ResourceId")]
@@ -3522,7 +3522,7 @@ pub struct ListTagsForResourceRequest {
     pub resource_type: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceResult {
     #[doc="<p>A list of tags.</p>"]
     #[serde(rename="TagList")]
@@ -3559,7 +3559,7 @@ pub struct MaintenanceWindowAutomationParameters {
 }
 
 #[doc="<p>Describes the information about an execution of a Maintenance Window. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MaintenanceWindowExecution {
     #[doc="<p>The time the execution finished.</p>"]
     #[serde(rename="EndTime")]
@@ -3588,7 +3588,7 @@ pub struct MaintenanceWindowExecution {
 }
 
 #[doc="<p>Information about a task execution performed as part of a Maintenance Window execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MaintenanceWindowExecutionTaskIdentity {
     #[doc="<p>The time the task execution finished.</p>"]
     #[serde(rename="EndTime")]
@@ -3625,7 +3625,7 @@ pub struct MaintenanceWindowExecutionTaskIdentity {
 }
 
 #[doc="<p>Describes the information about a task invocation for a particular target as part of a task execution performed as part of a Maintenance Window execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MaintenanceWindowExecutionTaskInvocationIdentity {
     #[doc="<p>The time the invocation finished.</p>"]
     #[serde(rename="EndTime")]
@@ -3678,7 +3678,7 @@ pub struct MaintenanceWindowExecutionTaskInvocationIdentity {
 }
 
 #[doc="<p>Filter used in the request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MaintenanceWindowFilter {
     #[doc="<p>The name of the filter.</p>"]
     #[serde(rename="Key")]
@@ -3691,7 +3691,7 @@ pub struct MaintenanceWindowFilter {
 }
 
 #[doc="<p>Information about the Maintenance Window.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MaintenanceWindowIdentity {
     #[doc="<p>The number of hours before the end of the Maintenance Window that Systems Manager stops scheduling new tasks for execution.</p>"]
     #[serde(rename="Cutoff")]
@@ -3795,7 +3795,7 @@ pub struct MaintenanceWindowStepFunctionsParameters {
 }
 
 #[doc="<p>The target registered with the Maintenance Window.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MaintenanceWindowTarget {
     #[doc="<p>A description of the target.</p>"]
     #[serde(rename="Description")]
@@ -3828,7 +3828,7 @@ pub struct MaintenanceWindowTarget {
 }
 
 #[doc="<p>Information about a task defined for a Maintenance Window.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MaintenanceWindowTask {
     #[doc="<p>A description of the task.</p>"]
     #[serde(rename="Description")]
@@ -3915,7 +3915,7 @@ pub struct MaintenanceWindowTaskParameterValueExpression {
     pub values: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDocumentPermissionRequest {
     #[doc="<p>The AWS user accounts that should have access to the document. The account IDs can either be a group of account IDs or <i>All</i>.</p>"]
     #[serde(rename="AccountIdsToAdd")]
@@ -3933,11 +3933,11 @@ pub struct ModifyDocumentPermissionRequest {
     pub permission_type: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyDocumentPermissionResponse;
 
 #[doc="<p>A summary of resources that are not compliant. The summary is organized according to resource type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NonCompliantSummary {
     #[doc="<p>The total number of compliance items that are not compliant.</p>"]
     #[serde(rename="NonCompliantCount")]
@@ -3967,7 +3967,7 @@ pub struct NotificationConfig {
 }
 
 #[doc="<p>An Amazon EC2 Systems Manager parameter in Parameter Store.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Parameter {
     #[doc="<p>The name of the parameter.</p>"]
     #[serde(rename="Name")]
@@ -3984,7 +3984,7 @@ pub struct Parameter {
 }
 
 #[doc="<p>Information about parameter usage.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ParameterHistory {
     #[doc="<p>Parameter names can include the following letters and symbols.</p> <p>a-zA-Z0-9_.-</p>"]
     #[serde(rename="AllowedPattern")]
@@ -4021,7 +4021,7 @@ pub struct ParameterHistory {
 }
 
 #[doc="<p>Metada includes information like the ARN of the last user and the date/time the parameter was last used.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ParameterMetadata {
     #[doc="<p>A parameter name can include only the following letters and symbols.</p> <p>a-zA-Z0-9_.-</p>"]
     #[serde(rename="AllowedPattern")]
@@ -4054,7 +4054,7 @@ pub struct ParameterMetadata {
 }
 
 #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ParameterStringFilter {
     #[doc="<p>The name of the filter.</p>"]
     #[serde(rename="Key")]
@@ -4070,7 +4070,7 @@ pub struct ParameterStringFilter {
 }
 
 #[doc="<p>One or more filters. Use a filter to return a more specific list of results.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ParametersFilter {
     #[doc="<p>The name of the filter.</p>"]
     #[serde(rename="Key")]
@@ -4081,7 +4081,7 @@ pub struct ParametersFilter {
 }
 
 #[doc="<p>Represents metadata about a patch.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Patch {
     #[doc="<p>The classification of the patch (for example, SecurityUpdates, Updates, CriticalUpdates).</p>"]
     #[serde(rename="Classification")]
@@ -4138,7 +4138,7 @@ pub struct Patch {
 }
 
 #[doc="<p>Defines the basic information about a patch baseline.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PatchBaselineIdentity {
     #[doc="<p>The description of the patch baseline.</p>"]
     #[serde(rename="BaselineDescription")]
@@ -4163,7 +4163,7 @@ pub struct PatchBaselineIdentity {
 }
 
 #[doc="<p>Information about the state of a patch on a particular instance as it relates to the patch baseline used to patch the instance.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PatchComplianceData {
     #[doc="<p>The classification of the patch (for example, SecurityUpdates, Updates, CriticalUpdates).</p>"]
     #[serde(rename="Classification")]
@@ -4205,7 +4205,7 @@ pub struct PatchFilterGroup {
 }
 
 #[doc="<p>The mapping between a patch group and the patch baseline the patch group is registered with.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PatchGroupPatchBaselineMapping {
     #[doc="<p>The patch baseline the patch group is registered with.</p>"]
     #[serde(rename="BaselineIdentity")]
@@ -4218,7 +4218,7 @@ pub struct PatchGroupPatchBaselineMapping {
 }
 
 #[doc="<p>Defines a filter used in Patch Manager APIs.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PatchOrchestratorFilter {
     #[doc="<p>The key for the filter.</p>"]
     #[serde(rename="Key")]
@@ -4254,7 +4254,7 @@ pub struct PatchRuleGroup {
 }
 
 #[doc="<p>Information about the approval status of a patch.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PatchStatus {
     #[doc="<p>The date the patch was approved (or will be approved if the status is PENDING_APPROVAL).</p>"]
     #[serde(rename="ApprovalDate")]
@@ -4270,7 +4270,7 @@ pub struct PatchStatus {
     pub deployment_status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutComplianceItemsRequest {
     #[doc="<p>Specify the compliance type. For example, specify Association (for a State Manager association), Patch, or Custom:<code>string</code>.</p>"]
     #[serde(rename="ComplianceType")]
@@ -4293,10 +4293,10 @@ pub struct PutComplianceItemsRequest {
     pub resource_type: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutComplianceItemsResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutInventoryRequest {
     #[doc="<p>One or more instance IDs where you want to add or update inventory items.</p>"]
     #[serde(rename="InstanceId")]
@@ -4306,10 +4306,10 @@ pub struct PutInventoryRequest {
     pub items: Vec<InventoryItem>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutInventoryResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutParameterRequest {
     #[doc="<p>A regular expression used to validate the parameter value. For example, for String types with values restricted to numbers, you can specify the following: AllowedPattern=^\\d+$ </p>"]
     #[serde(rename="AllowedPattern")]
@@ -4338,17 +4338,17 @@ pub struct PutParameterRequest {
     pub value: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutParameterResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterDefaultPatchBaselineRequest {
     #[doc="<p>The ID of the patch baseline that should be the default patch baseline.</p>"]
     #[serde(rename="BaselineId")]
     pub baseline_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterDefaultPatchBaselineResult {
     #[doc="<p>The ID of the default patch baseline.</p>"]
     #[serde(rename="BaselineId")]
@@ -4356,7 +4356,7 @@ pub struct RegisterDefaultPatchBaselineResult {
     pub baseline_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterPatchBaselineForPatchGroupRequest {
     #[doc="<p>The ID of the patch baseline to register the patch group with.</p>"]
     #[serde(rename="BaselineId")]
@@ -4366,7 +4366,7 @@ pub struct RegisterPatchBaselineForPatchGroupRequest {
     pub patch_group: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterPatchBaselineForPatchGroupResult {
     #[doc="<p>The ID of the patch baseline the patch group was registered with.</p>"]
     #[serde(rename="BaselineId")]
@@ -4378,7 +4378,7 @@ pub struct RegisterPatchBaselineForPatchGroupResult {
     pub patch_group: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterTargetWithMaintenanceWindowRequest {
     #[doc="<p>User-provided idempotency token.</p>"]
     #[serde(rename="ClientToken")]
@@ -4407,7 +4407,7 @@ pub struct RegisterTargetWithMaintenanceWindowRequest {
     pub window_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterTargetWithMaintenanceWindowResult {
     #[doc="<p>The ID of the target definition in this Maintenance Window.</p>"]
     #[serde(rename="WindowTargetId")]
@@ -4415,7 +4415,7 @@ pub struct RegisterTargetWithMaintenanceWindowResult {
     pub window_target_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterTaskWithMaintenanceWindowRequest {
     #[doc="<p>User-provided idempotency token.</p>"]
     #[serde(rename="ClientToken")]
@@ -4469,7 +4469,7 @@ pub struct RegisterTaskWithMaintenanceWindowRequest {
     pub window_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterTaskWithMaintenanceWindowResult {
     #[doc="<p>The id of the task in the Maintenance Window.</p>"]
     #[serde(rename="WindowTaskId")]
@@ -4477,7 +4477,7 @@ pub struct RegisterTaskWithMaintenanceWindowResult {
     pub window_task_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceRequest {
     #[doc="<p>The resource ID for which you want to remove tags.</p>"]
     #[serde(rename="ResourceId")]
@@ -4490,11 +4490,11 @@ pub struct RemoveTagsFromResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceResult;
 
 #[doc="<p>Compliance summary information for a specific resource. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceComplianceSummaryItem {
     #[doc="<p>The compliance type.</p>"]
     #[serde(rename="ComplianceType")]
@@ -4531,7 +4531,7 @@ pub struct ResourceComplianceSummaryItem {
 }
 
 #[doc="<p>Information about a Resource Data Sync configuration, including its current status and last successful sync.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceDataSyncItem {
     #[doc="<p>The status reported by the last sync.</p>"]
     #[serde(rename="LastStatus")]
@@ -4578,7 +4578,7 @@ pub struct ResourceDataSyncS3Destination {
 }
 
 #[doc="<p>The inventory item result attribute.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResultAttribute {
     #[doc="<p>Name of the inventory item type. Valid value: AWS:InstanceInformation. Default Value: AWS:InstanceInformation.</p>"]
     #[serde(rename="TypeName")]
@@ -4603,7 +4603,7 @@ pub struct S3OutputLocation {
 }
 
 #[doc="<p>A URL for the Amazon S3 bucket where you want to store the results of this request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct S3OutputUrl {
     #[doc="<p>A URL for an Amazon S3 bucket where you want to store the results of this request.</p>"]
     #[serde(rename="OutputUrl")]
@@ -4611,7 +4611,7 @@ pub struct S3OutputUrl {
     pub output_url: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendAutomationSignalRequest {
     #[doc="<p>The unique identifier for an existing Automation execution that you want to send the signal to.</p>"]
     #[serde(rename="AutomationExecutionId")]
@@ -4625,10 +4625,10 @@ pub struct SendAutomationSignalRequest {
     pub signal_type: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendAutomationSignalResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendCommandRequest {
     #[doc="<p>User-specified information about the command, such as a brief description of what the command should do.</p>"]
     #[serde(rename="Comment")]
@@ -4691,7 +4691,7 @@ pub struct SendCommandRequest {
     pub timeout_seconds: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendCommandResult {
     #[doc="<p>The request as it was received by Systems Manager. Also provides the command ID which can be used future references to this request.</p>"]
     #[serde(rename="Command")]
@@ -4700,7 +4700,7 @@ pub struct SendCommandResult {
 }
 
 #[doc="<p>The number of managed instances found for each patch severity level defined in the request filter.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SeveritySummary {
     #[doc="<p>The total number of resources or compliance items that have a severity level of critical. Critical severity is determined by the organization that published the compliance items.</p>"]
     #[serde(rename="CriticalCount")]
@@ -4728,7 +4728,7 @@ pub struct SeveritySummary {
     pub unspecified_count: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartAutomationExecutionRequest {
     #[doc="<p>The name of the Automation document to use for this execution.</p>"]
     #[serde(rename="DocumentName")]
@@ -4743,7 +4743,7 @@ pub struct StartAutomationExecutionRequest {
     pub parameters: Option<::std::collections::HashMap<String, Vec<String>>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartAutomationExecutionResult {
     #[doc="<p>The unique ID of a newly scheduled automation execution.</p>"]
     #[serde(rename="AutomationExecutionId")]
@@ -4752,7 +4752,7 @@ pub struct StartAutomationExecutionResult {
 }
 
 #[doc="<p>Detailed information about an the execution state of an Automation step.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StepExecution {
     #[doc="<p>The action this step performs. The action determines the behavior of the step.</p>"]
     #[serde(rename="Action")]
@@ -4800,14 +4800,14 @@ pub struct StepExecution {
     pub step_status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopAutomationExecutionRequest {
     #[doc="<p>The execution ID of the Automation to stop.</p>"]
     #[serde(rename="AutomationExecutionId")]
     pub automation_execution_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopAutomationExecutionResult;
 
 #[doc="<p>Metadata that you assign to your managed instances. Tags enable you to categorize your managed instances in different ways, for example, by purpose, owner, or environment.</p>"]
@@ -4834,7 +4834,7 @@ pub struct Target {
     pub values: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAssociationRequest {
     #[doc="<p>The ID of the association you want to update. </p>"]
     #[serde(rename="AssociationId")]
@@ -4873,7 +4873,7 @@ pub struct UpdateAssociationRequest {
     pub targets: Option<Vec<Target>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAssociationResult {
     #[doc="<p>The description of the association that was updated.</p>"]
     #[serde(rename="AssociationDescription")]
@@ -4881,7 +4881,7 @@ pub struct UpdateAssociationResult {
     pub association_description: Option<AssociationDescription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAssociationStatusRequest {
     #[doc="<p>The association status.</p>"]
     #[serde(rename="AssociationStatus")]
@@ -4894,7 +4894,7 @@ pub struct UpdateAssociationStatusRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateAssociationStatusResult {
     #[doc="<p>Information about the association.</p>"]
     #[serde(rename="AssociationDescription")]
@@ -4902,7 +4902,7 @@ pub struct UpdateAssociationStatusResult {
     pub association_description: Option<AssociationDescription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDocumentDefaultVersionRequest {
     #[doc="<p>The version of a custom document that you want to set as the default version.</p>"]
     #[serde(rename="DocumentVersion")]
@@ -4912,7 +4912,7 @@ pub struct UpdateDocumentDefaultVersionRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDocumentDefaultVersionResult {
     #[doc="<p>The description of a custom document that you want to set as the default version.</p>"]
     #[serde(rename="Description")]
@@ -4920,7 +4920,7 @@ pub struct UpdateDocumentDefaultVersionResult {
     pub description: Option<DocumentDefaultVersionDescription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDocumentRequest {
     #[doc="<p>The content in a document that you want to update.</p>"]
     #[serde(rename="Content")]
@@ -4934,7 +4934,7 @@ pub struct UpdateDocumentRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDocumentResult {
     #[doc="<p>A description of the document that was updated.</p>"]
     #[serde(rename="DocumentDescription")]
@@ -4942,7 +4942,7 @@ pub struct UpdateDocumentResult {
     pub document_description: Option<DocumentDescription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMaintenanceWindowRequest {
     #[doc="<p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>"]
     #[serde(rename="AllowUnassociatedTargets")]
@@ -4981,7 +4981,7 @@ pub struct UpdateMaintenanceWindowRequest {
     pub window_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMaintenanceWindowResult {
     #[doc="<p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>"]
     #[serde(rename="AllowUnassociatedTargets")]
@@ -5017,7 +5017,7 @@ pub struct UpdateMaintenanceWindowResult {
     pub window_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMaintenanceWindowTargetRequest {
     #[doc="<p>An optional description for the update.</p>"]
     #[serde(rename="Description")]
@@ -5047,7 +5047,7 @@ pub struct UpdateMaintenanceWindowTargetRequest {
     pub window_target_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMaintenanceWindowTargetResult {
     #[doc="<p>The updated description.</p>"]
     #[serde(rename="Description")]
@@ -5075,7 +5075,7 @@ pub struct UpdateMaintenanceWindowTargetResult {
     pub window_target_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMaintenanceWindowTaskRequest {
     #[doc="<p>The new task description to specify.</p>"]
     #[serde(rename="Description")]
@@ -5134,7 +5134,7 @@ pub struct UpdateMaintenanceWindowTaskRequest {
     pub window_task_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMaintenanceWindowTaskResult {
     #[doc="<p>The updated task description.</p>"]
     #[serde(rename="Description")]
@@ -5191,7 +5191,7 @@ pub struct UpdateMaintenanceWindowTaskResult {
     pub window_task_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateManagedInstanceRoleRequest {
     #[doc="<p>The IAM role you want to assign or change.</p>"]
     #[serde(rename="IamRole")]
@@ -5201,10 +5201,10 @@ pub struct UpdateManagedInstanceRoleRequest {
     pub instance_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateManagedInstanceRoleResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePatchBaselineRequest {
     #[doc="<p>A set of rules used to include patches in the baseline.</p>"]
     #[serde(rename="ApprovalRules")]
@@ -5239,7 +5239,7 @@ pub struct UpdatePatchBaselineRequest {
     pub rejected_patches: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdatePatchBaselineResult {
     #[doc="<p>A set of rules used to include patches in the baseline.</p>"]
     #[serde(rename="ApprovalRules")]

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -28,7 +28,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityFailedEventDetails {
     #[doc="<p>A more detailed explanation of the cause of the failure.</p>"]
     #[serde(rename="cause")]
@@ -40,7 +40,7 @@ pub struct ActivityFailedEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityListItem {
     #[doc="<p>The Amazon Resource Name (ARN) that identifies the activity.</p>"]
     #[serde(rename="activityArn")]
@@ -53,7 +53,7 @@ pub struct ActivityListItem {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityScheduleFailedEventDetails {
     #[doc="<p>A more detailed explanation of the cause of the failure.</p>"]
     #[serde(rename="cause")]
@@ -65,7 +65,7 @@ pub struct ActivityScheduleFailedEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityScheduledEventDetails {
     #[doc="<p>The maximum allowed duration between two heartbeats for the activity task.</p>"]
     #[serde(rename="heartbeatInSeconds")]
@@ -84,7 +84,7 @@ pub struct ActivityScheduledEventDetails {
     pub timeout_in_seconds: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityStartedEventDetails {
     #[doc="<p>The name of the worker that the task was assigned to. These names are provided by the workers when calling <a>GetActivityTask</a>.</p>"]
     #[serde(rename="workerName")]
@@ -92,7 +92,7 @@ pub struct ActivityStartedEventDetails {
     pub worker_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivitySucceededEventDetails {
     #[doc="<p>The JSON data output by the activity task.</p>"]
     #[serde(rename="output")]
@@ -100,7 +100,7 @@ pub struct ActivitySucceededEventDetails {
     pub output: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTimedOutEventDetails {
     #[doc="<p>A more detailed explanation of the cause of the timeout.</p>"]
     #[serde(rename="cause")]
@@ -112,14 +112,14 @@ pub struct ActivityTimedOutEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateActivityInput {
     #[doc="<p>The name of the activity to create. This name must be unique for your AWS account and region.</p>"]
     #[serde(rename="name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateActivityOutput {
     #[doc="<p>The Amazon Resource Name (ARN) that identifies the created activity.</p>"]
     #[serde(rename="activityArn")]
@@ -129,7 +129,7 @@ pub struct CreateActivityOutput {
     pub creation_date: f64,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStateMachineInput {
     #[doc="<p>The Amazon States Language definition of the state machine.</p>"]
     #[serde(rename="definition")]
@@ -142,7 +142,7 @@ pub struct CreateStateMachineInput {
     pub role_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStateMachineOutput {
     #[doc="<p>The date the state machine was created.</p>"]
     #[serde(rename="creationDate")]
@@ -152,34 +152,34 @@ pub struct CreateStateMachineOutput {
     pub state_machine_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteActivityInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the activity to delete.</p>"]
     #[serde(rename="activityArn")]
     pub activity_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteActivityOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStateMachineInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the state machine to delete.</p>"]
     #[serde(rename="stateMachineArn")]
     pub state_machine_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteStateMachineOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeActivityInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the activity to describe.</p>"]
     #[serde(rename="activityArn")]
     pub activity_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeActivityOutput {
     #[doc="<p>The Amazon Resource Name (ARN) that identifies the activity.</p>"]
     #[serde(rename="activityArn")]
@@ -192,14 +192,14 @@ pub struct DescribeActivityOutput {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExecutionInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the execution to describe.</p>"]
     #[serde(rename="executionArn")]
     pub execution_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeExecutionOutput {
     #[doc="<p>The Amazon Resource Name (ARN) that identifies the execution.</p>"]
     #[serde(rename="executionArn")]
@@ -230,14 +230,14 @@ pub struct DescribeExecutionOutput {
     pub stop_date: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStateMachineInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the state machine to describe.</p>"]
     #[serde(rename="stateMachineArn")]
     pub state_machine_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStateMachineOutput {
     #[doc="<p>The date the state machine was created.</p>"]
     #[serde(rename="creationDate")]
@@ -260,7 +260,7 @@ pub struct DescribeStateMachineOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecutionAbortedEventDetails {
     #[doc="<p>A more detailed explanation of the cause of the failure.</p>"]
     #[serde(rename="cause")]
@@ -272,7 +272,7 @@ pub struct ExecutionAbortedEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecutionFailedEventDetails {
     #[doc="<p>A more detailed explanation of the cause of the failure.</p>"]
     #[serde(rename="cause")]
@@ -284,7 +284,7 @@ pub struct ExecutionFailedEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecutionListItem {
     #[doc="<p>The Amazon Resource Name (ARN) that identifies the execution.</p>"]
     #[serde(rename="executionArn")]
@@ -307,7 +307,7 @@ pub struct ExecutionListItem {
     pub stop_date: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecutionStartedEventDetails {
     #[doc="<p>The JSON data input to the execution.</p>"]
     #[serde(rename="input")]
@@ -319,7 +319,7 @@ pub struct ExecutionStartedEventDetails {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecutionSucceededEventDetails {
     #[doc="<p>The JSON data output by the execution.</p>"]
     #[serde(rename="output")]
@@ -327,7 +327,7 @@ pub struct ExecutionSucceededEventDetails {
     pub output: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecutionTimedOutEventDetails {
     #[doc="<p>A more detailed explanation of the cause of the timeout.</p>"]
     #[serde(rename="cause")]
@@ -339,7 +339,7 @@ pub struct ExecutionTimedOutEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetActivityTaskInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the activity to retrieve tasks from.</p>"]
     #[serde(rename="activityArn")]
@@ -350,7 +350,7 @@ pub struct GetActivityTaskInput {
     pub worker_name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetActivityTaskOutput {
     #[doc="<p>The JSON input data for the task.</p>"]
     #[serde(rename="input")]
@@ -362,7 +362,7 @@ pub struct GetActivityTaskOutput {
     pub task_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetExecutionHistoryInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the execution.</p>"]
     #[serde(rename="executionArn")]
@@ -381,7 +381,7 @@ pub struct GetExecutionHistoryInput {
     pub reverse_order: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetExecutionHistoryOutput {
     #[doc="<p>The list of events that occurred in the execution.</p>"]
     #[serde(rename="events")]
@@ -392,7 +392,7 @@ pub struct GetExecutionHistoryOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HistoryEvent {
     #[serde(rename="activityFailedEventDetails")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -468,7 +468,7 @@ pub struct HistoryEvent {
     pub type_: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaFunctionFailedEventDetails {
     #[doc="<p>A more detailed explanation of the cause of the failure.</p>"]
     #[serde(rename="cause")]
@@ -480,7 +480,7 @@ pub struct LambdaFunctionFailedEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaFunctionScheduleFailedEventDetails {
     #[doc="<p>A more detailed explanation of the cause of the failure.</p>"]
     #[serde(rename="cause")]
@@ -492,7 +492,7 @@ pub struct LambdaFunctionScheduleFailedEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaFunctionScheduledEventDetails {
     #[doc="<p>The JSON data input to the lambda function.</p>"]
     #[serde(rename="input")]
@@ -507,7 +507,7 @@ pub struct LambdaFunctionScheduledEventDetails {
     pub timeout_in_seconds: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaFunctionStartFailedEventDetails {
     #[doc="<p>A more detailed explanation of the cause of the failure.</p>"]
     #[serde(rename="cause")]
@@ -519,7 +519,7 @@ pub struct LambdaFunctionStartFailedEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaFunctionSucceededEventDetails {
     #[doc="<p>The JSON data output by the lambda function.</p>"]
     #[serde(rename="output")]
@@ -527,7 +527,7 @@ pub struct LambdaFunctionSucceededEventDetails {
     pub output: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaFunctionTimedOutEventDetails {
     #[doc="<p>A more detailed explanation of the cause of the timeout.</p>"]
     #[serde(rename="cause")]
@@ -539,7 +539,7 @@ pub struct LambdaFunctionTimedOutEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListActivitiesInput {
     #[doc="<p>The maximum number of results that will be returned per call. <code>nextToken</code> can be used to obtain further pages of results. The default is 100 and the maximum allowed page size is 1000.</p> <p>This is an upper limit only; the actual number of results returned per call may be fewer than the specified maximum.</p>"]
     #[serde(rename="maxResults")]
@@ -551,7 +551,7 @@ pub struct ListActivitiesInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListActivitiesOutput {
     #[doc="<p>The list of activities.</p>"]
     #[serde(rename="activities")]
@@ -562,7 +562,7 @@ pub struct ListActivitiesOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListExecutionsInput {
     #[doc="<p>The maximum number of results that will be returned per call. <code>nextToken</code> can be used to obtain further pages of results. The default is 100 and the maximum allowed page size is 1000.</p> <p>This is an upper limit only; the actual number of results returned per call may be fewer than the specified maximum.</p>"]
     #[serde(rename="maxResults")]
@@ -581,7 +581,7 @@ pub struct ListExecutionsInput {
     pub status_filter: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListExecutionsOutput {
     #[doc="<p>The list of matching executions.</p>"]
     #[serde(rename="executions")]
@@ -592,7 +592,7 @@ pub struct ListExecutionsOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStateMachinesInput {
     #[doc="<p>The maximum number of results that will be returned per call. <code>nextToken</code> can be used to obtain further pages of results. The default is 100 and the maximum allowed page size is 1000.</p> <p>This is an upper limit only; the actual number of results returned per call may be fewer than the specified maximum.</p>"]
     #[serde(rename="maxResults")]
@@ -604,7 +604,7 @@ pub struct ListStateMachinesInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListStateMachinesOutput {
     #[doc="<p>If a <code>nextToken</code> is returned, there are more results available. To retrieve the next page of results, make the call again using the returned token in <code>nextToken</code>. Keep all other arguments unchanged.</p> <p>The configured <code>maxResults</code> determines how many results can be returned in a single call.</p>"]
     #[serde(rename="nextToken")]
@@ -614,7 +614,7 @@ pub struct ListStateMachinesOutput {
     pub state_machines: Vec<StateMachineListItem>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendTaskFailureInput {
     #[doc="<p>A more detailed explanation of the cause of the failure.</p>"]
     #[serde(rename="cause")]
@@ -629,20 +629,20 @@ pub struct SendTaskFailureInput {
     pub task_token: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendTaskFailureOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendTaskHeartbeatInput {
     #[doc="<p>The token that represents this task. Task tokens are generated by the service when the tasks are assigned to a worker (see GetActivityTask::taskToken).</p>"]
     #[serde(rename="taskToken")]
     pub task_token: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendTaskHeartbeatOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendTaskSuccessInput {
     #[doc="<p>The JSON output of the task.</p>"]
     #[serde(rename="output")]
@@ -652,10 +652,10 @@ pub struct SendTaskSuccessInput {
     pub task_token: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SendTaskSuccessOutput;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartExecutionInput {
     #[doc="<p>The JSON input data for the execution.</p>"]
     #[serde(rename="input")]
@@ -670,7 +670,7 @@ pub struct StartExecutionInput {
     pub state_machine_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartExecutionOutput {
     #[doc="<p>The Amazon Resource Name (ARN) that identifies the execution.</p>"]
     #[serde(rename="executionArn")]
@@ -680,7 +680,7 @@ pub struct StartExecutionOutput {
     pub start_date: f64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StateEnteredEventDetails {
     #[doc="<p>The JSON input data to the state.</p>"]
     #[serde(rename="input")]
@@ -691,7 +691,7 @@ pub struct StateEnteredEventDetails {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StateExitedEventDetails {
     #[doc="<p>The name of the state.</p>"]
     #[serde(rename="name")]
@@ -702,7 +702,7 @@ pub struct StateExitedEventDetails {
     pub output: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StateMachineListItem {
     #[doc="<p>The date the state machine was created.</p>"]
     #[serde(rename="creationDate")]
@@ -715,7 +715,7 @@ pub struct StateMachineListItem {
     pub state_machine_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopExecutionInput {
     #[doc="<p>A more detailed explanation of the cause of the termination.</p>"]
     #[serde(rename="cause")]
@@ -730,7 +730,7 @@ pub struct StopExecutionInput {
     pub execution_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopExecutionOutput {
     #[doc="<p>The date the execution was stopped.</p>"]
     #[serde(rename="stopDate")]

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>ActivateGatewayInput$ActivationKey</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayName</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayRegion</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayTimezone</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayType</a> </p> </li> <li> <p> <a>ActivateGatewayInput$TapeDriveType</a> </p> </li> <li> <p> <a>ActivateGatewayInput$MediumChangerType</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivateGatewayInput {
     #[doc="<p>Your gateway activation key. You can obtain the activation key by sending an HTTP GET request with redirects enabled to the gateway IP address (port 80). The redirect URL returned in the response provides you the activation key for your gateway in the query string parameter <code>activationKey</code>. It may also include other activation-related parameters, however, these are merely defaults -- the arguments you pass to the <code>ActivateGateway</code> API call determine the actual configuration of your gateway.</p>"]
     #[serde(rename="ActivationKey")]
@@ -58,14 +58,14 @@ pub struct ActivateGatewayInput {
 }
 
 #[doc="<p>AWS Storage Gateway returns the Amazon Resource Name (ARN) of the activated gateway. It is a string made of information such as your account, gateway name, and region. This ARN is used to reference the gateway in other API operations as well as resource-based authorization.</p> <note> <p>For gateways activated prior to September 02, 2015 the gateway ARN contains the gateway name rather than the gateway id. Changing the name of the gateway has no effect on the gateway ARN.</p> </note>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivateGatewayOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub gateway_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddCacheInput {
     #[serde(rename="DiskIds")]
     pub disk_ids: Vec<String>,
@@ -73,7 +73,7 @@ pub struct AddCacheInput {
     pub gateway_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddCacheOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -81,7 +81,7 @@ pub struct AddCacheOutput {
 }
 
 #[doc="<p>AddTagsToResourceInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource you want to add tags to.</p>"]
     #[serde(rename="ResourceARN")]
@@ -92,7 +92,7 @@ pub struct AddTagsToResourceInput {
 }
 
 #[doc="<p>AddTagsToResourceOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddTagsToResourceOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource you want to add tags to.</p>"]
     #[serde(rename="ResourceARN")]
@@ -100,7 +100,7 @@ pub struct AddTagsToResourceOutput {
     pub resource_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddUploadBufferInput {
     #[serde(rename="DiskIds")]
     pub disk_ids: Vec<String>,
@@ -108,7 +108,7 @@ pub struct AddUploadBufferInput {
     pub gateway_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddUploadBufferOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -116,7 +116,7 @@ pub struct AddUploadBufferOutput {
 }
 
 #[doc="<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>AddWorkingStorageInput$DiskIds</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddWorkingStorageInput {
     #[doc="<p>An array of strings that identify disks that are to be configured as working storage. Each string have a minimum length of 1 and maximum length of 300. You can get the disk IDs from the <a>ListLocalDisks</a> API.</p>"]
     #[serde(rename="DiskIds")]
@@ -126,7 +126,7 @@ pub struct AddWorkingStorageInput {
 }
 
 #[doc="<p>A JSON object containing the of the gateway for which working storage was configured.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddWorkingStorageOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -134,7 +134,7 @@ pub struct AddWorkingStorageOutput {
 }
 
 #[doc="<p>Describes an iSCSI cached volume.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CachediSCSIVolume {
     #[doc="<p>The date the volume was created. Volumes created prior to March 28, 2017 don’t have this time stamp.</p>"]
     #[serde(rename="CreatedDate")]
@@ -175,7 +175,7 @@ pub struct CachediSCSIVolume {
 }
 
 #[doc="<p>CancelArchivalInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelArchivalInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
@@ -185,7 +185,7 @@ pub struct CancelArchivalInput {
 }
 
 #[doc="<p>CancelArchivalOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelArchivalOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the virtual tape for which archiving was canceled.</p>"]
     #[serde(rename="TapeARN")]
@@ -194,7 +194,7 @@ pub struct CancelArchivalOutput {
 }
 
 #[doc="<p>CancelRetrievalInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelRetrievalInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
@@ -204,7 +204,7 @@ pub struct CancelRetrievalInput {
 }
 
 #[doc="<p>CancelRetrievalOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelRetrievalOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the virtual tape for which retrieval was canceled.</p>"]
     #[serde(rename="TapeARN")]
@@ -213,7 +213,7 @@ pub struct CancelRetrievalOutput {
 }
 
 #[doc="<p>Describes Challenge-Handshake Authentication Protocol (CHAP) information that supports authentication between your gateway and iSCSI initiators.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChapInfo {
     #[doc="<p>The iSCSI initiator that connects to the target.</p>"]
     #[serde(rename="InitiatorName")]
@@ -233,7 +233,7 @@ pub struct ChapInfo {
     pub target_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCachediSCSIVolumeInput {
     #[serde(rename="ClientToken")]
     pub client_token: String,
@@ -254,7 +254,7 @@ pub struct CreateCachediSCSIVolumeInput {
     pub volume_size_in_bytes: i64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCachediSCSIVolumeOutput {
     #[serde(rename="TargetARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -265,7 +265,7 @@ pub struct CreateCachediSCSIVolumeOutput {
 }
 
 #[doc="<p>CreateNFSFileShareInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNFSFileShareInput {
     #[doc="<p>The list of clients that are allowed to access the file gateway. The list must contain either valid IP addresses or valid CIDR blocks. </p>"]
     #[serde(rename="ClientList")]
@@ -310,7 +310,7 @@ pub struct CreateNFSFileShareInput {
 }
 
 #[doc="<p>CreateNFSFileShareOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNFSFileShareOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the newly created file share. </p>"]
     #[serde(rename="FileShareARN")]
@@ -318,7 +318,7 @@ pub struct CreateNFSFileShareOutput {
     pub file_share_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSnapshotFromVolumeRecoveryPointInput {
     #[serde(rename="SnapshotDescription")]
     pub snapshot_description: String,
@@ -326,7 +326,7 @@ pub struct CreateSnapshotFromVolumeRecoveryPointInput {
     pub volume_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSnapshotFromVolumeRecoveryPointOutput {
     #[serde(rename="SnapshotId")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -340,7 +340,7 @@ pub struct CreateSnapshotFromVolumeRecoveryPointOutput {
 }
 
 #[doc="<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>CreateSnapshotInput$SnapshotDescription</a> </p> </li> <li> <p> <a>CreateSnapshotInput$VolumeARN</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSnapshotInput {
     #[doc="<p>Textual description of the snapshot that appears in the Amazon EC2 console, Elastic Block Store snapshots panel in the <b>Description</b> field, and in the AWS Storage Gateway snapshot <b>Details</b> pane, <b>Description</b> field</p>"]
     #[serde(rename="SnapshotDescription")]
@@ -351,7 +351,7 @@ pub struct CreateSnapshotInput {
 }
 
 #[doc="<p>A JSON object containing the following fields:</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSnapshotOutput {
     #[doc="<p>The snapshot ID that is used to refer to the snapshot in future operations such as describing snapshots (Amazon Elastic Compute Cloud API <code>DescribeSnapshots</code>) or creating a volume from a snapshot (<a>CreateStorediSCSIVolume</a>).</p>"]
     #[serde(rename="SnapshotId")]
@@ -364,7 +364,7 @@ pub struct CreateSnapshotOutput {
 }
 
 #[doc="<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>CreateStorediSCSIVolumeInput$DiskId</a> </p> </li> <li> <p> <a>CreateStorediSCSIVolumeInput$NetworkInterfaceId</a> </p> </li> <li> <p> <a>CreateStorediSCSIVolumeInput$PreserveExistingData</a> </p> </li> <li> <p> <a>CreateStorediSCSIVolumeInput$SnapshotId</a> </p> </li> <li> <p> <a>CreateStorediSCSIVolumeInput$TargetName</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStorediSCSIVolumeInput {
     #[doc="<p>The unique identifier for the gateway local disk that is configured as a stored volume. Use <a href=\"http://docs.aws.amazon.com/storagegateway/latest/userguide/API_ListLocalDisks.html\">ListLocalDisks</a> to list disk IDs for a gateway.</p>"]
     #[serde(rename="DiskId")]
@@ -387,7 +387,7 @@ pub struct CreateStorediSCSIVolumeInput {
 }
 
 #[doc="<p>A JSON object containing the following fields:</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateStorediSCSIVolumeOutput {
     #[doc="<p>he Amazon Resource Name (ARN) of the volume target that includes the iSCSI name that initiators can use to connect to the target.</p>"]
     #[serde(rename="TargetARN")]
@@ -404,7 +404,7 @@ pub struct CreateStorediSCSIVolumeOutput {
 }
 
 #[doc="<p>CreateTapeWithBarcodeInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTapeWithBarcodeInput {
     #[doc="<p>The unique Amazon Resource Name (ARN) that represents the gateway to associate the virtual tape with. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p>"]
     #[serde(rename="GatewayARN")]
@@ -418,7 +418,7 @@ pub struct CreateTapeWithBarcodeInput {
 }
 
 #[doc="<p>CreateTapeOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTapeWithBarcodeOutput {
     #[doc="<p>A unique Amazon Resource Name (ARN) that represents the virtual tape that was created.</p>"]
     #[serde(rename="TapeARN")]
@@ -427,7 +427,7 @@ pub struct CreateTapeWithBarcodeOutput {
 }
 
 #[doc="<p>CreateTapesInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTapesInput {
     #[doc="<p>A unique identifier that you use to retry a request. If you retry a request, use the same <code>ClientToken</code> you specified in the initial request.</p> <note> <p>Using the same <code>ClientToken</code> prevents creating the tape multiple times.</p> </note>"]
     #[serde(rename="ClientToken")]
@@ -447,7 +447,7 @@ pub struct CreateTapesInput {
 }
 
 #[doc="<p>CreateTapeOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTapesOutput {
     #[doc="<p>A list of unique Amazon Resource Names (ARNs) that represents the virtual tapes that were created.</p>"]
     #[serde(rename="TapeARNs")]
@@ -456,7 +456,7 @@ pub struct CreateTapesOutput {
 }
 
 #[doc="<p>A JSON object containing the following fields:</p> <ul> <li> <p> <a>DeleteBandwidthRateLimitInput$BandwidthType</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBandwidthRateLimitInput {
     #[doc="<p>One of the BandwidthType values that indicates the gateway bandwidth rate limit to delete.</p> <p>Valid Values: <code>Upload</code>, <code>Download</code>, <code>All</code>.</p>"]
     #[serde(rename="BandwidthType")]
@@ -466,7 +466,7 @@ pub struct DeleteBandwidthRateLimitInput {
 }
 
 #[doc="<p>A JSON object containing the of the gateway whose bandwidth rate information was deleted.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteBandwidthRateLimitOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -474,7 +474,7 @@ pub struct DeleteBandwidthRateLimitOutput {
 }
 
 #[doc="<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>DeleteChapCredentialsInput$InitiatorName</a> </p> </li> <li> <p> <a>DeleteChapCredentialsInput$TargetARN</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteChapCredentialsInput {
     #[doc="<p>The iSCSI initiator that connects to the target.</p>"]
     #[serde(rename="InitiatorName")]
@@ -485,7 +485,7 @@ pub struct DeleteChapCredentialsInput {
 }
 
 #[doc="<p>A JSON object containing the following fields:</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteChapCredentialsOutput {
     #[doc="<p>The iSCSI initiator that connects to the target.</p>"]
     #[serde(rename="InitiatorName")]
@@ -498,7 +498,7 @@ pub struct DeleteChapCredentialsOutput {
 }
 
 #[doc="<p>DeleteFileShareInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFileShareInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the file share to be deleted. </p>"]
     #[serde(rename="FileShareARN")]
@@ -510,7 +510,7 @@ pub struct DeleteFileShareInput {
 }
 
 #[doc="<p>DeleteFileShareOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFileShareOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the deleted file share. </p>"]
     #[serde(rename="FileShareARN")]
@@ -519,27 +519,27 @@ pub struct DeleteFileShareOutput {
 }
 
 #[doc="<p>A JSON object containing the id of the gateway to delete.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteGatewayInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
 #[doc="<p>A JSON object containing the id of the deleted gateway.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteGatewayOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub gateway_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSnapshotScheduleInput {
     #[serde(rename="VolumeARN")]
     pub volume_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSnapshotScheduleOutput {
     #[serde(rename="VolumeARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -547,7 +547,7 @@ pub struct DeleteSnapshotScheduleOutput {
 }
 
 #[doc="<p>DeleteTapeArchiveInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTapeArchiveInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the virtual tape to delete from the virtual tape shelf (VTS).</p>"]
     #[serde(rename="TapeARN")]
@@ -555,7 +555,7 @@ pub struct DeleteTapeArchiveInput {
 }
 
 #[doc="<p>DeleteTapeArchiveOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTapeArchiveOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the virtual tape that was deleted from the virtual tape shelf (VTS).</p>"]
     #[serde(rename="TapeARN")]
@@ -564,7 +564,7 @@ pub struct DeleteTapeArchiveOutput {
 }
 
 #[doc="<p>DeleteTapeInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTapeInput {
     #[doc="<p>The unique Amazon Resource Name (ARN) of the gateway that the virtual tape to delete is associated with. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p>"]
     #[serde(rename="GatewayARN")]
@@ -575,7 +575,7 @@ pub struct DeleteTapeInput {
 }
 
 #[doc="<p>DeleteTapeOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTapeOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the deleted virtual tape.</p>"]
     #[serde(rename="TapeARN")]
@@ -584,7 +584,7 @@ pub struct DeleteTapeOutput {
 }
 
 #[doc="<p>A JSON object containing the <a>DeleteVolumeInput$VolumeARN</a> to delete.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVolumeInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the volume. Use the <a>ListVolumes</a> operation to return a list of gateway volumes.</p>"]
     #[serde(rename="VolumeARN")]
@@ -592,7 +592,7 @@ pub struct DeleteVolumeInput {
 }
 
 #[doc="<p>A JSON object containing the of the storage volume that was deleted</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteVolumeOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the storage volume that was deleted. It is the same ARN you provided in the request.</p>"]
     #[serde(rename="VolumeARN")]
@@ -601,14 +601,14 @@ pub struct DeleteVolumeOutput {
 }
 
 #[doc="<p>A JSON object containing the of the gateway.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBandwidthRateLimitInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
 #[doc="<p>A JSON object containing the following fields:</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeBandwidthRateLimitOutput {
     #[doc="<p>The average download bandwidth rate limit in bits per second. This field does not appear in the response if the download rate limit is not set.</p>"]
     #[serde(rename="AverageDownloadRateLimitInBitsPerSec")]
@@ -623,13 +623,13 @@ pub struct DescribeBandwidthRateLimitOutput {
     pub gateway_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCacheInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCacheOutput {
     #[serde(rename="CacheAllocatedInBytes")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -654,14 +654,14 @@ pub struct DescribeCacheOutput {
     pub gateway_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCachediSCSIVolumesInput {
     #[serde(rename="VolumeARNs")]
     pub volume_ar_ns: Vec<String>,
 }
 
 #[doc="<p>A JSON object containing the following fields:</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCachediSCSIVolumesOutput {
     #[doc="<p>An array of objects where each object contains metadata about one cached volume.</p>"]
     #[serde(rename="CachediSCSIVolumes")]
@@ -670,7 +670,7 @@ pub struct DescribeCachediSCSIVolumesOutput {
 }
 
 #[doc="<p>A JSON object containing the Amazon Resource Name (ARN) of the iSCSI volume target.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeChapCredentialsInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the iSCSI volume target. Use the <a>DescribeStorediSCSIVolumes</a> operation to return to retrieve the TargetARN for specified VolumeARN.</p>"]
     #[serde(rename="TargetARN")]
@@ -678,7 +678,7 @@ pub struct DescribeChapCredentialsInput {
 }
 
 #[doc="<p>A JSON object containing a .</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeChapCredentialsOutput {
     #[doc="<p>An array of <a>ChapInfo</a> objects that represent CHAP credentials. Each object in the array contains CHAP credential information for one target-initiator pair. If no CHAP credentials are set, an empty array is returned. CHAP credential information is provided in a JSON object with the following fields:</p> <ul> <li> <p> <b>InitiatorName</b>: The iSCSI initiator that connects to the target.</p> </li> <li> <p> <b>SecretToAuthenticateInitiator</b>: The secret key that the initiator (for example, the Windows client) must provide to participate in mutual CHAP with the target.</p> </li> <li> <p> <b>SecretToAuthenticateTarget</b>: The secret key that the target must provide to participate in mutual CHAP with the initiator (e.g. Windows client).</p> </li> <li> <p> <b>TargetARN</b>: The Amazon Resource Name (ARN) of the storage volume.</p> </li> </ul>"]
     #[serde(rename="ChapCredentials")]
@@ -687,14 +687,14 @@ pub struct DescribeChapCredentialsOutput {
 }
 
 #[doc="<p>A JSON object containing the id of the gateway.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeGatewayInformationInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
 #[doc="<p>A JSON object containing the following fields:</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeGatewayInformationOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -734,14 +734,14 @@ pub struct DescribeGatewayInformationOutput {
 }
 
 #[doc="<p>A JSON object containing the of the gateway.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceStartTimeInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
 #[doc="<p>A JSON object containing the following fields:</p> <ul> <li> <p> <a>DescribeMaintenanceStartTimeOutput$DayOfWeek</a> </p> </li> <li> <p> <a>DescribeMaintenanceStartTimeOutput$HourOfDay</a> </p> </li> <li> <p> <a>DescribeMaintenanceStartTimeOutput$MinuteOfHour</a> </p> </li> <li> <p> <a>DescribeMaintenanceStartTimeOutput$Timezone</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeMaintenanceStartTimeOutput {
     #[doc="<p>An ordinal number between 0 and 6 that represents the day of the week, where 0 represents Sunday and 6 represents Saturday. The day of week is in the time zone of the gateway.</p>"]
     #[serde(rename="DayOfWeek")]
@@ -764,7 +764,7 @@ pub struct DescribeMaintenanceStartTimeOutput {
 }
 
 #[doc="<p>DescribeNFSFileSharesInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNFSFileSharesInput {
     #[doc="<p>An array containing the Amazon Resource Name (ARN) of each file share to be described. </p>"]
     #[serde(rename="FileShareARNList")]
@@ -772,7 +772,7 @@ pub struct DescribeNFSFileSharesInput {
 }
 
 #[doc="<p>DescribeNFSFileSharesOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNFSFileSharesOutput {
     #[doc="<p>An array containing a description for each requested file share. </p>"]
     #[serde(rename="NFSFileShareInfoList")]
@@ -781,14 +781,14 @@ pub struct DescribeNFSFileSharesOutput {
 }
 
 #[doc="<p>A JSON object containing the <a>DescribeSnapshotScheduleInput$VolumeARN</a> of the volume.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSnapshotScheduleInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the volume. Use the <a>ListVolumes</a> operation to return a list of gateway volumes.</p>"]
     #[serde(rename="VolumeARN")]
     pub volume_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSnapshotScheduleOutput {
     #[serde(rename="Description")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -808,14 +808,14 @@ pub struct DescribeSnapshotScheduleOutput {
 }
 
 #[doc="<p>A JSON object containing a list of <a>DescribeStorediSCSIVolumesInput$VolumeARNs</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStorediSCSIVolumesInput {
     #[doc="<p>An array of strings where each string represents the Amazon Resource Name (ARN) of a stored volume. All of the specified stored volumes must from the same gateway. Use <a>ListVolumes</a> to get volume ARNs for a gateway.</p>"]
     #[serde(rename="VolumeARNs")]
     pub volume_ar_ns: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeStorediSCSIVolumesOutput {
     #[serde(rename="StorediSCSIVolumes")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -823,7 +823,7 @@ pub struct DescribeStorediSCSIVolumesOutput {
 }
 
 #[doc="<p>DescribeTapeArchivesInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTapeArchivesInput {
     #[doc="<p>Specifies that the number of virtual tapes descried be limited to the specified number.</p>"]
     #[serde(rename="Limit")]
@@ -840,7 +840,7 @@ pub struct DescribeTapeArchivesInput {
 }
 
 #[doc="<p>DescribeTapeArchivesOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTapeArchivesOutput {
     #[doc="<p>An opaque string that indicates the position at which the virtual tapes that were fetched for description ended. Use this marker in your next request to fetch the next set of virtual tapes in the virtual tape shelf (VTS). If there are no more virtual tapes to describe, this field does not appear in the response.</p>"]
     #[serde(rename="Marker")]
@@ -853,7 +853,7 @@ pub struct DescribeTapeArchivesOutput {
 }
 
 #[doc="<p>DescribeTapeRecoveryPointsInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTapeRecoveryPointsInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
@@ -868,7 +868,7 @@ pub struct DescribeTapeRecoveryPointsInput {
 }
 
 #[doc="<p>DescribeTapeRecoveryPointsOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTapeRecoveryPointsOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -884,7 +884,7 @@ pub struct DescribeTapeRecoveryPointsOutput {
 }
 
 #[doc="<p>DescribeTapesInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTapesInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
@@ -903,7 +903,7 @@ pub struct DescribeTapesInput {
 }
 
 #[doc="<p>DescribeTapesOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTapesOutput {
     #[doc="<p>An opaque string which can be used as part of a subsequent DescribeTapes call to retrieve the next page of results.</p> <p>If a response does not contain a marker, then there are no more results to be retrieved.</p>"]
     #[serde(rename="Marker")]
@@ -915,13 +915,13 @@ pub struct DescribeTapesOutput {
     pub tapes: Option<Vec<Tape>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUploadBufferInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUploadBufferOutput {
     #[serde(rename="DiskIds")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -938,7 +938,7 @@ pub struct DescribeUploadBufferOutput {
 }
 
 #[doc="<p>DescribeVTLDevicesInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVTLDevicesInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
@@ -957,7 +957,7 @@ pub struct DescribeVTLDevicesInput {
 }
 
 #[doc="<p>DescribeVTLDevicesOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeVTLDevicesOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -973,14 +973,14 @@ pub struct DescribeVTLDevicesOutput {
 }
 
 #[doc="<p>A JSON object containing the of the gateway.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkingStorageInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
 #[doc="<p>A JSON object containing the following fields:</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkingStorageOutput {
     #[doc="<p>An array of the gateway's local disk IDs that are configured as working storage. Each local disk ID is specified as a string (minimum length of 1 and maximum length of 300). If no local disks are configured as working storage, then the DiskIds array is empty.</p>"]
     #[serde(rename="DiskIds")]
@@ -1000,7 +1000,7 @@ pub struct DescribeWorkingStorageOutput {
 }
 
 #[doc="<p>Lists iSCSI information about a VTL device.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeviceiSCSIAttributes {
     #[doc="<p>Indicates whether mutual CHAP is enabled for the iSCSI target.</p>"]
     #[serde(rename="ChapEnabled")]
@@ -1021,14 +1021,14 @@ pub struct DeviceiSCSIAttributes {
 }
 
 #[doc="<p>DisableGatewayInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableGatewayInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
 #[doc="<p>DisableGatewayOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisableGatewayOutput {
     #[doc="<p>The unique Amazon Resource Name of the disabled gateway.</p>"]
     #[serde(rename="GatewayARN")]
@@ -1036,7 +1036,7 @@ pub struct DisableGatewayOutput {
     pub gateway_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Disk {
     #[serde(rename="DiskAllocationResource")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1062,7 +1062,7 @@ pub struct Disk {
 }
 
 #[doc="<p>Describes a file share.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FileShareInfo {
     #[serde(rename="FileShareARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1079,7 +1079,7 @@ pub struct FileShareInfo {
 }
 
 #[doc="<p>Describes a gateway object.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GatewayInfo {
     #[doc="<p>The Amazon Resource Name (ARN) of the gateway. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p>"]
     #[serde(rename="GatewayARN")]
@@ -1104,7 +1104,7 @@ pub struct GatewayInfo {
 }
 
 #[doc="<p>ListFileShareInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFileSharesInput {
     #[doc="<p>The Amazon resource Name (ARN) of the gateway whose file shares you want to list. If this field is not present, all file shares under your account are listed.</p>"]
     #[serde(rename="GatewayARN")]
@@ -1121,7 +1121,7 @@ pub struct ListFileSharesInput {
 }
 
 #[doc="<p>ListFileShareOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListFileSharesOutput {
     #[doc="<p>An array of information about the file gateway's file shares. </p>"]
     #[serde(rename="FileShareInfoList")]
@@ -1138,7 +1138,7 @@ pub struct ListFileSharesOutput {
 }
 
 #[doc="<p>A JSON object containing zero or more of the following fields:</p> <ul> <li> <p> <a>ListGatewaysInput$Limit</a> </p> </li> <li> <p> <a>ListGatewaysInput$Marker</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGatewaysInput {
     #[doc="<p>Specifies that the list of gateways returned be limited to the specified number of items.</p>"]
     #[serde(rename="Limit")]
@@ -1150,7 +1150,7 @@ pub struct ListGatewaysInput {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListGatewaysOutput {
     #[serde(rename="Gateways")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1161,13 +1161,13 @@ pub struct ListGatewaysOutput {
 }
 
 #[doc="<p>A JSON object containing the of the gateway.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLocalDisksInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListLocalDisksOutput {
     #[serde(rename="Disks")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1178,7 +1178,7 @@ pub struct ListLocalDisksOutput {
 }
 
 #[doc="<p>ListTagsForResourceInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceInput {
     #[doc="<p>Specifies that the list of tags returned be limited to the specified number of items.</p>"]
     #[serde(rename="Limit")]
@@ -1194,7 +1194,7 @@ pub struct ListTagsForResourceInput {
 }
 
 #[doc="<p>ListTagsForResourceOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTagsForResourceOutput {
     #[doc="<p>An opaque string that indicates the position at which to stop returning the list of tags.</p>"]
     #[serde(rename="Marker")]
@@ -1211,7 +1211,7 @@ pub struct ListTagsForResourceOutput {
 }
 
 #[doc="<p>A JSON object that contains one or more of the following fields:</p> <ul> <li> <p> <a>ListTapesInput$Limit</a> </p> </li> <li> <p> <a>ListTapesInput$Marker</a> </p> </li> <li> <p> <a>ListTapesInput$TapeARNs</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTapesInput {
     #[doc="<p>An optional number limit for the tapes in the list returned by this call.</p>"]
     #[serde(rename="Limit")]
@@ -1227,7 +1227,7 @@ pub struct ListTapesInput {
 }
 
 #[doc="<p>A JSON object containing the following fields:</p> <ul> <li> <p> <a>ListTapesOutput$Marker</a> </p> </li> <li> <p> <a>ListTapesOutput$VolumeInfos</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListTapesOutput {
     #[doc="<p>A string that indicates the position at which to begin returning the next list of tapes. Use the marker in your next request to continue pagination of tapes. If there are no more tapes to list, this element does not appear in the response body.</p>"]
     #[serde(rename="Marker")]
@@ -1239,7 +1239,7 @@ pub struct ListTapesOutput {
 }
 
 #[doc="<p>ListVolumeInitiatorsInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVolumeInitiatorsInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the volume. Use the <a>ListVolumes</a> operation to return a list of gateway volumes for the gateway.</p>"]
     #[serde(rename="VolumeARN")]
@@ -1247,7 +1247,7 @@ pub struct ListVolumeInitiatorsInput {
 }
 
 #[doc="<p>ListVolumeInitiatorsOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVolumeInitiatorsOutput {
     #[doc="<p>The host names and port numbers of all iSCSI initiators that are connected to the gateway.</p>"]
     #[serde(rename="Initiators")]
@@ -1255,13 +1255,13 @@ pub struct ListVolumeInitiatorsOutput {
     pub initiators: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVolumeRecoveryPointsInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVolumeRecoveryPointsOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1272,7 +1272,7 @@ pub struct ListVolumeRecoveryPointsOutput {
 }
 
 #[doc="<p>A JSON object that contains one or more of the following fields:</p> <ul> <li> <p> <a>ListVolumesInput$Limit</a> </p> </li> <li> <p> <a>ListVolumesInput$Marker</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVolumesInput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1287,7 +1287,7 @@ pub struct ListVolumesInput {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListVolumesOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1322,7 +1322,7 @@ pub struct NFSFileShareDefaults {
 }
 
 #[doc="<p>The Unix file permissions and ownership information assigned, by default, to native S3 objects when file gateway discovers them in S3 buckets. This operation is only supported in file gateways.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NFSFileShareInfo {
     #[serde(rename="ClientList")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1371,7 +1371,7 @@ pub struct NFSFileShareInfo {
 }
 
 #[doc="<p>Describes a gateway's network interface.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct NetworkInterface {
     #[doc="<p>The Internet Protocol version 4 (IPv4) address of the interface.</p>"]
     #[serde(rename="Ipv4Address")]
@@ -1387,13 +1387,13 @@ pub struct NetworkInterface {
     pub mac_address: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RefreshCacheInput {
     #[serde(rename="FileShareARN")]
     pub file_share_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RefreshCacheOutput {
     #[serde(rename="FileShareARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1401,7 +1401,7 @@ pub struct RefreshCacheOutput {
 }
 
 #[doc="<p>RemoveTagsFromResourceInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource you want to remove the tags from.</p>"]
     #[serde(rename="ResourceARN")]
@@ -1412,7 +1412,7 @@ pub struct RemoveTagsFromResourceInput {
 }
 
 #[doc="<p>RemoveTagsFromResourceOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveTagsFromResourceOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the resource that the tags were removed from.</p>"]
     #[serde(rename="ResourceARN")]
@@ -1420,13 +1420,13 @@ pub struct RemoveTagsFromResourceOutput {
     pub resource_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetCacheInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResetCacheOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1434,7 +1434,7 @@ pub struct ResetCacheOutput {
 }
 
 #[doc="<p>RetrieveTapeArchiveInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RetrieveTapeArchiveInput {
     #[doc="<p>The Amazon Resource Name (ARN) of the gateway you want to retrieve the virtual tape to. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p> <p>You retrieve archived virtual tapes to only one gateway and the gateway must be a tape gateway.</p>"]
     #[serde(rename="GatewayARN")]
@@ -1445,7 +1445,7 @@ pub struct RetrieveTapeArchiveInput {
 }
 
 #[doc="<p>RetrieveTapeArchiveOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RetrieveTapeArchiveOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the retrieved virtual tape.</p>"]
     #[serde(rename="TapeARN")]
@@ -1454,7 +1454,7 @@ pub struct RetrieveTapeArchiveOutput {
 }
 
 #[doc="<p>RetrieveTapeRecoveryPointInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RetrieveTapeRecoveryPointInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
@@ -1464,7 +1464,7 @@ pub struct RetrieveTapeRecoveryPointInput {
 }
 
 #[doc="<p>RetrieveTapeRecoveryPointOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RetrieveTapeRecoveryPointOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the virtual tape for which the recovery point was retrieved.</p>"]
     #[serde(rename="TapeARN")]
@@ -1473,7 +1473,7 @@ pub struct RetrieveTapeRecoveryPointOutput {
 }
 
 #[doc="<p>SetLocalConsolePasswordInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetLocalConsolePasswordInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
@@ -1482,7 +1482,7 @@ pub struct SetLocalConsolePasswordInput {
     pub local_console_password: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SetLocalConsolePasswordOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1490,14 +1490,14 @@ pub struct SetLocalConsolePasswordOutput {
 }
 
 #[doc="<p>A JSON object containing the of the gateway to shut down.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ShutdownGatewayInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
 #[doc="<p>A JSON object containing the of the gateway that was shut down.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ShutdownGatewayOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1505,14 +1505,14 @@ pub struct ShutdownGatewayOutput {
 }
 
 #[doc="<p>A JSON object containing the of the gateway to start.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartGatewayInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
 #[doc="<p>A JSON object containing the of the gateway that was restarted.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartGatewayOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1520,16 +1520,20 @@ pub struct StartGatewayOutput {
 }
 
 #[doc="<p>Provides additional information about an error that was returned by the service as an or. See the <code>errorCode</code> and <code>errorDetails</code> members for more information about the error.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StorageGatewayError {
     #[doc="<p>Additional information about the error.</p>"]
+    #[serde(rename="errorCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub error_code: Option<String>,
     #[doc="<p>Human-readable text that provides detail about the error that occurred.</p>"]
+    #[serde(rename="errorDetails")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub error_details: Option<::std::collections::HashMap<String, String>>,
 }
 
 #[doc="<p>Describes an iSCSI stored volume.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StorediSCSIVolume {
     #[doc="<p>The date the volume was created. Volumes created prior to March 28, 2017 don’t have this time stamp.</p>"]
     #[serde(rename="CreatedDate")]
@@ -1586,7 +1590,7 @@ pub struct Tag {
 }
 
 #[doc="<p>Describes a virtual tape object.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Tape {
     #[doc="<p>For archiving virtual tapes, indicates how much data remains to be uploaded before archiving is complete.</p> <p>Range: 0 (not started) to 100 (complete).</p>"]
     #[serde(rename="Progress")]
@@ -1623,7 +1627,7 @@ pub struct Tape {
 }
 
 #[doc="<p>Represents a virtual tape that is archived in the virtual tape shelf (VTS).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TapeArchive {
     #[doc="<p>The time that the archiving of the virtual tape was completed.</p> <p>The string format of the completion time is in the ISO8601 extended YYYY-MM-DD'T'HH:MM:SS'Z' format.</p>"]
     #[serde(rename="CompletionTime")]
@@ -1659,7 +1663,7 @@ pub struct TapeArchive {
 }
 
 #[doc="<p>Describes a virtual tape.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TapeInfo {
     #[doc="<p>The Amazon Resource Name (ARN) of the gateway. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p>"]
     #[serde(rename="GatewayARN")]
@@ -1684,7 +1688,7 @@ pub struct TapeInfo {
 }
 
 #[doc="<p>Describes a recovery point.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TapeRecoveryPointInfo {
     #[doc="<p>The Amazon Resource Name (ARN) of the virtual tape.</p>"]
     #[serde(rename="TapeARN")]
@@ -1704,7 +1708,7 @@ pub struct TapeRecoveryPointInfo {
 }
 
 #[doc="<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>UpdateBandwidthRateLimitInput$AverageDownloadRateLimitInBitsPerSec</a> </p> </li> <li> <p> <a>UpdateBandwidthRateLimitInput$AverageUploadRateLimitInBitsPerSec</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateBandwidthRateLimitInput {
     #[doc="<p>The average download bandwidth rate limit in bits per second.</p>"]
     #[serde(rename="AverageDownloadRateLimitInBitsPerSec")]
@@ -1719,7 +1723,7 @@ pub struct UpdateBandwidthRateLimitInput {
 }
 
 #[doc="<p>A JSON object containing the of the gateway whose throttle information was updated.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateBandwidthRateLimitOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1727,7 +1731,7 @@ pub struct UpdateBandwidthRateLimitOutput {
 }
 
 #[doc="<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>UpdateChapCredentialsInput$InitiatorName</a> </p> </li> <li> <p> <a>UpdateChapCredentialsInput$SecretToAuthenticateInitiator</a> </p> </li> <li> <p> <a>UpdateChapCredentialsInput$SecretToAuthenticateTarget</a> </p> </li> <li> <p> <a>UpdateChapCredentialsInput$TargetARN</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateChapCredentialsInput {
     #[doc="<p>The iSCSI initiator that connects to the target.</p>"]
     #[serde(rename="InitiatorName")]
@@ -1745,7 +1749,7 @@ pub struct UpdateChapCredentialsInput {
 }
 
 #[doc="<p>A JSON object containing the following fields:</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateChapCredentialsOutput {
     #[doc="<p>The iSCSI initiator that connects to the target. This is the same initiator name specified in the request.</p>"]
     #[serde(rename="InitiatorName")]
@@ -1757,7 +1761,7 @@ pub struct UpdateChapCredentialsOutput {
     pub target_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGatewayInformationInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
@@ -1770,7 +1774,7 @@ pub struct UpdateGatewayInformationInput {
 }
 
 #[doc="<p>A JSON object containing the ARN of the gateway that was updated.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGatewayInformationOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1781,14 +1785,14 @@ pub struct UpdateGatewayInformationOutput {
 }
 
 #[doc="<p>A JSON object containing the of the gateway to update.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGatewaySoftwareNowInput {
     #[serde(rename="GatewayARN")]
     pub gateway_arn: String,
 }
 
 #[doc="<p>A JSON object containing the of the gateway that was updated.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateGatewaySoftwareNowOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1796,7 +1800,7 @@ pub struct UpdateGatewaySoftwareNowOutput {
 }
 
 #[doc="<p>A JSON object containing the following fields:</p> <ul> <li> <p> <a>UpdateMaintenanceStartTimeInput$DayOfWeek</a> </p> </li> <li> <p> <a>UpdateMaintenanceStartTimeInput$HourOfDay</a> </p> </li> <li> <p> <a>UpdateMaintenanceStartTimeInput$MinuteOfHour</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMaintenanceStartTimeInput {
     #[doc="<p>The maintenance start time day of the week represented as an ordinal number from 0 to 6, where 0 represents Sunday and 6 Saturday.</p>"]
     #[serde(rename="DayOfWeek")]
@@ -1812,7 +1816,7 @@ pub struct UpdateMaintenanceStartTimeInput {
 }
 
 #[doc="<p>A JSON object containing the of the gateway whose maintenance start time is updated.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateMaintenanceStartTimeOutput {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1820,7 +1824,7 @@ pub struct UpdateMaintenanceStartTimeOutput {
 }
 
 #[doc="<p>UpdateNFSFileShareInput</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateNFSFileShareInput {
     #[doc="<p>The list of clients that are allowed to access the file gateway. The list must contain either valid IP addresses or valid CIDR blocks.</p>"]
     #[serde(rename="ClientList")]
@@ -1856,7 +1860,7 @@ pub struct UpdateNFSFileShareInput {
 }
 
 #[doc="<p>UpdateNFSFileShareOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateNFSFileShareOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the updated file share. </p>"]
     #[serde(rename="FileShareARN")]
@@ -1865,7 +1869,7 @@ pub struct UpdateNFSFileShareOutput {
 }
 
 #[doc="<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>UpdateSnapshotScheduleInput$Description</a> </p> </li> <li> <p> <a>UpdateSnapshotScheduleInput$RecurrenceInHours</a> </p> </li> <li> <p> <a>UpdateSnapshotScheduleInput$StartAt</a> </p> </li> <li> <p> <a>UpdateSnapshotScheduleInput$VolumeARN</a> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSnapshotScheduleInput {
     #[doc="<p>Optional description of the snapshot that overwrites the existing description.</p>"]
     #[serde(rename="Description")]
@@ -1883,7 +1887,7 @@ pub struct UpdateSnapshotScheduleInput {
 }
 
 #[doc="<p>A JSON object containing the of the updated storage volume.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSnapshotScheduleOutput {
     #[doc="<p/>"]
     #[serde(rename="VolumeARN")]
@@ -1891,7 +1895,7 @@ pub struct UpdateSnapshotScheduleOutput {
     pub volume_arn: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateVTLDeviceTypeInput {
     #[doc="<p>The type of medium changer you want to select.</p> <p> Valid Values: \"STK-L700\", \"AWS-Gateway-VTL\"</p>"]
     #[serde(rename="DeviceType")]
@@ -1902,7 +1906,7 @@ pub struct UpdateVTLDeviceTypeInput {
 }
 
 #[doc="<p>UpdateVTLDeviceTypeOutput</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateVTLDeviceTypeOutput {
     #[doc="<p>The Amazon Resource Name (ARN) of the medium changer you have selected.</p>"]
     #[serde(rename="VTLDeviceARN")]
@@ -1911,7 +1915,7 @@ pub struct UpdateVTLDeviceTypeOutput {
 }
 
 #[doc="<p>Represents a device object associated with a tape gateway.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VTLDevice {
     #[doc="<p>A list of iSCSI information about a VTL device.</p>"]
     #[serde(rename="DeviceiSCSIAttributes")]
@@ -1933,7 +1937,7 @@ pub struct VTLDevice {
 }
 
 #[doc="<p>Describes a storage volume object.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VolumeInfo {
     #[serde(rename="GatewayARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1959,7 +1963,7 @@ pub struct VolumeInfo {
     pub volume_type: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VolumeRecoveryPointInfo {
     #[serde(rename="VolumeARN")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -1976,7 +1980,7 @@ pub struct VolumeRecoveryPointInfo {
 }
 
 #[doc="<p>Lists iSCSI information about a volume.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct VolumeiSCSIAttributes {
     #[doc="<p>Indicates whether mutual CHAP is enabled for the iSCSI target.</p>"]
     #[serde(rename="ChapEnabled")]

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -95,21 +95,33 @@ impl ArnTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssumeRoleRequest {
     #[doc="<p>The duration, in seconds, of the role session. The value can range from 900 seconds (15 minutes) to 3600 seconds (1 hour). By default, the value is set to 3600 seconds.</p> <note> <p>This is separate from the duration of a console session that you might request using the returned credentials. The request to the federation endpoint for a console sign-in token takes a <code>SessionDuration</code> parameter that specifies the maximum length of the console session, separately from the <code>DurationSeconds</code> parameter on this API. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html\">Creating a URL that Enables Federated Users to Access the AWS Management Console</a> in the <i>IAM User Guide</i>.</p> </note>"]
+    #[serde(rename="DurationSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration_seconds: Option<i64>,
     #[doc="<p>A unique identifier that is used by third parties when assuming roles in their customers' accounts. For each role that the third party can assume, they should instruct their customers to ensure the role's trust policy checks for the external ID that the third party generated. Each time the third party assumes the role, they should pass the customer's external ID. The external ID is useful in order to help third parties bind a role to the customer who created it. For more information about the external ID, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html\">How to Use an External ID When Granting Access to Your AWS Resources to a Third Party</a> in the <i>IAM User Guide</i>.</p> <p>The regex used to validated this parameter is a string of characters consisting of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@:/-</p>"]
+    #[serde(rename="ExternalId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub external_id: Option<String>,
     #[doc="<p>An IAM policy in JSON format.</p> <p>This parameter is optional. If you pass a policy, the temporary security credentials that are returned by the operation have the permissions that are allowed by both (the intersection of) the access policy of the role that is being assumed, <i>and</i> the policy that you pass. This gives you a way to further restrict the permissions for the resulting temporary security credentials. You cannot use the passed policy to grant permissions that are in excess of those allowed by the access policy of the role that is being assumed. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_assumerole.html\">Permissions for AssumeRole, AssumeRoleWithSAML, and AssumeRoleWithWebIdentity</a> in the <i>IAM User Guide</i>.</p> <p>The format for this parameter, as described by its regex pattern, is a string of characters up to 2048 characters in length. The characters can be any ASCII character from the space character to the end of the valid character list (\\u0020-\\u00FF). It can also include the tab (\\u0009), linefeed (\\u000A), and carriage return (\\u000D) characters.</p> <note> <p>The policy plain text must be 2048 bytes or shorter. However, an internal conversion compresses it into a packed binary format with a separate limit. The PackedPolicySize response element indicates by percentage how close to the upper size limit the policy is, with 100% equaling the maximum allowed size.</p> </note>"]
+    #[serde(rename="Policy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the role to assume.</p>"]
+    #[serde(rename="RoleArn")]
     pub role_arn: String,
     #[doc="<p>An identifier for the assumed role session.</p> <p>Use the role session name to uniquely identify a session when the same role is assumed by different principals or for different reasons. In cross-account scenarios, the role session name is visible to, and can be logged by the account that owns the role. The role session name is also used in the ARN of the assumed role principal. This means that subsequent cross-account API requests using the temporary security credentials will expose the role session name to the external account in their CloudTrail logs.</p> <p>The regex used to validate this parameter is a string of characters consisting of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-</p>"]
+    #[serde(rename="RoleSessionName")]
     pub role_session_name: String,
     #[doc="<p>The identification number of the MFA device that is associated with the user who is making the <code>AssumeRole</code> call. Specify this value if the trust policy of the role being assumed includes a condition that requires MFA authentication. The value is either the serial number for a hardware device (such as <code>GAHT12345678</code>) or an Amazon Resource Name (ARN) for a virtual device (such as <code>arn:aws:iam::123456789012:mfa/user</code>).</p> <p>The regex used to validate this parameter is a string of characters consisting of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-</p>"]
+    #[serde(rename="SerialNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub serial_number: Option<String>,
     #[doc="<p>The value provided by the MFA device, if the trust policy of the role being assumed requires MFA (that is, if the policy includes a condition that tests for MFA). If the role being assumed requires MFA and if the <code>TokenCode</code> value is missing or expired, the <code>AssumeRole</code> call returns an \"access denied\" error.</p> <p>The format for this parameter, as described by its regex pattern, is a sequence of six numeric digits.</p>"]
+    #[serde(rename="TokenCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub token_code: Option<String>,
 }
 
@@ -152,13 +164,19 @@ impl AssumeRoleRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>AssumeRole</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssumeRoleResponse {
     #[doc="<p>The Amazon Resource Name (ARN) and the assumed role ID, which are identifiers that you can use to refer to the resulting temporary security credentials. For example, you can reference these credentials as a principal in a resource-based policy by using the ARN or assumed role ID. The ARN and ID include the <code>RoleSessionName</code> that you specified when you called <code>AssumeRole</code>. </p>"]
+    #[serde(rename="AssumedRoleUser")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub assumed_role_user: Option<AssumedRoleUser>,
     #[doc="<p>The temporary security credentials, which include an access key ID, a secret access key, and a security (or session) token.</p> <p> <b>Note:</b> The size of the security token that STS APIs return is not fixed. We strongly recommend that you make no assumptions about the maximum size. As of this writing, the typical size is less than 4096 bytes, but that can vary. Also, future updates to AWS might require larger sizes.</p>"]
+    #[serde(rename="Credentials")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub credentials: Option<Credentials>,
     #[doc="<p>A percentage value that indicates the size of the policy in packed form. The service rejects any policy with a packed size greater than 100 percent, which means the policy exceeded the allowed space.</p>"]
+    #[serde(rename="PackedPolicySize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub packed_policy_size: Option<i64>,
 }
 
@@ -215,17 +233,24 @@ impl AssumeRoleResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssumeRoleWithSAMLRequest {
     #[doc="<p>The duration, in seconds, of the role session. The value can range from 900 seconds (15 minutes) to 3600 seconds (1 hour). By default, the value is set to 3600 seconds. An expiration can also be specified in the SAML authentication response's <code>SessionNotOnOrAfter</code> value. The actual expiration time is whichever value is shorter. </p> <note> <p>This is separate from the duration of a console session that you might request using the returned credentials. The request to the federation endpoint for a console sign-in token takes a <code>SessionDuration</code> parameter that specifies the maximum length of the console session, separately from the <code>DurationSeconds</code> parameter on this API. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-saml.html\">Enabling SAML 2.0 Federated Users to Access the AWS Management Console</a> in the <i>IAM User Guide</i>.</p> </note>"]
+    #[serde(rename="DurationSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration_seconds: Option<i64>,
     #[doc="<p>An IAM policy in JSON format.</p> <p>The policy parameter is optional. If you pass a policy, the temporary security credentials that are returned by the operation have the permissions that are allowed by both the access policy of the role that is being assumed, <i> <b>and</b> </i> the policy that you pass. This gives you a way to further restrict the permissions for the resulting temporary security credentials. You cannot use the passed policy to grant permissions that are in excess of those allowed by the access policy of the role that is being assumed. For more information, <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_assumerole.html\">Permissions for AssumeRole, AssumeRoleWithSAML, and AssumeRoleWithWebIdentity</a> in the <i>IAM User Guide</i>. </p> <p>The format for this parameter, as described by its regex pattern, is a string of characters up to 2048 characters in length. The characters can be any ASCII character from the space character to the end of the valid character list (\\u0020-\\u00FF). It can also include the tab (\\u0009), linefeed (\\u000A), and carriage return (\\u000D) characters.</p> <note> <p>The policy plain text must be 2048 bytes or shorter. However, an internal conversion compresses it into a packed binary format with a separate limit. The PackedPolicySize response element indicates by percentage how close to the upper size limit the policy is, with 100% equaling the maximum allowed size.</p> </note>"]
+    #[serde(rename="Policy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the SAML provider in IAM that describes the IdP.</p>"]
+    #[serde(rename="PrincipalArn")]
     pub principal_arn: String,
     #[doc="<p>The Amazon Resource Name (ARN) of the role that the caller is assuming.</p>"]
+    #[serde(rename="RoleArn")]
     pub role_arn: String,
     #[doc="<p>The base-64 encoded SAML authentication response provided by the IdP.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/create-role-saml-IdP-tasks.html\">Configuring a Relying Party and Adding Claims</a> in the <i>Using IAM</i> guide. </p>"]
+    #[serde(rename="SAMLAssertion")]
     pub saml_assertion: String,
 }
 
@@ -258,23 +283,39 @@ impl AssumeRoleWithSAMLRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>AssumeRoleWithSAML</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssumeRoleWithSAMLResponse {
     #[doc="<p>The identifiers for the temporary security credentials that the operation returns.</p>"]
+    #[serde(rename="AssumedRoleUser")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub assumed_role_user: Option<AssumedRoleUser>,
     #[doc="<p> The value of the <code>Recipient</code> attribute of the <code>SubjectConfirmationData</code> element of the SAML assertion. </p>"]
+    #[serde(rename="Audience")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub audience: Option<String>,
     #[doc="<p>The temporary security credentials, which include an access key ID, a secret access key, and a security (or session) token.</p> <p> <b>Note:</b> The size of the security token that STS APIs return is not fixed. We strongly recommend that you make no assumptions about the maximum size. As of this writing, the typical size is less than 4096 bytes, but that can vary. Also, future updates to AWS might require larger sizes.</p>"]
+    #[serde(rename="Credentials")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub credentials: Option<Credentials>,
     #[doc="<p>The value of the <code>Issuer</code> element of the SAML assertion.</p>"]
+    #[serde(rename="Issuer")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub issuer: Option<String>,
     #[doc="<p>A hash value based on the concatenation of the <code>Issuer</code> response value, the AWS account ID, and the friendly name (the last part of the ARN) of the SAML provider in IAM. The combination of <code>NameQualifier</code> and <code>Subject</code> can be used to uniquely identify a federated user. </p> <p>The following pseudocode shows how the hash value is calculated:</p> <p> <code>BASE64 ( SHA1 ( \"https://example.com/saml\" + \"123456789012\" + \"/MySAMLIdP\" ) )</code> </p>"]
+    #[serde(rename="NameQualifier")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub name_qualifier: Option<String>,
     #[doc="<p>A percentage value that indicates the size of the policy in packed form. The service rejects any policy with a packed size greater than 100 percent, which means the policy exceeded the allowed space.</p>"]
+    #[serde(rename="PackedPolicySize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub packed_policy_size: Option<i64>,
     #[doc="<p>The value of the <code>NameID</code> element in the <code>Subject</code> element of the SAML assertion.</p>"]
+    #[serde(rename="Subject")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subject: Option<String>,
     #[doc="<p> The format of the name ID, as defined by the <code>Format</code> attribute in the <code>NameID</code> element of the SAML assertion. Typical examples of the format are <code>transient</code> or <code>persistent</code>. </p> <p> If the format includes the prefix <code>urn:oasis:names:tc:SAML:2.0:nameid-format</code>, that prefix is removed. For example, <code>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</code> is returned as <code>transient</code>. If the format includes any other prefix, the format is returned with no modifications.</p>"]
+    #[serde(rename="SubjectType")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subject_type: Option<String>,
 }
 
@@ -353,19 +394,28 @@ impl AssumeRoleWithSAMLResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssumeRoleWithWebIdentityRequest {
     #[doc="<p>The duration, in seconds, of the role session. The value can range from 900 seconds (15 minutes) to 3600 seconds (1 hour). By default, the value is set to 3600 seconds.</p> <note> <p>This is separate from the duration of a console session that you might request using the returned credentials. The request to the federation endpoint for a console sign-in token takes a <code>SessionDuration</code> parameter that specifies the maximum length of the console session, separately from the <code>DurationSeconds</code> parameter on this API. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html\">Creating a URL that Enables Federated Users to Access the AWS Management Console</a> in the <i>IAM User Guide</i>.</p> </note>"]
+    #[serde(rename="DurationSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration_seconds: Option<i64>,
     #[doc="<p>An IAM policy in JSON format.</p> <p>The policy parameter is optional. If you pass a policy, the temporary security credentials that are returned by the operation have the permissions that are allowed by both the access policy of the role that is being assumed, <i> <b>and</b> </i> the policy that you pass. This gives you a way to further restrict the permissions for the resulting temporary security credentials. You cannot use the passed policy to grant permissions that are in excess of those allowed by the access policy of the role that is being assumed. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_assumerole.html\">Permissions for AssumeRoleWithWebIdentity</a> in the <i>IAM User Guide</i>. </p> <p>The format for this parameter, as described by its regex pattern, is a string of characters up to 2048 characters in length. The characters can be any ASCII character from the space character to the end of the valid character list (\\u0020-\\u00FF). It can also include the tab (\\u0009), linefeed (\\u000A), and carriage return (\\u000D) characters.</p> <note> <p>The policy plain text must be 2048 bytes or shorter. However, an internal conversion compresses it into a packed binary format with a separate limit. The PackedPolicySize response element indicates by percentage how close to the upper size limit the policy is, with 100% equaling the maximum allowed size.</p> </note>"]
+    #[serde(rename="Policy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy: Option<String>,
     #[doc="<p>The fully qualified host component of the domain name of the identity provider.</p> <p>Specify this value only for OAuth 2.0 access tokens. Currently <code>www.amazon.com</code> and <code>graph.facebook.com</code> are the only supported identity providers for OAuth 2.0 access tokens. Do not include URL schemes and port numbers.</p> <p>Do not specify this value for OpenID Connect ID tokens.</p>"]
+    #[serde(rename="ProviderId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub provider_id: Option<String>,
     #[doc="<p>The Amazon Resource Name (ARN) of the role that the caller is assuming.</p>"]
+    #[serde(rename="RoleArn")]
     pub role_arn: String,
     #[doc="<p>An identifier for the assumed role session. Typically, you pass the name or identifier that is associated with the user who is using your application. That way, the temporary security credentials that your application will use are associated with that user. This session name is included as part of the ARN and assumed role ID in the <code>AssumedRoleUser</code> response element.</p> <p>The regex used to validate this parameter is a string of characters consisting of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-</p>"]
+    #[serde(rename="RoleSessionName")]
     pub role_session_name: String,
     #[doc="<p>The OAuth 2.0 access token or OpenID Connect ID token that is provided by the identity provider. Your application must get this token by authenticating the user who is using your application with a web identity provider before the application makes an <code>AssumeRoleWithWebIdentity</code> call. </p>"]
+    #[serde(rename="WebIdentityToken")]
     pub web_identity_token: String,
 }
 
@@ -402,19 +452,31 @@ impl AssumeRoleWithWebIdentityRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>AssumeRoleWithWebIdentity</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssumeRoleWithWebIdentityResponse {
     #[doc="<p>The Amazon Resource Name (ARN) and the assumed role ID, which are identifiers that you can use to refer to the resulting temporary security credentials. For example, you can reference these credentials as a principal in a resource-based policy by using the ARN or assumed role ID. The ARN and ID include the <code>RoleSessionName</code> that you specified when you called <code>AssumeRole</code>. </p>"]
+    #[serde(rename="AssumedRoleUser")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub assumed_role_user: Option<AssumedRoleUser>,
     #[doc="<p>The intended audience (also known as client ID) of the web identity token. This is traditionally the client identifier issued to the application that requested the web identity token.</p>"]
+    #[serde(rename="Audience")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub audience: Option<String>,
     #[doc="<p>The temporary security credentials, which include an access key ID, a secret access key, and a security token.</p> <p> <b>Note:</b> The size of the security token that STS APIs return is not fixed. We strongly recommend that you make no assumptions about the maximum size. As of this writing, the typical size is less than 4096 bytes, but that can vary. Also, future updates to AWS might require larger sizes.</p>"]
+    #[serde(rename="Credentials")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub credentials: Option<Credentials>,
     #[doc="<p>A percentage value that indicates the size of the policy in packed form. The service rejects any policy with a packed size greater than 100 percent, which means the policy exceeded the allowed space.</p>"]
+    #[serde(rename="PackedPolicySize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub packed_policy_size: Option<i64>,
     #[doc="<p> The issuing authority of the web identity token presented. For OpenID Connect ID Tokens this contains the value of the <code>iss</code> field. For OAuth 2.0 access tokens, this contains the value of the <code>ProviderId</code> parameter that was passed in the <code>AssumeRoleWithWebIdentity</code> request.</p>"]
+    #[serde(rename="Provider")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub provider: Option<String>,
     #[doc="<p>The unique user identifier that is returned by the identity provider. This identifier is associated with the <code>WebIdentityToken</code> that was submitted with the <code>AssumeRoleWithWebIdentity</code> call. The identifier is typically unique to the user and the application that acquired the <code>WebIdentityToken</code> (pairwise identifier). For OpenID Connect ID tokens, this field contains the value returned by the identity provider as the token's <code>sub</code> (Subject) claim. </p>"]
+    #[serde(rename="SubjectFromWebIdentityToken")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub subject_from_web_identity_token: Option<String>,
 }
 
@@ -500,11 +562,13 @@ impl AssumedRoleIdTypeDeserializer {
     }
 }
 #[doc="<p>The identifiers for the temporary security credentials that the operation returns.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssumedRoleUser {
     #[doc="<p>The ARN of the temporary security credentials that are returned from the <a>AssumeRole</a> action. For more information about ARNs and how to use them in policies, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html\">IAM Identifiers</a> in <i>Using IAM</i>. </p>"]
+    #[serde(rename="Arn")]
     pub arn: String,
     #[doc="<p>A unique identifier that contains the role ID and the role session name of the role that is being assumed. The role ID is generated by AWS when the role is created.</p>"]
+    #[serde(rename="AssumedRoleId")]
     pub assumed_role_id: String,
 }
 
@@ -569,15 +633,19 @@ impl AudienceDeserializer {
     }
 }
 #[doc="<p>AWS credentials for API authentication.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Credentials {
     #[doc="<p>The access key ID that identifies the temporary security credentials.</p>"]
+    #[serde(rename="AccessKeyId")]
     pub access_key_id: String,
     #[doc="<p>The date on which the current credentials expire.</p>"]
+    #[serde(rename="Expiration")]
     pub expiration: String,
     #[doc="<p>The secret access key that can be used to sign requests.</p>"]
+    #[serde(rename="SecretAccessKey")]
     pub secret_access_key: String,
     #[doc="<p>The token that users must pass to the service API to use the temporary credentials.</p>"]
+    #[serde(rename="SessionToken")]
     pub session_token: String,
 }
 
@@ -651,9 +719,10 @@ impl DateTypeDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecodeAuthorizationMessageRequest {
     #[doc="<p>The encoded message that was returned with the response.</p>"]
+    #[serde(rename="EncodedMessage")]
     pub encoded_message: String,
 }
 
@@ -674,9 +743,11 @@ impl DecodeAuthorizationMessageRequestSerializer {
 }
 
 #[doc="<p>A document that contains additional information about the authorization status of a request from an encoded message that is returned in response to an AWS request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecodeAuthorizationMessageResponse {
     #[doc="<p>An XML document that contains the decoded message.</p>"]
+    #[serde(rename="DecodedMessage")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub decoded_message: Option<String>,
 }
 
@@ -753,11 +824,13 @@ impl FederatedIdTypeDeserializer {
     }
 }
 #[doc="<p>Identifiers for the federated user that is associated with the credentials.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FederatedUser {
     #[doc="<p>The ARN that specifies the federated user that is associated with the credentials. For more information about ARNs and how to use them in policies, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html\">IAM Identifiers</a> in <i>Using IAM</i>. </p>"]
+    #[serde(rename="Arn")]
     pub arn: String,
     #[doc="<p>The string that identifies the federated user associated with the credentials, similar to the unique ID of an IAM user.</p>"]
+    #[serde(rename="FederatedUserId")]
     pub federated_user_id: String,
 }
 
@@ -807,7 +880,7 @@ impl FederatedUserDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCallerIdentityRequest;
 
 
@@ -826,13 +899,19 @@ impl GetCallerIdentityRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetCallerIdentity</a> request, including information about the entity making the request.</p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCallerIdentityResponse {
     #[doc="<p>The AWS account ID number of the account that owns or contains the calling entity.</p>"]
+    #[serde(rename="Account")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub account: Option<String>,
     #[doc="<p>The AWS ARN associated with the calling entity.</p>"]
+    #[serde(rename="Arn")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub arn: Option<String>,
     #[doc="<p>The unique identifier of the calling entity. The exact value depends on the type of entity making the call. The values returned are those listed in the <b>aws:userid</b> column in the <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable\">Principal table</a> found on the <b>Policy Variables</b> reference page in the <i>IAM User Guide</i>.</p>"]
+    #[serde(rename="UserId")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub user_id: Option<String>,
 }
 
@@ -885,13 +964,18 @@ impl GetCallerIdentityResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFederationTokenRequest {
     #[doc="<p>The duration, in seconds, that the session should last. Acceptable durations for federation sessions range from 900 seconds (15 minutes) to 129600 seconds (36 hours), with 43200 seconds (12 hours) as the default. Sessions obtained using AWS account (root) credentials are restricted to a maximum of 3600 seconds (one hour). If the specified duration is longer than one hour, the session obtained by using AWS account (root) credentials defaults to one hour.</p>"]
+    #[serde(rename="DurationSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration_seconds: Option<i64>,
     #[doc="<p>The name of the federated user. The name is used as an identifier for the temporary security credentials (such as <code>Bob</code>). For example, you can reference the federated user name in a resource-based policy, such as in an Amazon S3 bucket policy.</p> <p>The regex used to validate this parameter is a string of characters consisting of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-</p>"]
+    #[serde(rename="Name")]
     pub name: String,
     #[doc="<p>An IAM policy in JSON format that is passed with the <code>GetFederationToken</code> call and evaluated along with the policy or policies that are attached to the IAM user whose credentials are used to call <code>GetFederationToken</code>. The passed policy is used to scope down the permissions that are available to the IAM user, by allowing only a subset of the permissions that are granted to the IAM user. The passed policy cannot grant more permissions than those granted to the IAM user. The final permissions for the federated user are the most restrictive set based on the intersection of the passed policy and the IAM user policy.</p> <p>If you do not pass a policy, the resulting temporary security credentials have no effective permissions. The only exception is when the temporary security credentials are used to access a resource that has a resource-based policy that specifically allows the federated user to access the resource.</p> <p>The format for this parameter, as described by its regex pattern, is a string of characters up to 2048 characters in length. The characters can be any ASCII character from the space character to the end of the valid character list (\\u0020-\\u00FF). It can also include the tab (\\u0009), linefeed (\\u000A), and carriage return (\\u000D) characters.</p> <note> <p>The policy plain text must be 2048 bytes or shorter. However, an internal conversion compresses it into a packed binary format with a separate limit. The PackedPolicySize response element indicates by percentage how close to the upper size limit the policy is, with 100% equaling the maximum allowed size.</p> </note> <p>For more information about how permissions work, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_getfederationtoken.html\">Permissions for GetFederationToken</a>.</p>"]
+    #[serde(rename="Policy")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub policy: Option<String>,
 }
 
@@ -920,13 +1004,19 @@ impl GetFederationTokenRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetFederationToken</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFederationTokenResponse {
     #[doc="<p>The temporary security credentials, which include an access key ID, a secret access key, and a security (or session) token.</p> <p> <b>Note:</b> The size of the security token that STS APIs return is not fixed. We strongly recommend that you make no assumptions about the maximum size. As of this writing, the typical size is less than 4096 bytes, but that can vary. Also, future updates to AWS might require larger sizes.</p>"]
+    #[serde(rename="Credentials")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub credentials: Option<Credentials>,
     #[doc="<p>Identifiers for the federated user associated with the credentials (such as <code>arn:aws:sts::123456789012:federated-user/Bob</code> or <code>123456789012:Bob</code>). You can use the federated user's ARN in your resource-based policies, such as an Amazon S3 bucket policy. </p>"]
+    #[serde(rename="FederatedUser")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub federated_user: Option<FederatedUser>,
     #[doc="<p>A percentage value indicating the size of the policy in packed form. The service rejects policies for which the packed size is greater than 100 percent of the allowed value.</p>"]
+    #[serde(rename="PackedPolicySize")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub packed_policy_size: Option<i64>,
 }
 
@@ -983,13 +1073,19 @@ impl GetFederationTokenResponseDeserializer {
 
     }
 }
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSessionTokenRequest {
     #[doc="<p>The duration, in seconds, that the credentials should remain valid. Acceptable durations for IAM user sessions range from 900 seconds (15 minutes) to 129600 seconds (36 hours), with 43200 seconds (12 hours) as the default. Sessions for AWS account owners are restricted to a maximum of 3600 seconds (one hour). If the duration is longer than one hour, the session for AWS account owners defaults to one hour.</p>"]
+    #[serde(rename="DurationSeconds")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub duration_seconds: Option<i64>,
     #[doc="<p>The identification number of the MFA device that is associated with the IAM user who is making the <code>GetSessionToken</code> call. Specify this value if the IAM user has a policy that requires MFA authentication. The value is either the serial number for a hardware device (such as <code>GAHT12345678</code>) or an Amazon Resource Name (ARN) for a virtual device (such as <code>arn:aws:iam::123456789012:mfa/user</code>). You can find the device for an IAM user by going to the AWS Management Console and viewing the user's security credentials. </p> <p>The regex used to validated this parameter is a string of characters consisting of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@:/-</p>"]
+    #[serde(rename="SerialNumber")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub serial_number: Option<String>,
     #[doc="<p>The value provided by the MFA device, if MFA is required. If any policy requires the IAM user to submit an MFA code, specify this value. If MFA authentication is required, and the user does not provide a code when requesting a set of temporary security credentials, the user will receive an \"access denied\" response when requesting resources that require MFA authentication.</p> <p>The format for this parameter, as described by its regex pattern, is a sequence of six numeric digits.</p>"]
+    #[serde(rename="TokenCode")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub token_code: Option<String>,
 }
 
@@ -1020,9 +1116,11 @@ impl GetSessionTokenRequestSerializer {
 }
 
 #[doc="<p>Contains the response to a successful <a>GetSessionToken</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>"]
-#[derive(Default,Debug,Clone)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSessionTokenResponse {
     #[doc="<p>The temporary security credentials, which include an access key ID, a secret access key, and a security (or session) token.</p> <p> <b>Note:</b> The size of the security token that STS APIs return is not fixed. We strongly recommend that you make no assumptions about the maximum size. As of this writing, the typical size is less than 4096 bytes, but that can vary. Also, future updates to AWS might require larger sizes.</p>"]
+    #[serde(rename="Credentials")]
+    #[serde(skip_serializing_if="Option::is_none")]
     pub credentials: Option<Credentials>,
 }
 

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddAttachmentsToSetRequest {
     #[doc="<p>The ID of the attachment set. If an <code>attachmentSetId</code> is not specified, a new attachment set is created, and the ID of the set is returned in the response. If an <code>attachmentSetId</code> is specified, the attachments are added to the specified set, if it exists.</p>"]
     #[serde(rename="attachmentSetId")]
@@ -41,7 +41,7 @@ pub struct AddAttachmentsToSetRequest {
 }
 
 #[doc="<p>The ID and expiry time of the attachment set returned by the <a>AddAttachmentsToSet</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddAttachmentsToSetResponse {
     #[doc="<p>The ID of the attachment set. If an <code>attachmentSetId</code> was not specified, a new attachment set is created, and the ID of the set is returned in the response. If an <code>attachmentSetId</code> was specified, the attachments are added to the specified set, if it exists.</p>"]
     #[serde(rename="attachmentSetId")]
@@ -54,7 +54,7 @@ pub struct AddAttachmentsToSetResponse {
 }
 
 #[doc="<p>To be written.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddCommunicationToCaseRequest {
     #[doc="<p>The ID of a set of one or more attachments for the communication to add to the case. Create the set by calling <a>AddAttachmentsToSet</a> </p>"]
     #[serde(rename="attachmentSetId")]
@@ -74,7 +74,7 @@ pub struct AddCommunicationToCaseRequest {
 }
 
 #[doc="<p>The result of the <a>AddCommunicationToCase</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddCommunicationToCaseResponse {
     #[doc="<p>True if <a>AddCommunicationToCase</a> succeeds. Otherwise, returns an error.</p>"]
     #[serde(rename="result")]
@@ -100,7 +100,7 @@ pub struct Attachment {
 }
 
 #[doc="<p>The file name and ID of an attachment to a case communication. You can use the ID to retrieve the attachment with the <a>DescribeAttachment</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AttachmentDetails {
     #[doc="<p>The ID of the attachment.</p>"]
     #[serde(rename="attachmentId")]
@@ -113,7 +113,7 @@ pub struct AttachmentDetails {
 }
 
 #[doc="<p>A JSON-formatted object that contains the metadata for a support case. It is contained the response from a <a>DescribeCases</a> request. <b>CaseDetails</b> contains the following fields:</p> <ul> <li> <p> <b>caseId.</b> The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i>.</p> </li> <li> <p> <b>categoryCode.</b> The category of problem for the AWS Support case. Corresponds to the CategoryCode values returned by a call to <a>DescribeServices</a>.</p> </li> <li> <p> <b>displayId.</b> The identifier for the case on pages in the AWS Support Center.</p> </li> <li> <p> <b>language.</b> The ISO 639-1 code for the language in which AWS provides support. AWS Support currently supports English (\"en\") and Japanese (\"ja\"). Language parameters must be passed explicitly for operations that take them.</p> </li> <li> <p> <b>recentCommunications.</b> One or more <a>Communication</a> objects. Fields of these objects are <code>attachments</code>, <code>body</code>, <code>caseId</code>, <code>submittedBy</code>, and <code>timeCreated</code>.</p> </li> <li> <p> <b>nextToken.</b> A resumption point for pagination.</p> </li> <li> <p> <b>serviceCode.</b> The identifier for the AWS service that corresponds to the service code defined in the call to <a>DescribeServices</a>.</p> </li> <li> <p> <b>severityCode. </b>The severity code assigned to the case. Contains one of the values returned by the call to <a>DescribeSeverityLevels</a>.</p> </li> <li> <p> <b>status.</b> The status of the case in the AWS Support Center.</p> </li> <li> <p> <b>subject.</b> The subject line of the case.</p> </li> <li> <p> <b>submittedBy.</b> The email address of the account that submitted the case.</p> </li> <li> <p> <b>timeCreated.</b> The time the case was created, in ISO-8601 format.</p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CaseDetails {
     #[doc="<p>The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i> </p>"]
     #[serde(rename="caseId")]
@@ -166,7 +166,7 @@ pub struct CaseDetails {
 }
 
 #[doc="<p>A JSON-formatted name/value pair that represents the category name and category code of the problem, selected from the <a>DescribeServices</a> response for each AWS service.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Category {
     #[doc="<p>The category code for the support case.</p>"]
     #[serde(rename="code")]
@@ -179,7 +179,7 @@ pub struct Category {
 }
 
 #[doc="<p>A communication associated with an AWS Support case. The communication consists of the case ID, the message body, attachment information, the account email address, and the date and time of the communication.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Communication {
     #[doc="<p>Information about the attachments to the case communication.</p>"]
     #[serde(rename="attachmentSet")]
@@ -204,7 +204,7 @@ pub struct Communication {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCaseRequest {
     #[doc="<p>The ID of a set of one or more attachments for the case. Create the set by using <a>AddAttachmentsToSet</a>.</p>"]
     #[serde(rename="attachmentSetId")]
@@ -243,7 +243,7 @@ pub struct CreateCaseRequest {
 }
 
 #[doc="<p>The AWS Support case ID returned by a successful completion of the <a>CreateCase</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCaseResponse {
     #[doc="<p>The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i> </p>"]
     #[serde(rename="caseId")]
@@ -251,7 +251,7 @@ pub struct CreateCaseResponse {
     pub case_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAttachmentRequest {
     #[doc="<p>The ID of the attachment to return. Attachment IDs are returned by the <a>DescribeCommunications</a> operation.</p>"]
     #[serde(rename="attachmentId")]
@@ -259,7 +259,7 @@ pub struct DescribeAttachmentRequest {
 }
 
 #[doc="<p>The content and file name of the attachment returned by the <a>DescribeAttachment</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeAttachmentResponse {
     #[doc="<p>The attachment content and file name.</p>"]
     #[serde(rename="attachment")]
@@ -268,7 +268,7 @@ pub struct DescribeAttachmentResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCasesRequest {
     #[doc="<p>The start date for a filtered date search on support case communications. Case communications are available for 12 months after creation.</p>"]
     #[serde(rename="afterTime")]
@@ -309,7 +309,7 @@ pub struct DescribeCasesRequest {
 }
 
 #[doc="<p>Returns an array of <a>CaseDetails</a> objects and a <code>nextToken</code> that defines a point for pagination in the result set.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCasesResponse {
     #[doc="<p>The details for the cases that match the request.</p>"]
     #[serde(rename="cases")]
@@ -322,7 +322,7 @@ pub struct DescribeCasesResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCommunicationsRequest {
     #[doc="<p>The start date for a filtered date search on support case communications. Case communications are available for 12 months after creation.</p>"]
     #[serde(rename="afterTime")]
@@ -346,7 +346,7 @@ pub struct DescribeCommunicationsRequest {
 }
 
 #[doc="<p>The communications returned by the <a>DescribeCommunications</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCommunicationsResponse {
     #[doc="<p>The communications for the case.</p>"]
     #[serde(rename="communications")]
@@ -359,7 +359,7 @@ pub struct DescribeCommunicationsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeServicesRequest {
     #[doc="<p>The ISO 639-1 code for the language in which AWS provides support. AWS Support currently supports English (\"en\") and Japanese (\"ja\"). Language parameters must be passed explicitly for operations that take them.</p>"]
     #[serde(rename="language")]
@@ -372,7 +372,7 @@ pub struct DescribeServicesRequest {
 }
 
 #[doc="<p>The list of AWS services returned by the <a>DescribeServices</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeServicesResponse {
     #[doc="<p>A JSON-formatted list of AWS services.</p>"]
     #[serde(rename="services")]
@@ -381,7 +381,7 @@ pub struct DescribeServicesResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSeverityLevelsRequest {
     #[doc="<p>The ISO 639-1 code for the language in which AWS provides support. AWS Support currently supports English (\"en\") and Japanese (\"ja\"). Language parameters must be passed explicitly for operations that take them.</p>"]
     #[serde(rename="language")]
@@ -390,7 +390,7 @@ pub struct DescribeSeverityLevelsRequest {
 }
 
 #[doc="<p>The list of severity levels returned by the <a>DescribeSeverityLevels</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeSeverityLevelsResponse {
     #[doc="<p>The available severity levels for the support case. Available severity levels are defined by your service level agreement with AWS.</p>"]
     #[serde(rename="severityLevels")]
@@ -399,7 +399,7 @@ pub struct DescribeSeverityLevelsResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrustedAdvisorCheckRefreshStatusesRequest {
     #[doc="<p>The IDs of the Trusted Advisor checks to get the status of. <b>Note:</b> Specifying the check ID of a check that is automatically refreshed causes an <code>InvalidParameterValue</code> error.</p>"]
     #[serde(rename="checkIds")]
@@ -407,7 +407,7 @@ pub struct DescribeTrustedAdvisorCheckRefreshStatusesRequest {
 }
 
 #[doc="<p>The statuses of the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorCheckRefreshStatuses</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrustedAdvisorCheckRefreshStatusesResponse {
     #[doc="<p>The refresh status of the specified Trusted Advisor checks.</p>"]
     #[serde(rename="statuses")]
@@ -415,7 +415,7 @@ pub struct DescribeTrustedAdvisorCheckRefreshStatusesResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrustedAdvisorCheckResultRequest {
     #[doc="<p>The unique identifier for the Trusted Advisor check.</p>"]
     #[serde(rename="checkId")]
@@ -427,7 +427,7 @@ pub struct DescribeTrustedAdvisorCheckResultRequest {
 }
 
 #[doc="<p>The result of the Trusted Advisor check returned by the <a>DescribeTrustedAdvisorCheckResult</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrustedAdvisorCheckResultResponse {
     #[doc="<p>The detailed results of the Trusted Advisor check.</p>"]
     #[serde(rename="result")]
@@ -436,7 +436,7 @@ pub struct DescribeTrustedAdvisorCheckResultResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrustedAdvisorCheckSummariesRequest {
     #[doc="<p>The IDs of the Trusted Advisor checks.</p>"]
     #[serde(rename="checkIds")]
@@ -444,7 +444,7 @@ pub struct DescribeTrustedAdvisorCheckSummariesRequest {
 }
 
 #[doc="<p>The summaries of the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorCheckSummaries</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrustedAdvisorCheckSummariesResponse {
     #[doc="<p>The summary information for the requested Trusted Advisor checks.</p>"]
     #[serde(rename="summaries")]
@@ -452,7 +452,7 @@ pub struct DescribeTrustedAdvisorCheckSummariesResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrustedAdvisorChecksRequest {
     #[doc="<p>The ISO 639-1 code for the language in which AWS provides support. AWS Support currently supports English (\"en\") and Japanese (\"ja\"). Language parameters must be passed explicitly for operations that take them.</p>"]
     #[serde(rename="language")]
@@ -460,7 +460,7 @@ pub struct DescribeTrustedAdvisorChecksRequest {
 }
 
 #[doc="<p>Information about the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorChecks</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTrustedAdvisorChecksResponse {
     #[doc="<p>Information about all available Trusted Advisor checks.</p>"]
     #[serde(rename="checks")]
@@ -468,7 +468,7 @@ pub struct DescribeTrustedAdvisorChecksResponse {
 }
 
 #[doc="<p>The five most recent communications associated with the case.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecentCaseCommunications {
     #[doc="<p>The five most recent communications associated with the case.</p>"]
     #[serde(rename="communications")]
@@ -481,7 +481,7 @@ pub struct RecentCaseCommunications {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RefreshTrustedAdvisorCheckRequest {
     #[doc="<p>The unique identifier for the Trusted Advisor check to refresh. <b>Note:</b> Specifying the check ID of a check that is automatically refreshed causes an <code>InvalidParameterValue</code> error.</p>"]
     #[serde(rename="checkId")]
@@ -489,7 +489,7 @@ pub struct RefreshTrustedAdvisorCheckRequest {
 }
 
 #[doc="<p>The current refresh status of a Trusted Advisor check.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RefreshTrustedAdvisorCheckResponse {
     #[doc="<p>The current refresh status for a check, including the amount of time until the check is eligible for refresh.</p>"]
     #[serde(rename="status")]
@@ -497,7 +497,7 @@ pub struct RefreshTrustedAdvisorCheckResponse {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResolveCaseRequest {
     #[doc="<p>The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i> </p>"]
     #[serde(rename="caseId")]
@@ -506,7 +506,7 @@ pub struct ResolveCaseRequest {
 }
 
 #[doc="<p>The status of the case returned by the <a>ResolveCase</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResolveCaseResponse {
     #[doc="<p>The status of the case after the <a>ResolveCase</a> request was processed.</p>"]
     #[serde(rename="finalCaseStatus")]
@@ -519,7 +519,7 @@ pub struct ResolveCaseResponse {
 }
 
 #[doc="<p>Information about an AWS service returned by the <a>DescribeServices</a> operation. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Service {
     #[doc="<p>A list of categories that describe the type of support issue a case describes. Categories consist of a category name and a category code. Category names and codes are passed to AWS Support when you call <a>CreateCase</a>.</p>"]
     #[serde(rename="categories")]
@@ -536,7 +536,7 @@ pub struct Service {
 }
 
 #[doc="<p>A code and name pair that represent a severity level that can be applied to a support case.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SeverityLevel {
     #[doc="<p>One of four values: \"low,\" \"medium,\" \"high,\" and \"urgent\". These values correspond to response times returned to the caller in <code>severityLevel.name</code>. </p>"]
     #[serde(rename="code")]
@@ -549,7 +549,7 @@ pub struct SeverityLevel {
 }
 
 #[doc="<p>The container for summary information that relates to the category of the Trusted Advisor check.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TrustedAdvisorCategorySpecificSummary {
     #[doc="<p>The summary information about cost savings for a Trusted Advisor check that is in the Cost Optimizing category.</p>"]
     #[serde(rename="costOptimizing")]
@@ -558,7 +558,7 @@ pub struct TrustedAdvisorCategorySpecificSummary {
 }
 
 #[doc="<p>The description and metadata for a Trusted Advisor check.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TrustedAdvisorCheckDescription {
     #[doc="<p>The category of the Trusted Advisor check.</p>"]
     #[serde(rename="category")]
@@ -578,7 +578,7 @@ pub struct TrustedAdvisorCheckDescription {
 }
 
 #[doc="<p>The refresh status of a Trusted Advisor check.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TrustedAdvisorCheckRefreshStatus {
     #[doc="<p>The unique identifier for the Trusted Advisor check.</p>"]
     #[serde(rename="checkId")]
@@ -592,7 +592,7 @@ pub struct TrustedAdvisorCheckRefreshStatus {
 }
 
 #[doc="<p>The results of a Trusted Advisor check returned by <a>DescribeTrustedAdvisorCheckResult</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TrustedAdvisorCheckResult {
     #[doc="<p>Summary information that relates to the category of the check. Cost Optimizing is the only category that is currently supported.</p>"]
     #[serde(rename="categorySpecificSummary")]
@@ -614,7 +614,7 @@ pub struct TrustedAdvisorCheckResult {
 }
 
 #[doc="<p>A summary of a Trusted Advisor check result, including the alert status, last refresh, and number of resources examined.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TrustedAdvisorCheckSummary {
     #[doc="<p>Summary information that relates to the category of the check. Cost Optimizing is the only category that is currently supported.</p>"]
     #[serde(rename="categorySpecificSummary")]
@@ -637,7 +637,7 @@ pub struct TrustedAdvisorCheckSummary {
 }
 
 #[doc="<p>The estimated cost savings that might be realized if the recommended actions are taken.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TrustedAdvisorCostOptimizingSummary {
     #[doc="<p>The estimated monthly savings that might be realized if the recommended actions are taken.</p>"]
     #[serde(rename="estimatedMonthlySavings")]
@@ -648,7 +648,7 @@ pub struct TrustedAdvisorCostOptimizingSummary {
 }
 
 #[doc="<p>Contains information about a resource identified by a Trusted Advisor check.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TrustedAdvisorResourceDetail {
     #[doc="<p>Specifies whether the AWS resource was ignored by Trusted Advisor because it was marked as suppressed by the user.</p>"]
     #[serde(rename="isSuppressed")]
@@ -670,7 +670,7 @@ pub struct TrustedAdvisorResourceDetail {
 }
 
 #[doc="<p>Details about AWS resources that were analyzed in a call to Trusted Advisor <a>DescribeTrustedAdvisorCheckSummaries</a>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TrustedAdvisorResourcesSummary {
     #[doc="<p>The number of AWS resources that were flagged (listed) by the Trusted Advisor check.</p>"]
     #[serde(rename="resourcesFlagged")]

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Unit of work sent to an activity worker.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTask {
     #[doc="<p>The unique ID of the task.</p>"]
     #[serde(rename="activityId")]
@@ -53,7 +53,7 @@ pub struct ActivityTask {
 }
 
 #[doc="<p>Provides the details of the <code>ActivityTaskCancelRequested</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTaskCancelRequestedEventAttributes {
     #[doc="<p>The unique ID of the task.</p>"]
     #[serde(rename="activityId")]
@@ -64,7 +64,7 @@ pub struct ActivityTaskCancelRequestedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ActivityTaskCanceled</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTaskCanceledEventAttributes {
     #[doc="<p>Details of the cancellation.</p>"]
     #[serde(rename="details")]
@@ -83,7 +83,7 @@ pub struct ActivityTaskCanceledEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ActivityTaskCompleted</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTaskCompletedEventAttributes {
     #[doc="<p>The results of the activity task.</p>"]
     #[serde(rename="result")]
@@ -98,7 +98,7 @@ pub struct ActivityTaskCompletedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ActivityTaskFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTaskFailedEventAttributes {
     #[doc="<p>The details of the failure.</p>"]
     #[serde(rename="details")]
@@ -117,7 +117,7 @@ pub struct ActivityTaskFailedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ActivityTaskScheduled</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTaskScheduledEventAttributes {
     #[doc="<p>The unique ID of the activity task.</p>"]
     #[serde(rename="activityId")]
@@ -162,7 +162,7 @@ pub struct ActivityTaskScheduledEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ActivityTaskStarted</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTaskStartedEventAttributes {
     #[doc="<p>Identity of the worker that was assigned this task. This aids diagnostics when problems arise. The form of this identity is user defined.</p>"]
     #[serde(rename="identity")]
@@ -174,7 +174,7 @@ pub struct ActivityTaskStartedEventAttributes {
 }
 
 #[doc="<p>Status information about an activity task.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTaskStatus {
     #[doc="<p>Set to <code>true</code> if cancellation of the task is requested.</p>"]
     #[serde(rename="cancelRequested")]
@@ -182,7 +182,7 @@ pub struct ActivityTaskStatus {
 }
 
 #[doc="<p>Provides the details of the <code>ActivityTaskTimedOut</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTaskTimedOutEventAttributes {
     #[doc="<p>Contains the content of the <code>details</code> parameter for the last call made by the activity to <code>RecordActivityTaskHeartbeat</code>.</p>"]
     #[serde(rename="details")]
@@ -211,7 +211,7 @@ pub struct ActivityType {
 }
 
 #[doc="<p>Configuration settings registered with the activity type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTypeConfiguration {
     #[doc="<p> The default maximum time, in seconds, before which a worker processing a task must report progress by calling <a>RecordActivityTaskHeartbeat</a>.</p> <p>You can specify this value only when <i>registering</i> an activity type. The registered default value can be overridden when you schedule a task through the <code>ScheduleActivityTask</code> <a>Decision</a>. If the activity worker subsequently attempts to record a heartbeat or returns a result, the activity worker receives an <code>UnknownResource</code> fault. In this case, Amazon SWF no longer considers the activity task to be valid; the activity worker should clean up the activity task.</p> <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"]
     #[serde(rename="defaultTaskHeartbeatTimeout")]
@@ -240,7 +240,7 @@ pub struct ActivityTypeConfiguration {
 }
 
 #[doc="<p>Detailed information about an activity type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTypeDetail {
     #[doc="<p>The configuration settings registered with the activity type.</p>"]
     #[serde(rename="configuration")]
@@ -251,7 +251,7 @@ pub struct ActivityTypeDetail {
 }
 
 #[doc="<p>Detailed information about an activity type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTypeInfo {
     #[doc="<p>The <a>ActivityType</a> type structure representing the activity type.</p>"]
     #[serde(rename="activityType")]
@@ -273,7 +273,7 @@ pub struct ActivityTypeInfo {
 }
 
 #[doc="<p>Contains a paginated list of activity type information structures.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivityTypeInfos {
     #[doc="<p>If a <code>NextPageToken</code> was returned by a previous call, there are more results available. To retrieve the next page of results, make the call again using the returned token in <code>nextPageToken</code>. Keep all other arguments unchanged.</p> <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>"]
     #[serde(rename="nextPageToken")]
@@ -285,7 +285,7 @@ pub struct ActivityTypeInfos {
 }
 
 #[doc="<p>Provides the details of the <code>CancelTimer</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelTimerDecisionAttributes {
     #[doc="<p> The unique ID of the timer to cancel.</p>"]
     #[serde(rename="timerId")]
@@ -293,7 +293,7 @@ pub struct CancelTimerDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>CancelTimerFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelTimerFailedEventAttributes {
     #[doc="<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -307,7 +307,7 @@ pub struct CancelTimerFailedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>CancelWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelWorkflowExecutionDecisionAttributes {
     #[doc="<p> Details of the cancellation.</p>"]
     #[serde(rename="details")]
@@ -316,7 +316,7 @@ pub struct CancelWorkflowExecutionDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>CancelWorkflowExecutionFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CancelWorkflowExecutionFailedEventAttributes {
     #[doc="<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -327,7 +327,7 @@ pub struct CancelWorkflowExecutionFailedEventAttributes {
 }
 
 #[doc="<p>Provide details of the <code>ChildWorkflowExecutionCanceled</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChildWorkflowExecutionCanceledEventAttributes {
     #[doc="<p>Details of the cancellation (if provided).</p>"]
     #[serde(rename="details")]
@@ -348,7 +348,7 @@ pub struct ChildWorkflowExecutionCanceledEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ChildWorkflowExecutionCompleted</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChildWorkflowExecutionCompletedEventAttributes {
     #[doc="<p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="initiatedEventId")]
@@ -369,7 +369,7 @@ pub struct ChildWorkflowExecutionCompletedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ChildWorkflowExecutionFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChildWorkflowExecutionFailedEventAttributes {
     #[doc="<p>The details of the failure (if provided).</p>"]
     #[serde(rename="details")]
@@ -394,7 +394,7 @@ pub struct ChildWorkflowExecutionFailedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ChildWorkflowExecutionStarted</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChildWorkflowExecutionStartedEventAttributes {
     #[doc="<p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="initiatedEventId")]
@@ -408,7 +408,7 @@ pub struct ChildWorkflowExecutionStartedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ChildWorkflowExecutionTerminated</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChildWorkflowExecutionTerminatedEventAttributes {
     #[doc="<p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="initiatedEventId")]
@@ -425,7 +425,7 @@ pub struct ChildWorkflowExecutionTerminatedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ChildWorkflowExecutionTimedOut</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ChildWorkflowExecutionTimedOutEventAttributes {
     #[doc="<p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="initiatedEventId")]
@@ -445,7 +445,7 @@ pub struct ChildWorkflowExecutionTimedOutEventAttributes {
 }
 
 #[doc="<p>Used to filter the closed workflow executions in visibility APIs by their close status.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CloseStatusFilter {
     #[doc="<p> The close status that must match the close status of an execution for it to meet the criteria of this filter.</p>"]
     #[serde(rename="status")]
@@ -453,7 +453,7 @@ pub struct CloseStatusFilter {
 }
 
 #[doc="<p>Provides the details of the <code>CompleteWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompleteWorkflowExecutionDecisionAttributes {
     #[doc="<p>The result of the workflow execution. The form of the result is implementation defined.</p>"]
     #[serde(rename="result")]
@@ -462,7 +462,7 @@ pub struct CompleteWorkflowExecutionDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>CompleteWorkflowExecutionFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CompleteWorkflowExecutionFailedEventAttributes {
     #[doc="<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -473,7 +473,7 @@ pub struct CompleteWorkflowExecutionFailedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ContinueAsNewWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>Constrain the following parameters by using a <code>Condition</code> element with the appropriate keys.</p> <ul> <li> <p> <code>tag</code> – A tag used to identify the workflow execution</p> </li> <li> <p> <code>taskList</code> – String constraint. The key is <code>swf:taskList.name</code>.</p> </li> <li> <p> <code>workflowType.version</code> – String constraint. The key is <code>swf:workflowType.version</code>.</p> </li> </ul> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ContinueAsNewWorkflowExecutionDecisionAttributes {
     #[doc="<p>If set, specifies the policy to use for the child workflow executions of the new execution if it is terminated by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This policy overrides the default child policy specified when registering the workflow type using <a>RegisterWorkflowType</a>.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul> <note> <p>A child policy for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default child policy was specified at registration time then a fault is returned.</p> </note>"]
     #[serde(rename="childPolicy")]
@@ -514,7 +514,7 @@ pub struct ContinueAsNewWorkflowExecutionDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ContinueAsNewWorkflowExecutionFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ContinueAsNewWorkflowExecutionFailedEventAttributes {
     #[doc="<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -524,7 +524,7 @@ pub struct ContinueAsNewWorkflowExecutionFailedEventAttributes {
     pub decision_task_completed_event_id: i64,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CountClosedWorkflowExecutionsInput {
     #[doc="<p>If specified, only workflow executions that match this close status are counted. This filter has an affect only if <code>executionStatus</code> is specified as <code>CLOSED</code>.</p> <note> <p> <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a request.</p> </note>"]
     #[serde(rename="closeStatusFilter")]
@@ -555,7 +555,7 @@ pub struct CountClosedWorkflowExecutionsInput {
     pub type_filter: Option<WorkflowTypeFilter>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CountOpenWorkflowExecutionsInput {
     #[doc="<p>The name of the domain containing the workflow executions to count.</p>"]
     #[serde(rename="domain")]
@@ -577,7 +577,7 @@ pub struct CountOpenWorkflowExecutionsInput {
     pub type_filter: Option<WorkflowTypeFilter>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CountPendingActivityTasksInput {
     #[doc="<p>The name of the domain that contains the task list.</p>"]
     #[serde(rename="domain")]
@@ -587,7 +587,7 @@ pub struct CountPendingActivityTasksInput {
     pub task_list: TaskList,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CountPendingDecisionTasksInput {
     #[doc="<p>The name of the domain that contains the task list.</p>"]
     #[serde(rename="domain")]
@@ -598,7 +598,7 @@ pub struct CountPendingDecisionTasksInput {
 }
 
 #[doc="<p>Specifies a decision made by the decider. A decision can be one of these types:</p> <ul> <li> <p> <code>CancelTimer</code> – Cancels a previously started timer and records a <code>TimerCanceled</code> event in the history.</p> </li> <li> <p> <code>CancelWorkflowExecution</code> – Closes the workflow execution and records a <code>WorkflowExecutionCanceled</code> event in the history.</p> </li> <li> <p> <code>CompleteWorkflowExecution</code> – Closes the workflow execution and records a <code>WorkflowExecutionCompleted</code> event in the history .</p> </li> <li> <p> <code>ContinueAsNewWorkflowExecution</code> – Closes the workflow execution and starts a new workflow execution of the same type using the same workflow ID and a unique run Id. A <code>WorkflowExecutionContinuedAsNew</code> event is recorded in the history.</p> </li> <li> <p> <code>FailWorkflowExecution</code> – Closes the workflow execution and records a <code>WorkflowExecutionFailed</code> event in the history.</p> </li> <li> <p> <code>RecordMarker</code> – Records a <code>MarkerRecorded</code> event in the history. Markers can be used for adding custom information in the history for instance to let deciders know that they don't need to look at the history beyond the marker event.</p> </li> <li> <p> <code>RequestCancelActivityTask</code> – Attempts to cancel a previously scheduled activity task. If the activity task was scheduled but has not been assigned to a worker, then it is canceled. If the activity task was already assigned to a worker, then the worker is informed that cancellation has been requested in the response to <a>RecordActivityTaskHeartbeat</a>.</p> </li> <li> <p> <code>RequestCancelExternalWorkflowExecution</code> – Requests that a request be made to cancel the specified external workflow execution and records a <code>RequestCancelExternalWorkflowExecutionInitiated</code> event in the history.</p> </li> <li> <p> <code>ScheduleActivityTask</code> – Schedules an activity task.</p> </li> <li> <p> <code>SignalExternalWorkflowExecution</code> – Requests a signal to be delivered to the specified external workflow execution and records a <code>SignalExternalWorkflowExecutionInitiated</code> event in the history.</p> </li> <li> <p> <code>StartChildWorkflowExecution</code> – Requests that a child workflow execution be started and records a <code>StartChildWorkflowExecutionInitiated</code> event in the history. The child workflow execution is a separate workflow execution with its own history.</p> </li> <li> <p> <code>StartTimer</code> – Starts a timer for this workflow execution and records a <code>TimerStarted</code> event in the history. This timer fires after the specified delay and record a <code>TimerFired</code> event.</p> </li> </ul> <p> <b>Access Control</b> </p> <p>If you grant permission to use <code>RespondDecisionTaskCompleted</code>, you can use IAM policies to express permissions for the list of decisions returned by this action as if they were members of the API. Treating decisions as a pseudo API maintains a uniform conceptual model and helps keep policies readable. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> <p> <b>Decision Failure</b> </p> <p>Decisions can fail for several reasons</p> <ul> <li> <p>The ordering of decisions should follow a logical flow. Some decisions might not make sense in the current context of the workflow execution and therefore fails.</p> </li> <li> <p>A limit on your account was reached.</p> </li> <li> <p>The decision lacks sufficient permissions.</p> </li> </ul> <p>One of the following events might be added to the history to indicate an error. The event attribute's <code>cause</code> parameter indicates the cause. If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> <ul> <li> <p> <code>ScheduleActivityTaskFailed</code> – A <code>ScheduleActivityTask</code> decision failed. This could happen if the activity type specified in the decision isn't registered, is in a deprecated state, or the decision isn't properly configured.</p> </li> <li> <p> <code>RequestCancelActivityTaskFailed</code> – A <code>RequestCancelActivityTask</code> decision failed. This could happen if there is no open activity task with the specified activityId.</p> </li> <li> <p> <code>StartTimerFailed</code> – A <code>StartTimer</code> decision failed. This could happen if there is another open timer with the same timerId.</p> </li> <li> <p> <code>CancelTimerFailed</code> – A <code>CancelTimer</code> decision failed. This could happen if there is no open timer with the specified timerId.</p> </li> <li> <p> <code>StartChildWorkflowExecutionFailed</code> – A <code>StartChildWorkflowExecution</code> decision failed. This could happen if the workflow type specified isn't registered, is deprecated, or the decision isn't properly configured.</p> </li> <li> <p> <code>SignalExternalWorkflowExecutionFailed</code> – A <code>SignalExternalWorkflowExecution</code> decision failed. This could happen if the <code>workflowID</code> specified in the decision was incorrect.</p> </li> <li> <p> <code>RequestCancelExternalWorkflowExecutionFailed</code> – A <code>RequestCancelExternalWorkflowExecution</code> decision failed. This could happen if the <code>workflowID</code> specified in the decision was incorrect.</p> </li> <li> <p> <code>CancelWorkflowExecutionFailed</code> – A <code>CancelWorkflowExecution</code> decision failed. This could happen if there is an unhandled decision task pending in the workflow execution.</p> </li> <li> <p> <code>CompleteWorkflowExecutionFailed</code> – A <code>CompleteWorkflowExecution</code> decision failed. This could happen if there is an unhandled decision task pending in the workflow execution.</p> </li> <li> <p> <code>ContinueAsNewWorkflowExecutionFailed</code> – A <code>ContinueAsNewWorkflowExecution</code> decision failed. This could happen if there is an unhandled decision task pending in the workflow execution or the ContinueAsNewWorkflowExecution decision was not configured correctly.</p> </li> <li> <p> <code>FailWorkflowExecutionFailed</code> – A <code>FailWorkflowExecution</code> decision failed. This could happen if there is an unhandled decision task pending in the workflow execution.</p> </li> </ul> <p>The preceding error events might occur due to an error in the decider logic, which might put the workflow execution in an unstable state The cause field in the event structure for the error event indicates the cause of the error.</p> <note> <p>A workflow execution may be closed by the decider by returning one of the following decisions when completing a decision task: <code>CompleteWorkflowExecution</code>, <code>FailWorkflowExecution</code>, <code>CancelWorkflowExecution</code> and <code>ContinueAsNewWorkflowExecution</code>. An <code>UnhandledDecision</code> fault is returned if a workflow closing decision is specified and a signal or activity event had been added to the history while the decision task was being performed by the decider. Unlike the above situations which are logic issues, this fault is always possible because of race conditions in a distributed system. The right action here is to call <a>RespondDecisionTaskCompleted</a> without any decisions. This would result in another decision task with these new events included in the history. The decider should handle the new events and may decide to close the workflow execution.</p> </note> <p> <b>How to Code a Decision</b> </p> <p>You code a decision by first setting the decision type field to one of the above decision values, and then set the corresponding attributes field shown below:</p> <ul> <li> <p> <code> <a>ScheduleActivityTaskDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>RequestCancelActivityTaskDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>CompleteWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>FailWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>CancelWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>ContinueAsNewWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>RecordMarkerDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>StartTimerDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>CancelTimerDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>SignalExternalWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>RequestCancelExternalWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>StartChildWorkflowExecutionDecisionAttributes</a> </code> </p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Decision {
     #[doc="<p>Provides the details of the <code>CancelTimer</code> decision. It isn't set for other decision types.</p>"]
     #[serde(rename="cancelTimerDecisionAttributes")]
@@ -668,7 +668,7 @@ pub struct Decision {
 }
 
 #[doc="<p>A structure that represents a decision task. Decision tasks are sent to deciders in order for them to make decisions.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecisionTask {
     #[doc="<p>A paginated list of history events of the workflow execution. The decider uses this during the processing of the decision task.</p>"]
     #[serde(rename="events")]
@@ -696,7 +696,7 @@ pub struct DecisionTask {
 }
 
 #[doc="<p>Provides the details of the <code>DecisionTaskCompleted</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecisionTaskCompletedEventAttributes {
     #[doc="<p>User defined context for the workflow execution.</p>"]
     #[serde(rename="executionContext")]
@@ -711,7 +711,7 @@ pub struct DecisionTaskCompletedEventAttributes {
 }
 
 #[doc="<p>Provides details about the <code>DecisionTaskScheduled</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecisionTaskScheduledEventAttributes {
     #[doc="<p>The maximum duration for this decision task. The task is considered timed out if it doesn't completed within this duration.</p> <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"]
     #[serde(rename="startToCloseTimeout")]
@@ -727,7 +727,7 @@ pub struct DecisionTaskScheduledEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>DecisionTaskStarted</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecisionTaskStartedEventAttributes {
     #[doc="<p>Identity of the decider making the request. This enables diagnostic tracing when problems arise. The form of this identity is user defined.</p>"]
     #[serde(rename="identity")]
@@ -739,7 +739,7 @@ pub struct DecisionTaskStartedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>DecisionTaskTimedOut</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DecisionTaskTimedOutEventAttributes {
     #[doc="<p>The ID of the <code>DecisionTaskScheduled</code> event that was recorded when this decision task was scheduled. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="scheduledEventId")]
@@ -752,7 +752,7 @@ pub struct DecisionTaskTimedOutEventAttributes {
     pub timeout_type: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeprecateActivityTypeInput {
     #[doc="<p>The activity type to deprecate.</p>"]
     #[serde(rename="activityType")]
@@ -762,14 +762,14 @@ pub struct DeprecateActivityTypeInput {
     pub domain: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeprecateDomainInput {
     #[doc="<p>The name of the domain to deprecate.</p>"]
     #[serde(rename="name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeprecateWorkflowTypeInput {
     #[doc="<p>The name of the domain in which the workflow type is registered.</p>"]
     #[serde(rename="domain")]
@@ -779,7 +779,7 @@ pub struct DeprecateWorkflowTypeInput {
     pub workflow_type: WorkflowType,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeActivityTypeInput {
     #[doc="<p>The activity type to get information about. Activity types are identified by the <code>name</code> and <code>version</code> that were supplied when the activity was registered.</p>"]
     #[serde(rename="activityType")]
@@ -789,14 +789,14 @@ pub struct DescribeActivityTypeInput {
     pub domain: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDomainInput {
     #[doc="<p>The name of the domain to describe.</p>"]
     #[serde(rename="name")]
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkflowExecutionInput {
     #[doc="<p>The name of the domain containing the workflow execution.</p>"]
     #[serde(rename="domain")]
@@ -806,7 +806,7 @@ pub struct DescribeWorkflowExecutionInput {
     pub execution: WorkflowExecution,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkflowTypeInput {
     #[doc="<p>The name of the domain in which this workflow type is registered.</p>"]
     #[serde(rename="domain")]
@@ -817,7 +817,7 @@ pub struct DescribeWorkflowTypeInput {
 }
 
 #[doc="<p>Contains the configuration settings of a domain.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainConfiguration {
     #[doc="<p>The retention period for workflow executions in this domain.</p>"]
     #[serde(rename="workflowExecutionRetentionPeriodInDays")]
@@ -825,7 +825,7 @@ pub struct DomainConfiguration {
 }
 
 #[doc="<p>Contains details of a domain.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainDetail {
     #[doc="<p>The domain configuration. Currently, this includes only the domain's retention period.</p>"]
     #[serde(rename="configuration")]
@@ -836,7 +836,7 @@ pub struct DomainDetail {
 }
 
 #[doc="<p>Contains general information about a domain.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainInfo {
     #[doc="<p>The description of the domain provided through <a>RegisterDomain</a>.</p>"]
     #[serde(rename="description")]
@@ -851,7 +851,7 @@ pub struct DomainInfo {
 }
 
 #[doc="<p>Contains a paginated collection of DomainInfo structures.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DomainInfos {
     #[doc="<p>A list of DomainInfo structures.</p>"]
     #[serde(rename="domainInfos")]
@@ -863,7 +863,7 @@ pub struct DomainInfos {
 }
 
 #[doc="<p>Used to filter the workflow executions in visibility APIs by various time-based rules. Each parameter, if specified, defines a rule that must be satisfied by each returned query result. The parameter values are in the <a href=\"https://en.wikipedia.org/wiki/Unix_time\">Unix Time format</a>. For example: <code>\"oldestDate\": 1325376070.</code> </p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExecutionTimeFilter {
     #[doc="<p>Specifies the latest start or close date and time to return.</p>"]
     #[serde(rename="latestDate")]
@@ -875,7 +875,7 @@ pub struct ExecutionTimeFilter {
 }
 
 #[doc="<p>Provides the details of the <code>ExternalWorkflowExecutionCancelRequested</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExternalWorkflowExecutionCancelRequestedEventAttributes {
     #[doc="<p>The ID of the <code>RequestCancelExternalWorkflowExecutionInitiated</code> event corresponding to the <code>RequestCancelExternalWorkflowExecution</code> decision to cancel this external workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="initiatedEventId")]
@@ -886,7 +886,7 @@ pub struct ExternalWorkflowExecutionCancelRequestedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ExternalWorkflowExecutionSignaled</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ExternalWorkflowExecutionSignaledEventAttributes {
     #[doc="<p>The ID of the <code>SignalExternalWorkflowExecutionInitiated</code> event corresponding to the <code>SignalExternalWorkflowExecution</code> decision to request this signal. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="initiatedEventId")]
@@ -897,7 +897,7 @@ pub struct ExternalWorkflowExecutionSignaledEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>FailWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailWorkflowExecutionDecisionAttributes {
     #[doc="<p> Details of the failure.</p>"]
     #[serde(rename="details")]
@@ -910,7 +910,7 @@ pub struct FailWorkflowExecutionDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>FailWorkflowExecutionFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailWorkflowExecutionFailedEventAttributes {
     #[doc="<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -920,7 +920,7 @@ pub struct FailWorkflowExecutionFailedEventAttributes {
     pub decision_task_completed_event_id: i64,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetWorkflowExecutionHistoryInput {
     #[doc="<p>The name of the domain containing the workflow execution.</p>"]
     #[serde(rename="domain")]
@@ -943,7 +943,7 @@ pub struct GetWorkflowExecutionHistoryInput {
 }
 
 #[doc="<p>Paginated representation of a workflow history for a workflow execution. This is the up to date, complete and authoritative record of the events related to all tasks and events in the life of the workflow execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct History {
     #[doc="<p>The list of history events.</p>"]
     #[serde(rename="events")]
@@ -955,7 +955,7 @@ pub struct History {
 }
 
 #[doc="<p>Event within a workflow execution. A history event can be one of these types:</p> <ul> <li> <p> <code>ActivityTaskCancelRequested</code> – A <code>RequestCancelActivityTask</code> decision was received by the system.</p> </li> <li> <p> <code>ActivityTaskCanceled</code> – The activity task was successfully canceled.</p> </li> <li> <p> <code>ActivityTaskCompleted</code> – An activity worker successfully completed an activity task by calling <a>RespondActivityTaskCompleted</a>.</p> </li> <li> <p> <code>ActivityTaskFailed</code> – An activity worker failed an activity task by calling <a>RespondActivityTaskFailed</a>.</p> </li> <li> <p> <code>ActivityTaskScheduled</code> – An activity task was scheduled for execution.</p> </li> <li> <p> <code>ActivityTaskStarted</code> – The scheduled activity task was dispatched to a worker.</p> </li> <li> <p> <code>ActivityTaskTimedOut</code> – The activity task timed out.</p> </li> <li> <p> <code>CancelTimerFailed</code> – Failed to process CancelTimer decision. This happens when the decision isn't configured properly, for example no timer exists with the specified timer Id.</p> </li> <li> <p> <code>CancelWorkflowExecutionFailed</code> – A request to cancel a workflow execution failed.</p> </li> <li> <p> <code>ChildWorkflowExecutionCanceled</code> – A child workflow execution, started by this workflow execution, was canceled and closed.</p> </li> <li> <p> <code>ChildWorkflowExecutionCompleted</code> – A child workflow execution, started by this workflow execution, completed successfully and was closed.</p> </li> <li> <p> <code>ChildWorkflowExecutionFailed</code> – A child workflow execution, started by this workflow execution, failed to complete successfully and was closed.</p> </li> <li> <p> <code>ChildWorkflowExecutionStarted</code> – A child workflow execution was successfully started.</p> </li> <li> <p> <code>ChildWorkflowExecutionTerminated</code> – A child workflow execution, started by this workflow execution, was terminated.</p> </li> <li> <p> <code>ChildWorkflowExecutionTimedOut</code> – A child workflow execution, started by this workflow execution, timed out and was closed.</p> </li> <li> <p> <code>CompleteWorkflowExecutionFailed</code> – The workflow execution failed to complete.</p> </li> <li> <p> <code>ContinueAsNewWorkflowExecutionFailed</code> – The workflow execution failed to complete after being continued as a new workflow execution.</p> </li> <li> <p> <code>DecisionTaskCompleted</code> – The decider successfully completed a decision task by calling <a>RespondDecisionTaskCompleted</a>.</p> </li> <li> <p> <code>DecisionTaskScheduled</code> – A decision task was scheduled for the workflow execution.</p> </li> <li> <p> <code>DecisionTaskStarted</code> – The decision task was dispatched to a decider.</p> </li> <li> <p> <code>DecisionTaskTimedOut</code> – The decision task timed out.</p> </li> <li> <p> <code>ExternalWorkflowExecutionCancelRequested</code> – Request to cancel an external workflow execution was successfully delivered to the target execution.</p> </li> <li> <p> <code>ExternalWorkflowExecutionSignaled</code> – A signal, requested by this workflow execution, was successfully delivered to the target external workflow execution.</p> </li> <li> <p> <code>FailWorkflowExecutionFailed</code> – A request to mark a workflow execution as failed, itself failed.</p> </li> <li> <p> <code>MarkerRecorded</code> – A marker was recorded in the workflow history as the result of a <code>RecordMarker</code> decision.</p> </li> <li> <p> <code>RecordMarkerFailed</code> – A <code>RecordMarker</code> decision was returned as failed.</p> </li> <li> <p> <code>RequestCancelActivityTaskFailed</code> – Failed to process RequestCancelActivityTask decision. This happens when the decision isn't configured properly.</p> </li> <li> <p> <code>RequestCancelExternalWorkflowExecutionFailed</code> – Request to cancel an external workflow execution failed.</p> </li> <li> <p> <code>RequestCancelExternalWorkflowExecutionInitiated</code> – A request was made to request the cancellation of an external workflow execution.</p> </li> <li> <p> <code>ScheduleActivityTaskFailed</code> – Failed to process ScheduleActivityTask decision. This happens when the decision isn't configured properly, for example the activity type specified isn't registered.</p> </li> <li> <p> <code>SignalExternalWorkflowExecutionFailed</code> – The request to signal an external workflow execution failed.</p> </li> <li> <p> <code>SignalExternalWorkflowExecutionInitiated</code> – A request to signal an external workflow was made.</p> </li> <li> <p> <code>StartActivityTaskFailed</code> – A scheduled activity task failed to start.</p> </li> <li> <p> <code>StartChildWorkflowExecutionFailed</code> – Failed to process StartChildWorkflowExecution decision. This happens when the decision isn't configured properly, for example the workflow type specified isn't registered.</p> </li> <li> <p> <code>StartChildWorkflowExecutionInitiated</code> – A request was made to start a child workflow execution.</p> </li> <li> <p> <code>StartTimerFailed</code> – Failed to process StartTimer decision. This happens when the decision isn't configured properly, for example a timer already exists with the specified timer Id.</p> </li> <li> <p> <code>TimerCanceled</code> – A timer, previously started for this workflow execution, was successfully canceled.</p> </li> <li> <p> <code>TimerFired</code> – A timer, previously started for this workflow execution, fired.</p> </li> <li> <p> <code>TimerStarted</code> – A timer was started for the workflow execution due to a <code>StartTimer</code> decision.</p> </li> <li> <p> <code>WorkflowExecutionCancelRequested</code> – A request to cancel this workflow execution was made.</p> </li> <li> <p> <code>WorkflowExecutionCanceled</code> – The workflow execution was successfully canceled and closed.</p> </li> <li> <p> <code>WorkflowExecutionCompleted</code> – The workflow execution was closed due to successful completion.</p> </li> <li> <p> <code>WorkflowExecutionContinuedAsNew</code> – The workflow execution was closed and a new execution of the same type was created with the same workflowId.</p> </li> <li> <p> <code>WorkflowExecutionFailed</code> – The workflow execution closed due to a failure.</p> </li> <li> <p> <code>WorkflowExecutionSignaled</code> – An external signal was received for the workflow execution.</p> </li> <li> <p> <code>WorkflowExecutionStarted</code> – The workflow execution was started.</p> </li> <li> <p> <code>WorkflowExecutionTerminated</code> – The workflow execution was terminated.</p> </li> <li> <p> <code>WorkflowExecutionTimedOut</code> – The workflow execution was closed because a time out was exceeded.</p> </li> </ul>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HistoryEvent {
     #[doc="<p>If the event is of type <code>ActivityTaskcancelRequested</code> then this member is set and provides detailed information about the event. It isn't set for other event types.</p>"]
     #[serde(rename="activityTaskCancelRequestedEventAttributes")]
@@ -1220,7 +1220,7 @@ pub struct HistoryEvent {
 }
 
 #[doc="<p>Provides the details of the <code>LambdaFunctionCompleted</code> event. It isn't set for other event types.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaFunctionCompletedEventAttributes {
     #[doc="<p>The results of the Lambda task.</p>"]
     #[serde(rename="result")]
@@ -1235,7 +1235,7 @@ pub struct LambdaFunctionCompletedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>LambdaFunctionFailed</code> event. It isn't set for other event types.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaFunctionFailedEventAttributes {
     #[doc="<p>The details of the failure.</p>"]
     #[serde(rename="details")]
@@ -1254,7 +1254,7 @@ pub struct LambdaFunctionFailedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>LambdaFunctionScheduled</code> event. It isn't set for other event types.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaFunctionScheduledEventAttributes {
     #[doc="<p>Data attached to the event that the decider can use in subsequent workflow tasks. This data isn't sent to the Lambda task.</p>"]
     #[serde(rename="control")]
@@ -1280,7 +1280,7 @@ pub struct LambdaFunctionScheduledEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>LambdaFunctionStarted</code> event. It isn't set for other event types.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaFunctionStartedEventAttributes {
     #[doc="<p>The ID of the <code>LambdaFunctionScheduled</code> event that was recorded when this activity task was scheduled. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>"]
     #[serde(rename="scheduledEventId")]
@@ -1288,7 +1288,7 @@ pub struct LambdaFunctionStartedEventAttributes {
 }
 
 #[doc="<p>Provides details of the <code>LambdaFunctionTimedOut</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct LambdaFunctionTimedOutEventAttributes {
     #[doc="<p>The ID of the <code>LambdaFunctionScheduled</code> event that was recorded when this activity task was scheduled. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>"]
     #[serde(rename="scheduledEventId")]
@@ -1302,7 +1302,7 @@ pub struct LambdaFunctionTimedOutEventAttributes {
     pub timeout_type: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListActivityTypesInput {
     #[doc="<p>The name of the domain in which the activity types have been registered.</p>"]
     #[serde(rename="domain")]
@@ -1328,7 +1328,7 @@ pub struct ListActivityTypesInput {
     pub reverse_order: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListClosedWorkflowExecutionsInput {
     #[doc="<p>If specified, only workflow executions that match this <i>close status</i> are listed. For example, if TERMINATED is specified, then only TERMINATED workflow executions are listed.</p> <note> <p> <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a request.</p> </note>"]
     #[serde(rename="closeStatusFilter")]
@@ -1371,7 +1371,7 @@ pub struct ListClosedWorkflowExecutionsInput {
     pub type_filter: Option<WorkflowTypeFilter>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListDomainsInput {
     #[doc="<p>The maximum number of results that are returned per call. <code>nextPageToken</code> can be used to obtain futher pages of results. The default is 1000, which is the maximum allowed page size. You can, however, specify a page size <i>smaller</i> than the maximum.</p> <p>This is an upper limit only; the actual number of results returned per call may be fewer than the specified maximum.</p>"]
     #[serde(rename="maximumPageSize")]
@@ -1390,7 +1390,7 @@ pub struct ListDomainsInput {
     pub reverse_order: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListOpenWorkflowExecutionsInput {
     #[doc="<p>The name of the domain that contains the workflow executions to list.</p>"]
     #[serde(rename="domain")]
@@ -1424,7 +1424,7 @@ pub struct ListOpenWorkflowExecutionsInput {
     pub type_filter: Option<WorkflowTypeFilter>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListWorkflowTypesInput {
     #[doc="<p>The name of the domain in which the workflow types have been registered.</p>"]
     #[serde(rename="domain")]
@@ -1451,7 +1451,7 @@ pub struct ListWorkflowTypesInput {
 }
 
 #[doc="<p>Provides the details of the <code>MarkerRecorded</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct MarkerRecordedEventAttributes {
     #[doc="<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>RecordMarker</code> decision that requested this marker. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="decisionTaskCompletedEventId")]
@@ -1466,7 +1466,7 @@ pub struct MarkerRecordedEventAttributes {
 }
 
 #[doc="<p>Contains the count of tasks in a task list.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PendingTaskCount {
     #[doc="<p>The number of tasks in the task list.</p>"]
     #[serde(rename="count")]
@@ -1477,7 +1477,7 @@ pub struct PendingTaskCount {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PollForActivityTaskInput {
     #[doc="<p>The name of the domain that contains the task lists being polled.</p>"]
     #[serde(rename="domain")]
@@ -1491,7 +1491,7 @@ pub struct PollForActivityTaskInput {
     pub task_list: TaskList,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PollForDecisionTaskInput {
     #[doc="<p>The name of the domain containing the task lists to poll.</p>"]
     #[serde(rename="domain")]
@@ -1517,7 +1517,7 @@ pub struct PollForDecisionTaskInput {
     pub task_list: TaskList,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecordActivityTaskHeartbeatInput {
     #[doc="<p>If specified, contains details about the progress of the task.</p>"]
     #[serde(rename="details")]
@@ -1529,7 +1529,7 @@ pub struct RecordActivityTaskHeartbeatInput {
 }
 
 #[doc="<p>Provides the details of the <code>RecordMarker</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecordMarkerDecisionAttributes {
     #[doc="<p> The details of the marker.</p>"]
     #[serde(rename="details")]
@@ -1541,7 +1541,7 @@ pub struct RecordMarkerDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>RecordMarkerFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RecordMarkerFailedEventAttributes {
     #[doc="<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -1554,7 +1554,7 @@ pub struct RecordMarkerFailedEventAttributes {
     pub marker_name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterActivityTypeInput {
     #[doc="<p>If set, specifies the default maximum time before which a worker processing a task of this type must report progress by calling <a>RecordActivityTaskHeartbeat</a>. If the timeout is exceeded, the activity task is automatically timed out. This default can be overridden when scheduling an activity task using the <code>ScheduleActivityTask</code> <a>Decision</a>. If the activity worker subsequently attempts to record a heartbeat or returns a result, the activity worker receives an <code>UnknownResource</code> fault. In this case, Amazon SWF no longer considers the activity task to be valid; the activity worker should clean up the activity task.</p> <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"]
     #[serde(rename="defaultTaskHeartbeatTimeout")]
@@ -1595,7 +1595,7 @@ pub struct RegisterActivityTypeInput {
     pub version: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterDomainInput {
     #[doc="<p>A text description of the domain.</p>"]
     #[serde(rename="description")]
@@ -1609,7 +1609,7 @@ pub struct RegisterDomainInput {
     pub workflow_execution_retention_period_in_days: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RegisterWorkflowTypeInput {
     #[doc="<p>If set, specifies the default policy to use for the child workflow executions when a workflow execution of this type is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This default can be overridden when starting a workflow execution using the <a>StartWorkflowExecution</a> action or the <code>StartChildWorkflowExecution</code> <a>Decision</a>.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul>"]
     #[serde(rename="defaultChildPolicy")]
@@ -1651,7 +1651,7 @@ pub struct RegisterWorkflowTypeInput {
 }
 
 #[doc="<p>Provides the details of the <code>RequestCancelActivityTask</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestCancelActivityTaskDecisionAttributes {
     #[doc="<p>The <code>activityId</code> of the activity task to be canceled.</p>"]
     #[serde(rename="activityId")]
@@ -1659,7 +1659,7 @@ pub struct RequestCancelActivityTaskDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>RequestCancelActivityTaskFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestCancelActivityTaskFailedEventAttributes {
     #[doc="<p>The activityId provided in the <code>RequestCancelActivityTask</code> decision that failed.</p>"]
     #[serde(rename="activityId")]
@@ -1673,7 +1673,7 @@ pub struct RequestCancelActivityTaskFailedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>RequestCancelExternalWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestCancelExternalWorkflowExecutionDecisionAttributes {
     #[doc="<p>The data attached to the event that can be used by the decider in subsequent workflow tasks.</p>"]
     #[serde(rename="control")]
@@ -1689,7 +1689,7 @@ pub struct RequestCancelExternalWorkflowExecutionDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>RequestCancelExternalWorkflowExecutionFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestCancelExternalWorkflowExecutionFailedEventAttributes {
     #[doc="<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -1714,7 +1714,7 @@ pub struct RequestCancelExternalWorkflowExecutionFailedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>RequestCancelExternalWorkflowExecutionInitiated</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
     #[doc="<p>Data attached to the event that can be used by the decider in subsequent workflow tasks.</p>"]
     #[serde(rename="control")]
@@ -1732,7 +1732,7 @@ pub struct RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
     pub workflow_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RequestCancelWorkflowExecutionInput {
     #[doc="<p>The name of the domain containing the workflow execution to cancel.</p>"]
     #[serde(rename="domain")]
@@ -1746,7 +1746,7 @@ pub struct RequestCancelWorkflowExecutionInput {
     pub workflow_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RespondActivityTaskCanceledInput {
     #[doc="<p> Information about the cancellation.</p>"]
     #[serde(rename="details")]
@@ -1757,7 +1757,7 @@ pub struct RespondActivityTaskCanceledInput {
     pub task_token: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RespondActivityTaskCompletedInput {
     #[doc="<p>The result of the activity task. It is a free form string that is implementation specific.</p>"]
     #[serde(rename="result")]
@@ -1768,7 +1768,7 @@ pub struct RespondActivityTaskCompletedInput {
     pub task_token: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RespondActivityTaskFailedInput {
     #[doc="<p> Detailed information about the failure.</p>"]
     #[serde(rename="details")]
@@ -1784,7 +1784,7 @@ pub struct RespondActivityTaskFailedInput {
 }
 
 #[doc="<p>Input data for a TaskCompleted response to a decision task.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RespondDecisionTaskCompletedInput {
     #[doc="<p>The list of decisions (possibly empty) made by the decider while processing this decision task. See the docs for the <a>Decision</a> structure for details.</p>"]
     #[serde(rename="decisions")]
@@ -1800,7 +1800,7 @@ pub struct RespondDecisionTaskCompletedInput {
 }
 
 #[doc="<p>Specifies the <code>runId</code> of a workflow execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Run {
     #[doc="<p>The <code>runId</code> of a workflow execution. This ID is generated by the service and can be used to uniquely identify the workflow execution within a domain.</p>"]
     #[serde(rename="runId")]
@@ -1809,7 +1809,7 @@ pub struct Run {
 }
 
 #[doc="<p>Provides the details of the <code>ScheduleActivityTask</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>Constrain the following parameters by using a <code>Condition</code> element with the appropriate keys.</p> <ul> <li> <p> <code>activityType.name</code> – String constraint. The key is <code>swf:activityType.name</code>.</p> </li> <li> <p> <code>activityType.version</code> – String constraint. The key is <code>swf:activityType.version</code>.</p> </li> <li> <p> <code>taskList</code> – String constraint. The key is <code>swf:taskList.name</code>.</p> </li> </ul> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduleActivityTaskDecisionAttributes {
     #[doc="<p> The <code>activityId</code> of the activity task.</p> <p>The specified string must not start or end with whitespace. It must not contain a <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must not contain the literal string <code>arn</code>.</p>"]
     #[serde(rename="activityId")]
@@ -1852,7 +1852,7 @@ pub struct ScheduleActivityTaskDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ScheduleActivityTaskFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduleActivityTaskFailedEventAttributes {
     #[doc="<p>The activityId provided in the <code>ScheduleActivityTask</code> decision that failed.</p>"]
     #[serde(rename="activityId")]
@@ -1869,7 +1869,7 @@ pub struct ScheduleActivityTaskFailedEventAttributes {
 }
 
 #[doc="<p>Decision attributes specified in <code>scheduleLambdaFunctionDecisionAttributes</code> within the list of decisions <code>decisions</code> passed to <a>RespondDecisionTaskCompleted</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduleLambdaFunctionDecisionAttributes {
     #[doc="<p>The data attached to the event that the decider can use in subsequent workflow tasks. This data isn't sent to the Lambda task.</p>"]
     #[serde(rename="control")]
@@ -1892,7 +1892,7 @@ pub struct ScheduleLambdaFunctionDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>ScheduleLambdaFunctionFailed</code> event. It isn't set for other event types.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ScheduleLambdaFunctionFailedEventAttributes {
     #[doc="<p>The cause of the failure. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -1909,7 +1909,7 @@ pub struct ScheduleLambdaFunctionFailedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>SignalExternalWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SignalExternalWorkflowExecutionDecisionAttributes {
     #[doc="<p>The data attached to the event that can be used by the decider in subsequent decision tasks.</p>"]
     #[serde(rename="control")]
@@ -1932,7 +1932,7 @@ pub struct SignalExternalWorkflowExecutionDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>SignalExternalWorkflowExecutionFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SignalExternalWorkflowExecutionFailedEventAttributes {
     #[doc="<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -1957,7 +1957,7 @@ pub struct SignalExternalWorkflowExecutionFailedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>SignalExternalWorkflowExecutionInitiated</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SignalExternalWorkflowExecutionInitiatedEventAttributes {
     #[doc="<p>Data attached to the event that can be used by the decider in subsequent decision tasks.</p>"]
     #[serde(rename="control")]
@@ -1982,7 +1982,7 @@ pub struct SignalExternalWorkflowExecutionInitiatedEventAttributes {
     pub workflow_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SignalWorkflowExecutionInput {
     #[doc="<p>The name of the domain containing the workflow execution to signal.</p>"]
     #[serde(rename="domain")]
@@ -2004,7 +2004,7 @@ pub struct SignalWorkflowExecutionInput {
 }
 
 #[doc="<p>Provides the details of the <code>StartChildWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>Constrain the following parameters by using a <code>Condition</code> element with the appropriate keys.</p> <ul> <li> <p> <code>tagList.member.N</code> – The key is \"swf:tagList.N\" where N is the tag number from 0 to 4, inclusive.</p> </li> <li> <p> <code>taskList</code> – String constraint. The key is <code>swf:taskList.name</code>.</p> </li> <li> <p> <code>workflowType.name</code> – String constraint. The key is <code>swf:workflowType.name</code>.</p> </li> <li> <p> <code>workflowType.version</code> – String constraint. The key is <code>swf:workflowType.version</code>.</p> </li> </ul> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartChildWorkflowExecutionDecisionAttributes {
     #[doc="<p> If set, specifies the policy to use for the child workflow executions if the workflow execution being started is terminated by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This policy overrides the default child policy specified when registering the workflow type using <a>RegisterWorkflowType</a>.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul> <note> <p>A child policy for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default child policy was specified at registration time then a fault is returned.</p> </note>"]
     #[serde(rename="childPolicy")]
@@ -2051,7 +2051,7 @@ pub struct StartChildWorkflowExecutionDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>StartChildWorkflowExecutionFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartChildWorkflowExecutionFailedEventAttributes {
     #[doc="<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>When <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision fails because it lacks sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\"> Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -2075,7 +2075,7 @@ pub struct StartChildWorkflowExecutionFailedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>StartChildWorkflowExecutionInitiated</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartChildWorkflowExecutionInitiatedEventAttributes {
     #[doc="<p>The policy to use for the child workflow executions if this execution gets terminated by explicitly calling the <a>TerminateWorkflowExecution</a> action or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul>"]
     #[serde(rename="childPolicy")]
@@ -2123,7 +2123,7 @@ pub struct StartChildWorkflowExecutionInitiatedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>StartLambdaFunctionFailed</code> event. It isn't set for other event types.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartLambdaFunctionFailedEventAttributes {
     #[doc="<p>The cause of the failure. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because the IAM role attached to the execution lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/lambda-task.html\">Lambda Tasks</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -2140,7 +2140,7 @@ pub struct StartLambdaFunctionFailedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>StartTimer</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartTimerDecisionAttributes {
     #[doc="<p>The data attached to the event that can be used by the decider in subsequent workflow tasks.</p>"]
     #[serde(rename="control")]
@@ -2155,7 +2155,7 @@ pub struct StartTimerDecisionAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>StartTimerFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartTimerFailedEventAttributes {
     #[doc="<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note>"]
     #[serde(rename="cause")]
@@ -2168,7 +2168,7 @@ pub struct StartTimerFailedEventAttributes {
     pub timer_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartWorkflowExecutionInput {
     #[doc="<p>If set, specifies the policy to use for the child workflow executions of this workflow execution if it is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This policy overrides the default child policy specified when registering the workflow type using <a>RegisterWorkflowType</a>.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul> <note> <p>A child policy for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default child policy was specified at registration time then a fault is returned.</p> </note>"]
     #[serde(rename="childPolicy")]
@@ -2214,7 +2214,7 @@ pub struct StartWorkflowExecutionInput {
 }
 
 #[doc="<p>Used to filter the workflow executions in visibility APIs based on a tag.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TagFilter {
     #[doc="<p> Specifies the tag that must be associated with the execution for it to meet the filter criteria.</p>"]
     #[serde(rename="tag")]
@@ -2229,7 +2229,7 @@ pub struct TaskList {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateWorkflowExecutionInput {
     #[doc="<p>If set, specifies the policy to use for the child workflow executions of the workflow execution being terminated. This policy overrides the child policy specified for the workflow execution at registration time or when starting the execution.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul> <note> <p>A child policy for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default child policy was specified at registration time then a fault is returned.</p> </note>"]
     #[serde(rename="childPolicy")]
@@ -2256,7 +2256,7 @@ pub struct TerminateWorkflowExecutionInput {
 }
 
 #[doc="<p> Provides the details of the <code>TimerCanceled</code> event. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TimerCanceledEventAttributes {
     #[doc="<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CancelTimer</code> decision to cancel this timer. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="decisionTaskCompletedEventId")]
@@ -2270,7 +2270,7 @@ pub struct TimerCanceledEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>TimerFired</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TimerFiredEventAttributes {
     #[doc="<p>The ID of the <code>TimerStarted</code> event that was recorded when this timer was started. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="startedEventId")]
@@ -2281,7 +2281,7 @@ pub struct TimerFiredEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>TimerStarted</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TimerStartedEventAttributes {
     #[doc="<p>Data attached to the event that can be used by the decider in subsequent workflow tasks.</p>"]
     #[serde(rename="control")]
@@ -2310,7 +2310,7 @@ pub struct WorkflowExecution {
 }
 
 #[doc="<p>Provides the details of the <code>WorkflowExecutionCancelRequested</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionCancelRequestedEventAttributes {
     #[doc="<p>If set, indicates that the request to cancel the workflow execution was automatically generated, and specifies the cause. This happens if the parent workflow execution times out or is terminated, and the child policy is set to cancel child executions.</p>"]
     #[serde(rename="cause")]
@@ -2327,7 +2327,7 @@ pub struct WorkflowExecutionCancelRequestedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>WorkflowExecutionCanceled</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionCanceledEventAttributes {
     #[doc="<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CancelWorkflowExecution</code> decision for this cancellation request. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="decisionTaskCompletedEventId")]
@@ -2339,7 +2339,7 @@ pub struct WorkflowExecutionCanceledEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>WorkflowExecutionCompleted</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionCompletedEventAttributes {
     #[doc="<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CompleteWorkflowExecution</code> decision to complete this execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="decisionTaskCompletedEventId")]
@@ -2351,7 +2351,7 @@ pub struct WorkflowExecutionCompletedEventAttributes {
 }
 
 #[doc="<p>The configuration settings for a workflow execution including timeout values, tasklist etc. These configuration settings are determined from the defaults specified when registering the workflow type and those specified when starting the workflow execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionConfiguration {
     #[doc="<p>The policy to use for the child workflow executions if this workflow execution is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul>"]
     #[serde(rename="childPolicy")]
@@ -2376,7 +2376,7 @@ pub struct WorkflowExecutionConfiguration {
 }
 
 #[doc="<p>Provides the details of the <code>WorkflowExecutionContinuedAsNew</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionContinuedAsNewEventAttributes {
     #[doc="<p>The policy to use for the child workflow executions of the new execution if it is terminated by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul>"]
     #[serde(rename="childPolicy")]
@@ -2420,7 +2420,7 @@ pub struct WorkflowExecutionContinuedAsNewEventAttributes {
 }
 
 #[doc="<p>Contains the count of workflow executions returned from <a>CountOpenWorkflowExecutions</a> or <a>CountClosedWorkflowExecutions</a> </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionCount {
     #[doc="<p>The number of workflow executions.</p>"]
     #[serde(rename="count")]
@@ -2432,7 +2432,7 @@ pub struct WorkflowExecutionCount {
 }
 
 #[doc="<p>Contains details about a workflow execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionDetail {
     #[doc="<p>The configuration settings for this workflow execution including timeout values, tasklist etc.</p>"]
     #[serde(rename="executionConfiguration")]
@@ -2454,7 +2454,7 @@ pub struct WorkflowExecutionDetail {
 }
 
 #[doc="<p>Provides the details of the <code>WorkflowExecutionFailed</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionFailedEventAttributes {
     #[doc="<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>FailWorkflowExecution</code> decision to fail this execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"]
     #[serde(rename="decisionTaskCompletedEventId")]
@@ -2470,7 +2470,7 @@ pub struct WorkflowExecutionFailedEventAttributes {
 }
 
 #[doc="<p>Used to filter the workflow executions in visibility APIs by their <code>workflowId</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionFilter {
     #[doc="<p>The workflowId to pass of match the criteria of this filter.</p>"]
     #[serde(rename="workflowId")]
@@ -2478,7 +2478,7 @@ pub struct WorkflowExecutionFilter {
 }
 
 #[doc="<p>Contains information about a workflow execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionInfo {
     #[doc="<p>Set to true if a cancellation is requested for this workflow execution.</p>"]
     #[serde(rename="cancelRequested")]
@@ -2515,7 +2515,7 @@ pub struct WorkflowExecutionInfo {
 }
 
 #[doc="<p>Contains a paginated list of information about workflow executions.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionInfos {
     #[doc="<p>The list of workflow information structures.</p>"]
     #[serde(rename="executionInfos")]
@@ -2527,7 +2527,7 @@ pub struct WorkflowExecutionInfos {
 }
 
 #[doc="<p>Contains the counts of open tasks, child workflow executions and timers for a workflow execution.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionOpenCounts {
     #[doc="<p>The count of activity tasks whose status is <code>OPEN</code>.</p>"]
     #[serde(rename="openActivityTasks")]
@@ -2548,7 +2548,7 @@ pub struct WorkflowExecutionOpenCounts {
 }
 
 #[doc="<p>Provides the details of the <code>WorkflowExecutionSignaled</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionSignaledEventAttributes {
     #[doc="<p>The ID of the <code>SignalExternalWorkflowExecutionInitiated</code> event corresponding to the <code>SignalExternalWorkflow</code> decision to signal this workflow execution.The source event with this ID can be found in the history of the source workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event. This field is set only if the signal was initiated by another workflow execution.</p>"]
     #[serde(rename="externalInitiatedEventId")]
@@ -2568,7 +2568,7 @@ pub struct WorkflowExecutionSignaledEventAttributes {
 }
 
 #[doc="<p>Provides details of <code>WorkflowExecutionStarted</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionStartedEventAttributes {
     #[doc="<p>The policy to use for the child workflow executions if this workflow execution is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul>"]
     #[serde(rename="childPolicy")]
@@ -2618,7 +2618,7 @@ pub struct WorkflowExecutionStartedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>WorkflowExecutionTerminated</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionTerminatedEventAttributes {
     #[doc="<p>If set, indicates that the workflow execution was automatically terminated, and specifies the cause. This happens if the parent workflow execution times out or is terminated and the child policy is set to terminate child executions.</p>"]
     #[serde(rename="cause")]
@@ -2638,7 +2638,7 @@ pub struct WorkflowExecutionTerminatedEventAttributes {
 }
 
 #[doc="<p>Provides the details of the <code>WorkflowExecutionTimedOut</code> event.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowExecutionTimedOutEventAttributes {
     #[doc="<p>The policy used for the child workflow executions of this workflow execution.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul>"]
     #[serde(rename="childPolicy")]
@@ -2660,7 +2660,7 @@ pub struct WorkflowType {
 }
 
 #[doc="<p>The configuration settings of a workflow type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowTypeConfiguration {
     #[doc="<p> The default policy to use for the child workflow executions when a workflow execution of this type is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This default can be overridden when starting a workflow execution using the <a>StartWorkflowExecution</a> action or the <code>StartChildWorkflowExecution</code> <a>Decision</a>.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul>"]
     #[serde(rename="defaultChildPolicy")]
@@ -2689,7 +2689,7 @@ pub struct WorkflowTypeConfiguration {
 }
 
 #[doc="<p>Contains details about a workflow type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowTypeDetail {
     #[doc="<p>Configuration settings of the workflow type registered through <a>RegisterWorkflowType</a> </p>"]
     #[serde(rename="configuration")]
@@ -2700,7 +2700,7 @@ pub struct WorkflowTypeDetail {
 }
 
 #[doc="<p>Used to filter workflow execution query results by type. Each parameter, if specified, defines a rule that must be satisfied by each returned result.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowTypeFilter {
     #[doc="<p> Name of the workflow type.</p>"]
     #[serde(rename="name")]
@@ -2712,7 +2712,7 @@ pub struct WorkflowTypeFilter {
 }
 
 #[doc="<p>Contains information about a workflow type.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowTypeInfo {
     #[doc="<p>The date when this type was registered.</p>"]
     #[serde(rename="creationDate")]
@@ -2734,7 +2734,7 @@ pub struct WorkflowTypeInfo {
 }
 
 #[doc="<p>Contains a paginated list of information structures about workflow types.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkflowTypeInfos {
     #[doc="<p>If a <code>NextPageToken</code> was returned by a previous call, there are more results available. To retrieve the next page of results, make the call again using the returned token in <code>nextPageToken</code>. Keep all other arguments unchanged.</p> <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>"]
     #[serde(rename="nextPageToken")]

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -46,7 +46,7 @@ pub struct ActivatedRule {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateWebACLRequest {
     #[doc="<p>The ARN (Amazon Resource Name) of the resource to be protected.</p>"]
     #[serde(rename="ResourceArn")]
@@ -56,11 +56,11 @@ pub struct AssociateWebACLRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AssociateWebACLResponse;
 
 #[doc="<p>In a <a>GetByteMatchSet</a> request, <code>ByteMatchSet</code> is a complex type that contains the <code>ByteMatchSetId</code> and <code>Name</code> of a <code>ByteMatchSet</code>, and the values that you specified when you updated the <code>ByteMatchSet</code>. </p> <p>A complex type that contains <code>ByteMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect and the values that you want AWS WAF to search for. If a <code>ByteMatchSet</code> contains more than one <code>ByteMatchTuple</code> object, a request needs to match the settings in only one <code>ByteMatchTuple</code> to be considered a match.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ByteMatchSet {
     #[doc="<p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code> (see <a>GetByteMatchSet</a>), update a <code>ByteMatchSet</code> (see <a>UpdateByteMatchSet</a>), insert a <code>ByteMatchSet</code> into a <code>Rule</code> or delete one from a <code>Rule</code> (see <a>UpdateRule</a>), and delete a <code>ByteMatchSet</code> from AWS WAF (see <a>DeleteByteMatchSet</a>).</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>"]
     #[serde(rename="ByteMatchSetId")]
@@ -75,7 +75,7 @@ pub struct ByteMatchSet {
 }
 
 #[doc="<p>Returned by <a>ListByteMatchSets</a>. Each <code>ByteMatchSetSummary</code> object includes the <code>Name</code> and <code>ByteMatchSetId</code> for one <a>ByteMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ByteMatchSetSummary {
     #[doc="<p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code>, update a <code>ByteMatchSet</code>, remove a <code>ByteMatchSet</code> from a <code>Rule</code>, and delete a <code>ByteMatchSet</code> from AWS WAF.</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>"]
     #[serde(rename="ByteMatchSetId")]
@@ -86,7 +86,7 @@ pub struct ByteMatchSetSummary {
 }
 
 #[doc="<p>In an <a>UpdateByteMatchSet</a> request, <code>ByteMatchSetUpdate</code> specifies whether to insert or delete a <a>ByteMatchTuple</a> and includes the settings for the <code>ByteMatchTuple</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ByteMatchSetUpdate {
     #[doc="<p>Specifies whether to insert or delete a <a>ByteMatchTuple</a>.</p>"]
     #[serde(rename="Action")]
@@ -118,7 +118,7 @@ pub struct ByteMatchTuple {
     pub text_transformation: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateByteMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -128,7 +128,7 @@ pub struct CreateByteMatchSetRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateByteMatchSetResponse {
     #[doc="<p>A <a>ByteMatchSet</a> that contains no <code>ByteMatchTuple</code> objects.</p>"]
     #[serde(rename="ByteMatchSet")]
@@ -140,7 +140,7 @@ pub struct CreateByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateIPSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -150,7 +150,7 @@ pub struct CreateIPSetRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateIPSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -162,7 +162,7 @@ pub struct CreateIPSetResponse {
     pub ip_set: Option<IPSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRateBasedRuleRequest {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -181,7 +181,7 @@ pub struct CreateRateBasedRuleRequest {
     pub rate_limit: i64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRateBasedRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -193,7 +193,7 @@ pub struct CreateRateBasedRuleResponse {
     pub rule: Option<RateBasedRule>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRuleRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -206,7 +206,7 @@ pub struct CreateRuleRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -218,7 +218,7 @@ pub struct CreateRuleResponse {
     pub rule: Option<Rule>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSizeConstraintSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -228,7 +228,7 @@ pub struct CreateSizeConstraintSetRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSizeConstraintSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -241,7 +241,7 @@ pub struct CreateSizeConstraintSetResponse {
 }
 
 #[doc="<p>A request to create a <a>SqlInjectionMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSqlInjectionMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -252,7 +252,7 @@ pub struct CreateSqlInjectionMatchSetRequest {
 }
 
 #[doc="<p>The response to a <code>CreateSqlInjectionMatchSet</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSqlInjectionMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -264,7 +264,7 @@ pub struct CreateSqlInjectionMatchSetResponse {
     pub sql_injection_match_set: Option<SqlInjectionMatchSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateWebACLRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -280,7 +280,7 @@ pub struct CreateWebACLRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateWebACLResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -293,7 +293,7 @@ pub struct CreateWebACLResponse {
 }
 
 #[doc="<p>A request to create an <a>XssMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateXssMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -304,7 +304,7 @@ pub struct CreateXssMatchSetRequest {
 }
 
 #[doc="<p>The response to a <code>CreateXssMatchSet</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateXssMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -316,7 +316,7 @@ pub struct CreateXssMatchSetResponse {
     pub xss_match_set: Option<XssMatchSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteByteMatchSetRequest {
     #[doc="<p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to delete. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>"]
     #[serde(rename="ByteMatchSetId")]
@@ -326,7 +326,7 @@ pub struct DeleteByteMatchSetRequest {
     pub change_token: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteByteMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -334,7 +334,7 @@ pub struct DeleteByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIPSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -344,7 +344,7 @@ pub struct DeleteIPSetRequest {
     pub ip_set_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIPSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -352,7 +352,7 @@ pub struct DeleteIPSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRateBasedRuleRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -362,7 +362,7 @@ pub struct DeleteRateBasedRuleRequest {
     pub rule_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRateBasedRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -370,7 +370,7 @@ pub struct DeleteRateBasedRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRuleRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -380,7 +380,7 @@ pub struct DeleteRuleRequest {
     pub rule_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -388,7 +388,7 @@ pub struct DeleteRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSizeConstraintSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -398,7 +398,7 @@ pub struct DeleteSizeConstraintSetRequest {
     pub size_constraint_set_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSizeConstraintSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -407,7 +407,7 @@ pub struct DeleteSizeConstraintSetResponse {
 }
 
 #[doc="<p>A request to delete a <a>SqlInjectionMatchSet</a> from AWS WAF.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSqlInjectionMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -418,7 +418,7 @@ pub struct DeleteSqlInjectionMatchSetRequest {
 }
 
 #[doc="<p>The response to a request to delete a <a>SqlInjectionMatchSet</a> from AWS WAF.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSqlInjectionMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -426,7 +426,7 @@ pub struct DeleteSqlInjectionMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteWebACLRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -436,7 +436,7 @@ pub struct DeleteWebACLRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteWebACLResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -445,7 +445,7 @@ pub struct DeleteWebACLResponse {
 }
 
 #[doc="<p>A request to delete an <a>XssMatchSet</a> from AWS WAF.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteXssMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -456,7 +456,7 @@ pub struct DeleteXssMatchSetRequest {
 }
 
 #[doc="<p>The response to a request to delete an <a>XssMatchSet</a> from AWS WAF.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteXssMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -464,14 +464,14 @@ pub struct DeleteXssMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateWebACLRequest {
     #[doc="<p>The ARN (Amazon Resource Name) of the resource from which the web ACL is being removed.</p>"]
     #[serde(rename="ResourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DisassociateWebACLResponse;
 
 #[doc="<p>Specifies where in a web request to look for <code>TargetString</code>.</p>"]
@@ -486,14 +486,14 @@ pub struct FieldToMatch {
     pub type_: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetByteMatchSetRequest {
     #[doc="<p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to get. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>"]
     #[serde(rename="ByteMatchSetId")]
     pub byte_match_set_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetByteMatchSetResponse {
     #[doc="<p>Information about the <a>ByteMatchSet</a> that you specified in the <code>GetByteMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>ByteMatchSet</a>: Contains <code>ByteMatchSetId</code>, <code>ByteMatchTuples</code>, and <code>Name</code> </p> </li> <li> <p> <code>ByteMatchTuples</code>: Contains an array of <a>ByteMatchTuple</a> objects. Each <code>ByteMatchTuple</code> object contains <a>FieldToMatch</a>, <code>PositionalConstraint</code>, <code>TargetString</code>, and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="ByteMatchSet")]
@@ -501,10 +501,10 @@ pub struct GetByteMatchSetResponse {
     pub byte_match_set: Option<ByteMatchSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetChangeTokenRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetChangeTokenResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used in the request. Use this value in a <code>GetChangeTokenStatus</code> request to get the current status of the request. </p>"]
     #[serde(rename="ChangeToken")]
@@ -512,14 +512,14 @@ pub struct GetChangeTokenResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetChangeTokenStatusRequest {
     #[doc="<p>The change token for which you want to get the status. This change token was previously returned in the <code>GetChangeToken</code> response.</p>"]
     #[serde(rename="ChangeToken")]
     pub change_token: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetChangeTokenStatusResponse {
     #[doc="<p>The status of the change token.</p>"]
     #[serde(rename="ChangeTokenStatus")]
@@ -527,14 +527,14 @@ pub struct GetChangeTokenStatusResponse {
     pub change_token_status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIPSetRequest {
     #[doc="<p>The <code>IPSetId</code> of the <a>IPSet</a> that you want to get. <code>IPSetId</code> is returned by <a>CreateIPSet</a> and by <a>ListIPSets</a>.</p>"]
     #[serde(rename="IPSetId")]
     pub ip_set_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIPSetResponse {
     #[doc="<p>Information about the <a>IPSet</a> that you specified in the <code>GetIPSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>IPSet</a>: Contains <code>IPSetDescriptors</code>, <code>IPSetId</code>, and <code>Name</code> </p> </li> <li> <p> <code>IPSetDescriptors</code>: Contains an array of <a>IPSetDescriptor</a> objects. Each <code>IPSetDescriptor</code> object contains <code>Type</code> and <code>Value</code> </p> </li> </ul>"]
     #[serde(rename="IPSet")]
@@ -542,7 +542,7 @@ pub struct GetIPSetResponse {
     pub ip_set: Option<IPSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRateBasedRuleManagedKeysRequest {
     #[doc="<p>A null value and not currently used. Do not include this in your request.</p>"]
     #[serde(rename="NextMarker")]
@@ -553,7 +553,7 @@ pub struct GetRateBasedRuleManagedKeysRequest {
     pub rule_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRateBasedRuleManagedKeysResponse {
     #[doc="<p>An array of IP addresses that currently are blocked by the specified <a>RateBasedRule</a>. </p>"]
     #[serde(rename="ManagedKeys")]
@@ -565,14 +565,14 @@ pub struct GetRateBasedRuleManagedKeysResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRateBasedRuleRequest {
     #[doc="<p>The <code>RuleId</code> of the <a>RateBasedRule</a> that you want to get. <code>RuleId</code> is returned by <a>CreateRateBasedRule</a> and by <a>ListRateBasedRules</a>.</p>"]
     #[serde(rename="RuleId")]
     pub rule_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRateBasedRuleResponse {
     #[doc="<p>Information about the <a>RateBasedRule</a> that you specified in the <code>GetRateBasedRule</code> request.</p>"]
     #[serde(rename="Rule")]
@@ -580,14 +580,14 @@ pub struct GetRateBasedRuleResponse {
     pub rule: Option<RateBasedRule>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRuleRequest {
     #[doc="<p>The <code>RuleId</code> of the <a>Rule</a> that you want to get. <code>RuleId</code> is returned by <a>CreateRule</a> and by <a>ListRules</a>.</p>"]
     #[serde(rename="RuleId")]
     pub rule_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRuleResponse {
     #[doc="<p>Information about the <a>Rule</a> that you specified in the <code>GetRule</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>Rule</a>: Contains <code>MetricName</code>, <code>Name</code>, an array of <code>Predicate</code> objects, and <code>RuleId</code> </p> </li> <li> <p> <a>Predicate</a>: Each <code>Predicate</code> object contains <code>DataId</code>, <code>Negated</code>, and <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="Rule")]
@@ -595,7 +595,7 @@ pub struct GetRuleResponse {
     pub rule: Option<Rule>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSampledRequestsRequest {
     #[doc="<p>The number of requests that you want AWS WAF to return from among the first 5,000 requests that your AWS resource received during the time range. If your resource received fewer requests than the value of <code>MaxItems</code>, <code>GetSampledRequests</code> returns information about all of them. </p>"]
     #[serde(rename="MaxItems")]
@@ -611,7 +611,7 @@ pub struct GetSampledRequestsRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSampledRequestsResponse {
     #[doc="<p>The total number of requests from which <code>GetSampledRequests</code> got a sample of <code>MaxItems</code> requests. If <code>PopulationSize</code> is less than <code>MaxItems</code>, the sample includes every request that your AWS resource received during the specified time range.</p>"]
     #[serde(rename="PopulationSize")]
@@ -627,14 +627,14 @@ pub struct GetSampledRequestsResponse {
     pub time_window: Option<TimeWindow>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSizeConstraintSetRequest {
     #[doc="<p>The <code>SizeConstraintSetId</code> of the <a>SizeConstraintSet</a> that you want to get. <code>SizeConstraintSetId</code> is returned by <a>CreateSizeConstraintSet</a> and by <a>ListSizeConstraintSets</a>.</p>"]
     #[serde(rename="SizeConstraintSetId")]
     pub size_constraint_set_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSizeConstraintSetResponse {
     #[doc="<p>Information about the <a>SizeConstraintSet</a> that you specified in the <code>GetSizeConstraintSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SizeConstraintSet</a>: Contains <code>SizeConstraintSetId</code>, <code>SizeConstraints</code>, and <code>Name</code> </p> </li> <li> <p> <code>SizeConstraints</code>: Contains an array of <a>SizeConstraint</a> objects. Each <code>SizeConstraint</code> object contains <a>FieldToMatch</a>, <code>TextTransformation</code>, <code>ComparisonOperator</code>, and <code>Size</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="SizeConstraintSet")]
@@ -643,7 +643,7 @@ pub struct GetSizeConstraintSetResponse {
 }
 
 #[doc="<p>A request to get a <a>SqlInjectionMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSqlInjectionMatchSetRequest {
     #[doc="<p>The <code>SqlInjectionMatchSetId</code> of the <a>SqlInjectionMatchSet</a> that you want to get. <code>SqlInjectionMatchSetId</code> is returned by <a>CreateSqlInjectionMatchSet</a> and by <a>ListSqlInjectionMatchSets</a>.</p>"]
     #[serde(rename="SqlInjectionMatchSetId")]
@@ -651,7 +651,7 @@ pub struct GetSqlInjectionMatchSetRequest {
 }
 
 #[doc="<p>The response to a <a>GetSqlInjectionMatchSet</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSqlInjectionMatchSetResponse {
     #[doc="<p>Information about the <a>SqlInjectionMatchSet</a> that you specified in the <code>GetSqlInjectionMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SqlInjectionMatchSet</a>: Contains <code>Name</code>, <code>SqlInjectionMatchSetId</code>, and an array of <code>SqlInjectionMatchTuple</code> objects</p> </li> <li> <p> <a>SqlInjectionMatchTuple</a>: Each <code>SqlInjectionMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="SqlInjectionMatchSet")]
@@ -659,14 +659,14 @@ pub struct GetSqlInjectionMatchSetResponse {
     pub sql_injection_match_set: Option<SqlInjectionMatchSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetWebACLForResourceRequest {
     #[doc="<p>The ARN (Amazon Resource Name) of the resource for which to get the web ACL.</p>"]
     #[serde(rename="ResourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetWebACLForResourceResponse {
     #[doc="<p>Information about the web ACL that you specified in the <code>GetWebACLForResource</code> request. If there is no associated resource, a null WebACLSummary is returned.</p>"]
     #[serde(rename="WebACLSummary")]
@@ -674,14 +674,14 @@ pub struct GetWebACLForResourceResponse {
     pub web_acl_summary: Option<WebACLSummary>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetWebACLRequest {
     #[doc="<p>The <code>WebACLId</code> of the <a>WebACL</a> that you want to get. <code>WebACLId</code> is returned by <a>CreateWebACL</a> and by <a>ListWebACLs</a>.</p>"]
     #[serde(rename="WebACLId")]
     pub web_acl_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetWebACLResponse {
     #[doc="<p>Information about the <a>WebACL</a> that you specified in the <code>GetWebACL</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>WebACL</a>: Contains <code>DefaultAction</code>, <code>MetricName</code>, <code>Name</code>, an array of <code>Rule</code> objects, and <code>WebACLId</code> </p> </li> <li> <p> <code>DefaultAction</code> (Data type is <a>WafAction</a>): Contains <code>Type</code> </p> </li> <li> <p> <code>Rules</code>: Contains an array of <code>ActivatedRule</code> objects, which contain <code>Action</code>, <code>Priority</code>, and <code>RuleId</code> </p> </li> <li> <p> <code>Action</code>: Contains <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="WebACL")]
@@ -690,7 +690,7 @@ pub struct GetWebACLResponse {
 }
 
 #[doc="<p>A request to get an <a>XssMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetXssMatchSetRequest {
     #[doc="<p>The <code>XssMatchSetId</code> of the <a>XssMatchSet</a> that you want to get. <code>XssMatchSetId</code> is returned by <a>CreateXssMatchSet</a> and by <a>ListXssMatchSets</a>.</p>"]
     #[serde(rename="XssMatchSetId")]
@@ -698,7 +698,7 @@ pub struct GetXssMatchSetRequest {
 }
 
 #[doc="<p>The response to a <a>GetXssMatchSet</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetXssMatchSetResponse {
     #[doc="<p>Information about the <a>XssMatchSet</a> that you specified in the <code>GetXssMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>XssMatchSet</a>: Contains <code>Name</code>, <code>XssMatchSetId</code>, and an array of <code>XssMatchTuple</code> objects</p> </li> <li> <p> <a>XssMatchTuple</a>: Each <code>XssMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="XssMatchSet")]
@@ -707,7 +707,7 @@ pub struct GetXssMatchSetResponse {
 }
 
 #[doc="<p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPHeader</code> complex type that appears as <code>Headers</code> in the response syntax. <code>HTTPHeader</code> contains the names and values of all of the headers that appear in one of the web requests that were returned by <code>GetSampledRequests</code>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HTTPHeader {
     #[doc="<p>The name of one of the headers in the sampled web request.</p>"]
     #[serde(rename="Name")]
@@ -720,7 +720,7 @@ pub struct HTTPHeader {
 }
 
 #[doc="<p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPRequest</code> complex type that appears as <code>Request</code> in the response syntax. <code>HTTPRequest</code> contains information about one of the web requests that were returned by <code>GetSampledRequests</code>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HTTPRequest {
     #[doc="<p>The IP address that the request originated from. If the <code>WebACL</code> is associated with a CloudFront distribution, this is the value of one of the following fields in CloudFront access logs:</p> <ul> <li> <p> <code>c-ip</code>, if the viewer did not use an HTTP proxy or a load balancer to send the request</p> </li> <li> <p> <code>x-forwarded-for</code>, if the viewer did use an HTTP proxy or a load balancer to send the request</p> </li> </ul>"]
     #[serde(rename="ClientIP")]
@@ -749,7 +749,7 @@ pub struct HTTPRequest {
 }
 
 #[doc="<p>Contains one or more IP addresses or blocks of IP addresses specified in Classless Inter-Domain Routing (CIDR) notation. AWS WAF supports /8, /16, /24, and /32 IP address ranges for IPv4, and /24, /32, /48, /56, /64 and /128 for IPv6.</p> <p>To specify an individual IP address, you specify the four-part IP address followed by a <code>/32</code>, for example, 192.0.2.0/31. To block a range of IP addresses, you can specify a <code>/128</code>, <code>/64</code>, <code>/56</code>, <code>/48</code>, <code>/32</code>, <code>/24</code>, <code>/16</code>, or <code>/8</code> CIDR. For more information about CIDR notation, see the Wikipedia entry <a href=\"https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing\">Classless Inter-Domain Routing</a>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IPSet {
     #[doc="<p>The IP address type (<code>IPV4</code> or <code>IPV6</code>) and the IP address range (in CIDR notation) that web requests originate from. If the <code>WebACL</code> is associated with a CloudFront distribution and the viewer did not use an HTTP proxy or a load balancer to send the request, this is the value of the c-ip field in the CloudFront access logs.</p>"]
     #[serde(rename="IPSetDescriptors")]
@@ -775,7 +775,7 @@ pub struct IPSetDescriptor {
 }
 
 #[doc="<p>Contains the identifier and the name of the <code>IPSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IPSetSummary {
     #[doc="<p>The <code>IPSetId</code> for an <a>IPSet</a>. You can use <code>IPSetId</code> in a <a>GetIPSet</a> request to get detailed information about an <a>IPSet</a>.</p>"]
     #[serde(rename="IPSetId")]
@@ -786,7 +786,7 @@ pub struct IPSetSummary {
 }
 
 #[doc="<p>Specifies the type of update to perform to an <a>IPSet</a> with <a>UpdateIPSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IPSetUpdate {
     #[doc="<p>Specifies whether to insert or delete an IP address with <a>UpdateIPSet</a>.</p>"]
     #[serde(rename="Action")]
@@ -796,7 +796,7 @@ pub struct IPSetUpdate {
     pub ip_set_descriptor: IPSetDescriptor,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListByteMatchSetsRequest {
     #[doc="<p>Specifies the number of <code>ByteMatchSet</code> objects that you want AWS WAF to return for this request. If you have more <code>ByteMatchSets</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>ByteMatchSet</code> objects.</p>"]
     #[serde(rename="Limit")]
@@ -808,7 +808,7 @@ pub struct ListByteMatchSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListByteMatchSetsResponse {
     #[doc="<p>An array of <a>ByteMatchSetSummary</a> objects.</p>"]
     #[serde(rename="ByteMatchSets")]
@@ -820,7 +820,7 @@ pub struct ListByteMatchSetsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIPSetsRequest {
     #[doc="<p>Specifies the number of <code>IPSet</code> objects that you want AWS WAF to return for this request. If you have more <code>IPSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>IPSet</code> objects.</p>"]
     #[serde(rename="Limit")]
@@ -832,7 +832,7 @@ pub struct ListIPSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIPSetsResponse {
     #[doc="<p>An array of <a>IPSetSummary</a> objects.</p>"]
     #[serde(rename="IPSets")]
@@ -844,7 +844,7 @@ pub struct ListIPSetsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRateBasedRulesRequest {
     #[doc="<p>Specifies the number of <code>Rules</code> that you want AWS WAF to return for this request. If you have more <code>Rules</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>"]
     #[serde(rename="Limit")]
@@ -856,7 +856,7 @@ pub struct ListRateBasedRulesRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRateBasedRulesResponse {
     #[doc="<p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRateBasedRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -868,14 +868,14 @@ pub struct ListRateBasedRulesResponse {
     pub rules: Option<Vec<RuleSummary>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourcesForWebACLRequest {
     #[doc="<p>The unique identifier (ID) of the web ACL for which to list the associated resources.</p>"]
     #[serde(rename="WebACLId")]
     pub web_acl_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListResourcesForWebACLResponse {
     #[doc="<p>An array of ARNs (Amazon Resource Names) of the resources associated with the specified web ACL. An array with zero elements is returned if there are no resources associated with the web ACL.</p>"]
     #[serde(rename="ResourceArns")]
@@ -883,7 +883,7 @@ pub struct ListResourcesForWebACLResponse {
     pub resource_arns: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRulesRequest {
     #[doc="<p>Specifies the number of <code>Rules</code> that you want AWS WAF to return for this request. If you have more <code>Rules</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>"]
     #[serde(rename="Limit")]
@@ -895,7 +895,7 @@ pub struct ListRulesRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRulesResponse {
     #[doc="<p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -907,7 +907,7 @@ pub struct ListRulesResponse {
     pub rules: Option<Vec<RuleSummary>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSizeConstraintSetsRequest {
     #[doc="<p>Specifies the number of <code>SizeConstraintSet</code> objects that you want AWS WAF to return for this request. If you have more <code>SizeConstraintSets</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>SizeConstraintSet</code> objects.</p>"]
     #[serde(rename="Limit")]
@@ -919,7 +919,7 @@ pub struct ListSizeConstraintSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSizeConstraintSetsResponse {
     #[doc="<p>If you have more <code>SizeConstraintSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SizeConstraintSet</code> objects, submit another <code>ListSizeConstraintSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -932,7 +932,7 @@ pub struct ListSizeConstraintSetsResponse {
 }
 
 #[doc="<p>A request to list the <a>SqlInjectionMatchSet</a> objects created by the current AWS account.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSqlInjectionMatchSetsRequest {
     #[doc="<p>Specifies the number of <a>SqlInjectionMatchSet</a> objects that you want AWS WAF to return for this request. If you have more <code>SqlInjectionMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>"]
     #[serde(rename="Limit")]
@@ -945,7 +945,7 @@ pub struct ListSqlInjectionMatchSetsRequest {
 }
 
 #[doc="<p>The response to a <a>ListSqlInjectionMatchSets</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSqlInjectionMatchSetsResponse {
     #[doc="<p>If you have more <a>SqlInjectionMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SqlInjectionMatchSet</code> objects, submit another <code>ListSqlInjectionMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -957,7 +957,7 @@ pub struct ListSqlInjectionMatchSetsResponse {
     pub sql_injection_match_sets: Option<Vec<SqlInjectionMatchSetSummary>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListWebACLsRequest {
     #[doc="<p>Specifies the number of <code>WebACL</code> objects that you want AWS WAF to return for this request. If you have more <code>WebACL</code> objects than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>WebACL</code> objects.</p>"]
     #[serde(rename="Limit")]
@@ -969,7 +969,7 @@ pub struct ListWebACLsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListWebACLsResponse {
     #[doc="<p>If you have more <code>WebACL</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>WebACL</code> objects, submit another <code>ListWebACLs</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -982,7 +982,7 @@ pub struct ListWebACLsResponse {
 }
 
 #[doc="<p>A request to list the <a>XssMatchSet</a> objects created by the current AWS account.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListXssMatchSetsRequest {
     #[doc="<p>Specifies the number of <a>XssMatchSet</a> objects that you want AWS WAF to return for this request. If you have more <code>XssMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>"]
     #[serde(rename="Limit")]
@@ -995,7 +995,7 @@ pub struct ListXssMatchSetsRequest {
 }
 
 #[doc="<p>The response to a <a>ListXssMatchSets</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListXssMatchSetsResponse {
     #[doc="<p>If you have more <a>XssMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>XssMatchSet</code> objects, submit another <code>ListXssMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -1022,7 +1022,7 @@ pub struct Predicate {
 }
 
 #[doc="<p>A <code>RateBasedRule</code> is identical to a regular <a>Rule</a>, with one addition: a <code>RateBasedRule</code> counts the number of requests that arrive from a specified IP address every five minutes. For example, based on recent requests that you've seen from an attacker, you might create a <code>RateBasedRule</code> that includes the following conditions: </p> <ul> <li> <p>The requests come from 192.0.2.44.</p> </li> <li> <p>They contain the value <code>BadBot</code> in the <code>User-Agent</code> header.</p> </li> </ul> <p>In the rule, you also define the rate limit as 15,000.</p> <p>Requests that meet both of these conditions and exceed 15,000 requests every five minutes trigger the rule's action (block or count), which is defined in the web ACL.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RateBasedRule {
     #[doc="<p>The <code>Predicates</code> object contains one <code>Predicate</code> element for each <a>ByteMatchSet</a>, <a>IPSet</a>, or <a>SqlInjectionMatchSet</a> object that you want to include in a <code>RateBasedRule</code>.</p>"]
     #[serde(rename="MatchPredicates")]
@@ -1047,7 +1047,7 @@ pub struct RateBasedRule {
 }
 
 #[doc="<p>A combination of <a>ByteMatchSet</a>, <a>IPSet</a>, and/or <a>SqlInjectionMatchSet</a> objects that identify the web requests that you want to allow, block, or count. For example, you might create a <code>Rule</code> that includes the following predicates:</p> <ul> <li> <p>An <code>IPSet</code> that causes AWS WAF to search for web requests that originate from the IP address <code>192.0.2.44</code> </p> </li> <li> <p>A <code>ByteMatchSet</code> that causes AWS WAF to search for web requests for which the value of the <code>User-Agent</code> header is <code>BadBot</code>.</p> </li> </ul> <p>To match the settings in this <code>Rule</code>, a request must originate from <code>192.0.2.44</code> AND include a <code>User-Agent</code> header for which the value is <code>BadBot</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Rule {
     #[doc="<p>A friendly name or description for the metrics for this <code>Rule</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change <code>MetricName</code> after you create the <code>Rule</code>.</p>"]
     #[serde(rename="MetricName")]
@@ -1066,7 +1066,7 @@ pub struct Rule {
 }
 
 #[doc="<p>Contains the identifier and the friendly name or description of the <code>Rule</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RuleSummary {
     #[doc="<p>A friendly name or description of the <a>Rule</a>. You can't change the name of a <code>Rule</code> after you create it.</p>"]
     #[serde(rename="Name")]
@@ -1077,7 +1077,7 @@ pub struct RuleSummary {
 }
 
 #[doc="<p>Specifies a <code>Predicate</code> (such as an <code>IPSet</code>) and indicates whether you want to add it to a <code>Rule</code> or delete it from a <code>Rule</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RuleUpdate {
     #[doc="<p>Specify <code>INSERT</code> to add a <code>Predicate</code> to a <code>Rule</code>. Use <code>DELETE</code> to remove a <code>Predicate</code> from a <code>Rule</code>.</p>"]
     #[serde(rename="Action")]
@@ -1088,7 +1088,7 @@ pub struct RuleUpdate {
 }
 
 #[doc="<p>The response from a <a>GetSampledRequests</a> request includes a <code>SampledHTTPRequests</code> complex type that appears as <code>SampledRequests</code> in the response syntax. <code>SampledHTTPRequests</code> contains one <code>SampledHTTPRequest</code> object for each web request that is returned by <code>GetSampledRequests</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SampledHTTPRequest {
     #[doc="<p>The action for the <code>Rule</code> that the request matched: <code>ALLOW</code>, <code>BLOCK</code>, or <code>COUNT</code>.</p>"]
     #[serde(rename="Action")]
@@ -1124,7 +1124,7 @@ pub struct SizeConstraint {
 }
 
 #[doc="<p>A complex type that contains <code>SizeConstraint</code> objects, which specify the parts of web requests that you want AWS WAF to inspect the size of. If a <code>SizeConstraintSet</code> contains more than one <code>SizeConstraint</code> object, a request only needs to match one constraint to be considered a match.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SizeConstraintSet {
     #[doc="<p>The name, if any, of the <code>SizeConstraintSet</code>.</p>"]
     #[serde(rename="Name")]
@@ -1139,7 +1139,7 @@ pub struct SizeConstraintSet {
 }
 
 #[doc="<p>The <code>Id</code> and <code>Name</code> of a <code>SizeConstraintSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SizeConstraintSetSummary {
     #[doc="<p>The name of the <code>SizeConstraintSet</code>, if any.</p>"]
     #[serde(rename="Name")]
@@ -1150,7 +1150,7 @@ pub struct SizeConstraintSetSummary {
 }
 
 #[doc="<p>Specifies the part of a web request that you want to inspect the size of and indicates whether you want to add the specification to a <a>SizeConstraintSet</a> or delete it from a <code>SizeConstraintSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SizeConstraintSetUpdate {
     #[doc="<p>Specify <code>INSERT</code> to add a <a>SizeConstraintSetUpdate</a> to a <a>SizeConstraintSet</a>. Use <code>DELETE</code> to remove a <code>SizeConstraintSetUpdate</code> from a <code>SizeConstraintSet</code>.</p>"]
     #[serde(rename="Action")]
@@ -1161,7 +1161,7 @@ pub struct SizeConstraintSetUpdate {
 }
 
 #[doc="<p>A complex type that contains <code>SqlInjectionMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for snippets of malicious SQL code and, if you want AWS WAF to inspect a header, the name of the header. If a <code>SqlInjectionMatchSet</code> contains more than one <code>SqlInjectionMatchTuple</code> object, a request needs to include snippets of SQL code in only one of the specified parts of the request to be considered a match.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SqlInjectionMatchSet {
     #[doc="<p>The name, if any, of the <code>SqlInjectionMatchSet</code>.</p>"]
     #[serde(rename="Name")]
@@ -1176,7 +1176,7 @@ pub struct SqlInjectionMatchSet {
 }
 
 #[doc="<p>The <code>Id</code> and <code>Name</code> of a <code>SqlInjectionMatchSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SqlInjectionMatchSetSummary {
     #[doc="<p>The name of the <code>SqlInjectionMatchSet</code>, if any, specified by <code>Id</code>.</p>"]
     #[serde(rename="Name")]
@@ -1187,7 +1187,7 @@ pub struct SqlInjectionMatchSetSummary {
 }
 
 #[doc="<p>Specifies the part of a web request that you want to inspect for snippets of malicious SQL code and indicates whether you want to add the specification to a <a>SqlInjectionMatchSet</a> or delete it from a <code>SqlInjectionMatchSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SqlInjectionMatchSetUpdate {
     #[doc="<p>Specify <code>INSERT</code> to add a <a>SqlInjectionMatchSetUpdate</a> to a <a>SqlInjectionMatchSet</a>. Use <code>DELETE</code> to remove a <code>SqlInjectionMatchSetUpdate</code> from a <code>SqlInjectionMatchSet</code>.</p>"]
     #[serde(rename="Action")]
@@ -1219,7 +1219,7 @@ pub struct TimeWindow {
     pub start_time: f64,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateByteMatchSetRequest {
     #[doc="<p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to update. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>"]
     #[serde(rename="ByteMatchSetId")]
@@ -1232,7 +1232,7 @@ pub struct UpdateByteMatchSetRequest {
     pub updates: Vec<ByteMatchSetUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateByteMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1240,7 +1240,7 @@ pub struct UpdateByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateIPSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1253,7 +1253,7 @@ pub struct UpdateIPSetRequest {
     pub updates: Vec<IPSetUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateIPSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1261,7 +1261,7 @@ pub struct UpdateIPSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRateBasedRuleRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1277,7 +1277,7 @@ pub struct UpdateRateBasedRuleRequest {
     pub updates: Vec<RuleUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRateBasedRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1285,7 +1285,7 @@ pub struct UpdateRateBasedRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRuleRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1298,7 +1298,7 @@ pub struct UpdateRuleRequest {
     pub updates: Vec<RuleUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1306,7 +1306,7 @@ pub struct UpdateRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSizeConstraintSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1319,7 +1319,7 @@ pub struct UpdateSizeConstraintSetRequest {
     pub updates: Vec<SizeConstraintSetUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSizeConstraintSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1328,7 +1328,7 @@ pub struct UpdateSizeConstraintSetResponse {
 }
 
 #[doc="<p>A request to update a <a>SqlInjectionMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSqlInjectionMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1342,7 +1342,7 @@ pub struct UpdateSqlInjectionMatchSetRequest {
 }
 
 #[doc="<p>The response to an <a>UpdateSqlInjectionMatchSets</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSqlInjectionMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1350,7 +1350,7 @@ pub struct UpdateSqlInjectionMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateWebACLRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1368,7 +1368,7 @@ pub struct UpdateWebACLRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateWebACLResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1377,7 +1377,7 @@ pub struct UpdateWebACLResponse {
 }
 
 #[doc="<p>A request to update an <a>XssMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateXssMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1391,7 +1391,7 @@ pub struct UpdateXssMatchSetRequest {
 }
 
 #[doc="<p>The response to an <a>UpdateXssMatchSets</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateXssMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1408,7 +1408,7 @@ pub struct WafAction {
 }
 
 #[doc="<p>Contains the <code>Rules</code> that identify the requests that you want to allow, block, or count. In a <code>WebACL</code>, you also specify a default action (<code>ALLOW</code> or <code>BLOCK</code>), and the action for each <code>Rule</code> that you add to a <code>WebACL</code>, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the <code>WebACL</code> with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one <code>Rule</code> to a <code>WebACL</code>, a request needs to match only one of the specifications to be allowed, blocked, or counted. For more information, see <a>UpdateWebACL</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WebACL {
     #[doc="<p>The action to perform if none of the <code>Rules</code> contained in the <code>WebACL</code> match. The action is specified by the <a>WafAction</a> object.</p>"]
     #[serde(rename="DefaultAction")]
@@ -1430,7 +1430,7 @@ pub struct WebACL {
 }
 
 #[doc="<p>Contains the identifier and the name or description of the <a>WebACL</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WebACLSummary {
     #[doc="<p>A friendly name or description of the <a>WebACL</a>. You can't change the name of a <code>WebACL</code> after you create it.</p>"]
     #[serde(rename="Name")]
@@ -1441,7 +1441,7 @@ pub struct WebACLSummary {
 }
 
 #[doc="<p>Specifies whether to insert a <code>Rule</code> into or delete a <code>Rule</code> from a <code>WebACL</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WebACLUpdate {
     #[doc="<p>Specifies whether to insert a <code>Rule</code> into or delete a <code>Rule</code> from a <code>WebACL</code>.</p>"]
     #[serde(rename="Action")]
@@ -1452,7 +1452,7 @@ pub struct WebACLUpdate {
 }
 
 #[doc="<p>A complex type that contains <code>XssMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for cross-site scripting attacks and, if you want AWS WAF to inspect a header, the name of the header. If a <code>XssMatchSet</code> contains more than one <code>XssMatchTuple</code> object, a request needs to include cross-site scripting attacks in only one of the specified parts of the request to be considered a match.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct XssMatchSet {
     #[doc="<p>The name, if any, of the <code>XssMatchSet</code>.</p>"]
     #[serde(rename="Name")]
@@ -1467,7 +1467,7 @@ pub struct XssMatchSet {
 }
 
 #[doc="<p>The <code>Id</code> and <code>Name</code> of an <code>XssMatchSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct XssMatchSetSummary {
     #[doc="<p>The name of the <code>XssMatchSet</code>, if any, specified by <code>Id</code>.</p>"]
     #[serde(rename="Name")]
@@ -1478,7 +1478,7 @@ pub struct XssMatchSetSummary {
 }
 
 #[doc="<p>Specifies the part of a web request that you want to inspect for cross-site scripting attacks and indicates whether you want to add the specification to an <a>XssMatchSet</a> or delete it from an <code>XssMatchSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct XssMatchSetUpdate {
     #[doc="<p>Specify <code>INSERT</code> to add a <a>XssMatchSetUpdate</a> to an <a>XssMatchSet</a>. Use <code>DELETE</code> to remove a <code>XssMatchSetUpdate</code> from an <code>XssMatchSet</code>.</p>"]
     #[serde(rename="Action")]

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -47,7 +47,7 @@ pub struct ActivatedRule {
 }
 
 #[doc="<p>In a <a>GetByteMatchSet</a> request, <code>ByteMatchSet</code> is a complex type that contains the <code>ByteMatchSetId</code> and <code>Name</code> of a <code>ByteMatchSet</code>, and the values that you specified when you updated the <code>ByteMatchSet</code>. </p> <p>A complex type that contains <code>ByteMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect and the values that you want AWS WAF to search for. If a <code>ByteMatchSet</code> contains more than one <code>ByteMatchTuple</code> object, a request needs to match the settings in only one <code>ByteMatchTuple</code> to be considered a match.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ByteMatchSet {
     #[doc="<p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code> (see <a>GetByteMatchSet</a>), update a <code>ByteMatchSet</code> (see <a>UpdateByteMatchSet</a>), insert a <code>ByteMatchSet</code> into a <code>Rule</code> or delete one from a <code>Rule</code> (see <a>UpdateRule</a>), and delete a <code>ByteMatchSet</code> from AWS WAF (see <a>DeleteByteMatchSet</a>).</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>"]
     #[serde(rename="ByteMatchSetId")]
@@ -62,7 +62,7 @@ pub struct ByteMatchSet {
 }
 
 #[doc="<p>Returned by <a>ListByteMatchSets</a>. Each <code>ByteMatchSetSummary</code> object includes the <code>Name</code> and <code>ByteMatchSetId</code> for one <a>ByteMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ByteMatchSetSummary {
     #[doc="<p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code>, update a <code>ByteMatchSet</code>, remove a <code>ByteMatchSet</code> from a <code>Rule</code>, and delete a <code>ByteMatchSet</code> from AWS WAF.</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>"]
     #[serde(rename="ByteMatchSetId")]
@@ -73,7 +73,7 @@ pub struct ByteMatchSetSummary {
 }
 
 #[doc="<p>In an <a>UpdateByteMatchSet</a> request, <code>ByteMatchSetUpdate</code> specifies whether to insert or delete a <a>ByteMatchTuple</a> and includes the settings for the <code>ByteMatchTuple</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ByteMatchSetUpdate {
     #[doc="<p>Specifies whether to insert or delete a <a>ByteMatchTuple</a>.</p>"]
     #[serde(rename="Action")]
@@ -105,7 +105,7 @@ pub struct ByteMatchTuple {
     pub text_transformation: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateByteMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -115,7 +115,7 @@ pub struct CreateByteMatchSetRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateByteMatchSetResponse {
     #[doc="<p>A <a>ByteMatchSet</a> that contains no <code>ByteMatchTuple</code> objects.</p>"]
     #[serde(rename="ByteMatchSet")]
@@ -127,7 +127,7 @@ pub struct CreateByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateIPSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -137,7 +137,7 @@ pub struct CreateIPSetRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateIPSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -149,7 +149,7 @@ pub struct CreateIPSetResponse {
     pub ip_set: Option<IPSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRateBasedRuleRequest {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -168,7 +168,7 @@ pub struct CreateRateBasedRuleRequest {
     pub rate_limit: i64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRateBasedRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -180,7 +180,7 @@ pub struct CreateRateBasedRuleResponse {
     pub rule: Option<RateBasedRule>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRuleRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -193,7 +193,7 @@ pub struct CreateRuleRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -205,7 +205,7 @@ pub struct CreateRuleResponse {
     pub rule: Option<Rule>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSizeConstraintSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -215,7 +215,7 @@ pub struct CreateSizeConstraintSetRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSizeConstraintSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -228,7 +228,7 @@ pub struct CreateSizeConstraintSetResponse {
 }
 
 #[doc="<p>A request to create a <a>SqlInjectionMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSqlInjectionMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -239,7 +239,7 @@ pub struct CreateSqlInjectionMatchSetRequest {
 }
 
 #[doc="<p>The response to a <code>CreateSqlInjectionMatchSet</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateSqlInjectionMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -251,7 +251,7 @@ pub struct CreateSqlInjectionMatchSetResponse {
     pub sql_injection_match_set: Option<SqlInjectionMatchSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateWebACLRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -267,7 +267,7 @@ pub struct CreateWebACLRequest {
     pub name: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateWebACLResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -280,7 +280,7 @@ pub struct CreateWebACLResponse {
 }
 
 #[doc="<p>A request to create an <a>XssMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateXssMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -291,7 +291,7 @@ pub struct CreateXssMatchSetRequest {
 }
 
 #[doc="<p>The response to a <code>CreateXssMatchSet</code> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateXssMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>CreateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -303,7 +303,7 @@ pub struct CreateXssMatchSetResponse {
     pub xss_match_set: Option<XssMatchSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteByteMatchSetRequest {
     #[doc="<p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to delete. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>"]
     #[serde(rename="ByteMatchSetId")]
@@ -313,7 +313,7 @@ pub struct DeleteByteMatchSetRequest {
     pub change_token: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteByteMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -321,7 +321,7 @@ pub struct DeleteByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIPSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -331,7 +331,7 @@ pub struct DeleteIPSetRequest {
     pub ip_set_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteIPSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -339,7 +339,7 @@ pub struct DeleteIPSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRateBasedRuleRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -349,7 +349,7 @@ pub struct DeleteRateBasedRuleRequest {
     pub rule_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRateBasedRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -357,7 +357,7 @@ pub struct DeleteRateBasedRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRuleRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -367,7 +367,7 @@ pub struct DeleteRuleRequest {
     pub rule_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -375,7 +375,7 @@ pub struct DeleteRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSizeConstraintSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -385,7 +385,7 @@ pub struct DeleteSizeConstraintSetRequest {
     pub size_constraint_set_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSizeConstraintSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -394,7 +394,7 @@ pub struct DeleteSizeConstraintSetResponse {
 }
 
 #[doc="<p>A request to delete a <a>SqlInjectionMatchSet</a> from AWS WAF.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSqlInjectionMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -405,7 +405,7 @@ pub struct DeleteSqlInjectionMatchSetRequest {
 }
 
 #[doc="<p>The response to a request to delete a <a>SqlInjectionMatchSet</a> from AWS WAF.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteSqlInjectionMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -413,7 +413,7 @@ pub struct DeleteSqlInjectionMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteWebACLRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -423,7 +423,7 @@ pub struct DeleteWebACLRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteWebACLResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -432,7 +432,7 @@ pub struct DeleteWebACLResponse {
 }
 
 #[doc="<p>A request to delete an <a>XssMatchSet</a> from AWS WAF.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteXssMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -443,7 +443,7 @@ pub struct DeleteXssMatchSetRequest {
 }
 
 #[doc="<p>The response to a request to delete an <a>XssMatchSet</a> from AWS WAF.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteXssMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>DeleteXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -463,14 +463,14 @@ pub struct FieldToMatch {
     pub type_: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetByteMatchSetRequest {
     #[doc="<p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to get. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>"]
     #[serde(rename="ByteMatchSetId")]
     pub byte_match_set_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetByteMatchSetResponse {
     #[doc="<p>Information about the <a>ByteMatchSet</a> that you specified in the <code>GetByteMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>ByteMatchSet</a>: Contains <code>ByteMatchSetId</code>, <code>ByteMatchTuples</code>, and <code>Name</code> </p> </li> <li> <p> <code>ByteMatchTuples</code>: Contains an array of <a>ByteMatchTuple</a> objects. Each <code>ByteMatchTuple</code> object contains <a>FieldToMatch</a>, <code>PositionalConstraint</code>, <code>TargetString</code>, and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="ByteMatchSet")]
@@ -478,10 +478,10 @@ pub struct GetByteMatchSetResponse {
     pub byte_match_set: Option<ByteMatchSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetChangeTokenRequest;
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetChangeTokenResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used in the request. Use this value in a <code>GetChangeTokenStatus</code> request to get the current status of the request. </p>"]
     #[serde(rename="ChangeToken")]
@@ -489,14 +489,14 @@ pub struct GetChangeTokenResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetChangeTokenStatusRequest {
     #[doc="<p>The change token for which you want to get the status. This change token was previously returned in the <code>GetChangeToken</code> response.</p>"]
     #[serde(rename="ChangeToken")]
     pub change_token: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetChangeTokenStatusResponse {
     #[doc="<p>The status of the change token.</p>"]
     #[serde(rename="ChangeTokenStatus")]
@@ -504,14 +504,14 @@ pub struct GetChangeTokenStatusResponse {
     pub change_token_status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIPSetRequest {
     #[doc="<p>The <code>IPSetId</code> of the <a>IPSet</a> that you want to get. <code>IPSetId</code> is returned by <a>CreateIPSet</a> and by <a>ListIPSets</a>.</p>"]
     #[serde(rename="IPSetId")]
     pub ip_set_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetIPSetResponse {
     #[doc="<p>Information about the <a>IPSet</a> that you specified in the <code>GetIPSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>IPSet</a>: Contains <code>IPSetDescriptors</code>, <code>IPSetId</code>, and <code>Name</code> </p> </li> <li> <p> <code>IPSetDescriptors</code>: Contains an array of <a>IPSetDescriptor</a> objects. Each <code>IPSetDescriptor</code> object contains <code>Type</code> and <code>Value</code> </p> </li> </ul>"]
     #[serde(rename="IPSet")]
@@ -519,7 +519,7 @@ pub struct GetIPSetResponse {
     pub ip_set: Option<IPSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRateBasedRuleManagedKeysRequest {
     #[doc="<p>A null value and not currently used. Do not include this in your request.</p>"]
     #[serde(rename="NextMarker")]
@@ -530,7 +530,7 @@ pub struct GetRateBasedRuleManagedKeysRequest {
     pub rule_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRateBasedRuleManagedKeysResponse {
     #[doc="<p>An array of IP addresses that currently are blocked by the specified <a>RateBasedRule</a>. </p>"]
     #[serde(rename="ManagedKeys")]
@@ -542,14 +542,14 @@ pub struct GetRateBasedRuleManagedKeysResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRateBasedRuleRequest {
     #[doc="<p>The <code>RuleId</code> of the <a>RateBasedRule</a> that you want to get. <code>RuleId</code> is returned by <a>CreateRateBasedRule</a> and by <a>ListRateBasedRules</a>.</p>"]
     #[serde(rename="RuleId")]
     pub rule_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRateBasedRuleResponse {
     #[doc="<p>Information about the <a>RateBasedRule</a> that you specified in the <code>GetRateBasedRule</code> request.</p>"]
     #[serde(rename="Rule")]
@@ -557,14 +557,14 @@ pub struct GetRateBasedRuleResponse {
     pub rule: Option<RateBasedRule>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRuleRequest {
     #[doc="<p>The <code>RuleId</code> of the <a>Rule</a> that you want to get. <code>RuleId</code> is returned by <a>CreateRule</a> and by <a>ListRules</a>.</p>"]
     #[serde(rename="RuleId")]
     pub rule_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetRuleResponse {
     #[doc="<p>Information about the <a>Rule</a> that you specified in the <code>GetRule</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>Rule</a>: Contains <code>MetricName</code>, <code>Name</code>, an array of <code>Predicate</code> objects, and <code>RuleId</code> </p> </li> <li> <p> <a>Predicate</a>: Each <code>Predicate</code> object contains <code>DataId</code>, <code>Negated</code>, and <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="Rule")]
@@ -572,7 +572,7 @@ pub struct GetRuleResponse {
     pub rule: Option<Rule>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSampledRequestsRequest {
     #[doc="<p>The number of requests that you want AWS WAF to return from among the first 5,000 requests that your AWS resource received during the time range. If your resource received fewer requests than the value of <code>MaxItems</code>, <code>GetSampledRequests</code> returns information about all of them. </p>"]
     #[serde(rename="MaxItems")]
@@ -588,7 +588,7 @@ pub struct GetSampledRequestsRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSampledRequestsResponse {
     #[doc="<p>The total number of requests from which <code>GetSampledRequests</code> got a sample of <code>MaxItems</code> requests. If <code>PopulationSize</code> is less than <code>MaxItems</code>, the sample includes every request that your AWS resource received during the specified time range.</p>"]
     #[serde(rename="PopulationSize")]
@@ -604,14 +604,14 @@ pub struct GetSampledRequestsResponse {
     pub time_window: Option<TimeWindow>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSizeConstraintSetRequest {
     #[doc="<p>The <code>SizeConstraintSetId</code> of the <a>SizeConstraintSet</a> that you want to get. <code>SizeConstraintSetId</code> is returned by <a>CreateSizeConstraintSet</a> and by <a>ListSizeConstraintSets</a>.</p>"]
     #[serde(rename="SizeConstraintSetId")]
     pub size_constraint_set_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSizeConstraintSetResponse {
     #[doc="<p>Information about the <a>SizeConstraintSet</a> that you specified in the <code>GetSizeConstraintSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SizeConstraintSet</a>: Contains <code>SizeConstraintSetId</code>, <code>SizeConstraints</code>, and <code>Name</code> </p> </li> <li> <p> <code>SizeConstraints</code>: Contains an array of <a>SizeConstraint</a> objects. Each <code>SizeConstraint</code> object contains <a>FieldToMatch</a>, <code>TextTransformation</code>, <code>ComparisonOperator</code>, and <code>Size</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="SizeConstraintSet")]
@@ -620,7 +620,7 @@ pub struct GetSizeConstraintSetResponse {
 }
 
 #[doc="<p>A request to get a <a>SqlInjectionMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSqlInjectionMatchSetRequest {
     #[doc="<p>The <code>SqlInjectionMatchSetId</code> of the <a>SqlInjectionMatchSet</a> that you want to get. <code>SqlInjectionMatchSetId</code> is returned by <a>CreateSqlInjectionMatchSet</a> and by <a>ListSqlInjectionMatchSets</a>.</p>"]
     #[serde(rename="SqlInjectionMatchSetId")]
@@ -628,7 +628,7 @@ pub struct GetSqlInjectionMatchSetRequest {
 }
 
 #[doc="<p>The response to a <a>GetSqlInjectionMatchSet</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetSqlInjectionMatchSetResponse {
     #[doc="<p>Information about the <a>SqlInjectionMatchSet</a> that you specified in the <code>GetSqlInjectionMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SqlInjectionMatchSet</a>: Contains <code>Name</code>, <code>SqlInjectionMatchSetId</code>, and an array of <code>SqlInjectionMatchTuple</code> objects</p> </li> <li> <p> <a>SqlInjectionMatchTuple</a>: Each <code>SqlInjectionMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="SqlInjectionMatchSet")]
@@ -636,14 +636,14 @@ pub struct GetSqlInjectionMatchSetResponse {
     pub sql_injection_match_set: Option<SqlInjectionMatchSet>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetWebACLRequest {
     #[doc="<p>The <code>WebACLId</code> of the <a>WebACL</a> that you want to get. <code>WebACLId</code> is returned by <a>CreateWebACL</a> and by <a>ListWebACLs</a>.</p>"]
     #[serde(rename="WebACLId")]
     pub web_acl_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetWebACLResponse {
     #[doc="<p>Information about the <a>WebACL</a> that you specified in the <code>GetWebACL</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>WebACL</a>: Contains <code>DefaultAction</code>, <code>MetricName</code>, <code>Name</code>, an array of <code>Rule</code> objects, and <code>WebACLId</code> </p> </li> <li> <p> <code>DefaultAction</code> (Data type is <a>WafAction</a>): Contains <code>Type</code> </p> </li> <li> <p> <code>Rules</code>: Contains an array of <code>ActivatedRule</code> objects, which contain <code>Action</code>, <code>Priority</code>, and <code>RuleId</code> </p> </li> <li> <p> <code>Action</code>: Contains <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="WebACL")]
@@ -652,7 +652,7 @@ pub struct GetWebACLResponse {
 }
 
 #[doc="<p>A request to get an <a>XssMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetXssMatchSetRequest {
     #[doc="<p>The <code>XssMatchSetId</code> of the <a>XssMatchSet</a> that you want to get. <code>XssMatchSetId</code> is returned by <a>CreateXssMatchSet</a> and by <a>ListXssMatchSets</a>.</p>"]
     #[serde(rename="XssMatchSetId")]
@@ -660,7 +660,7 @@ pub struct GetXssMatchSetRequest {
 }
 
 #[doc="<p>The response to a <a>GetXssMatchSet</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetXssMatchSetResponse {
     #[doc="<p>Information about the <a>XssMatchSet</a> that you specified in the <code>GetXssMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>XssMatchSet</a>: Contains <code>Name</code>, <code>XssMatchSetId</code>, and an array of <code>XssMatchTuple</code> objects</p> </li> <li> <p> <a>XssMatchTuple</a>: Each <code>XssMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul>"]
     #[serde(rename="XssMatchSet")]
@@ -669,7 +669,7 @@ pub struct GetXssMatchSetResponse {
 }
 
 #[doc="<p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPHeader</code> complex type that appears as <code>Headers</code> in the response syntax. <code>HTTPHeader</code> contains the names and values of all of the headers that appear in one of the web requests that were returned by <code>GetSampledRequests</code>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HTTPHeader {
     #[doc="<p>The name of one of the headers in the sampled web request.</p>"]
     #[serde(rename="Name")]
@@ -682,7 +682,7 @@ pub struct HTTPHeader {
 }
 
 #[doc="<p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPRequest</code> complex type that appears as <code>Request</code> in the response syntax. <code>HTTPRequest</code> contains information about one of the web requests that were returned by <code>GetSampledRequests</code>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HTTPRequest {
     #[doc="<p>The IP address that the request originated from. If the <code>WebACL</code> is associated with a CloudFront distribution, this is the value of one of the following fields in CloudFront access logs:</p> <ul> <li> <p> <code>c-ip</code>, if the viewer did not use an HTTP proxy or a load balancer to send the request</p> </li> <li> <p> <code>x-forwarded-for</code>, if the viewer did use an HTTP proxy or a load balancer to send the request</p> </li> </ul>"]
     #[serde(rename="ClientIP")]
@@ -711,7 +711,7 @@ pub struct HTTPRequest {
 }
 
 #[doc="<p>Contains one or more IP addresses or blocks of IP addresses specified in Classless Inter-Domain Routing (CIDR) notation. AWS WAF supports /8, /16, /24, and /32 IP address ranges for IPv4, and /24, /32, /48, /56, /64 and /128 for IPv6.</p> <p>To specify an individual IP address, you specify the four-part IP address followed by a <code>/32</code>, for example, 192.0.2.0/31. To block a range of IP addresses, you can specify a <code>/128</code>, <code>/64</code>, <code>/56</code>, <code>/48</code>, <code>/32</code>, <code>/24</code>, <code>/16</code>, or <code>/8</code> CIDR. For more information about CIDR notation, see the Wikipedia entry <a href=\"https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing\">Classless Inter-Domain Routing</a>. </p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IPSet {
     #[doc="<p>The IP address type (<code>IPV4</code> or <code>IPV6</code>) and the IP address range (in CIDR notation) that web requests originate from. If the <code>WebACL</code> is associated with a CloudFront distribution and the viewer did not use an HTTP proxy or a load balancer to send the request, this is the value of the c-ip field in the CloudFront access logs.</p>"]
     #[serde(rename="IPSetDescriptors")]
@@ -737,7 +737,7 @@ pub struct IPSetDescriptor {
 }
 
 #[doc="<p>Contains the identifier and the name of the <code>IPSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IPSetSummary {
     #[doc="<p>The <code>IPSetId</code> for an <a>IPSet</a>. You can use <code>IPSetId</code> in a <a>GetIPSet</a> request to get detailed information about an <a>IPSet</a>.</p>"]
     #[serde(rename="IPSetId")]
@@ -748,7 +748,7 @@ pub struct IPSetSummary {
 }
 
 #[doc="<p>Specifies the type of update to perform to an <a>IPSet</a> with <a>UpdateIPSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct IPSetUpdate {
     #[doc="<p>Specifies whether to insert or delete an IP address with <a>UpdateIPSet</a>.</p>"]
     #[serde(rename="Action")]
@@ -758,7 +758,7 @@ pub struct IPSetUpdate {
     pub ip_set_descriptor: IPSetDescriptor,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListByteMatchSetsRequest {
     #[doc="<p>Specifies the number of <code>ByteMatchSet</code> objects that you want AWS WAF to return for this request. If you have more <code>ByteMatchSets</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>ByteMatchSet</code> objects.</p>"]
     #[serde(rename="Limit")]
@@ -770,7 +770,7 @@ pub struct ListByteMatchSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListByteMatchSetsResponse {
     #[doc="<p>An array of <a>ByteMatchSetSummary</a> objects.</p>"]
     #[serde(rename="ByteMatchSets")]
@@ -782,7 +782,7 @@ pub struct ListByteMatchSetsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIPSetsRequest {
     #[doc="<p>Specifies the number of <code>IPSet</code> objects that you want AWS WAF to return for this request. If you have more <code>IPSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>IPSet</code> objects.</p>"]
     #[serde(rename="Limit")]
@@ -794,7 +794,7 @@ pub struct ListIPSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListIPSetsResponse {
     #[doc="<p>An array of <a>IPSetSummary</a> objects.</p>"]
     #[serde(rename="IPSets")]
@@ -806,7 +806,7 @@ pub struct ListIPSetsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRateBasedRulesRequest {
     #[doc="<p>Specifies the number of <code>Rules</code> that you want AWS WAF to return for this request. If you have more <code>Rules</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>"]
     #[serde(rename="Limit")]
@@ -818,7 +818,7 @@ pub struct ListRateBasedRulesRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRateBasedRulesResponse {
     #[doc="<p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRateBasedRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -830,7 +830,7 @@ pub struct ListRateBasedRulesResponse {
     pub rules: Option<Vec<RuleSummary>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRulesRequest {
     #[doc="<p>Specifies the number of <code>Rules</code> that you want AWS WAF to return for this request. If you have more <code>Rules</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>"]
     #[serde(rename="Limit")]
@@ -842,7 +842,7 @@ pub struct ListRulesRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListRulesResponse {
     #[doc="<p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -854,7 +854,7 @@ pub struct ListRulesResponse {
     pub rules: Option<Vec<RuleSummary>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSizeConstraintSetsRequest {
     #[doc="<p>Specifies the number of <code>SizeConstraintSet</code> objects that you want AWS WAF to return for this request. If you have more <code>SizeConstraintSets</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>SizeConstraintSet</code> objects.</p>"]
     #[serde(rename="Limit")]
@@ -866,7 +866,7 @@ pub struct ListSizeConstraintSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSizeConstraintSetsResponse {
     #[doc="<p>If you have more <code>SizeConstraintSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SizeConstraintSet</code> objects, submit another <code>ListSizeConstraintSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -879,7 +879,7 @@ pub struct ListSizeConstraintSetsResponse {
 }
 
 #[doc="<p>A request to list the <a>SqlInjectionMatchSet</a> objects created by the current AWS account.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSqlInjectionMatchSetsRequest {
     #[doc="<p>Specifies the number of <a>SqlInjectionMatchSet</a> objects that you want AWS WAF to return for this request. If you have more <code>SqlInjectionMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>"]
     #[serde(rename="Limit")]
@@ -892,7 +892,7 @@ pub struct ListSqlInjectionMatchSetsRequest {
 }
 
 #[doc="<p>The response to a <a>ListSqlInjectionMatchSets</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListSqlInjectionMatchSetsResponse {
     #[doc="<p>If you have more <a>SqlInjectionMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SqlInjectionMatchSet</code> objects, submit another <code>ListSqlInjectionMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -904,7 +904,7 @@ pub struct ListSqlInjectionMatchSetsResponse {
     pub sql_injection_match_sets: Option<Vec<SqlInjectionMatchSetSummary>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListWebACLsRequest {
     #[doc="<p>Specifies the number of <code>WebACL</code> objects that you want AWS WAF to return for this request. If you have more <code>WebACL</code> objects than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>WebACL</code> objects.</p>"]
     #[serde(rename="Limit")]
@@ -916,7 +916,7 @@ pub struct ListWebACLsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListWebACLsResponse {
     #[doc="<p>If you have more <code>WebACL</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>WebACL</code> objects, submit another <code>ListWebACLs</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -929,7 +929,7 @@ pub struct ListWebACLsResponse {
 }
 
 #[doc="<p>A request to list the <a>XssMatchSet</a> objects created by the current AWS account.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListXssMatchSetsRequest {
     #[doc="<p>Specifies the number of <a>XssMatchSet</a> objects that you want AWS WAF to return for this request. If you have more <code>XssMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>"]
     #[serde(rename="Limit")]
@@ -942,7 +942,7 @@ pub struct ListXssMatchSetsRequest {
 }
 
 #[doc="<p>The response to a <a>ListXssMatchSets</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ListXssMatchSetsResponse {
     #[doc="<p>If you have more <a>XssMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>XssMatchSet</code> objects, submit another <code>ListXssMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>"]
     #[serde(rename="NextMarker")]
@@ -969,7 +969,7 @@ pub struct Predicate {
 }
 
 #[doc="<p>A <code>RateBasedRule</code> is identical to a regular <a>Rule</a>, with one addition: a <code>RateBasedRule</code> counts the number of requests that arrive from a specified IP address every five minutes. For example, based on recent requests that you've seen from an attacker, you might create a <code>RateBasedRule</code> that includes the following conditions: </p> <ul> <li> <p>The requests come from 192.0.2.44.</p> </li> <li> <p>They contain the value <code>BadBot</code> in the <code>User-Agent</code> header.</p> </li> </ul> <p>In the rule, you also define the rate limit as 15,000.</p> <p>Requests that meet both of these conditions and exceed 15,000 requests every five minutes trigger the rule's action (block or count), which is defined in the web ACL.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RateBasedRule {
     #[doc="<p>The <code>Predicates</code> object contains one <code>Predicate</code> element for each <a>ByteMatchSet</a>, <a>IPSet</a>, or <a>SqlInjectionMatchSet</a> object that you want to include in a <code>RateBasedRule</code>.</p>"]
     #[serde(rename="MatchPredicates")]
@@ -994,7 +994,7 @@ pub struct RateBasedRule {
 }
 
 #[doc="<p>A combination of <a>ByteMatchSet</a>, <a>IPSet</a>, and/or <a>SqlInjectionMatchSet</a> objects that identify the web requests that you want to allow, block, or count. For example, you might create a <code>Rule</code> that includes the following predicates:</p> <ul> <li> <p>An <code>IPSet</code> that causes AWS WAF to search for web requests that originate from the IP address <code>192.0.2.44</code> </p> </li> <li> <p>A <code>ByteMatchSet</code> that causes AWS WAF to search for web requests for which the value of the <code>User-Agent</code> header is <code>BadBot</code>.</p> </li> </ul> <p>To match the settings in this <code>Rule</code>, a request must originate from <code>192.0.2.44</code> AND include a <code>User-Agent</code> header for which the value is <code>BadBot</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Rule {
     #[doc="<p>A friendly name or description for the metrics for this <code>Rule</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change <code>MetricName</code> after you create the <code>Rule</code>.</p>"]
     #[serde(rename="MetricName")]
@@ -1013,7 +1013,7 @@ pub struct Rule {
 }
 
 #[doc="<p>Contains the identifier and the friendly name or description of the <code>Rule</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RuleSummary {
     #[doc="<p>A friendly name or description of the <a>Rule</a>. You can't change the name of a <code>Rule</code> after you create it.</p>"]
     #[serde(rename="Name")]
@@ -1024,7 +1024,7 @@ pub struct RuleSummary {
 }
 
 #[doc="<p>Specifies a <code>Predicate</code> (such as an <code>IPSet</code>) and indicates whether you want to add it to a <code>Rule</code> or delete it from a <code>Rule</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RuleUpdate {
     #[doc="<p>Specify <code>INSERT</code> to add a <code>Predicate</code> to a <code>Rule</code>. Use <code>DELETE</code> to remove a <code>Predicate</code> from a <code>Rule</code>.</p>"]
     #[serde(rename="Action")]
@@ -1035,7 +1035,7 @@ pub struct RuleUpdate {
 }
 
 #[doc="<p>The response from a <a>GetSampledRequests</a> request includes a <code>SampledHTTPRequests</code> complex type that appears as <code>SampledRequests</code> in the response syntax. <code>SampledHTTPRequests</code> contains one <code>SampledHTTPRequest</code> object for each web request that is returned by <code>GetSampledRequests</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SampledHTTPRequest {
     #[doc="<p>The action for the <code>Rule</code> that the request matched: <code>ALLOW</code>, <code>BLOCK</code>, or <code>COUNT</code>.</p>"]
     #[serde(rename="Action")]
@@ -1071,7 +1071,7 @@ pub struct SizeConstraint {
 }
 
 #[doc="<p>A complex type that contains <code>SizeConstraint</code> objects, which specify the parts of web requests that you want AWS WAF to inspect the size of. If a <code>SizeConstraintSet</code> contains more than one <code>SizeConstraint</code> object, a request only needs to match one constraint to be considered a match.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SizeConstraintSet {
     #[doc="<p>The name, if any, of the <code>SizeConstraintSet</code>.</p>"]
     #[serde(rename="Name")]
@@ -1086,7 +1086,7 @@ pub struct SizeConstraintSet {
 }
 
 #[doc="<p>The <code>Id</code> and <code>Name</code> of a <code>SizeConstraintSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SizeConstraintSetSummary {
     #[doc="<p>The name of the <code>SizeConstraintSet</code>, if any.</p>"]
     #[serde(rename="Name")]
@@ -1097,7 +1097,7 @@ pub struct SizeConstraintSetSummary {
 }
 
 #[doc="<p>Specifies the part of a web request that you want to inspect the size of and indicates whether you want to add the specification to a <a>SizeConstraintSet</a> or delete it from a <code>SizeConstraintSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SizeConstraintSetUpdate {
     #[doc="<p>Specify <code>INSERT</code> to add a <a>SizeConstraintSetUpdate</a> to a <a>SizeConstraintSet</a>. Use <code>DELETE</code> to remove a <code>SizeConstraintSetUpdate</code> from a <code>SizeConstraintSet</code>.</p>"]
     #[serde(rename="Action")]
@@ -1108,7 +1108,7 @@ pub struct SizeConstraintSetUpdate {
 }
 
 #[doc="<p>A complex type that contains <code>SqlInjectionMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for snippets of malicious SQL code and, if you want AWS WAF to inspect a header, the name of the header. If a <code>SqlInjectionMatchSet</code> contains more than one <code>SqlInjectionMatchTuple</code> object, a request needs to include snippets of SQL code in only one of the specified parts of the request to be considered a match.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SqlInjectionMatchSet {
     #[doc="<p>The name, if any, of the <code>SqlInjectionMatchSet</code>.</p>"]
     #[serde(rename="Name")]
@@ -1123,7 +1123,7 @@ pub struct SqlInjectionMatchSet {
 }
 
 #[doc="<p>The <code>Id</code> and <code>Name</code> of a <code>SqlInjectionMatchSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SqlInjectionMatchSetSummary {
     #[doc="<p>The name of the <code>SqlInjectionMatchSet</code>, if any, specified by <code>Id</code>.</p>"]
     #[serde(rename="Name")]
@@ -1134,7 +1134,7 @@ pub struct SqlInjectionMatchSetSummary {
 }
 
 #[doc="<p>Specifies the part of a web request that you want to inspect for snippets of malicious SQL code and indicates whether you want to add the specification to a <a>SqlInjectionMatchSet</a> or delete it from a <code>SqlInjectionMatchSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SqlInjectionMatchSetUpdate {
     #[doc="<p>Specify <code>INSERT</code> to add a <a>SqlInjectionMatchSetUpdate</a> to a <a>SqlInjectionMatchSet</a>. Use <code>DELETE</code> to remove a <code>SqlInjectionMatchSetUpdate</code> from a <code>SqlInjectionMatchSet</code>.</p>"]
     #[serde(rename="Action")]
@@ -1166,7 +1166,7 @@ pub struct TimeWindow {
     pub start_time: f64,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateByteMatchSetRequest {
     #[doc="<p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to update. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>"]
     #[serde(rename="ByteMatchSetId")]
@@ -1179,7 +1179,7 @@ pub struct UpdateByteMatchSetRequest {
     pub updates: Vec<ByteMatchSetUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateByteMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1187,7 +1187,7 @@ pub struct UpdateByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateIPSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1200,7 +1200,7 @@ pub struct UpdateIPSetRequest {
     pub updates: Vec<IPSetUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateIPSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1208,7 +1208,7 @@ pub struct UpdateIPSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRateBasedRuleRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1224,7 +1224,7 @@ pub struct UpdateRateBasedRuleRequest {
     pub updates: Vec<RuleUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRateBasedRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1232,7 +1232,7 @@ pub struct UpdateRateBasedRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRuleRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1245,7 +1245,7 @@ pub struct UpdateRuleRequest {
     pub updates: Vec<RuleUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateRuleResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1253,7 +1253,7 @@ pub struct UpdateRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSizeConstraintSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1266,7 +1266,7 @@ pub struct UpdateSizeConstraintSetRequest {
     pub updates: Vec<SizeConstraintSetUpdate>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSizeConstraintSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1275,7 +1275,7 @@ pub struct UpdateSizeConstraintSetResponse {
 }
 
 #[doc="<p>A request to update a <a>SqlInjectionMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSqlInjectionMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1289,7 +1289,7 @@ pub struct UpdateSqlInjectionMatchSetRequest {
 }
 
 #[doc="<p>The response to an <a>UpdateSqlInjectionMatchSets</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateSqlInjectionMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1297,7 +1297,7 @@ pub struct UpdateSqlInjectionMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateWebACLRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1315,7 +1315,7 @@ pub struct UpdateWebACLRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateWebACLResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1324,7 +1324,7 @@ pub struct UpdateWebACLResponse {
 }
 
 #[doc="<p>A request to update an <a>XssMatchSet</a>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateXssMatchSetRequest {
     #[doc="<p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1338,7 +1338,7 @@ pub struct UpdateXssMatchSetRequest {
 }
 
 #[doc="<p>The response to an <a>UpdateXssMatchSets</a> request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateXssMatchSetResponse {
     #[doc="<p>The <code>ChangeToken</code> that you used to submit the <code>UpdateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>"]
     #[serde(rename="ChangeToken")]
@@ -1355,7 +1355,7 @@ pub struct WafAction {
 }
 
 #[doc="<p>Contains the <code>Rules</code> that identify the requests that you want to allow, block, or count. In a <code>WebACL</code>, you also specify a default action (<code>ALLOW</code> or <code>BLOCK</code>), and the action for each <code>Rule</code> that you add to a <code>WebACL</code>, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the <code>WebACL</code> with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one <code>Rule</code> to a <code>WebACL</code>, a request needs to match only one of the specifications to be allowed, blocked, or counted. For more information, see <a>UpdateWebACL</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WebACL {
     #[doc="<p>The action to perform if none of the <code>Rules</code> contained in the <code>WebACL</code> match. The action is specified by the <a>WafAction</a> object.</p>"]
     #[serde(rename="DefaultAction")]
@@ -1377,7 +1377,7 @@ pub struct WebACL {
 }
 
 #[doc="<p>Contains the identifier and the name or description of the <a>WebACL</a>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WebACLSummary {
     #[doc="<p>A friendly name or description of the <a>WebACL</a>. You can't change the name of a <code>WebACL</code> after you create it.</p>"]
     #[serde(rename="Name")]
@@ -1388,7 +1388,7 @@ pub struct WebACLSummary {
 }
 
 #[doc="<p>Specifies whether to insert a <code>Rule</code> into or delete a <code>Rule</code> from a <code>WebACL</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WebACLUpdate {
     #[doc="<p>Specifies whether to insert a <code>Rule</code> into or delete a <code>Rule</code> from a <code>WebACL</code>.</p>"]
     #[serde(rename="Action")]
@@ -1399,7 +1399,7 @@ pub struct WebACLUpdate {
 }
 
 #[doc="<p>A complex type that contains <code>XssMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for cross-site scripting attacks and, if you want AWS WAF to inspect a header, the name of the header. If a <code>XssMatchSet</code> contains more than one <code>XssMatchTuple</code> object, a request needs to include cross-site scripting attacks in only one of the specified parts of the request to be considered a match.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct XssMatchSet {
     #[doc="<p>The name, if any, of the <code>XssMatchSet</code>.</p>"]
     #[serde(rename="Name")]
@@ -1414,7 +1414,7 @@ pub struct XssMatchSet {
 }
 
 #[doc="<p>The <code>Id</code> and <code>Name</code> of an <code>XssMatchSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct XssMatchSetSummary {
     #[doc="<p>The name of the <code>XssMatchSet</code>, if any, specified by <code>Id</code>.</p>"]
     #[serde(rename="Name")]
@@ -1425,7 +1425,7 @@ pub struct XssMatchSetSummary {
 }
 
 #[doc="<p>Specifies the part of a web request that you want to inspect for cross-site scripting attacks and indicates whether you want to add the specification to an <a>XssMatchSet</a> or delete it from an <code>XssMatchSet</code>.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct XssMatchSetUpdate {
     #[doc="<p>Specify <code>INSERT</code> to add a <a>XssMatchSetUpdate</a> to an <a>XssMatchSet</a>. Use <code>DELETE</code> to remove a <code>XssMatchSetUpdate</code> from an <code>XssMatchSet</code>.</p>"]
     #[serde(rename="Action")]

--- a/rusoto/services/workdocs/src/generated.rs
+++ b/rusoto/services/workdocs/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AbortDocumentVersionUploadRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -43,7 +43,7 @@ pub struct AbortDocumentVersionUploadRequest {
     pub version_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivateUserRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -54,7 +54,7 @@ pub struct ActivateUserRequest {
     pub user_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ActivateUserResponse {
     #[doc="<p>The user information.</p>"]
     #[serde(rename="User")]
@@ -63,7 +63,7 @@ pub struct ActivateUserResponse {
 }
 
 #[doc="<p>Describes the activity information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Activity {
     #[doc="<p>Metadata of the commenting activity. This is an optional field and is filled for commenting activities.</p>"]
     #[serde(rename="CommentMetadata")]
@@ -99,7 +99,7 @@ pub struct Activity {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddResourcePermissionsRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -113,7 +113,7 @@ pub struct AddResourcePermissionsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AddResourcePermissionsResponse {
     #[doc="<p>The share results.</p>"]
     #[serde(rename="ShareResults")]
@@ -122,7 +122,7 @@ pub struct AddResourcePermissionsResponse {
 }
 
 #[doc="<p>Describes a comment.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Comment {
     #[doc="<p>The ID of the comment.</p>"]
     #[serde(rename="CommentId")]
@@ -162,7 +162,7 @@ pub struct Comment {
 }
 
 #[doc="<p>Describes the metadata of a comment.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CommentMetadata {
     #[doc="<p>The ID of the comment.</p>"]
     #[serde(rename="CommentId")]
@@ -184,7 +184,7 @@ pub struct CommentMetadata {
     pub recipient_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCommentRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -217,7 +217,7 @@ pub struct CreateCommentRequest {
     pub visibility: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCommentResponse {
     #[doc="<p>The comment that has been created.</p>"]
     #[serde(rename="Comment")]
@@ -225,7 +225,7 @@ pub struct CreateCommentResponse {
     pub comment: Option<Comment>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCustomMetadataRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -243,10 +243,10 @@ pub struct CreateCustomMetadataRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateCustomMetadataResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFolderRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -261,7 +261,7 @@ pub struct CreateFolderRequest {
     pub parent_folder_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateFolderResponse {
     #[doc="<p>The metadata of the folder.</p>"]
     #[serde(rename="Metadata")]
@@ -269,7 +269,7 @@ pub struct CreateFolderResponse {
     pub metadata: Option<FolderMetadata>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLabelsRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -283,10 +283,10 @@ pub struct CreateLabelsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateLabelsResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNotificationSubscriptionRequest {
     #[doc="<p>The endpoint to receive the notifications. If the protocol is HTTPS, the endpoint is a URL that begins with \"https://\".</p>"]
     #[serde(rename="Endpoint")]
@@ -302,7 +302,7 @@ pub struct CreateNotificationSubscriptionRequest {
     pub subscription_type: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateNotificationSubscriptionResponse {
     #[doc="<p>The subscription.</p>"]
     #[serde(rename="Subscription")]
@@ -310,7 +310,7 @@ pub struct CreateNotificationSubscriptionResponse {
     pub subscription: Option<Subscription>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -346,7 +346,7 @@ pub struct CreateUserRequest {
     pub username: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateUserResponse {
     #[doc="<p>The user information.</p>"]
     #[serde(rename="User")]
@@ -354,7 +354,7 @@ pub struct CreateUserResponse {
     pub user: Option<User>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeactivateUserRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -365,7 +365,7 @@ pub struct DeactivateUserRequest {
     pub user_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCommentRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -382,7 +382,7 @@ pub struct DeleteCommentRequest {
     pub version_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCustomMetadataRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -405,10 +405,10 @@ pub struct DeleteCustomMetadataRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteCustomMetadataResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteDocumentRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -419,7 +419,7 @@ pub struct DeleteDocumentRequest {
     pub document_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFolderContentsRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -430,7 +430,7 @@ pub struct DeleteFolderContentsRequest {
     pub folder_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteFolderRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -441,7 +441,7 @@ pub struct DeleteFolderRequest {
     pub folder_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLabelsRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -460,10 +460,10 @@ pub struct DeleteLabelsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteLabelsResponse;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteNotificationSubscriptionRequest {
     #[doc="<p>The ID of the organization.</p>"]
     #[serde(rename="OrganizationId")]
@@ -473,7 +473,7 @@ pub struct DeleteNotificationSubscriptionRequest {
     pub subscription_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteUserRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -484,7 +484,7 @@ pub struct DeleteUserRequest {
     pub user_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeActivitiesRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -516,7 +516,7 @@ pub struct DescribeActivitiesRequest {
     pub user_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeActivitiesResponse {
     #[doc="<p>The marker for the next set of results.</p>"]
     #[serde(rename="Marker")]
@@ -528,7 +528,7 @@ pub struct DescribeActivitiesResponse {
     pub user_activities: Option<Vec<Activity>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCommentsRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -550,7 +550,7 @@ pub struct DescribeCommentsRequest {
     pub version_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeCommentsResponse {
     #[doc="<p>The list of comments for the specified document version.</p>"]
     #[serde(rename="Comments")]
@@ -562,7 +562,7 @@ pub struct DescribeCommentsResponse {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDocumentVersionsRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -589,7 +589,7 @@ pub struct DescribeDocumentVersionsRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeDocumentVersionsResponse {
     #[doc="<p>The document versions.</p>"]
     #[serde(rename="DocumentVersions")]
@@ -601,7 +601,7 @@ pub struct DescribeDocumentVersionsResponse {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFolderContentsRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -636,7 +636,7 @@ pub struct DescribeFolderContentsRequest {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeFolderContentsResponse {
     #[doc="<p>The documents in the specified folder.</p>"]
     #[serde(rename="Documents")]
@@ -652,7 +652,7 @@ pub struct DescribeFolderContentsResponse {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNotificationSubscriptionsRequest {
     #[doc="<p>The maximum number of items to return with this call.</p>"]
     #[serde(rename="Limit")]
@@ -667,7 +667,7 @@ pub struct DescribeNotificationSubscriptionsRequest {
     pub organization_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeNotificationSubscriptionsResponse {
     #[doc="<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>"]
     #[serde(rename="Marker")]
@@ -679,7 +679,7 @@ pub struct DescribeNotificationSubscriptionsResponse {
     pub subscriptions: Option<Vec<Subscription>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeResourcePermissionsRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -698,7 +698,7 @@ pub struct DescribeResourcePermissionsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeResourcePermissionsResponse {
     #[doc="<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>"]
     #[serde(rename="Marker")]
@@ -710,7 +710,7 @@ pub struct DescribeResourcePermissionsResponse {
     pub principals: Option<Vec<Principal>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRootFoldersRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -725,7 +725,7 @@ pub struct DescribeRootFoldersRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeRootFoldersResponse {
     #[doc="<p>The user's special folders.</p>"]
     #[serde(rename="Folders")]
@@ -737,7 +737,7 @@ pub struct DescribeRootFoldersResponse {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUsersRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -781,7 +781,7 @@ pub struct DescribeUsersRequest {
     pub user_ids: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeUsersResponse {
     #[doc="<p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>"]
     #[serde(rename="Marker")]
@@ -798,7 +798,7 @@ pub struct DescribeUsersResponse {
 }
 
 #[doc="<p>Describes the document.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentMetadata {
     #[doc="<p>The time when the document was created.</p>"]
     #[serde(rename="CreatedTimestamp")]
@@ -835,7 +835,7 @@ pub struct DocumentMetadata {
 }
 
 #[doc="<p>Describes a version of a document.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DocumentVersionMetadata {
     #[doc="<p>The time stamp when the content of the document was originally created.</p>"]
     #[serde(rename="ContentCreatedTimestamp")]
@@ -892,7 +892,7 @@ pub struct DocumentVersionMetadata {
 }
 
 #[doc="<p>Describes a folder.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FolderMetadata {
     #[doc="<p>The time when the folder was created.</p>"]
     #[serde(rename="CreatedTimestamp")]
@@ -940,14 +940,14 @@ pub struct FolderMetadata {
     pub size: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCurrentUserRequest {
     #[doc="<p>Amazon WorkDocs authentication token.</p>"]
     #[serde(rename="AuthenticationToken")]
     pub authentication_token: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetCurrentUserResponse {
     #[doc="<p>Metadata of the user.</p>"]
     #[serde(rename="User")]
@@ -955,7 +955,7 @@ pub struct GetCurrentUserResponse {
     pub user: Option<User>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentPathRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -978,7 +978,7 @@ pub struct GetDocumentPathRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentPathResponse {
     #[doc="<p>The path information.</p>"]
     #[serde(rename="Path")]
@@ -986,7 +986,7 @@ pub struct GetDocumentPathResponse {
     pub path: Option<ResourcePath>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -1001,7 +1001,7 @@ pub struct GetDocumentRequest {
     pub include_custom_metadata: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentResponse {
     #[doc="<p>The custom metadata on the document.</p>"]
     #[serde(rename="CustomMetadata")]
@@ -1013,7 +1013,7 @@ pub struct GetDocumentResponse {
     pub metadata: Option<DocumentMetadata>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentVersionRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -1035,7 +1035,7 @@ pub struct GetDocumentVersionRequest {
     pub version_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetDocumentVersionResponse {
     #[doc="<p>The custom metadata on the document version.</p>"]
     #[serde(rename="CustomMetadata")]
@@ -1047,7 +1047,7 @@ pub struct GetDocumentVersionResponse {
     pub metadata: Option<DocumentVersionMetadata>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFolderPathRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -1070,7 +1070,7 @@ pub struct GetFolderPathRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFolderPathResponse {
     #[doc="<p>The path information.</p>"]
     #[serde(rename="Path")]
@@ -1078,7 +1078,7 @@ pub struct GetFolderPathResponse {
     pub path: Option<ResourcePath>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFolderRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -1093,7 +1093,7 @@ pub struct GetFolderRequest {
     pub include_custom_metadata: Option<bool>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetFolderResponse {
     #[doc="<p>The custom metadata on the folder.</p>"]
     #[serde(rename="CustomMetadata")]
@@ -1106,7 +1106,7 @@ pub struct GetFolderResponse {
 }
 
 #[doc="<p>Describes the metadata of a user group.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GroupMetadata {
     #[doc="<p>The ID of the user group.</p>"]
     #[serde(rename="Id")]
@@ -1118,7 +1118,7 @@ pub struct GroupMetadata {
     pub name: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateDocumentVersionUploadRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -1153,7 +1153,7 @@ pub struct InitiateDocumentVersionUploadRequest {
     pub parent_folder_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct InitiateDocumentVersionUploadResponse {
     #[doc="<p>The document metadata.</p>"]
     #[serde(rename="Metadata")]
@@ -1166,7 +1166,7 @@ pub struct InitiateDocumentVersionUploadResponse {
 }
 
 #[doc="<p>Describes the users and/or user groups.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Participants {
     #[doc="<p>The list of user groups.</p>"]
     #[serde(rename="Groups")]
@@ -1179,7 +1179,7 @@ pub struct Participants {
 }
 
 #[doc="<p>Describes the permissions.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PermissionInfo {
     #[doc="<p>The role of the user.</p>"]
     #[serde(rename="Role")]
@@ -1192,7 +1192,7 @@ pub struct PermissionInfo {
 }
 
 #[doc="<p>Describes a resource.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Principal {
     #[doc="<p>The ID of the resource.</p>"]
     #[serde(rename="Id")]
@@ -1208,7 +1208,7 @@ pub struct Principal {
     pub type_: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveAllResourcePermissionsRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -1219,7 +1219,7 @@ pub struct RemoveAllResourcePermissionsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RemoveResourcePermissionRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -1238,7 +1238,7 @@ pub struct RemoveResourcePermissionRequest {
 }
 
 #[doc="<p>Describes the metadata of a resource.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourceMetadata {
     #[doc="<p>The ID of the resource.</p>"]
     #[serde(rename="Id")]
@@ -1271,7 +1271,7 @@ pub struct ResourceMetadata {
 }
 
 #[doc="<p>Describes the path information of a resource.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourcePath {
     #[doc="<p>The components of the resource path.</p>"]
     #[serde(rename="Components")]
@@ -1280,7 +1280,7 @@ pub struct ResourcePath {
 }
 
 #[doc="<p>Describes the resource path.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ResourcePathComponent {
     #[doc="<p>The ID of the resource path.</p>"]
     #[serde(rename="Id")]
@@ -1293,7 +1293,7 @@ pub struct ResourcePathComponent {
 }
 
 #[doc="<p>Describes the recipient type and ID, if available.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct SharePrincipal {
     #[doc="<p>The ID of the recipient.</p>"]
     #[serde(rename="Id")]
@@ -1307,7 +1307,7 @@ pub struct SharePrincipal {
 }
 
 #[doc="<p>Describes the share results of a resource.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ShareResult {
     #[doc="<p>The ID of the principal.</p>"]
     #[serde(rename="PrincipalId")]
@@ -1345,7 +1345,7 @@ pub struct StorageRuleType {
 }
 
 #[doc="<p>Describes a subscription.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Subscription {
     #[doc="<p>The endpoint of the subscription.</p>"]
     #[serde(rename="EndPoint")]
@@ -1361,7 +1361,7 @@ pub struct Subscription {
     pub subscription_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDocumentRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -1384,7 +1384,7 @@ pub struct UpdateDocumentRequest {
     pub resource_state: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateDocumentVersionRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -1402,7 +1402,7 @@ pub struct UpdateDocumentVersionRequest {
     pub version_status: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateFolderRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -1425,7 +1425,7 @@ pub struct UpdateFolderRequest {
     pub resource_state: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserRequest {
     #[doc="<p>Amazon WorkDocs authentication token. This field should not be set when using administrative API actions, as in accessing the API using AWS credentials.</p>"]
     #[serde(rename="AuthenticationToken")]
@@ -1460,7 +1460,7 @@ pub struct UpdateUserRequest {
     pub user_id: String,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UpdateUserResponse {
     #[doc="<p>The user information.</p>"]
     #[serde(rename="User")]
@@ -1469,7 +1469,7 @@ pub struct UpdateUserResponse {
 }
 
 #[doc="<p>Describes the upload.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UploadMetadata {
     #[doc="<p>The signed headers.</p>"]
     #[serde(rename="SignedHeaders")]
@@ -1482,7 +1482,7 @@ pub struct UploadMetadata {
 }
 
 #[doc="<p>Describes a user.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct User {
     #[doc="<p>The time when the user was created.</p>"]
     #[serde(rename="CreatedTimestamp")]
@@ -1547,7 +1547,7 @@ pub struct User {
 }
 
 #[doc="<p>Describes the metadata of the user.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserMetadata {
     #[doc="<p>The email address of the user.</p>"]
     #[serde(rename="EmailAddress")]
@@ -1572,7 +1572,7 @@ pub struct UserMetadata {
 }
 
 #[doc="<p>Describes the storage for a user.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserStorageMetadata {
     #[doc="<p>The storage for a user.</p>"]
     #[serde(rename="StorageRule")]

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
 #[doc="<p>Contains information about the compute type of a WorkSpace bundle.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ComputeType {
     #[doc="<p>The name of the compute type for the bundle.</p>"]
     #[serde(rename="Name")]
@@ -38,7 +38,7 @@ pub struct ComputeType {
 }
 
 #[doc="<p>The request of the <a>CreateTags</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTagsRequest {
     #[doc="<p>The resource ID of the request.</p>"]
     #[serde(rename="ResourceId")]
@@ -49,11 +49,11 @@ pub struct CreateTagsRequest {
 }
 
 #[doc="<p>The result of the <a>CreateTags</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateTagsResult;
 
 #[doc="<p>Contains the inputs for the <a>CreateWorkspaces</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateWorkspacesRequest {
     #[doc="<p>An array of structures that specify the WorkSpaces to create.</p>"]
     #[serde(rename="Workspaces")]
@@ -61,7 +61,7 @@ pub struct CreateWorkspacesRequest {
 }
 
 #[doc="<p>Contains the result of the <a>CreateWorkspaces</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct CreateWorkspacesResult {
     #[doc="<p>An array of structures that represent the WorkSpaces that could not be created.</p>"]
     #[serde(rename="FailedRequests")]
@@ -74,7 +74,7 @@ pub struct CreateWorkspacesResult {
 }
 
 #[doc="<p>Contains default WorkSpace creation information.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DefaultWorkspaceCreationProperties {
     #[doc="<p>The identifier of any custom security groups that are applied to the WorkSpaces when they are created.</p>"]
     #[serde(rename="CustomSecurityGroupId")]
@@ -99,7 +99,7 @@ pub struct DefaultWorkspaceCreationProperties {
 }
 
 #[doc="<p>The request of the <a>DeleteTags</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsRequest {
     #[doc="<p>The resource ID of the request.</p>"]
     #[serde(rename="ResourceId")]
@@ -110,11 +110,11 @@ pub struct DeleteTagsRequest {
 }
 
 #[doc="<p>The result of the <a>DeleteTags</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DeleteTagsResult;
 
 #[doc="<p>The request of the <a>DescribeTags</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsRequest {
     #[doc="<p>The resource ID of the request.</p>"]
     #[serde(rename="ResourceId")]
@@ -122,7 +122,7 @@ pub struct DescribeTagsRequest {
 }
 
 #[doc="<p>The result of the <a>DescribeTags</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeTagsResult {
     #[doc="<p>The list of tags.</p>"]
     #[serde(rename="TagList")]
@@ -131,7 +131,7 @@ pub struct DescribeTagsResult {
 }
 
 #[doc="<p>Contains the inputs for the <a>DescribeWorkspaceBundles</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkspaceBundlesRequest {
     #[doc="<p>An array of strings that contains the identifiers of the bundles to retrieve. This parameter cannot be combined with any other filter parameter.</p>"]
     #[serde(rename="BundleIds")]
@@ -148,7 +148,7 @@ pub struct DescribeWorkspaceBundlesRequest {
 }
 
 #[doc="<p>Contains the results of the <a>DescribeWorkspaceBundles</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkspaceBundlesResult {
     #[doc="<p>An array of structures that contain information about the bundles.</p>"]
     #[serde(rename="Bundles")]
@@ -161,7 +161,7 @@ pub struct DescribeWorkspaceBundlesResult {
 }
 
 #[doc="<p>Contains the inputs for the <a>DescribeWorkspaceDirectories</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkspaceDirectoriesRequest {
     #[doc="<p>An array of strings that contains the directory identifiers to retrieve information for. If this member is null, all directories are retrieved.</p>"]
     #[serde(rename="DirectoryIds")]
@@ -174,7 +174,7 @@ pub struct DescribeWorkspaceDirectoriesRequest {
 }
 
 #[doc="<p>Contains the results of the <a>DescribeWorkspaceDirectories</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkspaceDirectoriesResult {
     #[doc="<p>An array of structures that contain information about the directories.</p>"]
     #[serde(rename="Directories")]
@@ -186,7 +186,7 @@ pub struct DescribeWorkspaceDirectoriesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkspacesConnectionStatusRequest {
     #[doc="<p>The next token of the request.</p>"]
     #[serde(rename="NextToken")]
@@ -198,7 +198,7 @@ pub struct DescribeWorkspacesConnectionStatusRequest {
     pub workspace_ids: Option<Vec<String>>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkspacesConnectionStatusResult {
     #[doc="<p>The next token of the result.</p>"]
     #[serde(rename="NextToken")]
@@ -211,7 +211,7 @@ pub struct DescribeWorkspacesConnectionStatusResult {
 }
 
 #[doc="<p>Contains the inputs for the <a>DescribeWorkspaces</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkspacesRequest {
     #[doc="<p>The identifier of a bundle to obtain the WorkSpaces for. All WorkSpaces that are created from this bundle will be retrieved. This parameter cannot be combined with any other filter parameter.</p>"]
     #[serde(rename="BundleId")]
@@ -240,7 +240,7 @@ pub struct DescribeWorkspacesRequest {
 }
 
 #[doc="<p>Contains the results for the <a>DescribeWorkspaces</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct DescribeWorkspacesResult {
     #[doc="<p>If not null, more results are available. Pass this value for the <code>NextToken</code> parameter in a subsequent call to this operation to retrieve the next set of items. This token is valid for one day and must be used within that time frame.</p>"]
     #[serde(rename="NextToken")]
@@ -253,7 +253,7 @@ pub struct DescribeWorkspacesResult {
 }
 
 #[doc="<p>Contains information about a WorkSpace that could not be created.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailedCreateWorkspaceRequest {
     #[doc="<p>The error code.</p>"]
     #[serde(rename="ErrorCode")]
@@ -270,7 +270,7 @@ pub struct FailedCreateWorkspaceRequest {
 }
 
 #[doc="<p>Contains information about a WorkSpace that could not be rebooted (<a>RebootWorkspaces</a>), rebuilt (<a>RebuildWorkspaces</a>), terminated (<a>TerminateWorkspaces</a>), started (<a>StartWorkspaces</a>), or stopped (<a>StopWorkspaces</a>).</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FailedWorkspaceChangeRequest {
     #[doc="<p>The error code.</p>"]
     #[serde(rename="ErrorCode")]
@@ -286,7 +286,7 @@ pub struct FailedWorkspaceChangeRequest {
     pub workspace_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyWorkspacePropertiesRequest {
     #[doc="<p>The ID of the WorkSpace.</p>"]
     #[serde(rename="WorkspaceId")]
@@ -296,11 +296,11 @@ pub struct ModifyWorkspacePropertiesRequest {
     pub workspace_properties: WorkspaceProperties,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ModifyWorkspacePropertiesResult;
 
 #[doc="<p>Contains information used with the <a>RebootWorkspaces</a> operation to reboot a WorkSpace.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootRequest {
     #[doc="<p>The identifier of the WorkSpace to reboot.</p>"]
     #[serde(rename="WorkspaceId")]
@@ -308,7 +308,7 @@ pub struct RebootRequest {
 }
 
 #[doc="<p>Contains the inputs for the <a>RebootWorkspaces</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootWorkspacesRequest {
     #[doc="<p>An array of structures that specify the WorkSpaces to reboot.</p>"]
     #[serde(rename="RebootWorkspaceRequests")]
@@ -316,7 +316,7 @@ pub struct RebootWorkspacesRequest {
 }
 
 #[doc="<p>Contains the results of the <a>RebootWorkspaces</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebootWorkspacesResult {
     #[doc="<p>An array of structures representing any WorkSpaces that could not be rebooted.</p>"]
     #[serde(rename="FailedRequests")]
@@ -325,7 +325,7 @@ pub struct RebootWorkspacesResult {
 }
 
 #[doc="<p>Contains information used with the <a>RebuildWorkspaces</a> operation to rebuild a WorkSpace.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebuildRequest {
     #[doc="<p>The identifier of the WorkSpace to rebuild.</p>"]
     #[serde(rename="WorkspaceId")]
@@ -333,7 +333,7 @@ pub struct RebuildRequest {
 }
 
 #[doc="<p>Contains the inputs for the <a>RebuildWorkspaces</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebuildWorkspacesRequest {
     #[doc="<p>An array of structures that specify the WorkSpaces to rebuild.</p>"]
     #[serde(rename="RebuildWorkspaceRequests")]
@@ -341,7 +341,7 @@ pub struct RebuildWorkspacesRequest {
 }
 
 #[doc="<p>Contains the results of the <a>RebuildWorkspaces</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct RebuildWorkspacesResult {
     #[doc="<p>An array of structures representing any WorkSpaces that could not be rebuilt.</p>"]
     #[serde(rename="FailedRequests")]
@@ -350,7 +350,7 @@ pub struct RebuildWorkspacesResult {
 }
 
 #[doc="<p>Describes the start request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartRequest {
     #[doc="<p>The ID of the WorkSpace.</p>"]
     #[serde(rename="WorkspaceId")]
@@ -358,14 +358,14 @@ pub struct StartRequest {
     pub workspace_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartWorkspacesRequest {
     #[doc="<p>The requests.</p>"]
     #[serde(rename="StartWorkspaceRequests")]
     pub start_workspace_requests: Vec<StartRequest>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StartWorkspacesResult {
     #[doc="<p>The failed requests.</p>"]
     #[serde(rename="FailedRequests")]
@@ -374,7 +374,7 @@ pub struct StartWorkspacesResult {
 }
 
 #[doc="<p>Describes the stop request.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopRequest {
     #[doc="<p>The ID of the WorkSpace.</p>"]
     #[serde(rename="WorkspaceId")]
@@ -382,14 +382,14 @@ pub struct StopRequest {
     pub workspace_id: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopWorkspacesRequest {
     #[doc="<p>The requests.</p>"]
     #[serde(rename="StopWorkspaceRequests")]
     pub stop_workspace_requests: Vec<StopRequest>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct StopWorkspacesResult {
     #[doc="<p>The failed requests.</p>"]
     #[serde(rename="FailedRequests")]
@@ -410,7 +410,7 @@ pub struct Tag {
 }
 
 #[doc="<p>Contains information used with the <a>TerminateWorkspaces</a> operation to terminate a WorkSpace.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateRequest {
     #[doc="<p>The identifier of the WorkSpace to terminate.</p>"]
     #[serde(rename="WorkspaceId")]
@@ -418,7 +418,7 @@ pub struct TerminateRequest {
 }
 
 #[doc="<p>Contains the inputs for the <a>TerminateWorkspaces</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateWorkspacesRequest {
     #[doc="<p>An array of structures that specify the WorkSpaces to terminate.</p>"]
     #[serde(rename="TerminateWorkspaceRequests")]
@@ -426,7 +426,7 @@ pub struct TerminateWorkspacesRequest {
 }
 
 #[doc="<p>Contains the results of the <a>TerminateWorkspaces</a> operation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TerminateWorkspacesResult {
     #[doc="<p>An array of structures representing any WorkSpaces that could not be terminated.</p>"]
     #[serde(rename="FailedRequests")]
@@ -435,7 +435,7 @@ pub struct TerminateWorkspacesResult {
 }
 
 #[doc="<p>Contains information about the user storage for a WorkSpace bundle.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UserStorage {
     #[doc="<p>The amount of user storage for the bundle.</p>"]
     #[serde(rename="Capacity")]
@@ -444,7 +444,7 @@ pub struct UserStorage {
 }
 
 #[doc="<p>Contains information about a WorkSpace.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Workspace {
     #[doc="<p>The identifier of the bundle that the WorkSpace was created from.</p>"]
     #[serde(rename="BundleId")]
@@ -504,7 +504,7 @@ pub struct Workspace {
 }
 
 #[doc="<p>Contains information about a WorkSpace bundle.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkspaceBundle {
     #[doc="<p>The bundle identifier.</p>"]
     #[serde(rename="BundleId")]
@@ -533,7 +533,7 @@ pub struct WorkspaceBundle {
 }
 
 #[doc="<p>Describes the connection status of a WorkSpace.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkspaceConnectionStatus {
     #[doc="<p>The connection state of the WorkSpace. Returns UNKOWN if the WorkSpace is in a Stopped state.</p>"]
     #[serde(rename="ConnectionState")]
@@ -554,7 +554,7 @@ pub struct WorkspaceConnectionStatus {
 }
 
 #[doc="<p>Contains information about an AWS Directory Service directory for use with Amazon WorkSpaces.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct WorkspaceDirectory {
     #[doc="<p>The directory alias.</p>"]
     #[serde(rename="Alias")]

--- a/rusoto/services/xray/src/generated.rs
+++ b/rusoto/services/xray/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 #[doc="<p>An alias for an edge.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Alias {
     #[doc="<p>The canonical name of the alias.</p>"]
     #[serde(rename="Name")]
@@ -46,7 +46,7 @@ pub struct Alias {
 }
 
 #[doc="<p>Value of a segment annotation. Has one of three value types: Number, Boolean or String.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct AnnotationValue {
     #[doc="<p>Value for a Boolean annotation.</p>"]
     #[serde(rename="BooleanValue")]
@@ -63,7 +63,7 @@ pub struct AnnotationValue {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BackendConnectionErrors {
     #[doc="<p/>"]
     #[serde(rename="ConnectionRefusedCount")]
@@ -91,7 +91,7 @@ pub struct BackendConnectionErrors {
     pub unknown_host_count: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetTracesRequest {
     #[doc="<p>Pagination token. Not used.</p>"]
     #[serde(rename="NextToken")]
@@ -102,7 +102,7 @@ pub struct BatchGetTracesRequest {
     pub trace_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct BatchGetTracesResult {
     #[doc="<p>Pagination token. Not used.</p>"]
     #[serde(rename="NextToken")]
@@ -119,7 +119,7 @@ pub struct BatchGetTracesResult {
 }
 
 #[doc="<p>Information about a connection between two services.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Edge {
     #[doc="<p>Aliases for the edge.</p>"]
     #[serde(rename="Aliases")]
@@ -148,7 +148,7 @@ pub struct Edge {
 }
 
 #[doc="<p>Response statistics for an edge.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct EdgeStatistics {
     #[doc="<p>Information about requests that failed with a 4xx Client Error status code.</p>"]
     #[serde(rename="ErrorStatistics")]
@@ -173,7 +173,7 @@ pub struct EdgeStatistics {
 }
 
 #[doc="<p>Information about requests that failed with a 4xx Client Error status code.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ErrorStatistics {
     #[doc="<p>The number of requests that failed with untracked 4xx Client Error status codes.</p>"]
     #[serde(rename="OtherCount")]
@@ -190,7 +190,7 @@ pub struct ErrorStatistics {
 }
 
 #[doc="<p>Information about requests that failed with a 5xx Server Error status code.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct FaultStatistics {
     #[doc="<p>The number of requests that failed with untracked 5xx Server Error status codes.</p>"]
     #[serde(rename="OtherCount")]
@@ -202,7 +202,7 @@ pub struct FaultStatistics {
     pub total_count: Option<i64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetServiceGraphRequest {
     #[doc="<p>The end of the time frame for which to generate a graph.</p>"]
     #[serde(rename="EndTime")]
@@ -216,7 +216,7 @@ pub struct GetServiceGraphRequest {
     pub start_time: f64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetServiceGraphResult {
     #[doc="<p>The end of the time frame for which the graph was generated.</p>"]
     #[serde(rename="EndTime")]
@@ -236,7 +236,7 @@ pub struct GetServiceGraphResult {
     pub start_time: Option<f64>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTraceGraphRequest {
     #[doc="<p>Pagination token. Not used.</p>"]
     #[serde(rename="NextToken")]
@@ -247,7 +247,7 @@ pub struct GetTraceGraphRequest {
     pub trace_ids: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTraceGraphResult {
     #[doc="<p>Pagination token. Not used.</p>"]
     #[serde(rename="NextToken")]
@@ -259,7 +259,7 @@ pub struct GetTraceGraphResult {
     pub services: Option<Vec<Service>>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTraceSummariesRequest {
     #[doc="<p>The end of the time frame for which to retrieve traces.</p>"]
     #[serde(rename="EndTime")]
@@ -281,7 +281,7 @@ pub struct GetTraceSummariesRequest {
     pub start_time: f64,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct GetTraceSummariesResult {
     #[doc="<p>The start time of this page of results.</p>"]
     #[serde(rename="ApproximateTime")]
@@ -302,7 +302,7 @@ pub struct GetTraceSummariesResult {
 }
 
 #[doc="<p>An entry in a histogram for a statistic. A histogram maps the range of observed values on the X axis, and the prevalence of each value on the Y axis.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct HistogramEntry {
     #[doc="<p>The prevalence of the entry.</p>"]
     #[serde(rename="Count")]
@@ -315,7 +315,7 @@ pub struct HistogramEntry {
 }
 
 #[doc="<p>Information about an HTTP request.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Http {
     #[doc="<p>The IP address of the requestor.</p>"]
     #[serde(rename="ClientIp")]
@@ -339,7 +339,7 @@ pub struct Http {
     pub user_agent: Option<String>,
 }
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutTelemetryRecordsRequest {
     #[doc="<p/>"]
     #[serde(rename="EC2InstanceId")]
@@ -358,17 +358,17 @@ pub struct PutTelemetryRecordsRequest {
     pub telemetry_records: Vec<TelemetryRecord>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutTelemetryRecordsResult;
 
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutTraceSegmentsRequest {
     #[doc="<p>A string containing a JSON document defining one or more segments or subsegments.</p>"]
     #[serde(rename="TraceSegmentDocuments")]
     pub trace_segment_documents: Vec<String>,
 }
 
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct PutTraceSegmentsResult {
     #[doc="<p>Segments that failed processing.</p>"]
     #[serde(rename="UnprocessedTraceSegments")]
@@ -377,7 +377,7 @@ pub struct PutTraceSegmentsResult {
 }
 
 #[doc="<p>A segment from a trace that has been ingested by the X-Ray service. The segment can be compiled from documents uploaded with <a>PutTraceSegments</a>, or an <code>inferred</code> segment for a downstream service, generated from a subsegment sent by the service that called it.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Segment {
     #[doc="<p>The segment document</p>"]
     #[serde(rename="Document")]
@@ -390,7 +390,7 @@ pub struct Segment {
 }
 
 #[doc="<p>Information about an application that processed requests, users that made requests, or downstream services, resources and applications that an application used.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Service {
     #[doc="<p>Identifier of the AWS account in which the service runs.</p>"]
     #[serde(rename="AccountId")]
@@ -447,7 +447,7 @@ pub struct Service {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ServiceId {
     #[doc="<p/>"]
     #[serde(rename="AccountId")]
@@ -468,7 +468,7 @@ pub struct ServiceId {
 }
 
 #[doc="<p>Response statistics for a service.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ServiceStatistics {
     #[doc="<p>Information about requests that failed with a 4xx Client Error status code.</p>"]
     #[serde(rename="ErrorStatistics")]
@@ -493,7 +493,7 @@ pub struct ServiceStatistics {
 }
 
 #[doc="<p/>"]
-#[derive(Default,Debug,Clone,Serialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TelemetryRecord {
     #[doc="<p/>"]
     #[serde(rename="BackendConnectionErrors")]
@@ -522,7 +522,7 @@ pub struct TelemetryRecord {
 }
 
 #[doc="<p>A collection of segment documents with matching trace IDs.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct Trace {
     #[doc="<p>The length of time in seconds between the start time of the root segment and the end time of the last segment that completed.</p>"]
     #[serde(rename="Duration")]
@@ -539,7 +539,7 @@ pub struct Trace {
 }
 
 #[doc="<p>Metadata generated from the segment documents in a trace.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TraceSummary {
     #[doc="<p>Annotations from the trace's segment documents.</p>"]
     #[serde(rename="Annotations")]
@@ -588,7 +588,7 @@ pub struct TraceSummary {
 }
 
 #[doc="<p>Information about a user recorded in segment documents.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct TraceUser {
     #[doc="<p>Services that the user's request hit.</p>"]
     #[serde(rename="ServiceIds")]
@@ -601,7 +601,7 @@ pub struct TraceUser {
 }
 
 #[doc="<p>Information about a segment that failed processing.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct UnprocessedTraceSegment {
     #[doc="<p>The error that caused processing to fail.</p>"]
     #[serde(rename="ErrorCode")]
@@ -618,7 +618,7 @@ pub struct UnprocessedTraceSegment {
 }
 
 #[doc="<p>Information about a segment annotation.</p>"]
-#[derive(Default,Debug,Clone,Deserialize)]
+#[derive(Default,Debug,Clone,Serialize,Deserialize)]
 pub struct ValueWithServiceIds {
     #[doc="<p>Values of the annotation.</p>"]
     #[serde(rename="AnnotationValue")]

--- a/service_crategen/src/commands/generate/codegen/json.rs
+++ b/service_crategen/src/commands/generate/codegen/json.rs
@@ -85,15 +85,7 @@ impl GenerateProtocol for JsonGenerator {
                                   serialized: bool,
                                   deserialized: bool)
                                   -> String {
-        let mut derived = vec!["Default", "Debug", "Clone"];
-
-        if serialized {
-            derived.push("Serialize");
-        }
-
-        if deserialized {
-            derived.push("Deserialize")
-        }
+        let mut derived = vec!["Default", "Debug", "Clone", "Serialize", "Deserialize"];
 
         format!("#[derive({})]", derived.join(","))
     }

--- a/service_crategen/src/commands/generate/codegen/json.rs
+++ b/service_crategen/src/commands/generate/codegen/json.rs
@@ -82,10 +82,10 @@ impl GenerateProtocol for JsonGenerator {
     }
 
     fn generate_struct_attributes(&self,
-                                  serialized: bool,
-                                  deserialized: bool)
+                                  _serialized: bool,
+                                  _deserialized: bool)
                                   -> String {
-        let mut derived = vec!["Default", "Debug", "Clone", "Serialize", "Deserialize"];
+        let derived = vec!["Default", "Debug", "Clone", "Serialize", "Deserialize"];
 
         format!("#[derive({})]", derived.join(","))
     }

--- a/service_crategen/src/commands/generate/codegen/rest_json.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_json.rs
@@ -117,15 +117,7 @@ impl GenerateProtocol for RestJsonGenerator {
     }
 
     fn generate_struct_attributes(&self, serialized: bool, deserialized: bool) -> String {
-        let mut derived = vec!["Default", "Debug", "Clone"];
-
-        if serialized {
-            derived.push("Serialize");
-        }
-
-        if deserialized {
-            derived.push("Deserialize")
-        }
+        let mut derived = vec!["Default", "Debug", "Clone", "Serialize", "Deserialize"];
 
         format!("#[derive({})]", derived.join(","))
     }

--- a/service_crategen/src/commands/generate/codegen/rest_json.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_json.rs
@@ -116,8 +116,8 @@ impl GenerateProtocol for RestJsonGenerator {
 
     }
 
-    fn generate_struct_attributes(&self, serialized: bool, deserialized: bool) -> String {
-        let mut derived = vec!["Default", "Debug", "Clone", "Serialize", "Deserialize"];
+    fn generate_struct_attributes(&self, _serialized: bool, _deserialized: bool) -> String {
+        let derived = vec!["Default", "Debug", "Clone", "Serialize", "Deserialize"];
 
         format!("#[derive({})]", derived.join(","))
     }

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -120,7 +120,7 @@ impl GenerateProtocol for RestXmlGenerator {
                                   _serialized: bool,
                                   _deserialized: bool)
                                   -> String {
-        let derived = vec!["Default", "Debug"];
+        let derived = vec!["Default", "Debug", "Serialize", "Deserialize"];
 
         format!("#[derive({})]", derived.join(","))
     }

--- a/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
+++ b/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
@@ -5,7 +5,7 @@ use botocore::{Member, Operation, Shape, ShapeType};
 use super::{generate_field_name, mutate_type_name, mutate_type_name_for_streaming};
 
 pub fn generate_struct_attributes(_deserialized: bool) -> String {
-    let derived = vec!["Default", "Debug", "Clone"];
+    let derived = vec!["Default", "Debug", "Clone", "Serialize", "Deserialize"];
     format!("#[derive({})]", derived.join(","))
 }
 


### PR DESCRIPTION
I understand if this is outside the responsibilities of rusoto itself, but I'm working on a tool for which this functionality would be a huge help. The ability to serialize/deserialize values from rusoto inputs/outputs into arbitrary structures is a hugely simplifying shortcut from user config to AWS actions.