### PR TITLE
Fix #944 Flickering profile provider test

### DIFF
--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -407,6 +407,7 @@ mod tests {
 
     #[test]
     fn profile_provider_profile_name() {
+        let _guard = lock(&ENV_MUTEX);
         let mut provider = ProfileProvider::new().unwrap();
         assert_eq!("default", provider.profile());
         provider.set_profile("foo");


### PR DESCRIPTION
This fixes #944 by ensuring that all test that rely on environment variables synchronize on ENV_MUTEX.