### PR TITLE
Update sample for running crategen check command.

### DIFF
--- a/service_crategen/README.md
+++ b/service_crategen/README.md
@@ -43,7 +43,7 @@ This will tests service crates, in addition to the `rusoto_core` crate.
 The crate generator is also able to check for any missing or outdated services with the `check` command:
 
 ```bash
-$ cargo run -- check -c ./services.json
+$ cargo +nightly run -- check -c ./services.json
 ```
 
 If there are any missing or outdated services, they will be output in a formatted list along with useful information.


### PR DESCRIPTION
Since the move to requiring nightly Rust in the crategen crate for `rustfmt`, our docs got out of sync. This updates it.

Found when updating https://github.com/rusoto/rusoto/issues/436 . 😄 