### PR TITLE
replace ring by hmac/sha2

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -24,14 +24,15 @@ appveyor = { repository = "rusoto/rusoto", branch = "master" }
 rustc_version = "0.2.1"
 
 [dependencies]
+hmac = "0.5.0"
 hyper = "0.10.0"
 hyper-native-tls = "0.2.1"
 lazy_static = "0.2.1"
 log = "0.3.6"
-ring = "0.12"
 base64 = "0.6"
 hex = "0.2"
 serde = "1.0.2"
+sha2 = "0.7.0"
 time = "0.1.35"
 url = "1.2.0"
 xml-rs = "0.7"

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -45,11 +45,12 @@ extern crate hyper_native_tls;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-extern crate ring;
 extern crate hex;
+extern crate hmac;
 extern crate base64;
 pub extern crate rusoto_credential as credential;
 extern crate serde;
+extern crate sha2;
 extern crate time;
 extern crate url;
 extern crate xml;


### PR DESCRIPTION
`ring` is broken on current nightly (see https://github.com/briansmith/ring/issues/598), which prompted me to investigate this change.

[`hmac`](https://crates.io/crates/hmac) and [`sha2`](https://crates.io/crates/sha2) are published by the `RustCrypto` folks, and are a much more lightweight dependency than all of `ring`, especially since it's being used for hashing/hmac only.

This is more of a proposal than anything else (and a quick change to make my stuff that depends on rusoto usable on nightly again), so I'm totally fine if you'd prefer sticking to `ring` .