### PR TITLE
Adding a public constructor to StreamingBody to facilitate mocking/testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Allow setting both, Region name and endpoint, via `Region::Custom`
 - Added China-northwest, US-Gov-West & Paris regions
 - Switched crategen from rustfmt to rustfmt-nightly
-- Removed unused AsciiExt imports 
+- Removed unused AsciiExt imports
+- S3 StreamingBody now has public constructor 
 
 ## [0.30.0] - 2017-12-02
 

--- a/rusoto/services/s3/src/custom/custom_tests.rs
+++ b/rusoto/services/s3/src/custom/custom_tests.rs
@@ -4,6 +4,7 @@ use ::*;
 
 use rusoto_core::{Region, SignedRequest};
 use self::rusoto_mock::*;
+use std::fs::File;
 
 #[test]
 fn initiate_multipart_upload_happy_path() {
@@ -323,6 +324,15 @@ fn should_parse_location_constraint() {
             assert_eq!(sstr("EU"), result.location_constraint);
         }
     }
+}
+
+#[test]
+fn can_construct_streaming_body() {
+    let test_body = File::open("test_resources/custom/s3_simple_body.txt").expect("couldn't find test_resources/custom/s3_simple_body.txt");
+    let mut streaming_body = StreamingBody::new(test_body);
+    let mut read_string = String::new();
+    let _bytes = streaming_body.read_to_string(&mut read_string);
+    assert_eq!("Simple Body Test", read_string);
 }
 
 /// returns Some(String)

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -1029,8 +1029,8 @@ impl AnalyticsS3ExportFileFormatSerializer {
 pub struct StreamingBody(Box<Read>);
 
 impl StreamingBody {
-    pub fn new(read: Box<Read>) -> StreamingBody {
-        StreamingBody(read)
+    pub fn new<R: Read + 'static>(read: R) -> StreamingBody {
+        StreamingBody(Box::new(read))
     }
 }
 

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -1028,6 +1028,12 @@ impl AnalyticsS3ExportFileFormatSerializer {
 
 pub struct StreamingBody(Box<Read>);
 
+impl StreamingBody {
+    pub fn new(read: Box<Read>) -> StreamingBody {
+        StreamingBody(read)
+    }
+}
+
 impl fmt::Debug for StreamingBody {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<Body: streaming content>")

--- a/rusoto/services/s3/test_resources/custom/s3_simple_body.txt
+++ b/rusoto/services/s3/test_resources/custom/s3_simple_body.txt
@@ -1,0 +1,1 @@
+Simple Body Test

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -314,8 +314,8 @@ fn generate_types<P>(writer: &mut FileWriter, service: &Service, protocol_genera
                      "pub struct {streaming_name}(Box<Read>);
 
                      impl {streaming_name} {{
-                         pub fn new(read: Box<Read>) -> {streaming_name} {{
-                             {streaming_name}(read)
+                         pub fn new<R: Read + 'static>(read: R) -> {streaming_name} {{
+                             {streaming_name}(Box::new(read))
                          }}
                      }}
 

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -313,6 +313,12 @@ fn generate_types<P>(writer: &mut FileWriter, service: &Service, protocol_genera
             writeln!(writer,
                      "pub struct {streaming_name}(Box<Read>);
 
+                     impl {streaming_name} {{
+                         pub fn new(read: Box<Read>) -> {streaming_name} {{
+                             {streaming_name}(read)
+                         }}
+                     }}
+
                      impl fmt::Debug for {streaming_name} {{
                          fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{
                              write!(f, \"<{name}: streaming content>\")


### PR DESCRIPTION
This fixes Issue #919 which I created earlier today