### PR TITLE
Implement timeouts for ContainerProvider and InstanceMetadataProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Change credential expiration for non-temporary crendentials to be optional and add support for ```AWS_CREDENTIAL_EXPIRATION``` to EnvironmentProvider
 - Improve ContainerProvider to mimik the behavior of the other SDKs by also considering ```AWS_CONTAINER_AUTHORIZATION_TOKEN``` and ```AWS_CONTAINER_CREDENTIALS_FULL_URI```
 - Implement per-call timeouts for the `DispatchSignedRequest` trait
+- Implement timeouts for `ContainerProvider` and `InstanceMetadataProvider`
 
 ## [0.31.0] - 2018-01-21
 

--- a/rusoto/credential/src/instance_metadata.rs
+++ b/rusoto/credential/src/instance_metadata.rs
@@ -1,42 +1,79 @@
 //! The Credentials Provider for an AWS Resource's IAM Role.
 
+use std::time::Duration;
+
 use futures::{Future, Poll};
 use futures::future::{FutureResult, result};
-use hyper::{Client, Uri, Request, Method};
-use hyper::client::HttpConnector;
+use hyper::{Uri, Request, Method};
 use tokio_core::reactor::Handle;
 
 use {AwsCredentials, CredentialsError, ProvideAwsCredentials,
-     make_request, parse_credentials_from_aws_service};
+     parse_credentials_from_aws_service};
+use request::{HttpClient, HttpClientFuture};
 
 const AWS_CREDENTIALS_PROVIDER_IP: &str = "169.254.169.254";
 const AWS_CREDENTIALS_PROVIDER_PATH: &str = "latest/meta-data/iam/security-credentials";
 
 /// Provides AWS credentials from a resource's IAM role.
