### PR TITLE
mark dynamodb example as "no_run" rather than "ignore"

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -50,6 +50,10 @@ rand = "^0.3.14"
 serde_json = "1.0.1"
 serde_test = "1.0.1"
 
+[dev-dependencies.rusoto_dynamodb]
+path = "../services/dynamodb"
+version = "0.30"
+
 [features]
 nightly-testing = ["clippy", "rusoto_credential/nightly-testing"]
 unstable = []

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -13,30 +13,36 @@
 //! The following code shows a simple example of using Rusoto's DynamoDB API to
 //! list the names of all tables in a database.
 //!
-//! ```rust,ignore
-//! use rusoto_core::{DefaultCredentialsProvider, Region};
+//! ```rust,no_run
+//! extern crate rusoto_core;
+//! extern crate rusoto_dynamodb;
+//!
+//! use rusoto_core::{default_tls_client, DefaultCredentialsProvider, Region};
 //! use rusoto_dynamodb::{DynamoDb, DynamoDbClient, ListTablesInput};
 //!
-//! let provider = DefaultCredentialsProvider::new().unwrap();
-//! let client = DynamoDbClient::new(provider, Region::UsEast1);
-//! let list_tables_input: ListTablesInput = Default::default();
+//! fn main() {
+//!     let dispatcher = default_tls_client().unwrap();
+//!     let provider = DefaultCredentialsProvider::new().unwrap();
+//!     let client = DynamoDbClient::new(dispatcher, provider, Region::UsEast1);
+//!     let list_tables_input: ListTablesInput = Default::default();
 //!
-//! match client.list_tables(&list_tables_input) {
-//!     Ok(output) => {
-//!         match output.table_names {
-//!             Some(table_name_list) => {
-//!                 println!("Tables in database:");
+//!     match client.list_tables(&list_tables_input) {
+//!         Ok(output) => {
+//!             match output.table_names {
+//!                 Some(table_name_list) => {
+//!                     println!("Tables in database:");
 //!
-//!                 for table_name in table_name_list {
-//!                     println!("{}", table_name);
-//!                 }
-//!             },
-//!             None => println!("No tables in database!"),
-//!         }
-//!     },
-//!     Err(error) => {
-//!         println!("Error: {:?}", error);
-//!     },
+//!                     for table_name in table_name_list {
+//!                         println!("{}", table_name);
+//!                     }
+//!                 },
+//!                 None => println!("No tables in database!"),
+//!             }
+//!         },
+//!         Err(error) => {
+//!             println!("Error: {:?}", error);
+//!         },
+//!     }
 //! }
 
 extern crate hyper;


### PR DESCRIPTION
Related to the discussion in #904, this marks the DynamoDB example in `rusoto_core` as `no_run` rather than `ignore`.

The difference is that while `ignore` causes the doc-tests to skip the code completely, `no_run` still triggers a compilation of the code, but prevents the code from running.

This seems to be exactly what we want for local development, as contributors might not have access to an AWS account to test their changes, but we'd want to catch breaking API changes that make the examples invalid.

Case in point, this PR also corrects the example code itself since the `DynamoDbClient` was not being constructed correctly.