### PR TITLE
only cargo-check integration tests on travis and appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   - |
       echo "Building integration tests" &&
       ( cd integration_tests && \
-        cargo test --features "all" --no-run && \
+        cargo check --tests --features "all" && \
         cd .. )
   - |
       echo "Running cargo docs on stable Rust on Linux" &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ test_script:
   - cargo update
   - cargo test --all --lib -v
   - cd integration_tests
-  - cargo test --features "all" --no-run
+  - cargo check --tests --features "all"
   - cd ..
 
 branches:


### PR DESCRIPTION
We've started to regularly run into the Travis time-outs again.

Since the integration tests are not being run, but only compiled (and then the compilation results discarded as the build exits), this PR changes the Travis and Appveyor tests to only `cargo check` the integration tests. This should shave some time off the builds.

I would advocate that for running integration tests in CI at a later point we use a separate pipeline (maybe use CircleCI or a custom Jenkins setup rather than chucking it on top of the existing ones), so we have a clean separation of concerns and keep the build times in check.
  