+///
+/// The provider has a default timeout of 30 seconds. While it should work well for most setups,
+/// you can change the timeout using the `set_timeout` method.
+///
+/// # Example
+///
+/// ```rust
+/// extern crate rusoto_credential;
+/// extern crate tokio_core;
+///
+/// use std::time::Duration;
+///
+/// use rusoto_credential::InstanceMetadataProvider;
+/// use tokio_core::reactor::Core;
+///
+/// fn main() {
+///   let core = Core::new().unwrap();
+///
+///   let mut provider = InstanceMetadataProvider::new(&core.handle());
+///   // you can overwrite the default timeout like this:
+///   provider.set_timeout(Duration::from_secs(60));
+///
+///   // ...
+/// }
+/// ```
 #[derive(Clone, Debug)]
 pub struct InstanceMetadataProvider {
-    client: Client<HttpConnector>
+    client: HttpClient,
+    timeout: Duration
 }
 
 impl InstanceMetadataProvider {
     /// Create a new provider with the given handle.
     pub fn new(handle: &Handle) -> Self {
-        let client = Client::configure().build(handle);
-        InstanceMetadataProvider { client: client }
+        let client = HttpClient::new(handle);
+        InstanceMetadataProvider {
+            client: client,
+            timeout: Duration::from_secs(30)
+        }
+    }
+
+    /// Set the timeout on the provider to the specified duration.
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        self.timeout = timeout;
     }
 }
 
 enum InstanceMetadataFutureState {
     Start,
-    GetRoleName(Box<Future<Item=String, Error=CredentialsError>>),
-    GetCredentialsFromRole(Box<Future<Item=String, Error=CredentialsError>>),
+    GetRoleName(HttpClientFuture),
+    GetCredentialsFromRole(HttpClientFuture),
     Done(FutureResult<AwsCredentials, CredentialsError>)
 }
 
 /// Future returned from `InstanceMetadataProvider`.
 pub struct InstanceMetadataProviderFuture {
     state: InstanceMetadataFutureState,
-    client: Client<HttpConnector>
+    client: HttpClient,
+    timeout: Duration
 }
 
 impl Future for InstanceMetadataProviderFuture {
@@ -46,12 +83,12 @@ impl Future for InstanceMetadataProviderFuture {
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let new_state = match self.state {
             InstanceMetadataFutureState::Start => {
-                let new_future = get_role_name(&self.client)?;
+                let new_future = get_role_name(&self.client, self.timeout)?;
                 InstanceMetadataFutureState::GetRoleName(new_future)
             }
             InstanceMetadataFutureState::GetRoleName(ref mut future) => {
                 let role_name = try_ready!(future.poll());
-                let new_future = get_credentials_from_role(&self.client, &role_name)?;
+                let new_future = get_credentials_from_role(&self.client, self.timeout, &role_name)?;
                 InstanceMetadataFutureState::GetCredentialsFromRole(new_future)
             },
             InstanceMetadataFutureState::GetCredentialsFromRole(ref mut future) => {
@@ -75,27 +112,29 @@ impl ProvideAwsCredentials for InstanceMetadataProvider {
     fn credentials(&self) -> Self::Future {
         InstanceMetadataProviderFuture {
             state: InstanceMetadataFutureState::Start,
-            client: self.client.clone()
+            client: self.client.clone(),
+            timeout: self.timeout
         }
     }
 }
 
 /// Gets the role name to get credentials for using the IAM Metadata Service (169.254.169.254).
-fn get_role_name(client: &Client<HttpConnector>) -> Result<Box<Future<Item=String, Error=CredentialsError>>, CredentialsError> {
+fn get_role_name(client: &HttpClient, timeout: Duration) -> Result<HttpClientFuture, CredentialsError> {
     let role_name_address = format!(
         "http://{}/{}/",
         AWS_CREDENTIALS_PROVIDER_IP,
         AWS_CREDENTIALS_PROVIDER_PATH
     );
     let uri = role_name_address.parse::<Uri>()?;
-    Ok(make_request(client, Request::new(Method::Get, uri)))
+    Ok(client.request(Request::new(Method::Get, uri), timeout))
 }
 
 /// Gets the credentials for an EC2 Instances IAM Role.
 fn get_credentials_from_role(
-    client: &Client<HttpConnector>,
+    client: &HttpClient,
+    timeout: Duration,
     role_name: &str
-) -> Result<Box<Future<Item=String, Error=CredentialsError>>, CredentialsError> {
+) -> Result<HttpClientFuture, CredentialsError> {
     let credentials_provider_url = format!(
         "http://{}/{}/{}",
         AWS_CREDENTIALS_PROVIDER_IP,
@@ -104,5 +143,5 @@ fn get_credentials_from_role(
     );
 
     let uri = credentials_provider_url.parse::<Uri>()?;
-    Ok(make_request(client, Request::new(Method::Get, uri)))
+    Ok(client.request(Request::new(Method::Get, uri), timeout))
 }

--- a/rusoto/credential/src/request.rs
+++ b/rusoto/credential/src/request.rs
@@ -1,0 +1,126 @@
+use std::io::{Error as IoError};
+use std::io::ErrorKind::InvalidData;
+use std::mem;
+use std::time::Duration;
+
+use futures::{Async, Future, Poll, Stream};
+use futures::future::{Either, Select2};
+use futures::stream::Concat2;
+use hyper::{Client as HyperClient, Body, Request};
+use hyper::client::{FutureResponse as HyperFutureResponse, HttpConnector};
+use tokio_core::reactor::{Handle, Timeout};
+
+use super::CredentialsError;
+
+/// A future that will resolve to an `HttpResponse`.
+pub struct HttpClientFuture(ClientFutureInner);
+
+enum RequestFuture {
+    Waiting(HyperFutureResponse),
+    Buffering(Concat2<Body>),
+    Swapping
+}
+
+impl Future for RequestFuture {
+    type Item = String;
+    type Error = CredentialsError;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match mem::replace(self, RequestFuture::Swapping) {
+            RequestFuture::Waiting(mut hyper_future) => {
+                match hyper_future.poll()? {
+                    Async::NotReady => {
+                        *self = RequestFuture::Waiting(hyper_future);
+                        Ok(Async::NotReady)
+                    },
+                    Async::Ready(res) => {
+                        if !res.status().is_success() {
+                            Err(CredentialsError {
+                                message: format!("Invalid Response Code: {}", res.status())
+                            })
+                        } else {
+                            *self = RequestFuture::Buffering(res.body().concat2());
+                            self.poll()
+                        }
+                    }
+                }
+            },
+            RequestFuture::Buffering(mut concat_future) => {
+                match concat_future.poll()? {
+                    Async::NotReady => {
+                        *self = RequestFuture::Buffering(concat_future);
+                        Ok(Async::NotReady)
+                    },
+                    Async::Ready(body) => {
+                        let string_body = String::from_utf8(body.to_vec())
+                            .map_err(|_| IoError::new(InvalidData, "Non UTF-8 Data returned"))?;
+                        Ok(Async::Ready(string_body))
+                    }
+                }
+            },
+            RequestFuture::Swapping => unreachable!()
+        }
+    }
+}
+
+enum ClientFutureInner {
+    Request(Select2<RequestFuture, Timeout>),
+    Error(String)
+}
+
+impl Future for HttpClientFuture {
+    type Item = String;
+    type Error = CredentialsError;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.0 {
+            ClientFutureInner::Error(ref message) =>
+                Err(CredentialsError { message: message.clone() }),
+            ClientFutureInner::Request(ref mut select_future) => {
+                match select_future.poll() {
+                    Err(Either::A((err, _))) =>
+                        Err(err),
+                    Err(Either::B((io_err, _))) =>
+                        Err(io_err.into()),
+                    Ok(Async::NotReady) =>
+                        Ok(Async::NotReady),
+                    Ok(Async::Ready(Either::A((body, _)))) =>
+                        Ok(Async::Ready(body)),
+                    Ok(Async::Ready(Either::B(((), _)))) =>
+                        Err(CredentialsError { message: "Request timed out".into() })
+                }
+            }
+        }
+    }
+}
+
+/// Http client for use in a credentials provider.
+#[derive(Debug, Clone)]
+pub struct HttpClient {
+    inner: HyperClient<HttpConnector>,
+    handle: Handle
+}
+
+impl HttpClient {
+    /// Create an http client.
+    pub fn new(handle: &Handle) -> HttpClient {
+        HttpClient {
+            inner: HyperClient::configure().build(handle),
+            handle: handle.clone()
+        }
+    }
+
+    pub fn request(&self, request: Request, timeout: Duration) -> HttpClientFuture {
+        let request_future = RequestFuture::Waiting(self.inner.request(request));
+
+        let inner = match Timeout::new(timeout, &self.handle) {
+            Err(err) => ClientFutureInner::Error(format!("Error creating timeout future {}", err)),
+            Ok(timeout_future) => {
+                let future = request_future.select2(timeout_future);
+                ClientFutureInner::Request(future)
+            }
+        };
+
+        HttpClientFuture(inner)
+    }
+}


### PR DESCRIPTION
/cc @SecurityInsanity 

Here we go, this PR adds timeout support for the credential providers `ContainerProvider` and `InstanceMetadataProvider`.

In terms of the public API, these are the relevant changes:

- `ContainerProvider` gains a `set_timeout` method to override the default timeout of 30s
- `InstanceMetadataProvider` gains a `set_timeout` method to override the default timeout of 30s
- `BaseAutoRefreshingProvider` gains `get_ref` and `get_mut` methods to access the wrapped provider (enables calling `set_timeout` on a wrapped provider)
- `ChainProvider` gains a `set_timeout` method which calls `set_timeout` on the underlying `ContainerProvider` and `InstanceMetadataProvider`

Overall I'm a bit concerned by the lack of test coverage for the I/O bits in this part of Rusoto. Have you thought about building up some integration tests using [WireMock](http://wiremock.org/) or similar? Any other pointers as to how I could tests this better?