### PR TITLE
remove AsciiExt imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: rust
 cache: cargo
 # run builds for all the trains (and more)
 rust:
+  - 1.23.0 # test against minimum Rust version supported
   - stable
   - beta
   - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
  
 - Allow setting both, Region name and endpoint, via `Region::Custom`
 - Added China-northwest, US-Gov-West & Paris regions
-
 - Switched crategen from rustfmt to rustfmt-nightly
+- Removed unused AsciiExt imports 
 
 ## [0.30.0] - 2017-12-02
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You may be looking for:
 
 ## Requirements
 
-Rust 1.17.0 or later is required.
+Rust 1.23.0 or later is required.
 
 On Linux, OpenSSL is required.
 

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(feature = "nightly-testing", plugin(clippy))]
 #![cfg_attr(feature = "nightly-testing", allow(cyclomatic_complexity, used_underscore_binding, ptr_arg, suspicious_else_formatting))]
 #![allow(dead_code)]
+#![cfg_attr(not(feature = "unstable"), deny(warnings))]
 #![deny(missing_docs)]
 
 //! Rusoto is an [AWS](https://aws.amazon.com/) SDK for Rust.

--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -6,7 +6,6 @@
 //! If needed, the request will be re-issued to a temporary redirect endpoint.  This can happen with
 //! newly created S3 buckets not in us-standard/us-east-1.
 
-use std::ascii::AsciiExt;
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::str;

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(feature = "nightly-testing", feature(plugin))]
 #![cfg_attr(feature = "nightly-testing", plugin(clippy))]
+#![cfg_attr(not(feature = "unstable"), deny(warnings))]
 #![deny(missing_docs)]
 
 //! Types for loading and managing AWS access credentials for API requests.

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -1,7 +1,6 @@
 //! The Credentials Provider for Credentials stored in a profile inside of a Credentials file.
 
 use regex::Regex;
-use std::ascii::AsciiExt;
 use std::collections::HashMap;
 use std::env::{home_dir, var as env_var};
 use std::fs;


### PR DESCRIPTION
Fixes #885 by reverting the changes done in 8b69b198ccc3bbb7d1c15dda8bc40afba55a9478.

Also sets up Travis to test against the minimum supported Rust version in addition to stable/beta/nightly. This will help us ensure that we keep compatibility to 1.23 until we make a conscious choice to bump the minimum supported version.