### PR TITLE
Hide secrets in Debug impl of AwsCredentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 (Please put an entry here in each PR)
 
+- Show secret keys and tokens as `"**********"` in `Debug` output
 - Use ```$AWS_PROFILE``` to obtain default profile name 
 - Implement `Default` for `Region`
 - Derive Clone for remaining types (affects CloudFront, Route 53 and S3)

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -23,6 +23,7 @@ tokio-core = "0.1"
 
 [dev-dependencies]
 lazy_static = "1.0"
+quickcheck = "0.6"
 
 [dependencies.clippy]
 optional = true

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -48,7 +48,7 @@ use tokio_core::reactor::Handle;
 
 /// AWS API access credentials, including access key, secret key, token (for IAM profiles),
 /// expiration timestamp, and claims from federated login.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct AwsCredentials {
     key: String,
     secret: String,
@@ -118,6 +118,18 @@ impl AwsCredentials {
     /// Get the mutable token claims
     pub fn claims_mut(&mut self) -> &mut BTreeMap<String, String> {
         &mut self.claims
+    }
+}
+
+impl fmt::Debug for AwsCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("AwsCredentials")
+            .field("key", &self.key)
+            .field("secret", &"**********")
+            .field("token", &self.token.as_ref().map(|_| "**********"))
+            .field("expires_at", &self.expires_at)
+            .field("claims", &self.claims)
+            .finish()
     }
 }
 

