### PR TITLE
Relax what HTTP status code we accept when the definition doesn't spe…

### DIFF
--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AddTagsToCertificateRequest {
     /// <p>String that contains the ARN of the ACM Certificate to which the tag is to be applied. This must be of the form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>. </p>

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -17114,7 +17114,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17154,7 +17154,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17206,7 +17206,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17247,7 +17247,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17296,7 +17296,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17337,7 +17337,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17386,7 +17386,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17426,7 +17426,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17472,7 +17472,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17521,7 +17521,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17570,7 +17570,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17610,7 +17610,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17670,7 +17670,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17710,7 +17710,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17758,7 +17758,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17798,7 +17798,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17844,7 +17844,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17937,7 +17937,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -17986,7 +17986,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18028,7 +18028,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18065,7 +18065,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18104,7 +18104,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18141,7 +18141,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18185,7 +18185,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18226,7 +18226,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18272,7 +18272,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18313,7 +18313,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18362,7 +18362,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18408,7 +18408,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18462,7 +18462,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18496,7 +18496,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18542,7 +18542,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18624,7 +18624,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18669,7 +18669,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18707,7 +18707,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18750,7 +18750,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18793,7 +18793,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18844,7 +18844,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18884,7 +18884,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18977,7 +18977,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19026,7 +19026,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19060,7 +19060,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19106,7 +19106,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19205,7 +19205,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19519,7 +19519,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19592,7 +19592,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19638,7 +19638,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19710,7 +19710,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19750,7 +19750,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19794,7 +19794,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19838,7 +19838,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19881,7 +19881,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19925,7 +19925,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19968,7 +19968,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20011,7 +20011,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20054,7 +20054,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20098,7 +20098,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20143,7 +20143,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20183,7 +20183,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20228,7 +20228,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20309,7 +20309,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20353,7 +20353,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20397,7 +20397,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20437,7 +20437,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20478,7 +20478,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20519,7 +20519,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20562,7 +20562,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20602,7 +20602,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -28,6 +27,7 @@ use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::param::{Params, ServiceParams};
+use hyper::StatusCode;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;

--- a/rusoto/services/application-autoscaling/src/generated.rs
+++ b/rusoto/services/application-autoscaling/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Represents a CloudWatch alarm associated with a scaling policy.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct Alarm {

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Describes an application in the application catalog.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct Application {

--- a/rusoto/services/athena/src/generated.rs
+++ b/rusoto/services/athena/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct BatchGetNamedQueryInput {
     /// <p>An array of query IDs.</p>

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -2507,7 +2507,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2547,7 +2547,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2588,7 +2588,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2628,7 +2628,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2669,7 +2669,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2709,7 +2709,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2750,7 +2750,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2792,7 +2792,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2833,7 +2833,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2874,7 +2874,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2911,7 +2911,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2951,7 +2951,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -2992,7 +2992,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -3032,7 +3032,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -3072,7 +3072,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -3113,7 +3113,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 

--- a/rusoto/services/budgets/src/generated.rs
+++ b/rusoto/services/budgets/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>AWS Budget model</p>
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Budget {

--- a/rusoto/services/clouddirectory/src/generated.rs
+++ b/rusoto/services/clouddirectory/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -27,6 +26,7 @@ use rusoto_core::request::HttpDispatchError;
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
+use hyper::StatusCode;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -39,6 +38,7 @@ use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
+use hyper::StatusCode;
 enum DeserializerNext {
     Close,
     Skip,

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AddTagsToResourceRequest {
     /// <p>The Amazon Resource Name (ARN) of the AWS CloudHSM resource to tag.</p>

--- a/rusoto/services/cloudhsmv2/src/generated.rs
+++ b/rusoto/services/cloudhsmv2/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Contains information about a backup of an AWS CloudHSM cluster.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct Backup {

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/cloudsearchdomain/src/generated.rs
+++ b/rusoto/services/cloudsearchdomain/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;

--- a/rusoto/services/cloudsearchdomain/src/generated.rs
+++ b/rusoto/services/cloudsearchdomain/src/generated.rs
@@ -681,7 +681,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -726,7 +726,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -771,7 +771,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Specifies the tags to add to a trail.</p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AddTagsRequest {

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/codebuild/src/generated.rs
+++ b/rusoto/services/codebuild/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct BatchDeleteBuildsInput {
     /// <p>The IDs of the builds to delete.</p>

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Represents the input of a batch get repositories operation.</p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct BatchGetRepositoriesInput {

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Represents the input of, and adds tags to, an on-premises instance operation.</p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AddTagsToOnPremisesInstancesInput {

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Represents an AWS session credentials object. These credentials are temporary credentials that are issued by AWS Secure Token Service (STS). They can be used to access input and output artifacts in the Amazon S3 bucket used to store artifact for the pipeline in AWS CodePipeline.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AWSSessionCredentials {

--- a/rusoto/services/codestar/src/generated.rs
+++ b/rusoto/services/codestar/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AssociateTeamMemberRequest {
     /// <p>A user- or system-generated token that identifies the entity that requested the team member association to the project. This token can be used to repeat the request.</p>

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>A provider representing an Amazon Cognito Identity User Pool and its client ID.</p>
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct CognitoIdentityProvider {

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Account takeover action type.</p>
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct AccountTakeoverActionType {

--- a/rusoto/services/cognito-sync/src/generated.rs
+++ b/rusoto/services/cognito-sync/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -28,6 +27,7 @@ use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::param::{Params, ServiceParams};
+use hyper::StatusCode;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Indicates whether an AWS resource or AWS Config rule is compliant and provides the number of contributors that affect the compliance.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct Compliance {

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Request of DeleteReportDefinition</p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct DeleteReportDefinitionRequest {

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Contains the parameters for ActivatePipeline.</p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct ActivatePipelineInput {

--- a/rusoto/services/dax/src/generated.rs
+++ b/rusoto/services/dax/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Contains all of the attributes of a specific DAX cluster.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct Cluster {

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>A container for account-level settings within AWS Device Farm.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AccountSettings {

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Container for the parameters to the AllocateConnectionOnInterconnect operation.</p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AllocateConnectionOnInterconnectRequest {

--- a/rusoto/services/discovery/src/generated.rs
+++ b/rusoto/services/discovery/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Information about agents or connectors that were instructed to start collecting data. Information includes the agent/connector ID, a description of the operation, and whether the agent/connector configuration was updated.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AgentConfigurationStatus {

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Describes a quota for an AWS account, for example, the number of replication instances allowed.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AccountQuota {

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AddIpRoutesRequest {
     /// <p>Identifier (ID) of the directory to which to add the address block.</p>

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Represents an attribute for describing the key schema for the table and indexes.</p>
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct AttributeDefinition {

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Represents the data for an attribute. You can set one, and only one, of the elements.</p> <p>Each attribute in an item is a name-value pair. An attribute can be single-valued or multi-valued set. For example, a book item can have title and authors attributes. Each book has one title but can have many authors. The multi-valued attribute is a set; duplicate values are not allowed.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AttributeValue {

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>An object representing authorization data for an Amazon ECR registry.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AuthorizationData {

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>An object representing a container instance or task attachment.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct Attachment {

--- a/rusoto/services/efs/src/generated.rs
+++ b/rusoto/services/efs/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -28,6 +27,7 @@ use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::param::{Params, ServiceParams};
+use hyper::StatusCode;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -28,6 +27,7 @@ use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::param::{Params, ServiceParams};
+use hyper::StatusCode;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -3458,7 +3458,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -3506,7 +3506,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -3553,7 +3553,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -3600,7 +3600,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -3635,7 +3635,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -3673,7 +3673,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -3711,7 +3711,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -3831,7 +3831,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -3874,7 +3874,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AddInstanceFleetInput {
     /// <p>The unique identifier of the cluster.</p>

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct DeleteRuleRequest {
     /// <p>The name of the rule.</p>

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Describes hints for the buffering to perform before delivering data to the destination. Please note that these options are treated as hints, and therefore Kinesis Firehose may choose to use different values when it is optimal.</p>
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct BufferingHints {

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Represents the input for a request action.</p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AcceptMatchInput {

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -28,6 +27,7 @@ use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::param::{Params, ServiceParams};
+use hyper::StatusCode;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -5177,7 +5177,7 @@ where
         request.add_header("x-amz-glacier-version", "2012-06-01");
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -5219,7 +5219,7 @@ where
         request.add_header("x-amz-glacier-version", "2012-06-01");
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -5260,7 +5260,7 @@ where
         request.add_header("x-amz-glacier-version", "2012-06-01");
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -5308,7 +5308,7 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut result = GetJobOutputOutput::default();
                     result.body = Some(response.body);
@@ -5366,7 +5366,7 @@ where
         request.add_header("x-amz-glacier-version", "2012-06-01");
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -5409,7 +5409,7 @@ where
         request.add_header("x-amz-glacier-version", "2012-06-01");
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -5451,7 +5451,7 @@ where
         request.add_header("x-amz-glacier-version", "2012-06-01");
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -5678,7 +5678,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -5729,7 +5729,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -5779,7 +5779,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -5820,7 +5820,7 @@ where
         request.add_header("x-amz-glacier-version", "2012-06-01");
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -5863,7 +5863,7 @@ where
         request.add_header("x-amz-glacier-version", "2012-06-01");
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -5910,7 +5910,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 

--- a/rusoto/services/glue/src/generated.rs
+++ b/rusoto/services/glue/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Defines an action to be initiated by a trigger.</p>
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Action {

--- a/rusoto/services/greengrass/src/generated.rs
+++ b/rusoto/services/greengrass/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -28,6 +27,7 @@ use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::param::{Params, ServiceParams};
+use hyper::StatusCode;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Information about an entity that is affected by a Health event.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AffectedEntity {

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AddAttributesToFindingsRequest {
     /// <p>The array of attributes that you want to assign to specified findings.</p>

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -18260,7 +18260,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -18293,7 +18293,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18335,7 +18335,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18377,7 +18377,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -18413,7 +18413,7 @@ where
         request.add_header("x-amzn-iot-principal", &input.principal);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -18449,7 +18449,7 @@ where
         request.add_header("x-amzn-principal", &input.principal);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18492,7 +18492,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -18525,7 +18525,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18563,7 +18563,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18608,7 +18608,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18655,7 +18655,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18697,7 +18697,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18742,7 +18742,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18787,7 +18787,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18828,7 +18828,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18878,7 +18878,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18920,7 +18920,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -18961,7 +18961,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19002,7 +19002,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19046,7 +19046,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19090,7 +19090,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19131,7 +19131,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -19165,7 +19165,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19207,7 +19207,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19256,7 +19256,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -19290,7 +19290,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19326,7 +19326,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -19361,7 +19361,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -19391,7 +19391,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19431,7 +19431,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19470,7 +19470,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19515,7 +19515,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19563,7 +19563,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19605,7 +19605,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19644,7 +19644,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -19680,7 +19680,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -19716,7 +19716,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19759,7 +19759,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19802,7 +19802,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19845,7 +19845,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19884,7 +19884,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19930,7 +19930,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -19968,7 +19968,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20009,7 +20009,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20048,7 +20048,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20097,7 +20097,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20137,7 +20137,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20177,7 +20177,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20216,7 +20216,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20258,7 +20258,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20302,7 +20302,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20346,7 +20346,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20388,7 +20388,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -20424,7 +20424,7 @@ where
         request.add_header("x-amzn-iot-principal", &input.principal);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -20460,7 +20460,7 @@ where
         request.add_header("x-amzn-principal", &input.principal);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20500,7 +20500,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -20531,7 +20531,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -20570,7 +20570,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20609,7 +20609,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20649,7 +20649,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20687,7 +20687,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20730,7 +20730,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20769,7 +20769,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20812,7 +20812,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20850,7 +20850,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20890,7 +20890,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20928,7 +20928,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -20980,7 +20980,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21035,7 +21035,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21086,7 +21086,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21138,7 +21138,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21192,7 +21192,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21241,7 +21241,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21292,7 +21292,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21344,7 +21344,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21402,7 +21402,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21453,7 +21453,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21504,7 +21504,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21556,7 +21556,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21608,7 +21608,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21651,7 +21651,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21704,7 +21704,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21754,7 +21754,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21806,7 +21806,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21857,7 +21857,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21908,7 +21908,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -21966,7 +21966,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22017,7 +22017,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22060,7 +22060,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22114,7 +22114,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22167,7 +22167,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22220,7 +22220,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22277,7 +22277,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22331,7 +22331,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22386,7 +22386,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22437,7 +22437,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22488,7 +22488,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22530,7 +22530,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22572,7 +22572,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22616,7 +22616,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -22649,7 +22649,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22691,7 +22691,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -22724,7 +22724,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22765,7 +22765,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22809,7 +22809,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -22842,7 +22842,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -22875,7 +22875,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -22908,7 +22908,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -22941,7 +22941,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -22985,7 +22985,7 @@ where
         request.set_endpoint_prefix("iot".to_string());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -23033,7 +23033,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -23078,7 +23078,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -23127,7 +23127,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -23172,7 +23172,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -23225,7 +23225,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -23263,7 +23263,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let result = ::std::mem::drop(response);
 
@@ -23296,7 +23296,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -23338,7 +23338,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -23381,7 +23381,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -23422,7 +23422,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -23463,7 +23463,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -23507,7 +23507,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -23548,7 +23548,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Represents the input for <code>AddTagsToStream</code>.</p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AddTagsToStreamInput {

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AddApplicationCloudWatchLoggingOptionRequest {
     /// <p>The Kinesis Analytics application name.</p>

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Contains information about an alias.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AliasListEntry {

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -4863,7 +4863,7 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut result = InvocationResponse::default();
                     result.payload = Some(response.body);
@@ -5104,7 +5104,7 @@ where
         request.set_content_type("application/x-amz-json-1.1".to_owned());
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -28,6 +27,7 @@ use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::param::{Params, ServiceParams};
+use hyper::StatusCode;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;

--- a/rusoto/services/lex-models/src/generated.rs
+++ b/rusoto/services/lex-models/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -28,6 +27,7 @@ use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::param::{Params, ServiceParams};
+use hyper::StatusCode;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;

--- a/rusoto/services/lex-runtime/src/generated.rs
+++ b/rusoto/services/lex-runtime/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;

--- a/rusoto/services/lex-runtime/src/generated.rs
+++ b/rusoto/services/lex-runtime/src/generated.rs
@@ -531,7 +531,7 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut result = PostContentResponse::default();
                     result.audio_stream = Some(response.body);
@@ -604,7 +604,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AllocateStaticIpRequest {
     /// <p>The name of the static IP address.</p>

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AssociateKmsKeyRequest {
     /// <p>The Amazon Resource Name (ARN) of the CMK to use when encrypting log data. For more information, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms">Amazon Resource Names - AWS Key Management Service (AWS KMS)</a>.</p>

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AddTagsInput {
     /// <p>The ID of the ML object to tag. For example, <code>exampleModelId</code>.</p>

--- a/rusoto/services/marketplace-entitlement/src/generated.rs
+++ b/rusoto/services/marketplace-entitlement/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>An entitlement represents capacity in a product owned by the customer. For example, a customer might own some number of users or seats in an SaaS application or some amount of data capacity in a multi-tenant database.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct Entitlement {

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Container for the parameters to the GenerateDataSet operation.</p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct GenerateDataSetRequest {

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>A BatchMeterUsageRequest contains UsageRecords, which indicate quantities of usage within your application.</p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct BatchMeterUsageRequest {

--- a/rusoto/services/mgh/src/generated.rs
+++ b/rusoto/services/mgh/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AssociateCreatedArtifactRequest {
     /// <p>An ARN of the AWS resource related to the migration (e.g., AMI, EC2 instance, RDS instance, etc.) </p>

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AcceptQualificationRequestRequest {
     /// <p> The value of the Qualification. You can omit this value if you are using the presence or absence of the Qualification as the basis for a HIT requirement. </p>

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Describes an agent version.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AgentVersion {

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Stores account attributes. </p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AccountAttribute {

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AcceptHandshakeRequest {
     /// <p>The unique identifier (ID) of the handshake that you want to accept.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for handshake ID string requires "h-" followed by from 8 to 32 lower-case letters or digits.</p>

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -28,6 +27,7 @@ use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::param::{Params, ServiceParams};
+use hyper::StatusCode;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Structure containing the estimated age range, in years, for a face.</p> <p>Rekognition estimates an age-range for faces detected in the input image. Estimated age ranges can overlap; a face of a 5 year old may have an estimated range of 4-6 whilst the face of a 6 year old may have an estimated range of 4-8.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AgeRange {

--- a/rusoto/services/resourcegroupstaggingapi/src/generated.rs
+++ b/rusoto/services/resourcegroupstaggingapi/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Details of the common errors that all actions return.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct FailureInfo {

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -39,6 +38,7 @@ use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
+use hyper::StatusCode;
 enum DeserializerNext {
     Close,
     Skip,

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Information for one billing record.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct BillingRecord {

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -39,6 +38,7 @@ use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
+use hyper::StatusCode;
 enum DeserializerNext {
     Close,
     Skip,

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AcceptPortfolioShareInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/shield/src/generated.rs
+++ b/rusoto/services/shield/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>The details of a DDoS attack.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AttackDetail {

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Object representing a Connector</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct Connector {

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>The address that you want the Snowball or Snowballs associated with a specific job to be shipped to. Addresses are validated at the time of creation. The address you provide must be located within the serviceable area of your region. Although no individual elements of the <code>Address</code> are required, if the address is invalid or unsupported, then an exception is thrown.</p>
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Address {

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>An activation registers one or more on-premises servers or virtual machines (VMs) with AWS so that you can configure those servers or VMs using Run Command. A server or VM that has been registered with AWS is called a managed instance.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct Activation {

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Contains details about an activity which failed during an execution.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct ActivityFailedEventDetails {

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p><p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>ActivateGatewayInput$ActivationKey</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayName</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayRegion</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayTimezone</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayType</a> </p> </li> <li> <p> <a>ActivateGatewayInput$TapeDriveType</a> </p> </li> <li> <p> <a>ActivateGatewayInput$MediumChangerType</a> </p> </li> </ul></p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct ActivateGatewayInput {

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -36,6 +35,7 @@ use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
                            start_element};
 use rusoto_core::xmlerror::*;
+use hyper::StatusCode;
 
 enum DeserializerNext {
     Close,

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct AddAttachmentsToSetRequest {

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Unit of work sent to an activity worker.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct ActivityTask {

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>The <code>ActivatedRule</code> object in an <a>UpdateWebACL</a> request specifies a <code>Rule</code> that you want to insert or delete, the priority of the <code>Rule</code> in the <code>WebACL</code>, and the action that you want AWS WAF to take when a web request matches the <code>Rule</code> (<code>ALLOW</code>, <code>BLOCK</code>, or <code>COUNT</code>).</p> <p>To specify whether to insert or delete a <code>Rule</code>, use the <code>Action</code> parameter in the <a>WebACLUpdate</a> data type.</p>
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct ActivatedRule {

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>The <code>ActivatedRule</code> object in an <a>UpdateWebACL</a> request specifies a <code>Rule</code> that you want to insert or delete, the priority of the <code>Rule</code> in the <code>WebACL</code>, and the action that you want AWS WAF to take when a web request matches the <code>Rule</code> (<code>ALLOW</code>, <code>BLOCK</code>, or <code>COUNT</code>).</p> <p>To specify whether to insert or delete a <code>Rule</code>, use the <code>Action</code> parameter in the <a>WebACLUpdate</a> data type.</p>
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct ActivatedRule {

--- a/rusoto/services/workdocs/src/generated.rs
+++ b/rusoto/services/workdocs/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -28,6 +27,7 @@ use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 
 use serde_json;
 use rusoto_core::param::{Params, ServiceParams};
+use hyper::StatusCode;
 use rusoto_core::signature::SignedRequest;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;
@@ -30,6 +29,7 @@ use serde_json;
 use rusoto_core::signature::SignedRequest;
 use serde_json::Value as SerdeJsonValue;
 use serde_json::from_str;
+use hyper::StatusCode;
 /// <p>Information about the compute type.</p>
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct ComputeType {

--- a/rusoto/services/xray/src/generated.rs
+++ b/rusoto/services/xray/src/generated.rs
@@ -1234,7 +1234,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -1274,7 +1274,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -1314,7 +1314,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -1354,7 +1354,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -1394,7 +1394,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 
@@ -1435,7 +1435,7 @@ where
         request.set_payload(encoded);
 
         let future = self.inner.sign_and_dispatch(request).and_then(|response| {
-            if response.status == StatusCode::Ok {
+            if response.status.is_success() {
                 future::Either::A(response.buffer().from_err().map(|response| {
                     let mut body = response.body;
 

--- a/rusoto/services/xray/src/generated.rs
+++ b/rusoto/services/xray/src/generated.rs
@@ -17,7 +17,6 @@ use std::io;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
-use hyper::StatusCode;
 use rusoto_core::reactor::{CredentialsProvider, RequestDispatcher};
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::region;

--- a/service_crategen/src/commands/generate/codegen/json.rs
+++ b/service_crategen/src/commands/generate/codegen/json.rs
@@ -76,7 +76,8 @@ impl GenerateProtocol for JsonGenerator {
                  "use serde_json;
         use rusoto_core::signature::SignedRequest;
         use serde_json::Value as SerdeJsonValue;
-        use serde_json::from_str;")
+        use serde_json::from_str;
+        use hyper::StatusCode;")
     }
 
     fn generate_struct_attributes(&self,

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -120,7 +120,6 @@ fn generate<P, E>(writer: &mut FileWriter,
         #[allow(warnings)]
         use futures::future;
         use futures::Future;
-        use hyper::StatusCode;
         use rusoto_core::reactor::{{CredentialsProvider, RequestDispatcher}};
         use rusoto_core::request::DispatchSignedRequest;
         use rusoto_core::region;

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -77,6 +77,7 @@ impl GenerateProtocol for QueryGenerator {
             use rusoto_core::xmlutil::{{Next, Peek, XmlParseError, XmlResponse}};
             use rusoto_core::xmlutil::{{characters, end_element, find_start_element, start_element, skip_tree, peek_at_name}};
             use rusoto_core::xmlerror::*;
+            use hyper::StatusCode;
 
             enum DeserializerNext {{
                 Close,

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -95,6 +95,7 @@ impl GenerateProtocol for RestXmlGenerator {
             use rusoto_core::xmlerror::*;
             use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
             use rusoto_core::xmlutil::{peek_at_name, characters, end_element, find_start_element, start_element, skip_tree};
+            use hyper::StatusCode;
             enum DeserializerNext {
                 Close,
                 Skip,


### PR DESCRIPTION
…cify it.

A fix for https://github.com/rusoto/rusoto/issues/893 . Some work to go still due to compilation warnings, but it appears to work.

Test case (`cargo test --features lambda -- --nocapture`):

```rust
#[test]
fn should_run_function() {
    let client = LambdaClient::simple(Region::UsWest2);
    let request = InvocationRequest {
        function_name: "rusototest".to_owned(),
        invocation_type: Some("Event".to_owned()),
        ..Default::default()
    };

    let result = client.invoke(&request).sync().unwrap();
    println!("{:#?}", result);
}
```

`master`:

```
thread 'should_run_function' panicked at 'called `Result::unwrap()` on an `Err` value: Unknown("")', src/libcore/result.rs:906:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

This branch:

```
InvocationResponse {
    executed_version: None,
    function_error: None,
    log_result: None,
    payload: Some(
        []
    ),
    status_code: Some(
        202
    )
}
```