### PR TITLE
bump rand dependency to 0.4.2

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -49,7 +49,7 @@ version = "0.0"
 
 [dev-dependencies]
 env_logger = "0.5"
-rand = "^0.3.14"
+rand = "0.4.2"
 serde_json = "1.0.1"
 serde_test = "1.0.1"
 


### PR DESCRIPTION
Just a little bit of house keeping, bumping the `rand` dev-dependency on rusoto_core to 0.4.2.