--- a/rusoto/credential/src/static_provider.rs
+++ b/rusoto/credential/src/static_provider.rs
@@ -9,19 +9,18 @@ use {AwsCredentials, CredentialsError, ProvideAwsCredentials};
 /// Provides AWS credentials from statically/programmatically provided strings.
 #[derive(Clone, Debug)]
 pub struct StaticProvider {
-    /// The AWS Access Key ID to use for authenticating to AWS.
-    aws_access_key_id: String,
-    /// The AWS Secret Access Key to use for authenticating to AWS.
-    aws_secret_access_key: String,
-    /// The optional token to use for authenticating to AWS.
-    token: Option<String>,
-    /// The time in seconds each issued token should be valid for.
+    /// AWS credentials
+    credentials: AwsCredentials,
+
+    /// The time in seconds for which each issued token is valid.
     valid_for: Option<i64>,
 }
 
 impl StaticProvider {
     /// Creates a new Static Provider. This should be used when you want to statically, or programmatically
     /// provide access to AWS.
+    ///
+    /// `valid_for` is the number of seconds for which issued tokens are valid.
     pub fn new(
         access_key: String,
         secret_access_key: String,
@@ -29,9 +28,12 @@ impl StaticProvider {
         valid_for: Option<i64>,
     ) -> StaticProvider {
         StaticProvider {
-            aws_access_key_id: access_key,
-            aws_secret_access_key: secret_access_key,
-            token: token,
+            credentials: AwsCredentials::new(
+                access_key,
+                secret_access_key,
+                token,
+                None
+            ),
             valid_for: valid_for,
         }
     }
@@ -39,31 +41,34 @@ impl StaticProvider {
     /// Creates a new minimal Static Provider. This will set the token as optional none.
     pub fn new_minimal(access_key: String, secret_access_key: String) -> StaticProvider {
         StaticProvider {
-            aws_access_key_id: access_key,
-            aws_secret_access_key: secret_access_key,
-            token: None,
+            credentials: AwsCredentials::new(
+                access_key,
+                secret_access_key,
+                None,
+                None
+            ),
             valid_for: None,
         }
     }
 
     /// Gets the AWS Access Key ID for this Static Provider.
     pub fn get_aws_access_key_id(&self) -> &str {
-        &self.aws_access_key_id
+        &self.credentials.key
     }
 
     /// Gets the AWS Secret Access Key for this Static Provider.
     pub fn get_aws_secret_access_key(&self) -> &str {
-        &self.aws_secret_access_key
+        &self.credentials.secret
     }
 
     /// Determines if this Static Provider was given a Token.
     pub fn has_token(&self) -> bool {
-        self.token.is_some()
+        self.credentials.token.is_some()
     }
 
     /// Gets The Token this Static Provider was given.
     pub fn get_token(&self) -> &Option<String> {
-        &self.token
+        &self.credentials.token
     }
 
     /// Returns the length in seconds this Static Provider will be valid for.
@@ -76,18 +81,17 @@ impl ProvideAwsCredentials for StaticProvider {
     type Future = FutureResult<AwsCredentials, CredentialsError>;
 
     fn credentials(&self) -> Self::Future {
-        ok(AwsCredentials::new(
-            self.aws_access_key_id.clone(),
-            self.aws_secret_access_key.clone(),
-            self.token.clone(),
-            self.valid_for.map(|v| Utc::now() + Duration::seconds(v)),
-        ))
+        let mut creds = self.credentials.clone();
+        creds.expires_at = self.valid_for.map(|v| Utc::now() + Duration::seconds(v));
+        ok(creds)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use futures::Future;
+    use std::thread;
+    use std::time;
 
     use ProvideAwsCredentials;
     use super::*;
@@ -124,8 +128,22 @@ mod tests {
         let finalized = result.unwrap();
         let expires_at = finalized.expires_at().unwrap().clone();
 
-        // Give a wide range of time, just incase there's somehow an immense amount of lag.
+        // Give a wide range of time, just in case there's somehow an immense amount of lag.
         assert!(start_time + Duration::minutes(100) < expires_at);
         assert!(expires_at < start_time + Duration::minutes(200));
+    }
+
+    #[test]
+    fn test_static_provider_expiration_time_is_recalculated() {
+        let provider = StaticProvider::new(
+            "fake-key".to_owned(),
+            "fake-secret".to_owned(),
+            None,
+            Some(10000),
+        );
+        let creds1 = provider.credentials().wait().unwrap();
+        thread::sleep(time::Duration::from_secs(1));
+        let creds2 = provider.credentials().wait().unwrap();
+        assert!(creds1.expires_at() < creds2.expires_at());
     }
 }

--- a/rusoto/credential/src/static_provider.rs
+++ b/rusoto/credential/src/static_provider.rs
@@ -93,6 +93,7 @@ mod tests {
     use std::thread;
     use std::time;
 
+    use test_utils::{is_secret_hidden_behind_asterisks, SECRET};
     use ProvideAwsCredentials;
     use super::*;
 
@@ -145,5 +146,22 @@ mod tests {
         thread::sleep(time::Duration::from_secs(1));
         let creds2 = provider.credentials().wait().unwrap();
         assert!(creds1.expires_at() < creds2.expires_at());
+    }
+
+    #[test]
+    quickcheck! {
+        fn test_static_provider_secrets_not_in_debug(
+            access_key: String,
+            token: Option<()>,
+            valid_for: Option<i64>
+        ) -> bool {
+            let provider = StaticProvider::new(
+                access_key,
+                SECRET.to_owned(),
+                token.map(|_| SECRET.to_owned()),
+                valid_for
+            );
+            is_secret_hidden_behind_asterisks(&provider)
+        }
     }
 }

--- a/rusoto/credential/src/test_utils.rs
+++ b/rusoto/credential/src/test_utils.rs
@@ -1,0 +1,10 @@
+#![cfg(test)]
+
+use std::fmt::Debug;
+
+pub const SECRET: &str = &"TtnuieannGt2rGuie2t8Tt7urarg5nauedRndrur";
+
+pub fn is_secret_hidden_behind_asterisks<D>(obj: &D) -> bool where D: Debug {
+    let debug = format!("{:?}", obj);
+    !debug.contains(SECRET) && debug.contains("**********")
+}


### PR DESCRIPTION
Show secret key and token as `"**********"` to avoid that they accidentally appear in stack traces or logs.