### PR TITLE
Bugfix: Prevent reactor from hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 (Please put an entry here in each PR)
 
 - More efficiently and correctly remove scheme from `Region::Custom` endpoints
+- Prevent reactor from hanging indefinitely when using the new tokio release
 
 ## [0.32.0] - 2018-03-03
 

--- a/rusoto/core/src/reactor.rs
+++ b/rusoto/core/src/reactor.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use std::thread;
 
 use futures::{Async, Future, Poll, Stream};
-use futures::future::{Either, ok};
+use futures::future::{Either, empty, ok};
 use futures::sync::{mpsc, oneshot};
 use tokio_core::reactor::{Core, Handle, Remote};
 
@@ -60,9 +60,7 @@ impl Reactor {
                 }
             };
 
-            loop {
-                core.turn(None);
-            }
+            core.run(empty::<(), ()>()).unwrap();
         });
 
         let remote = init_rx.wait()


### PR DESCRIPTION
Potential fix for #1000, pending confirmation from @pgerber.

We should cut a bug fix release for `rusoto_core` with this as soon as possible, otherwise Rusoto will be broken when used with the two latest versions of `tokio-core`.